### PR TITLE
Fixing filename of labels pdf

### DIFF
--- a/arlo-client/src/components/AuditForms/CalculateRiskMeasurement.tsx
+++ b/arlo-client/src/components/AuditForms/CalculateRiskMeasurement.tsx
@@ -139,7 +139,7 @@ const CalculateRiskMeasurement: React.FC<Props> = ({
         labels.text(`Ballot Number: ${ballot.position}`, x, y[2])
       })
       labels.autoPrint()
-      labels.save(`Round ${r + 1} Placeholders.pdf`)
+      labels.save(`Round ${r + 1} Labels.pdf`)
     }
   }
 


### PR DESCRIPTION
**DESCRIPTION**

- Changed file name of labels to say 'labels' instead of 'placeholders'

**New Tests**

N/A
