### PR TITLE
fix: use `Intl.NumberFormat` to format percentages

### DIFF
--- a/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
+++ b/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
@@ -260,6 +260,10 @@ const SelectBallotsToAudit: React.FC<IProps> = ({
     return acc
   }, {})
 
+  const percentFormatter = new Intl.NumberFormat(undefined, {
+    style: 'percent',
+  })
+
   return (
     <Formik
       initialValues={initialState}
@@ -315,8 +319,9 @@ const SelectBallotsToAudit: React.FC<IProps> = ({
                                   : ''}
                                 {`${option.size} samples`}
                                 {option.prob
-                                  ? ` (${option.prob *
-                                      100}% chance of reaching risk limit and completing the audit in one round)`
+                                  ? ` (${percentFormatter.format(
+                                      option.prob
+                                    )} chance of reaching risk limit and completing the audit in one round)`
                                   : ''}
                               </Radio>
                             )


### PR DESCRIPTION
Doing math in JavaScript is just begging for floating point problems. For example, `0.55 * 100` is `55.00000000000001`. Yay JavaScript! To work around this we let the built-in number formatter format our percentage values properly.

Closes #213
