### PR TITLE
fix: create audit board with lexicographically-sortable names

### DIFF
--- a/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
+++ b/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
@@ -25,7 +25,8 @@ import { api, testNumber } from '../utilities'
 import { generateOptions, ErrorLabel } from '../Form/_helpers'
 import FormTitle from '../Form/FormTitle'
 import FormField from '../Form/FormField'
-import number from '../../utils/number-schema'
+import number, { parse as parseNumber } from '../../utils/number-schema'
+import { formattedUpTo } from '../../utils/indexes'
 
 export const Select = styled(HTMLSelect)`
   margin-left: 5px;
@@ -82,12 +83,12 @@ const SelectBallotsToAudit: React.FC<Props> = ({
 
   const handlePost = async (values: SelectBallotsToAuditValues) => {
     try {
-      const auditBoards = Array.from(
-        Array(parseInt(values.auditBoards)).keys()
-      ).map(i => {
+      const auditBoards = [
+        ...formattedUpTo(parseNumber(values.auditBoards)),
+      ].map(auditBoardIndex => {
         return {
           id: uuidv4(),
-          name: `Audit Board #${i + 1}`,
+          name: `Audit Board #${auditBoardIndex}`,
           members: [],
         }
       })
@@ -97,8 +98,8 @@ const SelectBallotsToAudit: React.FC<Props> = ({
         {
           id: uuidv4(),
           name: 'Jurisdiction 1',
-          contests: [...audit.contests].map(contest => contest.id),
-          auditBoards: auditBoards,
+          contests: audit.contests.map(contest => contest.id),
+          auditBoards,
         },
       ]
       setIsLoading(true)

--- a/arlo-client/src/utils/indexes.test.ts
+++ b/arlo-client/src/utils/indexes.test.ts
@@ -1,0 +1,40 @@
+import { upTo, formattedUpTo } from './indexes'
+
+test('upTo yields nothing given maximum below 1', () => {
+  expect([...upTo(0)]).toEqual([])
+})
+
+test('upTo yields 1 given maximum of 1', () => {
+  expect([...upTo(1)]).toEqual([1])
+})
+
+test('upTo yields values from 1 through the given maximum', () => {
+  expect([...upTo(7)]).toEqual([1, 2, 3, 4, 5, 6, 7])
+})
+
+test('formattedUpTo yields nothing given maximum below 1', () => {
+  expect([...formattedUpTo(0)]).toEqual([])
+})
+
+test('formattedUpTo yields 1 given maximum of 1', () => {
+  expect([...formattedUpTo(1)]).toEqual(['1'])
+})
+
+test('formattedUpTo yields values from 1 through the given maximum', () => {
+  expect([...formattedUpTo(7)]).toEqual(['1', '2', '3', '4', '5', '6', '7'])
+})
+
+test('formattedUpTo yields values left-padded with zeros so that they are all the same width', () => {
+  expect([...formattedUpTo(10)]).toEqual([
+    '01',
+    '02',
+    '03',
+    '04',
+    '05',
+    '06',
+    '07',
+    '08',
+    '09',
+    '10',
+  ])
+})

--- a/arlo-client/src/utils/indexes.ts
+++ b/arlo-client/src/utils/indexes.ts
@@ -1,0 +1,27 @@
+/**
+ * Yields indexes from 1 through `maximum`.
+ */
+export function* upTo(maximum: number): IterableIterator<number> {
+  for (let i = 1; i <= maximum; i++) {
+    yield i
+  }
+}
+
+/**
+ * Yields formatted indexes from 1 through `maximum` that all have the same
+ * width padded at the start with '0's.
+ *
+ * @example
+ *
+ * ```ts
+ * Array.from(formattedUpTo(3)) // ['1', '2', '3']
+ * Array.from(formattedUpTo(10)) // ['01', '02', '03', '04', '05', '06', '07'. '08', '09', '10']
+ * ```
+ */
+export function* formattedUpTo(maximum: number): IterableIterator<string> {
+  const maxLength = maximum.toString().length
+
+  for (const index of upTo(maximum)) {
+    yield index.toString().padStart(maxLength, '0')
+  }
+}

--- a/arlo-client/tsconfig.json
+++ b/arlo-client/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This pads the audit board numbers such that they all have the same number of digits and can be sorted lexicographically.

Closes #137, since this makes `AuditBoard.name` properly sortable and retrieval lists are already being sorted by `AuditBoard.name, Batch.name, 'ballot_position'`.
