### PR TITLE
Update api to support selecting sample size

### DIFF
--- a/API.md
+++ b/API.md
@@ -137,12 +137,11 @@ JSON for sure.
 }
 ```
 
-- `POST /audit/sampleSize` -- the selected sample size from the given sampleSizeOptions
+- `POST /audit/sample-size` -- the selected sample size from the given sampleSizeOptions
 
 ```
 {
-	'contest-id-1': 578,
-	'contest-id-2': 130
+	'size': 578,
 }
 ```
 

--- a/models.py
+++ b/models.py
@@ -14,6 +14,7 @@ class Election(db.Model):
     risk_limit = db.Column(db.Integer, nullable=True)
     random_seed = db.Column(db.String(100), nullable=True)
     sample_size_options = db.Column(db.String(1000), nullable=True)
+    chosen_sample_size = db.Column(db.Integer, nullable=True)
     jurisdictions = relationship('Jurisdiction', back_populates='election')
     contests = relationship('TargetedContest', back_populates='election')
     rounds = relationship('Round', back_populates='election')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -111,6 +111,18 @@ def test_whole_audit_flow(client):
     assert jurisdiction["auditBoards"][1]["id"] == "audit-board-2"
     assert jurisdiction["contests"] == ["contest-1"]
 
+    # choose a sample size
+    sample_size_90 = [option for option in status["contests"][0]["sampleSizeOptions"] if option["prob"] == 0.9]
+    assert len(sample_size_90) == 1
+    sample_size = sample_size_90[0]["size"]
+
+    # set the sample_size
+    rv = post_json(client, '/audit/sample-size', {
+        "size": sample_size
+    })
+
+    assert json.loads(rv.data)["status"] == "ok"
+
     # upload the manifest
     data = {}
     data['manifest'] = (open(manifest_file_path, "rb"), 'manifest.csv')
@@ -154,6 +166,7 @@ def test_whole_audit_flow(client):
     rv = client.get('/jurisdiction/adams-county/1/retrieval-list')
     lines = rv.data.decode('utf-8').split("\r\n")
     assert lines[0] == "Batch Name,Ballot Number,Storage Location,Tabulator,Times Selected,Audit Board"
+    assert len(lines) > 5
     assert 'attachment' in rv.headers['Content-Disposition']
 
     num_ballots = sum([int(line.split(",")[4]) for line in lines[1:] if line!=""])
@@ -267,6 +280,16 @@ def test_small_election(client):
     assert jurisdiction["auditBoards"][1]["id"] == "audit-board-2"
     assert jurisdiction["contests"] == ["contest-1"]
 
+    # choose a sample size
+    sample_size_90 = [option for option in status["contests"][0]["sampleSizeOptions"] if option["prob"] == 0.9]
+    assert len(sample_size_90) == 1
+    sample_size = sample_size_90[0]["size"]
+
+    # set the sample_size
+    rv = post_json(client, '/audit/sample-size', {
+        "size": sample_size
+    })
+    
     # upload the manifest
     data = {}
     data['manifest'] = (open(small_manifest_file_path, "rb"), 'small-manifest.csv')


### PR DESCRIPTION
After posting the initial form to `/audit/basic` we need `sampleSizeOptions` returned on the `contests` array with the other contest info.

```
contests: [
  ...
  sampleSizeOptions: [
    {"prob": 0.5, "size": 143},
    ...
  ]
]
```

There should be another api endpoint (suggested: `/audit/sampleSize`) that accepts the selected sample size for generating the rounds. This will be posted to along with the `POST /audit/jurisdictions` and `POST /jurisdiction/<jurisdiction_id>/manifest` calls. Suggested structure:

```
{
  [contest-id]: 578,
  // and if multiple contests
  [contest-id2]: 578
}
```

This will provide the needed information for the UI to present the options to the user at the right point, and support multiple contests if needed. The sample size for each round is returned in the `rounds` array as currently.