### PR TITLE
refactor: remove arbitrary path route

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import os, datetime, csv, io, math, json, uuid
-from flask import Flask, send_from_directory, jsonify, request, Response
+from flask import Flask, jsonify, request, Response
 from flask_sqlalchemy import SQLAlchemy
 from sampler import Sampler
 
@@ -572,14 +572,10 @@ def audit_reset(election_id=None):
 
 
 # React App
-@app.route('/', defaults={'path': ''})
-@app.route('/election/<election_id>', defaults={'path': ''})
-@app.route('/<path:path>')
-def serve(path, election_id=None):
-    if path != "" and os.path.exists(app.static_folder + path):
-        return send_from_directory(app.static_folder, path)
-    else:
-        return send_from_directory(app.static_folder, 'index.html')
+@app.route('/')
+@app.route('/election/<election_id>')
+def serve(election_id=None):
+    return app.send_static_file('index.html')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
flask automatically creates a route for serving static files if `app.static_folder` is set. https://github.com/pallets/flask/blob/b7f6fae9b34341b9be7742b86f6caffe07fc6f25/src/flask/app.py#L596-L605

Also, we can just use `app.send_static_file` to send a named static file rather than building the path ourselves.
