### PR TITLE
chore: ignore vim temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ node_modules
 .mypy_cache
 .pytest_cache
 config/database.cfg
+
+# vim temp files
+*~
+*.swo
+*.swp


### PR DESCRIPTION
So [this](https://github.com/votingworks/arlo/commit/615d609b4d0b9f145c9405dc3b89cd4dc0f38bc4#diff-ea3ccf358dc5d823409a493c26b81d93) doesn't happen anymore.