### PR TITLE
fix(docker): correct build settings for client-tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
 
   # provides a way to run client tests easily
   client-tests:
-    build: arlo-client
+    image: node:12.13.0
     command: /bin/true
     working_dir: /code
     volumes:


### PR DESCRIPTION
Previously I'd had a `Dockerfile` in `arlo-client`, but I removed it because it was no longer needed since I could just use the `node` image directly. However, I only changed the config for `client` and not `client-tests`. This commit fixes that problem.
