### PR TITLE
test(db): reset db on each test run

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -25,6 +25,10 @@ def client():
 
     yield client
 
+    # clear database between test runs
+    app.db.drop_all()
+    app.db.create_all()
+
 def test_index(client):
     rv = client.get('/')
     assert b'Arlo (by VotingWorks)' in rv.data
@@ -114,25 +118,25 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed):
     rv = post_json(
         client, '{}/audit/jurisdictions'.format(url_prefix),
         {
-        "jurisdictions": [
-        {
-            "id": jurisdiction_id,
-            "name": "adams county",
-            "contests": [contest_id],
+            "jurisdictions": [
+                {
+                    "id": jurisdiction_id,
+                    "name": "adams county",
+                    "contests": [contest_id],
                     "auditBoards": [
-            {
-                "id": audit_board_id_1,
+                        {
+                            "id": audit_board_id_1,
                             "name": "audit board #1",
-                "members": []
-            },
-            {
-                "id": audit_board_id_2,
+                            "members": []
+                        },
+                        {
+                            "id": audit_board_id_2,
                             "name": "audit board #2",
-                "members": []
-            }
+                            "members": []
+                        }
+                    ]
+                }
             ]
-        }
-        ]
         })
 
     assert json.loads(rv.data)['status'] == 'ok'


### PR DESCRIPTION
I've seen issues locally where I'm getting unexpected results in `test_ballot_list_ordering` that imply some data from previous test runs is somehow being included in the db results. This _shouldn't_ happen since each election and its related records should be completely independent. That said, resetting the test database on each test run is still a good idea. Typically this is done by rolling back a transaction, but getting that working was fairly involved and this was a rather simple solution that seems to work.