### PR TITLE
test: remove annotation that was causing a warning

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -260,7 +260,6 @@ def run_election_reset(client, election_id):
     assert status["jurisdictions"] == []
     assert status["rounds"] == []        
     
-@pytest.mark.quick
 def test_small_election(client):
     rv = post_json(
         client, '/audit/basic',


### PR DESCRIPTION
```
/Users/donovan/.local/share/virtualenvs/arlo-GJ_PAFem/lib/python3.7/site-packages/_pytest/mark/structures.py:325
  /Users/donovan/.local/share/virtualenvs/arlo-GJ_PAFem/lib/python3.7/site-packages/_pytest/mark/structures.py:325: PytestUnknownMarkWarning: Unknown pytest.mark.quick - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,
```
