### PR TITLE
refactor: do not assume an election with id '1'

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,10 +43,9 @@ def create_election(election_id=None):
 
 def init_db():
     db.create_all()
-    create_election(election_id='1')
 
-def get_election(election_id=None):
-    return Election.query.filter_by(id = (election_id or '1')).one()
+def get_election(election_id):
+    return Election.query.filter_by(id = election_id).one()
 
 def contest_status(election):
     contests = {}
@@ -269,7 +268,6 @@ def election_new():
     return jsonify(electionId = election_id)
 
 @app.route('/election/<election_id>/audit/status', methods=["GET"])
-@app.route('/audit/status', methods=["GET"])
 def audit_status(election_id = None):
     election = get_election(election_id)
 
@@ -348,8 +346,7 @@ def audit_status(election_id = None):
     )
 
 @app.route('/election/<election_id>/audit/basic', methods=["POST"])
-@app.route('/audit/basic', methods=["POST"])
-def audit_basic_update(election_id=None):
+def audit_basic_update(election_id):
     election = get_election(election_id)
     info = request.get_json()
     election.name = info['name']
@@ -381,8 +378,7 @@ def audit_basic_update(election_id=None):
     return jsonify(status="ok")
 
 @app.route('/election/<election_id>/audit/sample-size', methods=["POST"])
-@app.route('/audit/sample-size', methods=["POST"])
-def samplesize_set(election_id=None):
+def samplesize_set(election_id):
     election = get_election(election_id)
 
     # only works if there's only one round
@@ -397,8 +393,7 @@ def samplesize_set(election_id=None):
 
 
 @app.route('/election/<election_id>/audit/jurisdictions', methods=["POST"])
-@app.route('/audit/jurisdictions', methods=["POST"])
-def jurisdictions_set(election_id=None):
+def jurisdictions_set(election_id):
     election = get_election(election_id)
     jurisdictions = request.get_json()['jurisdictions']
     
@@ -432,8 +427,7 @@ def jurisdictions_set(election_id=None):
     return jsonify(status="ok")
 
 @app.route('/election/<election_id>/jurisdiction/<jurisdiction_id>/manifest', methods=["DELETE","POST"])
-@app.route('/jurisdiction/<jurisdiction_id>/manifest', methods=["DELETE","POST"])
-def jurisdiction_manifest(jurisdiction_id, election_id=None):
+def jurisdiction_manifest(jurisdiction_id, election_id):
     BATCH_NAME = 'Batch Name'
     NUMBER_OF_BALLOTS = 'Number of Ballots'
     STORAGE_LOCATION = 'Storage Location'
@@ -715,8 +709,7 @@ def ballot_set(election_id, jurisdiction_id, batch_id, round_id, ballot_position
     return jsonify(status="ok")
 
 @app.route('/election/<election_id>/jurisdiction/<jurisdiction_id>/<round_num>/retrieval-list', methods=["GET"])
-@app.route('/jurisdiction/<jurisdiction_id>/<round_num>/retrieval-list', methods=["GET"])
-def jurisdiction_retrieval_list(jurisdiction_id, round_num, election_id=None):
+def jurisdiction_retrieval_list(election_id, jurisdiction_id, round_num):
     election = get_election(election_id)
     csv_io = io.StringIO()
     retrieval_list_writer = csv.writer(csv_io)
@@ -736,8 +729,7 @@ def jurisdiction_retrieval_list(jurisdiction_id, round_num, election_id=None):
     return response
 
 @app.route('/election/<election_id>/jurisdiction/<jurisdiction_id>/<round_num>/results', methods=["POST"])
-@app.route('/jurisdiction/<jurisdiction_id>/<round_num>/results', methods=["POST"])
-def jurisdiction_results(jurisdiction_id, round_num, election_id=None):
+def jurisdiction_results(election_id, jurisdiction_id, round_num):
     election = get_election(election_id)
     results = request.get_json()
 
@@ -764,8 +756,7 @@ def jurisdiction_results(jurisdiction_id, round_num, election_id=None):
     return jsonify(status="ok")
 
 @app.route('/election/<election_id>/audit/report', methods=["GET"])
-@app.route('/audit/report', methods=["GET"])
-def audit_report(election_id=None):
+def audit_report(election_id):
     election = get_election(election_id)
     jurisdiction = election.jurisdictions[0]
 
@@ -811,13 +802,12 @@ def audit_report(election_id=None):
     
 
 @app.route('/election/<election_id>/audit/reset', methods=["POST"])
-@app.route('/audit/reset', methods=["POST"])
-def audit_reset(election_id=None):
+def audit_reset(election_id):
     # deleting the election cascades to all the data structures
-    Election.query.filter_by(id = (election_id or '1')).delete()
+    Election.query.filter_by(id = election_id).delete()
     db.session.commit()
 
-    create_election(election_id or '1')
+    create_election(election_id)
     db.session.commit()
     
     return jsonify(status="ok")

--- a/arlo-client/docs/api_sequence.md
+++ b/arlo-client/docs/api_sequence.md
@@ -14,7 +14,7 @@
 }
 ```
 
-### Initial data from /audit/status
+### Initial data from /election/{electionId}/audit/status
 
 - `GET /election/{electionId}/audit/status`
 

--- a/arlo-client/docs/release_notes.md
+++ b/arlo-client/docs/release_notes.md
@@ -9,8 +9,8 @@
 - Possible number of audit boards changed from 5 to 15
 - Added support for IE11
 - Form validation and warnings
-- Driving default form state from `/audit/status` endpoint to preserve progress
-  through sessions
+- Driving default form state from `/election/{electionId}/audit/status` endpoint
+  to preserve progress through sessions
 - Layout improvements
 - Internal refactoring for efficiency and maintainability
 

--- a/arlo-client/docs/style.md
+++ b/arlo-client/docs/style.md
@@ -24,8 +24,9 @@ make it to live code.
 
 In order to make sure that the client and the server data are in sync, and to
 handle concurrency, the app state will come from the server state directly
-through API calls. The `/audit/status` endpoint will be called to update the
-component data on page load and also after data is sent to the server.
+through API calls. The `/election/{electionId}/audit/status` endpoint will be
+called to update the component data on page load and also after data is sent to
+the server.
 
 5. Formik form library & Yup validation library
 

--- a/arlo-client/src/components/AuditForms/CalculateRiskMeasurement.tsx
+++ b/arlo-client/src/components/AuditForms/CalculateRiskMeasurement.tsx
@@ -80,8 +80,7 @@ const CalculateRiskMeasurement: React.FC<Props> = ({
   const getBallots = async (r: number): Promise<Ballot[]> => {
     const round = audit.rounds[r]
     const { ballots } = await api<{ ballots: Ballot[] }>(
-      `/jurisdiction/${audit.jurisdictions[0].id}/round/${round.id}/ballot-list`,
-      { electionId }
+      `/election/${electionId}/jurisdiction/${audit.jurisdictions[0].id}/round/${round.id}/ballot-list`
     )
     return ballots
   }
@@ -187,14 +186,16 @@ const CalculateRiskMeasurement: React.FC<Props> = ({
 
     try {
       setIsLoading(true)
-      await api(`/jurisdiction/${jurisdictionID}/${values.round}/results`, {
-        electionId,
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(body),
-      })
+      await api(
+        `/election/${electionId}/jurisdiction/${jurisdictionID}/${values.round}/results`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        }
+      )
       const condition = async () => {
         const { rounds } = await getStatus()
         const { contests } = rounds[rounds.length - 1]

--- a/arlo-client/src/components/AuditForms/EstimateSampleSize.test.tsx
+++ b/arlo-client/src/components/AuditForms/EstimateSampleSize.test.tsx
@@ -428,7 +428,9 @@ describe('EstimateSampleSize', () => {
       const { body } = apiMock.mock.calls[0][1] as { body: string }
       expect(setIsLoadingMock).toBeCalledTimes(2)
       expect(apiMock).toBeCalledTimes(1)
-      expect(apiMock.mock.calls[0][0]).toBe('/audit/basic')
+      expect(apiMock.mock.calls[0][0]).toMatch(
+        /\/election\/[^/]+\/audit\/basic/
+      )
       expect(JSON.parse(body)).toMatchObject(estimateSampleSizeMocks.post.body)
       expect(getStatusMock).toBeCalledTimes(3)
       expect(updateAuditMock).toBeCalledTimes(1)
@@ -475,7 +477,9 @@ describe('EstimateSampleSize', () => {
     await wait(() => {
       expect(apiMock).toBeCalled()
       const { body } = apiMock.mock.calls[0][1] as { body: string }
-      expect(apiMock.mock.calls[0][0]).toBe('/audit/basic')
+      expect(apiMock.mock.calls[0][0]).toMatch(
+        /\/election\/[^/]+\/audit\/basic/
+      )
       expect(JSON.parse(body)).toMatchObject(estimateSampleSizeMocks.post.body)
       expect(getStatusMock).toBeCalled()
       expect(dateSpy).toBeCalledTimes(2)

--- a/arlo-client/src/components/AuditForms/EstimateSampleSize.tsx
+++ b/arlo-client/src/components/AuditForms/EstimateSampleSize.tsx
@@ -183,8 +183,7 @@ const EstimateSampleSize: React.FC<Props> = ({
     }
     try {
       setIsLoading(true)
-      await api(`/audit/basic`, {
-        electionId,
+      await api(`/election/${electionId}/audit/basic`, {
         method: 'POST',
         body: JSON.stringify(data),
         headers: {

--- a/arlo-client/src/components/AuditForms/ResetButton.tsx
+++ b/arlo-client/src/components/AuditForms/ResetButton.tsx
@@ -16,7 +16,7 @@ const ResetButton: React.FC<Props> = ({
 }: Props) => {
   const resetButtonWrapper = document.getElementById('reset-button-wrapper')
   const reset = async () => {
-    await api(`/audit/reset`, { electionId, method: 'POST' })
+    await api(`/election/${electionId}/audit/reset`, { method: 'POST' })
 
     updateAudit()
   }

--- a/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
+++ b/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
@@ -112,8 +112,7 @@ const SelectBallotsToAudit: React.FC<Props> = ({
         const body = {
           size, // until multiple contests are supported
         }
-        await api('/audit/sample-size', {
-          electionId,
+        await api(`/election/${electionId}/audit/sample-size`, {
           method: 'POST',
           body: JSON.stringify(body),
           headers: {
@@ -121,8 +120,7 @@ const SelectBallotsToAudit: React.FC<Props> = ({
           },
         })
       }
-      await api('/audit/jurisdictions', {
-        electionId,
+      await api(`/election/${electionId}/audit/jurisdictions`, {
         method: 'POST',
         body: JSON.stringify({ jurisdictions: data }),
         headers: {
@@ -136,11 +134,13 @@ const SelectBallotsToAudit: React.FC<Props> = ({
       if (values.manifest) {
         const formData: FormData = new FormData()
         formData.append('manifest', values.manifest, values.manifest.name)
-        await api(`/jurisdiction/${jurisdictionID}/manifest`, {
-          electionId,
-          method: 'POST',
-          body: formData,
-        })
+        await api(
+          `/election/${electionId}/jurisdiction/${jurisdictionID}/manifest`,
+          {
+            method: 'POST',
+            body: formData,
+          }
+        )
       }
 
       updateAudit()

--- a/arlo-client/src/components/AuditForms/index.test.tsx
+++ b/arlo-client/src/components/AuditForms/index.test.tsx
@@ -33,7 +33,9 @@ describe('RiskLimitingAuditForm', () => {
     expect(container).toMatchSnapshot()
     await wait(() => {
       expect(apiMock).toBeCalledTimes(1)
-      expect(apiMock.mock.calls[0][0]).toBe('/audit/status')
+      expect(apiMock.mock.calls[0][0]).toMatch(
+        /\/election\/[^/]+\/audit\/status/
+      )
       expect(apiMock.mock.results[0].value).resolves.toBe(statusStates[0])
     })
   })
@@ -59,7 +61,9 @@ describe('RiskLimitingAuditForm', () => {
     expect(container).toMatchSnapshot()
     await wait(() => {
       expect(apiMock).toBeCalledTimes(1)
-      expect(apiMock.mock.calls[0][0]).toBe('/audit/status')
+      expect(apiMock.mock.calls[0][0]).toMatch(
+        /\/election\/[^/]+\/audit\/status/
+      )
       expect(apiMock.mock.results[0].value).resolves.toBe(statusStates[1])
     })
   })
@@ -80,7 +84,9 @@ describe('RiskLimitingAuditForm', () => {
     expect(container).toMatchSnapshot()
     await wait(() => {
       expect(apiMock).toBeCalledTimes(1)
-      expect(apiMock.mock.calls[0][0]).toBe('/audit/status')
+      expect(apiMock.mock.calls[0][0]).toMatch(
+        /\/election\/[^/]+\/audit\/status/
+      )
       expect(apiMock.mock.results[0].value).resolves.toBe(statusStates[2])
     })
   })
@@ -102,7 +108,9 @@ describe('RiskLimitingAuditForm', () => {
     expect(container).toMatchSnapshot()
     await wait(() => {
       expect(apiMock).toBeCalledTimes(1)
-      expect(apiMock.mock.calls[0][0]).toBe('/audit/status')
+      expect(apiMock.mock.calls[0][0]).toMatch(
+        /\/election\/[^/]+\/audit\/status/
+      )
       expect(apiMock.mock.results[0].value).resolves.toBe(statusStates[3])
     })
   })
@@ -123,7 +131,9 @@ describe('RiskLimitingAuditForm', () => {
     expect(container).toMatchSnapshot()
     await wait(() => {
       expect(apiMock).toBeCalledTimes(1)
-      expect(apiMock.mock.calls[0][0]).toBe('/audit/status')
+      expect(apiMock.mock.calls[0][0]).toMatch(
+        /\/election\/[^/]+\/audit\/status/
+      )
       expect(apiMock.mock.results[0].value).resolves.toBe(statusStates[4])
     })
   })

--- a/arlo-client/src/components/AuditForms/index.tsx
+++ b/arlo-client/src/components/AuditForms/index.tsx
@@ -43,7 +43,7 @@ const AuditForms: React.FC<Props> = ({
   const [audit, setAudit] = useState(initialData)
 
   const getStatus = useCallback(async (): Promise<Audit> => {
-    const audit: Audit = await api('/audit/status', { electionId })
+    const audit: Audit = await api(`/election/${electionId}/audit/status`)
     return audit
   }, [electionId])
 

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -25,7 +25,6 @@ const CreateAudit = ({ history }: RouteComponentProps<Params>) => {
   const onClick = async () => {
     setLoading(true)
     const { electionId } = await api('/election/new', {
-      electionId: '',
       method: 'POST',
     })
     history.push(`/election/${electionId}`)

--- a/arlo-client/src/components/utilities.test.ts
+++ b/arlo-client/src/components/utilities.test.ts
@@ -16,20 +16,9 @@ afterEach(() => {
 
 describe('utilities.ts', () => {
   describe('api', () => {
-    it('calls fetch with electionId', async () => {
+    it('calls fetch', async () => {
       fetchSpy.mockImplementationOnce(async () => response())
-      const result = await api('/test', { method: 'GET', electionId: '1' })
-
-      expect(result).toEqual({ success: true })
-      expect(window.fetch).toBeCalledTimes(1)
-      expect(window.fetch).toBeCalledWith('/election/1/test', {
-        method: 'GET',
-      })
-    })
-
-    it('calls fetch without electionId', async () => {
-      fetchSpy.mockImplementationOnce(async () => response())
-      const result = await api('/test', { method: 'GET', electionId: '' })
+      const result = await api('/test', { method: 'GET' })
 
       expect(result).toEqual({ success: true })
       expect(window.fetch).toBeCalledTimes(1)
@@ -40,12 +29,12 @@ describe('utilities.ts', () => {
 
     it('throws an error', async () => {
       fetchSpy.mockImplementationOnce(async () => badResponse())
-      await expect(
-        api('/test', { method: 'GET', electionId: '1' })
-      ).rejects.toThrow('A test error')
+      await expect(api('/test', { method: 'GET' })).rejects.toThrow(
+        'A test error'
+      )
       expect(window.fetch).toBeCalledTimes(1)
 
-      expect(window.fetch).toBeCalledWith('/election/1/test', {
+      expect(window.fetch).toBeCalledWith('/test', {
         method: 'GET',
       })
     })

--- a/arlo-client/src/components/utilities.ts
+++ b/arlo-client/src/components/utilities.ts
@@ -1,12 +1,10 @@
-import { Params } from '../types'
 import number from '../utils/number-schema'
 
 export const api = async <T>(
   endpoint: string,
-  { electionId, ...options }: Params & RequestInit
+  options?: RequestInit
 ): Promise<T> => {
-  const apiBaseURL = electionId ? `/election/${electionId}` : ''
-  const res = await fetch(apiBaseURL + endpoint, options)
+  const res = await fetch(endpoint, options)
   if (!res.ok) {
     throw new Error(res.statusText)
   }


### PR DESCRIPTION
This will make testing easier if we're operating against a persistent database (#199) since each election will have its own id and we don't have to worry about rolling back transactions per test. We probably should do that anyway, but this is some cleanup that should have been done a while ago.
