### PR TITLE
WIP - UUID Inquiry

### DIFF
--- a/arlo-client/package.json
+++ b/arlo-client/package.json
@@ -10,7 +10,7 @@
     "@types/react-tap-event-plugin": "^0.0.30",
     "@types/react-toastify": "^4.0.2",
     "@types/styled-components": "^4.1.15",
-    "@types/uuid": "^3.4.4",
+    "@types/uuidv4": "^2.0.0",
     "http-proxy-middleware": "^0.19.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
@@ -20,7 +20,7 @@
     "react-toastify": "^5.3.1",
     "styled-components": "^4.3.2",
     "typescript": "3.5.1",
-    "uuid": "^3.3.2"
+    "uuidv4": "^4.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/arlo-client/src/components/AuditForms/RiskLimitingAuditForm.tsx
+++ b/arlo-client/src/components/AuditForms/RiskLimitingAuditForm.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import { toast } from 'react-toastify'
+import uuidv4 from 'uuidv4'
 import EstimateSampleSize from './EstimateSampleSize'
 import SelectBallotsToAudit from './SelectBallotsToAudit'
 import CalculateRiskMeasurement from './CalculateRiskMeasurement'
-
-const uuidv4 = require('uuid/v4')
 
 const apiBaseURL = ''
 interface Candidate {
@@ -223,12 +222,12 @@ class AuditForms extends React.Component<any, any> {
 
   public calculateRiskMeasurement = async (data: any, evt: any) => {
     evt.preventDefault()
-    const { id, candidateOne, candidateTwo } = data
+    const { id, candidateOne, candidateTwo } = data // support n candidates?
     const contests = this.state.audit.contests.map((contest: any) => ({
       id: contest.id,
       results: {
-        'candidate-1': Number(candidateOne),
-        'candidate-2': Number(candidateTwo),
+        [contest.choices[0].id]: Number(candidateOne),
+        [contest.choices[1].id]: Number(candidateTwo),
       },
     }))
     try {
@@ -239,6 +238,7 @@ class AuditForms extends React.Component<any, any> {
 
       this.setState({ isLoading: true })
       await api(`/jurisdiction/${jurisdictionID}/${id}/results`, {
+        // throws 500 internal server error
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/arlo-client/yarn.lock
+++ b/arlo-client/yarn.lock
@@ -1480,12 +1480,10 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/uuid@^3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
-  integrity sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==
-  dependencies:
-    "@types/node" "*"
+"@types/uuidv4@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuidv4/-/uuidv4-2.0.0.tgz#9579daf4812281a40c93028012635eed08d7210d"
+  integrity sha512-qMAfgZE8tjisI2/4/rkGvtSYpuI+t/6Q+wa38X3v6RfeaqI1ZM6W6Aye93d1WNPT2SgeFeHVbO+7uEJmIVbiwA==
 
 "@types/vfile-message@*":
   version "1.0.1"
@@ -11378,10 +11376,17 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.0.1, uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuidv4@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/uuidv4/-/uuidv4-4.0.0.tgz#ac4b05ecf0efa62dda532d55b7a8de8f726f8f7c"
+  integrity sha512-mG90kcW04v6frNmnLsnd7xqiKubIYgaQHxaHoBplAJpR95hgqkTDq8wpZQU5cN5w9gtKphqdsflHoEnXr2+ing==
+  dependencies:
+    uuid "3.3.2"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
**The work on this PR so far is to achieve the below technical and business requirements.**

- Look into driving all identifiers from one place. Details: when creating new objects with new identifiers, use uuid(), then wait for status call to return the identifiers, stash the data in `state`, then use the identifiers therein for future calls. (One exception to uuid's: audit-board IDs, they should just be audit-board-1, audit-board-2, ...) 

- Support for multiple candidates per contest 

Whenever a contest was sent in with a unique id rather than contest-1 it was returning a 500 server error. 

**Questions:**

1. Does the API need to be updated in order to support unique IDs on contests/ multiple contests? It appears as though the API is expecting a hard coded contest ID. 