### PR TITLE
chore: forward Arlo web port

### DIFF
--- a/arlo.code-workspace
+++ b/arlo.code-workspace
@@ -7,5 +7,13 @@
 			"path": "arlo-client"
 		}
 	],
-	"settings": {}
+	"settings": {
+		"remote.SSH.defaultForwardedPorts": [
+			{
+				"localPort": 3000,
+				"name": "Arlo Web",
+				"remotePort": 3000
+			}
+		]
+	}
 }


### PR DESCRIPTION
This makes it so you don't have to manually configure it in VS Code.
