### PR TITLE
fix(security): compare passwords in constant-time

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-import os, datetime, csv, io, math, json, uuid, locale, re
+import os, datetime, csv, io, math, json, uuid, locale, re, hmac
 from flask import Flask, jsonify, request, Response
 from flask_sqlalchemy import SQLAlchemy
 from flask_httpauth import HTTPBasicAuth
@@ -284,7 +284,9 @@ if ADMIN_PASSWORD:
 
     @auth.verify_password
     def verify_password(username, password):
-        return password == ADMIN_PASSWORD
+        # use a comparison method that prevents timing attacks:
+        # https://securitypitfalls.wordpress.com/2018/08/03/constant-time-compare-in-python/
+        return password is not None and hmac.compare_digest(password, ADMIN_PASSWORD)
     
     @app.route('/admin', methods=["GET"])
     @auth.login_required


### PR DESCRIPTION
Without this, the `/admin` route is vulnerable to timing attacks: https://en.wikipedia.org/wiki/Timing_attack
    
I realize this admin setup is intended to be short-lived, but I do not want to leave an obvious security vulnerability in the codebase for any length of time.
    
I could have used `safe_str_cmp` from `werkzeug.security`, but it just delegates to `hmac.compare_digest` when it's available. Since it was added in Python 3.3, we're fine to use it directly.