### PR TITLE
refactor: minor improvements to `utilities.ts`

### DIFF
--- a/arlo-client/src/components/AuditForms/ResetButton.test.tsx
+++ b/arlo-client/src/components/AuditForms/ResetButton.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, fireEvent, wait } from '@testing-library/react'
 import ResetButton from './ResetButton'
-import api from '../utilities'
+import { api } from '../utilities'
 
 const apiMock = api as jest.Mock<ReturnType<typeof api>, Parameters<typeof api>>
 

--- a/arlo-client/src/components/AuditForms/index.test.tsx
+++ b/arlo-client/src/components/AuditForms/index.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@testing-library/react'
 import AuditForms from './index'
 import statusStates from './_mocks'
-import api from '../utilities'
+import { api } from '../utilities'
 import { routerTestProps } from '../testUtilities'
 
 const apiMock = api as jest.Mock<ReturnType<typeof api>, Parameters<typeof api>>

--- a/arlo-client/src/components/CreateAudit.test.tsx
+++ b/arlo-client/src/components/CreateAudit.test.tsx
@@ -4,7 +4,7 @@ import { RouteComponentProps } from 'react-router-dom'
 import CreateAudit from './CreateAudit'
 import { Params } from '../types'
 import { routerTestProps } from './testUtilities'
-import api from './utilities'
+import { api } from './utilities'
 
 const apiMock = api as jest.Mock<ReturnType<typeof api>, Parameters<typeof api>>
 

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import { RouteComponentProps } from 'react-router-dom'
 import FormButton from './Form/FormButton'
-import api from './utilities'
+import { api } from './utilities'
 import { Params } from '../types'
 
 const Button = styled(FormButton)`

--- a/arlo-client/src/components/utilities.test.ts
+++ b/arlo-client/src/components/utilities.test.ts
@@ -1,4 +1,4 @@
-import api, { testNumber } from './utilities'
+import { api, testNumber } from './utilities'
 
 const response = () =>
   new Response(new Blob([JSON.stringify({ success: true })]))

--- a/arlo-client/src/components/utilities.ts
+++ b/arlo-client/src/components/utilities.ts
@@ -1,22 +1,21 @@
 import * as Yup from 'yup'
 import { Params } from '../types'
 
-export const api = <T>(
+export const api = async <T>(
   endpoint: string,
   { electionId, ...options }: Params & RequestInit
 ): Promise<T> => {
   const apiBaseURL = electionId ? `/election/${electionId}` : ''
-  return fetch(apiBaseURL + endpoint, options).then(res => {
-    if (!res.ok) {
-      throw new Error(res.statusText)
-    }
-    return res.json() as Promise<T>
-  })
+  const res = await fetch(apiBaseURL + endpoint, options)
+  if (!res.ok) {
+    throw new Error(res.statusText)
+  }
+  return res.json() as Promise<T>
 }
 
 export const poll = (
   condition: () => Promise<boolean>,
-  callback: () => any,
+  callback: () => void,
   errback: (arg0: Error) => void,
   timeout: number = 120000,
   interval: number = 1000
@@ -40,27 +39,21 @@ const numberSchema = Yup.number()
   .min(0, 'Must be a positive number')
   .required('Required')
 
-export const testNumber = (max?: number, message?: string) => (value: any) =>
-  numberSchema.validate(value).then(
-    success => {
-      if (max) {
-        const schema = Yup.number().test(
-          'cap',
-          message || `Must be smaller than ${max}`,
-          function(v) {
-            /* istanbul ignore else */
-            if (this.options.context) {
-              const { max } = this.options.context as { max: number }
-              return v <= max
-            } else return true
-          }
-        )
-        return schema
-          .validate(value, { context: { max } })
-          .then(success => undefined, error => error.errors[0])
-      } else return undefined
-    },
-    error => error.errors[0]
-  )
+export const testNumber = (
+  max?: number,
+  message?: string
+): ((value: number) => Promise<string | undefined>) => {
+  const schema = max
+    ? numberSchema.concat(
+        Yup.number().max(max, message || `Must be smaller than ${max}`)
+      )
+    : numberSchema
 
-export default api
+  return async (value: unknown) => {
+    try {
+      await schema.validate(value)
+    } catch (error) {
+      return error.errors[0]
+    }
+  }
+}


### PR DESCRIPTION
- don't export `api` as default, just use named export
- use `async`/`await`
- don't use `any`
- use `Yup` API instead of custom schema
