### PR TITLE
build: don't require enumerating types packages

### DIFF
--- a/arlo-client/src/test/types/webdriverio.d.ts
+++ b/arlo-client/src/test/types/webdriverio.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@wdio/sync" />

--- a/arlo-client/tsconfig.json
+++ b/arlo-client/tsconfig.json
@@ -14,8 +14,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "preserve",
-    "noUnusedLocals": true,
-    "types": ["node", "@wdio/sync", "@wdio/jasmine-framework", "@types/jest"]
+    "noUnusedLocals": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This makes webdriver's types available without having to explicitly enumerate it in `tsconfig.json`. Doing so seems to require us to enumerate some (but not all?) of the types packages we use. This way TS will see the webdriverio.d.ts file which then pulls in types from `@wdio/sync`.
