### PR TITLE
refactor: simplify `Audit` property types

### DIFF
--- a/arlo-client/src/types.ts
+++ b/arlo-client/src/types.ts
@@ -69,7 +69,7 @@ export interface Audit {
   name: string
   riskLimit: number | string
   randomSeed: string
-  contests: Contest[] | []
-  jurisdictions: Jurisdiction[] | []
-  rounds: Round[] | []
+  contests: Contest[]
+  jurisdictions: Jurisdiction[]
+  rounds: Round[]
 }


### PR DESCRIPTION
**DESCRIPTION**

The `| []` union does not add anything to the base type, i.e. `Contest[]` encompasses `[]`.

**Checklist**

- [x] package.json is committed if I added any dependencies
- [x] No errors/warnings in the browser console ( ﾟヮﾟ)/
- [x] Tests added as needed to ensure code base still has 100% passing coverage
- [x] Tests added as needed to cover new functionality
