### PR TITLE
Changing number of possible audit boards from 5 to 15

### DIFF
--- a/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
+++ b/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
@@ -40,7 +40,7 @@ const schema = Yup.object().shape({
   auditBoards: Yup.number()
     .typeError('Must be a number')
     .min(1, 'Too few Audit Boards')
-    .max(5, 'Too many Audit Boards')
+    .max(15, 'Too many Audit Boards')
     .required('Required'),
   manifest: Yup.mixed()
     .required('You must upload a manifest')
@@ -236,7 +236,7 @@ const SelectBallotsToAudit = (props: Props) => {
                 onBlur={handleBlur}
                 disabled={!!audit.rounds.length}
               >
-                {generateOptions(5)}
+                {generateOptions(15)}
               </select>
               {errors.auditBoards && touched.auditBoards && (
                 <ErrorLabel>{errors.auditBoards}</ErrorLabel>

--- a/arlo-client/src/components/AuditForms/__snapshots__/SelectBallotsToAudit.test.tsx.snap
+++ b/arlo-client/src/components/AuditForms/__snapshots__/SelectBallotsToAudit.test.tsx.snap
@@ -125,6 +125,36 @@ Object {
               <option>
                 5
               </option>
+              <option>
+                6
+              </option>
+              <option>
+                7
+              </option>
+              <option>
+                8
+              </option>
+              <option>
+                9
+              </option>
+              <option>
+                10
+              </option>
+              <option>
+                11
+              </option>
+              <option>
+                12
+              </option>
+              <option>
+                13
+              </option>
+              <option>
+                14
+              </option>
+              <option>
+                15
+              </option>
             </select>
           </div>
           <div
@@ -280,6 +310,36 @@ Object {
             </option>
             <option>
               5
+            </option>
+            <option>
+              6
+            </option>
+            <option>
+              7
+            </option>
+            <option>
+              8
+            </option>
+            <option>
+              9
+            </option>
+            <option>
+              10
+            </option>
+            <option>
+              11
+            </option>
+            <option>
+              12
+            </option>
+            <option>
+              13
+            </option>
+            <option>
+              14
+            </option>
+            <option>
+              15
             </option>
           </select>
         </div>


### PR DESCRIPTION
**Description**

- Changes the dropdown for selecting the number of audit boards to show 1-15 instead of 1-5

- Updates the validation to correspond.