### PR TITLE
refactor(db): exclusively use postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,12 @@ jobs:
   build-and-test:
     docker:
       - image: circleci/python:3.7.3-node
+        environment:
+          DATABASE_URL: postgres://root@localhost:5432/arlo-test
+      - image: circleci/postgres:9.6.2-alpine
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: arlo-test
     steps:
       - checkout
       - run:
@@ -12,7 +18,7 @@ jobs:
       - run:
           name: create data model
           command: |
-            make resetdb-sqlite
+            make resetdb
       - run:
           name: type check
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.pyc
-*.db
 *.DS_Store
 node_modules
 .mypy_cache
 .pytest_cache
+config/database.cfg

--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,8 @@ install-development:
 	pipenv install --dev
 	yarn --cwd arlo-client install
 
-resetdb-sqlite:
-	rm -f arlo.db
-	DATABASE_URL="" pipenv run python create.py
-
-resetdb-postgres:
-	dropdb arlo
-	createdb arlo
-	pipenv run python create.py
+resetdb:
+	pipenv run python resetdb.py
 
 typecheck:
 	pipenv run mypy .
@@ -25,4 +19,4 @@ test-client:
 	yarn --cwd arlo-client test
 
 test-server:
-	pipenv run python -m pytest --ignore=arlo-client
+	FLASK_ENV=test pipenv run python -m pytest --ignore=arlo-client

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ flask-sqlalchemy = "*"
 joblib = "*"
 numpy = "*"
 psycopg2 = "*"
+sqlalchemy-utils = "*"
 uuid = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ac8e9071d16716d04fa7410c2ef76098b0afde436f68972d3c560f28f6920ae2"
+            "sha256": "c4dffb991d7e852f6c3be30480e82c593757b1cf80e46701d6c448c6b6445f7f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -112,37 +112,39 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:0b0dd8f47fb177d00fa6ef2d58783c4f41ad3126b139c91dd2f7c4b3fdf5e9a5",
-                "sha256:25ffe71f96878e1da7e014467e19e7db90ae7d4e12affbc73101bcf61785214e",
-                "sha256:26efd7f7d755e6ca966a5c0ac5a930a87dbbaab1c51716ac26a38f42ecc9bc4b",
-                "sha256:28b1180c758abf34a5c3fea76fcee66a87def1656724c42bb14a6f9717a5bdf7",
-                "sha256:2e418f0a59473dac424f888dd57e85f77502a593b207809211c76e5396ae4f5c",
-                "sha256:30c84e3a62cfcb9e3066f25226e131451312a044f1fe2040e69ce792cb7de418",
-                "sha256:4650d94bb9c947151737ee022b934b7d9a845a7c76e476f3e460f09a0c8c6f39",
-                "sha256:4dd830a11e8724c9c9379feed1d1be43113f8bcce55f47ea7186d3946769ce26",
-                "sha256:4f2a2b279efde194877aff1f76cf61c68e840db242a5c7169f1ff0fd59a2b1e2",
-                "sha256:62d22566b3e3428dfc9ec972014c38ed9a4db4f8969c78f5414012ccd80a149e",
-                "sha256:669795516d62f38845c7033679c648903200980d68935baaa17ac5c7ae03ae0c",
-                "sha256:75fcd60d682db3e1f8fbe2b8b0c6761937ad56d01c1dc73edf4ef2748d5b6bc4",
-                "sha256:9395b0a41e8b7e9a284e3be7060db9d14ad80273841c952c83a5afc241d2bd98",
-                "sha256:9e37c35fc4e9410093b04a77d11a34c64bf658565e30df7cbe882056088a91c1",
-                "sha256:a0678793096205a4d784bd99f32803ba8100f639cf3b932dc63b21621390ea7e",
-                "sha256:b46554ad4dafb2927f88de5a1d207398c5385edbb5c84d30b3ef187c4a3894d8",
-                "sha256:c867eeccd934920a800f65c6068acdd6b87e80d45cd8c8beefff783b23cdc462",
-                "sha256:dd0667f5be56fb1b570154c2c0516a528e02d50da121bbbb2cbb0b6f87f59bc2",
-                "sha256:de2b1c20494bdf47f0160bd88ed05f5e48ae5dc336b8de7cfade71abcc95c0b9",
-                "sha256:f1df7b2b7740dd777571c732f98adb5aad5450aee32772f1b39249c8a50386f6",
-                "sha256:ffca69e29079f7880c5392bf675eb8b4146479d976ae1924d01cd92b04cccbcc"
+                "sha256:0a7a1dd123aecc9f0076934288ceed7fd9a81ba3919f11a855a7887cbe82a02f",
+                "sha256:0c0763787133dfeec19904c22c7e358b231c87ba3206b211652f8cbe1241deb6",
+                "sha256:3d52298d0be333583739f1aec9026f3b09fdfe3ddf7c7028cb16d9d2af1cca7e",
+                "sha256:43bb4b70585f1c2d153e45323a886839f98af8bfa810f7014b20be714c37c447",
+                "sha256:475963c5b9e116c38ad7347e154e5651d05a2286d86455671f5b1eebba5feb76",
+                "sha256:64874913367f18eb3013b16123c9fed113962e75d809fca5b78ebfbb73ed93ba",
+                "sha256:683828e50c339fc9e68720396f2de14253992c495fdddef77a1e17de55f1decc",
+                "sha256:6ca4000c4a6f95a78c33c7dadbb9495c10880be9c89316aa536eac359ab820ae",
+                "sha256:75fd817b7061f6378e4659dd792c84c0b60533e867f83e0d1e52d5d8e53df88c",
+                "sha256:7d81d784bdbed30137aca242ab307f3e65c8d93f4c7b7d8f322110b2e90177f9",
+                "sha256:8d0af8d3664f142414fd5b15cabfd3b6cc3ef242a3c7a7493257025be5a6955f",
+                "sha256:9679831005fb16c6df3dd35d17aa31dc0d4d7573d84f0b44cc481490a65c7725",
+                "sha256:a8f67ebfae9f575d85fa859b54d3bdecaeece74e3274b0b5c5f804d7ca789fe1",
+                "sha256:acbf5c52db4adb366c064d0b7c7899e3e778d89db585feadd23b06b587d64761",
+                "sha256:ada4805ed51f5bcaa3a06d3dd94939351869c095e30a2b54264f5a5004b52170",
+                "sha256:c7354e8f0eca5c110b7e978034cd86ed98a7a5ffcf69ca97535445a595e07b8e",
+                "sha256:e2e9d8c87120ba2c591f60e32736b82b67f72c37ba88a4c23c81b5b8fa49c018",
+                "sha256:e467c57121fe1b78a8f68dd9255fbb3bb3f4f7547c6b9e109f31d14569f490c3",
+                "sha256:ede47b98de79565fcd7f2decb475e2dcc85ee4097743e551fe26cfc7eb3ff143",
+                "sha256:f58913e9227400f1395c7b800503ebfdb0772f1c33ff8cb4d6451c06cabdf316",
+                "sha256:fe39f5fd4103ec4ca3cb8600b19216cd1ff316b4990f4c0b6057ad982c0a34d5"
             ],
             "index": "pypi",
-            "version": "==1.17.3"
+            "version": "==1.17.4"
         },
         "psycopg2": {
             "hashes": [
+                "sha256:4212ca404c4445dc5746c0d68db27d2cbfb87b523fe233dc84ecd24062e35677",
                 "sha256:47fc642bf6f427805daf52d6e52619fe0637648fe27017062d898f3bf891419d",
                 "sha256:72772181d9bad1fa349792a1e7384dde56742c14af2b9986013eb94a240f005b",
                 "sha256:8396be6e5ff844282d4d49b81631772f80dabae5658d432202faf101f5283b7c",
                 "sha256:893c11064b347b24ecdd277a094413e1954f8a4e8cdaf7ffbe7ca3db87c103f0",
+                "sha256:92a07dfd4d7c325dd177548c4134052d4842222833576c8391aab6f74038fc3f",
                 "sha256:965c4c93e33e6984d8031f74e51227bd755376a9df6993774fd5b6fb3288b1f4",
                 "sha256:9ab75e0b2820880ae24b7136c4d230383e07db014456a476d096591172569c38",
                 "sha256:b0845e3bdd4aa18dc2f9b6fb78fbd3d9d371ad167fd6d1b7ad01c0a6cdad4fc6",
@@ -156,30 +158,49 @@
         },
         "scipy": {
             "hashes": [
-                "sha256:0baa64bf42592032f6f6445a07144e355ca876b177f47ad8d0612901c9375bef",
-                "sha256:243b04730d7223d2b844bda9500310eecc9eda0cba9ceaf0cde1839f8287dfa8",
-                "sha256:2643cfb46d97b7797d1dbdb6f3c23fe3402904e3c90e6facfe6a9b98d808c1b5",
-                "sha256:396eb4cdad421f846a1498299474f0a3752921229388f91f60dc3eda55a00488",
-                "sha256:3ae3692616975d3c10aca6d574d6b4ff95568768d4525f76222fb60f142075b9",
-                "sha256:435d19f80b4dcf67dc090cc04fde2c5c8a70b3372e64f6a9c58c5b806abfa5a8",
-                "sha256:46a5e55850cfe02332998b3aef481d33f1efee1960fe6cfee0202c7dd6fc21ab",
-                "sha256:75b513c462e58eeca82b22fc00f0d1875a37b12913eee9d979233349fce5c8b2",
-                "sha256:7ccfa44a08226825126c4ef0027aa46a38c928a10f0a8a8483c80dd9f9a0ad44",
-                "sha256:89dd6a6d329e3f693d1204d5562dd63af0fd7a17854ced17f9cbc37d5b853c8d",
-                "sha256:a81da2fe32f4eab8b60d56ad43e44d93d392da228a77e229e59b51508a00299c",
-                "sha256:a9d606d11eb2eec7ef893eb825017fbb6eef1e1d0b98a5b7fc11446ebeb2b9b1",
-                "sha256:ac37eb652248e2d7cbbfd89619dce5ecfd27d657e714ed049d82f19b162e8d45",
-                "sha256:cbc0611699e420774e945f6a4e2830f7ca2b3ee3483fca1aa659100049487dd5",
-                "sha256:d02d813ec9958ed63b390ded463163685af6025cb2e9a226ec2c477df90c6957",
-                "sha256:dd3b52e00f93fd1c86f2d78243dfb0d02743c94dd1d34ffea10055438e63b99d"
+                "sha256:0359576d8cc058bd615999cf985e2423dc6cc824666d60e8b8d4810569a04655",
+                "sha256:07673b5b96dbe28c88f3a53ca9af67f802aa853de7402e31f473b4dd6501c799",
+                "sha256:0f81e71149539ac09053a3f9165659367b060eceef3bbde11e6600e1c341f1f2",
+                "sha256:125aa82f7b3d4bd7f77fed6c3c6e31be47e33f129d829799569389ae59f913e7",
+                "sha256:2dc26e5b3eb86b7adad506b6b04020f6a87e1102c9acd039e937d28bdcee7fa6",
+                "sha256:2e4b5fdb635dd425bf46fbd6381612692d3c795f1eb6fe62410305a440691d46",
+                "sha256:33ac3213ee617bbc0eac84d02b130d69093ed7738afb281dfdeb12a9dbdf1530",
+                "sha256:34c48d922760782732d6f8f4532e320984d1280763c6787c6582021d34c8ad79",
+                "sha256:3f556f63e070e9596624e42e99d23b259d8f0fc63ec093bef97a9f1c579565b2",
+                "sha256:470d8fc76ccab6cfff60a9de4ce316a23ee7f63615d948c7446dc7c1bb45042d",
+                "sha256:4ad7a3ae9831d2085d6f50b81bfcd76368293eafdf31f4ac9f109c6061309c24",
+                "sha256:61812a7db0d9bc3f13653e52b8ddb1935cf444ec55f39160fc2778aeb2719057",
+                "sha256:7a0477929e6f9d5928fe81fe75d00b7da9545a49109e66028d85848b18aeef99",
+                "sha256:9c3221039da50f3b60da70b65d6b020ea26cefbb097116cfec696010432d1f6c",
+                "sha256:a03939b431994289f39373c57bbe452974a7da724ae7f9620a1beee575434da4",
+                "sha256:df4dbd3d40db3f667e0145dba5f50954bf28b2dd5b8b400c79d5e3fe8cb67ce2",
+                "sha256:e837c8068bd1929a533e9d51562faf6584ddb5303d9e218d8c11aa4719dcd617",
+                "sha256:ecfd45ca0ce1d6c13bef17794b4052cc9a9574f4be8d44c9bcfd7e34294bd2d7",
+                "sha256:ee5888c62cd83c9bf9927ffcee08434e7d5c81a8f31e5b85af5470e511022c08",
+                "sha256:f018892621b787b9abf76d51d1f0c21611c71752ebb1891ccf7992e0bf973708",
+                "sha256:f2d5db81d90d14a32d4aff920f52fca5639bcaaaf87b4f61bce83a1d238f49fc"
             ],
-            "version": "==1.3.1"
+            "version": "==1.3.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+            ],
+            "version": "==1.13.0"
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:0f0768b5db594517e1f5e1572c73d14cf295140756431270d89496dc13d5e46c"
+                "sha256:afa5541e9dea8ad0014251bc9d56171ca3d8b130c9627c6cb3681cff30be3f8a"
             ],
-            "version": "==1.3.10"
+            "version": "==1.3.11"
+        },
+        "sqlalchemy-utils": {
+            "hashes": [
+                "sha256:01f0f0ebed696386bc7bf9231cd6894087baba374dd60f40eb1b07512d6b1a5e"
+            ],
+            "index": "pypi",
+            "version": "==0.35.0"
         },
         "uuid": {
             "hashes": [
@@ -197,13 +218,6 @@
         }
     },
     "develop": {
-        "atomicwrites": {
-            "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
-            ],
-            "version": "==1.3.0"
-        },
         "attrs": {
             "hashes": [
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
@@ -280,25 +294,25 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
+                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.5"
         },
         "pytest": {
             "hashes": [
-                "sha256:27abc3fef618a01bebb1f0d6d303d2816a99aa87a5968ebc32fe971be91eb1e6",
-                "sha256:58cee9e09242937e136dbb3dab466116ba20d6b7828c7620f23947f37eb4dae4"
+                "sha256:1897d74f60a5d8be02e06d708b41bf2445da2ee777066bd68edf14474fc201eb",
+                "sha256:f6a567e20c04259d41adce9a360bd8991e6aa29dd9695c5e6bd25a9779272673"
             ],
             "index": "pypi",
-            "version": "==5.2.2"
+            "version": "==5.3.0"
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "sqlalchemy-stubs": {
             "hashes": [

--- a/app.py
+++ b/app.py
@@ -4,28 +4,15 @@ from flask_sqlalchemy import SQLAlchemy
 from sampler import Sampler
 from werkzeug.exceptions import InternalServerError
 
-from sqlalchemy.engine import Engine
 from sqlalchemy import event
+from config import DATABASE_URL
 
 from util.binpacking import Bucket, BalancedBucketList
 
 app = Flask(__name__, static_folder='arlo-client/build/')
 
 # database config
-SQLITE_DATABASE_URL = 'sqlite:///./arlo.db'
-database_url = os.environ.get('DATABASE_URL', SQLITE_DATABASE_URL)
-if database_url == "":
-    database_url = SQLITE_DATABASE_URL
-
-# enforce foreign keys in SQLite
-if database_url.startswith("sqlite:"):
-    @event.listens_for(Engine, "connect")
-    def set_sqlite_pragma(dbapi_connection, connection_record):
-        cursor = dbapi_connection.cursor()
-        cursor.execute("PRAGMA foreign_keys=ON")
-        cursor.close()
-
-app.config['SQLALCHEMY_DATABASE_URI'] = database_url
+app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,27 @@
+import configparser
+import os
+import sys
+
+DEFAULT_DATABASE_URL = 'postgres://postgres@localhost:5432/arlo'
+
+def read_database_url_config() -> str:
+  environment_database_url = os.environ.get('DATABASE_URL', None)
+
+  if environment_database_url:
+    return environment_database_url
+
+  database_cfg_path = os.path.normpath(os.path.join(__file__, '..', 'database.cfg'))
+  database_config = configparser.ConfigParser()
+  database_config.read(database_cfg_path)
+
+  flask_env = os.environ.get('FLASK_ENV', 'development')
+  result = database_config.get(flask_env, 'database_url', fallback=None)
+
+  if not result:
+    print(f'WARNING: no database url was configured, falling back to default: {DEFAULT_DATABASE_URL}', file=sys.stderr)
+    print(f'To configure your own database url, either run with a DATABASE_URL environment variable', file=sys.stderr)
+    print(f'or copy `config/database.cfg.example` to `config/database.cfg` and edit it as needed.', file=sys.stderr)
+
+  return result or DEFAULT_DATABASE_URL
+
+DATABASE_URL = read_database_url_config()

--- a/config/database.cfg.example
+++ b/config/database.cfg.example
@@ -1,0 +1,14 @@
+# Configure your database connection by editing each section as appropriate.
+# Sections are named for $FLASK_ENV environment variable values.
+
+[development]
+database_url = postgres://postgres@localhost:5432/arlo
+
+[test]
+database_url = postgres://postgres@localhost:5432/arlo-test
+
+# [staging]
+# omitted, perhaps provided by $DATABASE_URL environment variable
+
+# [production]
+# omitted, perhaps provided by $DATABASE_URL environment variable

--- a/create.py
+++ b/create.py
@@ -1,3 +1,15 @@
 from app import init_db
-init_db()
+from config import DATABASE_URL
+from sqlalchemy import create_engine
+from sqlalchemy_utils import database_exists, create_database
 
+if __name__ == '__main__':
+    engine = create_engine(DATABASE_URL)
+    print(f'database: {engine.url}')
+
+    if not database_exists(engine.url):
+        print('creating database…')
+        create_database(engine.url)
+
+    print('creating tables…')
+    init_db()

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,3 +9,6 @@ ignore_missing_imports = True
 
 [mypy-scipy]
 ignore_missing_imports = True
+
+[mypy-sqlalchemy_utils]
+ignore_missing_imports = True

--- a/resetdb.py
+++ b/resetdb.py
@@ -1,0 +1,18 @@
+from app import init_db
+from config import DATABASE_URL
+from sqlalchemy import create_engine
+from sqlalchemy_utils import database_exists, create_database, drop_database
+
+if __name__ == '__main__':
+    engine = create_engine(DATABASE_URL)
+    print(f'database: {engine.url}')
+
+    if database_exists(engine.url):
+        print('dropping database…')
+        drop_database(engine.url)
+
+    print('creating database…')
+    create_database(engine.url)
+
+    print('creating tables…')
+    init_db()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,8 +17,6 @@ def post_json(client, url, obj):
 
 @pytest.fixture
 def client():
-    db_fd, db_path = tempfile.mkstemp()
-    app.app.config['SQLALCHEMY_DATABASE_URI'] = "sqlite:///" + db_path
     app.app.config['TESTING'] = True
     client = app.app.test_client()
 
@@ -26,9 +24,6 @@ def client():
         app.init_db()
 
     yield client
-
-    os.close(db_fd)
-    os.unlink(db_path)
 
 def test_index(client):
     rv = client.get('/')
@@ -119,25 +114,25 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed):
     rv = post_json(
         client, '{}/audit/jurisdictions'.format(url_prefix),
         {
-	    "jurisdictions": [
-		{
-		    "id": jurisdiction_id,
-		    "name": "adams county",
-		    "contests": [contest_id],
+        "jurisdictions": [
+        {
+            "id": jurisdiction_id,
+            "name": "adams county",
+            "contests": [contest_id],
                     "auditBoards": [
-			{
-			    "id": audit_board_id_1,
+            {
+                "id": audit_board_id_1,
                             "name": "audit board #1",
-			    "members": []
-			},
-			{
-			    "id": audit_board_id_2,
+                "members": []
+            },
+            {
+                "id": audit_board_id_2,
                             "name": "audit board #2",
-			    "members": []
-			}
-		    ]
-		}
-	    ]
+                "members": []
+            }
+            ]
+        }
+        ]
         })
 
     assert json.loads(rv.data)['status'] == 'ok'
@@ -283,25 +278,25 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
     rv = post_json(
         client, '{}/audit/jurisdictions'.format(url_prefix),
         {
-	    "jurisdictions": [
-		{
-		    "id": jurisdiction_id,
-		    "name": "adams county",
-		    "contests": [contest_id],
+            "jurisdictions": [
+                {
+                    "id": jurisdiction_id,
+                    "name": "adams county",
+                    "contests": [contest_id],
                     "auditBoards": [
-			{
-			    "id": audit_board_id_1,
+                        {
+                            "id": audit_board_id_1,
                             "name": "audit board #1",
-			    "members": []
-			},
-			{
-			    "id": audit_board_id_2,
+                            "members": []
+                        },
+                        {
+                            "id": audit_board_id_2,
                             "name": "audit board #2",
-			    "members": []
-			}
-		    ]
-		}
-	    ]
+                            "members": []
+                        }
+                    ]
+                }
+            ]
         })
 
     assert json.loads(rv.data)['status'] == 'ok'
@@ -384,17 +379,17 @@ def run_whole_audit_flow(client, election_id, name, risk_limit, random_seed):
     num_for_winner = int(num_ballots * 0.56)
     num_for_loser = num_ballots - num_for_winner
     rv = post_json(client, '{}/jurisdiction/{}/1/results'.format(url_prefix, jurisdiction_id),
-                   {
-	               "contests": [
-		           {
-			       "id": contest_id,
-   			       "results": {
-				   candidate_id_1: num_for_winner,
-				   candidate_id_2: num_for_loser
-			       }
-		           }
-	               ]
-                   })
+        {
+            "contests": [
+                {
+                    "id": contest_id,
+                    "results": {
+                        candidate_id_1: num_for_winner,
+                        candidate_id_2: num_for_loser
+                    }
+                }
+            ]
+        })
 
     assert json.loads(rv.data)['status'] == 'ok'
 
@@ -429,6 +424,10 @@ def test_small_election(client):
     rv = post_json(client, '/election/new', {})
     election_id = json.loads(rv.data)['electionId']
 
+    contest_id = str(uuid.uuid4())
+    candidate_id_1 = str(uuid.uuid4())
+    candidate_id_2 = str(uuid.uuid4())
+
     rv = post_json(
         client, f'/election/{election_id}/audit/basic',
         {
@@ -438,16 +437,16 @@ def test_small_election(client):
 
             "contests" : [
                 {
-                    "id": "contest-1",
+                    "id": contest_id,
                     "name": "Contest 1",
                     "choices": [
                         {
-                            "id": "candidate-1",
+                            "id": candidate_id_1,
                             "name": "Candidate 1",
                             "numVotes": 1325
                         },
                         {
-                            "id": "candidate-2",
+                            "id": candidate_id_2,
                             "name": "Candidate 2",
                             "numVotes": 792
                         }                        
@@ -467,28 +466,32 @@ def test_small_election(client):
 
     assert status["name"] == "Small Test 2019"
 
+    jurisdiction_id = str(uuid.uuid4())
+    audit_board_id_1 = str(uuid.uuid4())
+    audit_board_id_2 = str(uuid.uuid4())
+
     rv = post_json(
         client, f'/election/{election_id}/audit/jurisdictions',
         {
-	    "jurisdictions": [
-		{
-		    "id": "county-1",
-		    "name": "County 1",
-		    "contests": ["contest-1"],
+            "jurisdictions": [
+                {
+                    "id": jurisdiction_id,
+                    "name": "County 1",
+                    "contests": [contest_id],
                     "auditBoards": [
-			{
-			    "id": "1a528034-acf1-11e9-bac5-2fee92515700",
+                        {
+                            "id": audit_board_id_1,
                             "name": "Audit Board #1",
-			    "members": []
-			},
-			{
-			    "id": "22e68ce0-acf1-11e9-9e25-e38239fbbe6b",
+                            "members": []
+                        },
+                        {
+                            "id": audit_board_id_2,
                             "name": "Audit Board #2",
-			    "members": []
-			}
-		    ]
-		}
-	    ]
+                            "members": []
+                        }
+                    ]
+                }
+            ]
         })
 
     assert json.loads(rv.data)['status'] == 'ok'
@@ -500,7 +503,7 @@ def test_small_election(client):
     jurisdiction = status["jurisdictions"][0]
     assert jurisdiction["name"] == "County 1"
     assert jurisdiction["auditBoards"][1]["name"] == "Audit Board #2"
-    assert jurisdiction["contests"] == ["contest-1"]
+    assert jurisdiction["contests"] == [contest_id]
 
     # choose a sample size
     sample_size_90 = [option for option in status["rounds"][0]["contests"][0]["sampleSizeOptions"] if option["prob"] == 0.9]
@@ -516,7 +519,7 @@ def test_small_election(client):
     data = {}
     data['manifest'] = (open(small_manifest_file_path, "rb"), 'small-manifest.csv')
     rv = client.post(
-        f'/election/{election_id}/jurisdiction/county-1/manifest', data=data,
+        f'/election/{election_id}/jurisdiction/{jurisdiction_id}/manifest', data=data,
         content_type='multipart/form-data')
 
     assert json.loads(rv.data)['status'] == 'ok'
@@ -531,7 +534,7 @@ def test_small_election(client):
     assert manifest['uploadedAt']
 
     # get the retrieval list for round 1
-    rv = client.get(f'/election/{election_id}/jurisdiction/county-1/1/retrieval-list')
+    rv = client.get(f'/election/{election_id}/jurisdiction/{jurisdiction_id}/1/retrieval-list')
     lines = rv.data.decode('utf-8').splitlines()
     assert lines[0] == "Batch Name,Ballot Number,Storage Location,Tabulator,Times Selected,Audit Board"
     assert 'attachment' in rv.headers['Content-Disposition']
@@ -541,27 +544,27 @@ def test_small_election(client):
     # post results for round 1
     num_for_winner = int(num_ballots * 0.61)
     num_for_loser = num_ballots - num_for_winner
-    rv = post_json(client, f'/election/{election_id}/jurisdiction/county-1/1/results',
-                   {
-	               "contests": [
-		           {
-			       "id": "contest-1",
-   			       "results": {
-				   "candidate-1": num_for_winner,
-				   "candidate-2": num_for_loser
-			       }
-		           }
-	               ]
-                   })
+    rv = post_json(client, f'/election/{election_id}/jurisdiction/{jurisdiction_id}/1/results',
+        {
+            "contests": [
+                {
+                    "id": contest_id,
+                    "results": {
+                        candidate_id_1: num_for_winner,
+                        candidate_id_2: num_for_loser
+                    }
+                }
+            ]
+        })
 
     assert json.loads(rv.data)['status'] == 'ok'
 
     rv = client.get(f'/election/{election_id}/audit/status')
     status = json.loads(rv.data)
     round_contest = status["rounds"][0]["contests"][0]
-    assert round_contest["id"] == "contest-1"
-    assert round_contest["results"]["candidate-1"] == num_for_winner
-    assert round_contest["results"]["candidate-2"] == num_for_loser
+    assert round_contest["id"] == contest_id
+    assert round_contest["results"][candidate_id_1] == num_for_winner
+    assert round_contest["results"][candidate_id_2] == num_for_loser
     assert round_contest["endMeasurements"]["isComplete"]
     assert math.floor(round_contest["endMeasurements"]["pvalue"] * 100) <= 9
 
@@ -581,17 +584,17 @@ def test_multi_round_audit(client):
     num_for_winner = int(num_ballots * 0.5)
     num_for_loser = num_ballots - num_for_winner
     rv = post_json(client, '{}/jurisdiction/{}/1/results'.format(url_prefix, jurisdiction_id),
-                   {
-	               "contests": [
-		           {
-			       "id": contest_id,
-   			       "results": {
-				   candidate_id_1: num_for_winner,
-				   candidate_id_2: num_for_loser
-			       }
-		           }
-	               ]
-                   })
+        {
+            "contests": [
+                {
+                    "id": contest_id,
+                    "results": {
+                        candidate_id_1: num_for_winner,
+                        candidate_id_2: num_for_loser
+                    }
+                }
+            ]
+        })
 
     assert json.loads(rv.data)['status'] == 'ok'
 
@@ -628,6 +631,11 @@ def test_multi_winner_election(client):
     rv = post_json(client, '/election/new', {})
     election_id = json.loads(rv.data)['electionId']
 
+    contest_id = str(uuid.uuid4())
+    candidate_id_1 = str(uuid.uuid4())
+    candidate_id_2 = str(uuid.uuid4())
+    candidate_id_3 = str(uuid.uuid4())
+
     rv = post_json(
         client, f'/election/{election_id}/audit/basic',
         {
@@ -637,21 +645,21 @@ def test_multi_winner_election(client):
 
             "contests" : [
                 {
-                    "id": "contest-1",
+                    "id": contest_id,
                     "name": "Contest 1",
                     "choices": [
                         {
-                            "id": "candidate-1",
+                            "id": candidate_id_1,
                             "name": "Candidate 1",
                             "numVotes": 1000
                         },
                         {
-                            "id": "candidate-2",
+                            "id": candidate_id_2,
                             "name": "Candidate 2",
                             "numVotes": 792
                         },
                         {
-                            "id": "candidate-3",
+                            "id": candidate_id_3,
                             "name": "Candidate 3",
                             "numVotes": 331
                         },
@@ -672,28 +680,32 @@ def test_multi_winner_election(client):
 
     assert status["name"] == "Small Multi-winner Test 2019"
 
+    jurisdiction_id = str(uuid.uuid4())
+    audit_board_id_1 = str(uuid.uuid4())
+    audit_board_id_2 = str(uuid.uuid4())    
+
     rv = post_json(
         client, f'/election/{election_id}/audit/jurisdictions',
         {
-	    "jurisdictions": [
-		{
-		    "id": "county-1",
-		    "name": "County 1",
-		    "contests": ["contest-1"],
+            "jurisdictions": [
+                {
+                    "id": jurisdiction_id,
+                    "name": "County 1",
+                    "contests": [contest_id],
                     "auditBoards": [
-			{
-			    "id": "1a528034-acf1-11e9-bac5-2fee92515700",
+                        {
+                            "id": audit_board_id_1,
                             "name": "Audit Board #1",
-			    "members": []
-			},
-			{
-			    "id": "22e68ce0-acf1-11e9-9e25-e38239fbbe6b",
+                            "members": []
+                        },
+                        {
+                            "id": audit_board_id_2,
                             "name": "Audit Board #2",
-			    "members": []
-			}
-		    ]
-		}
-	    ]
+                            "members": []
+                        }
+                    ]
+                }
+            ]
         })
 
     assert json.loads(rv.data)['status'] == 'ok'
@@ -705,7 +717,7 @@ def test_multi_winner_election(client):
     jurisdiction = status["jurisdictions"][0]
     assert jurisdiction["name"] == "County 1"
     assert jurisdiction["auditBoards"][1]["name"] == "Audit Board #2"
-    assert jurisdiction["contests"] == ["contest-1"]
+    assert jurisdiction["contests"] == [contest_id]
 
     # choose a sample size
     sample_size_asn = [option for option in status["rounds"][0]["contests"][0]["sampleSizeOptions"]]
@@ -721,7 +733,7 @@ def test_multi_winner_election(client):
     data = {}
     data['manifest'] = (open(small_manifest_file_path, "rb"), 'small-manifest.csv')
     rv = client.post(
-        f'/election/{election_id}/jurisdiction/county-1/manifest', data=data,
+        f'/election/{election_id}/jurisdiction/{jurisdiction_id}/manifest', data=data,
         content_type='multipart/form-data')
 
     assert json.loads(rv.data)['status'] == 'ok'
@@ -736,7 +748,7 @@ def test_multi_winner_election(client):
     assert manifest['uploadedAt']
 
     # get the retrieval list for round 1
-    rv = client.get(f'/election/{election_id}/jurisdiction/county-1/1/retrieval-list')
+    rv = client.get(f'/election/{election_id}/jurisdiction/{jurisdiction_id}/1/retrieval-list')
     lines = rv.data.decode('utf-8').split("\r\n")
     assert lines[0] == "Batch Name,Ballot Number,Storage Location,Tabulator,Times Selected,Audit Board"
     assert 'attachment' in rv.headers['Content-Disposition']
@@ -747,29 +759,29 @@ def test_multi_winner_election(client):
     num_for_winner = int(num_ballots * 0.61)
     num_for_winner2 = int(num_ballots * 0.3)
     num_for_loser = num_ballots - num_for_winner - num_for_winner2
-    rv = post_json(client, f'/election/{election_id}/jurisdiction/county-1/1/results',
-                   {
-	               "contests": [
-		           {
-			       "id": "contest-1",
-   			       "results": {
-				   "candidate-1": num_for_winner,
-				   "candidate-2": num_for_winner2,
-                                   "candidate-3": num_for_loser
-			       }
-		           }
-	               ]
-                   })
+    rv = post_json(client, f'/election/{election_id}/jurisdiction/{jurisdiction_id}/1/results',
+        {
+            "contests": [
+                {
+                    "id": contest_id,
+                    "results": {
+                        candidate_id_1: num_for_winner,
+                        candidate_id_2: num_for_winner2,
+                        candidate_id_3: num_for_loser
+                    }
+                }
+            ]
+        })
 
     assert json.loads(rv.data)['status'] == 'ok'
 
     rv = client.get(f'/election/{election_id}/audit/status')
     status = json.loads(rv.data)
     round_contest = status["rounds"][0]["contests"][0]
-    assert round_contest["id"] == "contest-1"
-    assert round_contest["results"]["candidate-1"] == num_for_winner
-    assert round_contest["results"]["candidate-2"] == num_for_winner2
-    assert round_contest["results"]["candidate-3"] == num_for_loser
+    assert round_contest["id"] == contest_id
+    assert round_contest["results"][candidate_id_1] == num_for_winner
+    assert round_contest["results"][candidate_id_2] == num_for_winner2
+    assert round_contest["results"][candidate_id_3] == num_for_loser
     assert round_contest["endMeasurements"]["isComplete"]
     assert math.floor(round_contest["endMeasurements"]["pvalue"] * 100) <= 9
 
@@ -790,18 +802,18 @@ def test_multi_round_multi_winner_audit(client):
     num_for_winner2 = int(num_ballots*0.4)
     num_for_loser = num_ballots - num_for_winner - num_for_winner2
     rv = post_json(client, '{}/jurisdiction/{}/1/results'.format(url_prefix, jurisdiction_id),
-                   {
-	               "contests": [
-		           {
-			       "id": contest_id,
-   			       "results": {
-				   candidate_id_1: num_for_winner,
-				   candidate_id_2: num_for_winner2,
-                                   candidate_id_3: num_for_loser,
-			       }
-		           }
-	               ]
-                   })
+        {
+            "contests": [
+                {
+                    "id": contest_id,
+                    "results": {
+                        candidate_id_1: num_for_winner,
+                        candidate_id_2: num_for_winner2,
+                        candidate_id_3: num_for_loser,
+                    }
+                }
+            ]
+        })
 
     assert json.loads(rv.data)['status'] == 'ok'
 


### PR DESCRIPTION
Using sqlite for development and testing is easy, but it differs from postgres in ways that make troubleshooting staging and production issues difficult. This commit switches everything from sqlite to postgres in all environments.

The difficulty I had in making this change was primarily around ensuring we're able to easily provide the application with the right configuration in whatever environment it happens to be running in. For example, we need to continue to respect the `DATABASE_URL` environment variable because that's what heroku is using. However, asking people to set environment variables in their shell or IDE to run Arlo properly is not great.

To address this, I set up a system that vaguely resembles Rails with a `config/database.cfg` that is ignored by git but can have per-`FLASK_ENV` database configuration.

Finally, because tests now run against a persisted database we have the possibility of primary key collisions. Since there were lots of primary keys hardcoded in the tests, this happened quite a bit. I fixed this by ensuring that primary keys are always generated randomly, but really we should be using something like https://github.com/jeancochrane/pytest-flask-sqlalchemy to automatically roll back sessions for each test. This was more difficult to set up than I expected, so I'm leaving it as a future task.

Closes #199