### PR TITLE
chore: add VS Code workspace config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "python.pythonPath": "/usr/bin/python3.7"
+  "python.pythonPath": "/usr/bin/python3.7",
+  "files.exclude": {
+    "arlo-client": true
+  }
 }

--- a/arlo.code-workspace
+++ b/arlo.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "arlo-client"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
Setting up a workspace in this way has proven to work pretty well when working on both the client and server together. VS Code has the ability to open multiple "root" folders at the same time, and that's what this does. To make sure that files in the `arlo-client` directory don't show up twice, we exclude `arlo-client` from the `arlo` folder.

Why even bother with this? Well, if you just open the root `arlo` folder in VS Code it tries to use that as the base for the node module / react app as well, which means TypeScript tries to find a `tsconfig.json` at that level and of course fails. This way, `arlo` is loaded as a root python project and `arlo-client` as a root node project.
