### PR TITLE
feat: allow arbitrary seed data

### DIFF
--- a/arlo-client/src/components/AuditForms/EstimateSampleSize.test.tsx
+++ b/arlo-client/src/components/AuditForms/EstimateSampleSize.test.tsx
@@ -41,8 +41,8 @@ const estimateSampleSizeMocks = {
     },
     {
       key:
-        'Enter the random number to seed the pseudo-random number generator.',
-      value: '12345678901234512345',
+        'Enter the random characters to seed the pseudo-random number generator.',
+      value: '12345678901234567890abcdefghijklmnopqrstuvwxyz😊',
     },
   ],
   errorInputs: [
@@ -133,28 +133,22 @@ const estimateSampleSizeMocks = {
     },
     {
       key:
-        'Enter the random number to seed the pseudo-random number generator.',
+        'Enter the random characters to seed the pseudo-random number generator.',
       value: '',
       error: 'Required',
     },
     {
       key:
-        'Enter the random number to seed the pseudo-random number generator.',
-      value: 'test',
-      error: 'Must be only numbers',
-    },
-    {
-      key:
-        'Enter the random number to seed the pseudo-random number generator.',
-      value: '123451234512345123451',
-      error: 'Must be 20 digits or less',
+        'Enter the random characters to seed the pseudo-random number generator.',
+      value: 'x'.repeat(101),
+      error: 'Must be 100 characters or fewer',
     },
   ],
   post: {
     method: 'POST',
     body: {
       name: 'Election Name',
-      randomSeed: '12345678901234512345',
+      randomSeed: '12345678901234567890abcdefghijklmnopqrstuvwxyz😊',
       riskLimit: 2,
       contests: [
         {

--- a/arlo-client/src/components/AuditForms/EstimateSampleSize.tsx
+++ b/arlo-client/src/components/AuditForms/EstimateSampleSize.tsx
@@ -144,8 +144,7 @@ const contestsSchema = Yup.array()
 const schema = Yup.object().shape({
   name: Yup.string().required('Required'),
   randomSeed: Yup.string()
-    .max(20, 'Must be 20 digits or less')
-    .matches(/^\d+$/, 'Must be only numbers')
+    .max(100, 'Must be 100 characters or fewer')
     .required('Required'),
   riskLimit: number()
     .typeError('Must be a number')
@@ -434,7 +433,7 @@ const EstimateSampleSize: React.FC<Props> = ({
               <FormSection label="Random Seed">
                 {/* eslint-disable jsx-a11y/label-has-associated-control */}
                 <label htmlFor="random-seed" id="random-seed-label">
-                  Enter the random number to seed the pseudo-random number
+                  Enter the random characters to seed the pseudo-random number
                   generator.
                   <Field
                     id="random-seed"

--- a/arlo-client/src/components/AuditForms/__snapshots__/EstimateSampleSize.test.tsx.snap
+++ b/arlo-client/src/components/AuditForms/__snapshots__/EstimateSampleSize.test.tsx.snap
@@ -389,7 +389,7 @@ exports[`EstimateSampleSize renders after contests creation correctly 1`] = `
           for="random-seed"
           id="random-seed-label"
         >
-          Enter the random number to seed the pseudo-random number generator.
+          Enter the random characters to seed the pseudo-random number generator.
           <div
             class="sc-bZQynM iEAxBy"
           >
@@ -404,7 +404,7 @@ exports[`EstimateSampleSize renders after contests creation correctly 1`] = `
                 name="randomSeed"
                 style="padding-right: 10px;"
                 type="text"
-                value="123456789"
+                value="12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
               />
             </div>
           </div>
@@ -796,7 +796,7 @@ exports[`EstimateSampleSize renders after contests creation correctly 2`] = `
           for="random-seed"
           id="random-seed-label"
         >
-          Enter the random number to seed the pseudo-random number generator.
+          Enter the random characters to seed the pseudo-random number generator.
           <div
             class="sc-bZQynM iEAxBy"
           >
@@ -811,7 +811,7 @@ exports[`EstimateSampleSize renders after contests creation correctly 2`] = `
                 name="randomSeed"
                 style="padding-right: 10px;"
                 type="text"
-                value="123456789"
+                value="12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
               />
             </div>
           </div>
@@ -1229,7 +1229,7 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 1`] = `
           for="random-seed"
           id="random-seed-label"
         >
-          Enter the random number to seed the pseudo-random number generator.
+          Enter the random characters to seed the pseudo-random number generator.
           <div
             class="sc-bZQynM iEAxBy"
           >
@@ -1244,7 +1244,7 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 1`] = `
                 name="randomSeed"
                 style="padding-right: 10px;"
                 type="text"
-                value="123456789"
+                value="12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
               />
             </div>
           </div>
@@ -1636,7 +1636,7 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 2`] = `
           for="random-seed"
           id="random-seed-label"
         >
-          Enter the random number to seed the pseudo-random number generator.
+          Enter the random characters to seed the pseudo-random number generator.
           <div
             class="sc-bZQynM iEAxBy"
           >
@@ -1651,7 +1651,7 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 2`] = `
                 name="randomSeed"
                 style="padding-right: 10px;"
                 type="text"
-                value="123456789"
+                value="12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
               />
             </div>
           </div>
@@ -2069,7 +2069,7 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 1`]
           for="random-seed"
           id="random-seed-label"
         >
-          Enter the random number to seed the pseudo-random number generator.
+          Enter the random characters to seed the pseudo-random number generator.
           <div
             class="sc-bZQynM iEAxBy"
           >
@@ -2084,7 +2084,7 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 1`]
                 name="randomSeed"
                 style="padding-right: 10px;"
                 type="text"
-                value="123456789"
+                value="12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
               />
             </div>
           </div>
@@ -2476,7 +2476,7 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 2`]
           for="random-seed"
           id="random-seed-label"
         >
-          Enter the random number to seed the pseudo-random number generator.
+          Enter the random characters to seed the pseudo-random number generator.
           <div
             class="sc-bZQynM iEAxBy"
           >
@@ -2491,7 +2491,7 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 2`]
                 name="randomSeed"
                 style="padding-right: 10px;"
                 type="text"
-                value="123456789"
+                value="12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
               />
             </div>
           </div>
@@ -2909,7 +2909,7 @@ exports[`EstimateSampleSize renders during rounds stage correctly 1`] = `
           for="random-seed"
           id="random-seed-label"
         >
-          Enter the random number to seed the pseudo-random number generator.
+          Enter the random characters to seed the pseudo-random number generator.
           <div
             class="sc-bZQynM iEAxBy"
           >
@@ -2924,7 +2924,7 @@ exports[`EstimateSampleSize renders during rounds stage correctly 1`] = `
                 name="randomSeed"
                 style="padding-right: 10px;"
                 type="text"
-                value="123456789"
+                value="12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
               />
             </div>
           </div>
@@ -3316,7 +3316,7 @@ exports[`EstimateSampleSize renders during rounds stage correctly 2`] = `
           for="random-seed"
           id="random-seed-label"
         >
-          Enter the random number to seed the pseudo-random number generator.
+          Enter the random characters to seed the pseudo-random number generator.
           <div
             class="sc-bZQynM iEAxBy"
           >
@@ -3331,7 +3331,7 @@ exports[`EstimateSampleSize renders during rounds stage correctly 2`] = `
                 name="randomSeed"
                 style="padding-right: 10px;"
                 type="text"
-                value="123456789"
+                value="12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
               />
             </div>
           </div>
@@ -3745,7 +3745,7 @@ exports[`EstimateSampleSize renders empty state correctly 1`] = `
           for="random-seed"
           id="random-seed-label"
         >
-          Enter the random number to seed the pseudo-random number generator.
+          Enter the random characters to seed the pseudo-random number generator.
           <div
             class="sc-bZQynM iEAxBy"
           >
@@ -4161,7 +4161,7 @@ exports[`EstimateSampleSize renders empty state correctly 2`] = `
           for="random-seed"
           id="random-seed-label"
         >
-          Enter the random number to seed the pseudo-random number generator.
+          Enter the random characters to seed the pseudo-random number generator.
           <div
             class="sc-bZQynM iEAxBy"
           >

--- a/arlo-client/src/components/AuditForms/__snapshots__/index.test.tsx.snap
+++ b/arlo-client/src/components/AuditForms/__snapshots__/index.test.tsx.snap
@@ -384,7 +384,7 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
             for="random-seed"
             id="random-seed-label"
           >
-            Enter the random number to seed the pseudo-random number generator.
+            Enter the random characters to seed the pseudo-random number generator.
             <div
               class="sc-bZQynM iEAxBy"
             >
@@ -399,7 +399,7 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
                   name="randomSeed"
                   style="padding-right: 10px;"
                   type="text"
-                  value="123456789"
+                  value="12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
                 />
               </div>
             </div>
@@ -1018,7 +1018,7 @@ exports[`RiskLimitingAuditForm does not render SelectBallotsToAudit when /audit/
             for="random-seed"
             id="random-seed-label"
           >
-            Enter the random number to seed the pseudo-random number generator.
+            Enter the random characters to seed the pseudo-random number generator.
             <div
               class="sc-bZQynM iEAxBy"
             >
@@ -1438,7 +1438,7 @@ exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
             for="random-seed"
             id="random-seed-label"
           >
-            Enter the random number to seed the pseudo-random number generator.
+            Enter the random characters to seed the pseudo-random number generator.
             <div
               class="sc-bZQynM iEAxBy"
             >
@@ -1862,7 +1862,7 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
             for="random-seed"
             id="random-seed-label"
           >
-            Enter the random number to seed the pseudo-random number generator.
+            Enter the random characters to seed the pseudo-random number generator.
             <div
               class="sc-bZQynM iEAxBy"
             >
@@ -1877,7 +1877,7 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
                   name="randomSeed"
                   style="padding-right: 10px;"
                   type="text"
-                  value="123456789"
+                  value="12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
                 />
               </div>
             </div>
@@ -2678,7 +2678,7 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
             for="random-seed"
             id="random-seed-label"
           >
-            Enter the random number to seed the pseudo-random number generator.
+            Enter the random characters to seed the pseudo-random number generator.
             <div
               class="sc-bZQynM iEAxBy"
             >
@@ -3312,7 +3312,7 @@ exports[`RiskLimitingAuditForm renders correctly with initialData 1`] = `
             for="random-seed"
             id="random-seed-label"
           >
-            Enter the random number to seed the pseudo-random number generator.
+            Enter the random characters to seed the pseudo-random number generator.
             <div
               class="sc-bZQynM iEAxBy"
             >

--- a/arlo-client/src/components/AuditForms/_mocks.ts
+++ b/arlo-client/src/components/AuditForms/_mocks.ts
@@ -53,7 +53,7 @@ export const statusStates: Audit[] = [
       },
     ],
     name: 'contest name',
-    randomSeed: '123456789',
+    randomSeed: '12345678901234567890abcdefghijklmnopqrstuvwxyz😊',
     riskLimit: '1',
   },
   {
@@ -170,7 +170,7 @@ export const statusStates: Audit[] = [
       },
     ],
     name: 'contest name',
-    randomSeed: '123456789',
+    randomSeed: '12345678901234567890abcdefghijklmnopqrstuvwxyz😊',
     riskLimit: '1',
   },
   {
@@ -238,7 +238,7 @@ export const statusStates: Audit[] = [
       },
     ],
     name: 'contest name',
-    randomSeed: '123456789',
+    randomSeed: '12345678901234567890abcdefghijklmnopqrstuvwxyz😊',
     riskLimit: '1',
   },
   {
@@ -309,7 +309,7 @@ export const statusStates: Audit[] = [
       },
     ],
     name: 'contest name',
-    randomSeed: '123456789',
+    randomSeed: '12345678901234567890abcdefghijklmnopqrstuvwxyz😊',
     riskLimit: '1',
   },
   {
@@ -373,7 +373,7 @@ export const statusStates: Audit[] = [
       },
     ],
     name: 'contest name',
-    randomSeed: '123456789',
+    randomSeed: '12345678901234567890abcdefghijklmnopqrstuvwxyz😊',
     riskLimit: '1',
   },
 ]

--- a/tests/test_bravo.py
+++ b/tests/test_bravo.py
@@ -6,7 +6,7 @@ from sampler import Sampler
 
 @pytest.fixture
 def sampler():
-    seed = 12345678901234567890
+    seed = '12345678901234567890abcdefghijklmnopqrstuvwxyz😊'
 
     risk_limit = .1
     contests = {

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -6,7 +6,7 @@ from sampler import Sampler
 
 @pytest.fixture
 def sampler():
-    seed = 12345678901234567890
+    seed = '12345678901234567890abcdefghijklmnopqrstuvwxyz😊'
 
     risk_limit = .1
     contests = {
@@ -133,49 +133,49 @@ def test_draw_more_samples(sampler):
 
 expected_sample = [
     ('pct 1', 4),
+    ('pct 1', 7),
+    ('pct 1', 8),
     ('pct 1', 12),
-    ('pct 1', 19),
-    ('pct 1', 21),
+    ('pct 1', 20),
+    ('pct 1', 20),
+    ('pct 1', 20),
     ('pct 1', 22),
-    ('pct 1', 24),
-    ('pct 2', 2),
-    ('pct 2', 5),
-    ('pct 2', 6),
-    ('pct 2', 6),
-    ('pct 2', 15),
-    ('pct 2', 21),
-    ('pct 2', 23),
-    ('pct 4', 7),
-    ('pct 4', 11),
-    ('pct 4', 14),
-    ('pct 4', 18),
+    ('pct 2', 1),
+    ('pct 2', 3),
+    ('pct 2', 9),
+    ('pct 3', 10),
+    ('pct 3', 12),
+    ('pct 3', 15),
+    ('pct 3', 20),
+    ('pct 3', 24),
+    ('pct 4', 3),
+    ('pct 4', 17),
     ('pct 4', 19),
-    ('pct 4', 21),
-    ('pct 4', 23),
+    ('pct 4', 20)
 ]
 
 expected_first_sample = [
-    ('pct 1', 4),
-    ('pct 1', 19),
+    ('pct 1', 7),
+    ('pct 1', 8),
+    ('pct 1', 20),
+    ('pct 1', 20),
     ('pct 1', 22),
-    ('pct 2', 2),
-    ('pct 2', 6),
-    ('pct 2', 15),
-    ('pct 2', 21),
-    ('pct 4', 7),
-    ('pct 4', 11),
-    ('pct 4', 14),
+    ('pct 2', 3),
+    ('pct 3', 12),
+    ('pct 3', 15),
+    ('pct 3', 24),
+    ('pct 4', 19)
 ]
 
 expected_second_sample = [
+    ('pct 1', 4),
     ('pct 1', 12),
-    ('pct 1', 21),
-    ('pct 1', 24),
-    ('pct 2', 5),
-    ('pct 2', 6),
-    ('pct 2', 23),
-    ('pct 4', 18),
-    ('pct 4', 19),
-    ('pct 4', 21),
-    ('pct 4', 23),
+    ('pct 1', 20),
+    ('pct 2', 1),
+    ('pct 2', 9),
+    ('pct 3', 10),
+    ('pct 3', 20),
+    ('pct 4', 3),
+    ('pct 4', 17),
+    ('pct 4', 20)
 ]


### PR DESCRIPTION
Seed data can now be a string that includes any characters. I included an emoji in test data just to make sure that'd work. The server previously had defined the maximum length to be 100, so I just left that as-is.

Closes #190
