### PR TITLE
Moving asyncActRender from utilities to testUtilities

### DIFF
--- a/arlo-client/package.json
+++ b/arlo-client/package.json
@@ -7,6 +7,7 @@
     "@blueprintjs/core": "^3.20.0",
     "@blueprintjs/table": "^3.8.1",
     "@testing-library/jest-dom": "^4.0.0",
+    "@testing-library/react": "^9.3.2",
     "@types/jest": "^24.0.15",
     "@types/jsdom": "^12.2.4",
     "@types/jspdf": "^1.3.1",
@@ -132,7 +133,6 @@
     ]
   },
   "devDependencies": {
-    "@testing-library/react": "^9.3.2",
     "@wdio/cli": "^5.14.4",
     "@wdio/dot-reporter": "^5.14.4",
     "@wdio/local-runner": "^5.14.4",

--- a/arlo-client/src/components/AuditFlow/index.test.tsx
+++ b/arlo-client/src/components/AuditFlow/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, wait, fireEvent } from '@testing-library/react'
 import { StaticRouter } from 'react-router-dom'
-import { routerTestProps } from '../testUtilities'
+import { routerTestProps, asyncActRender } from '../testUtilities'
 import AuditFlow from './index'
 import { dummyBoard, dummyBallots } from './_mocks'
 import { statusStates } from '../AuditForms/_mocks'
@@ -76,7 +76,7 @@ describe('AuditFlow ballot interaction', () => {
         }
       }
     )
-    const { queryByText } = await utilities.asyncActRender(
+    const { queryByText } = await asyncActRender(
       <StaticRouter {...staticRouteProps}>
         <AuditFlow {...routeProps} />
       </StaticRouter>
@@ -188,7 +188,7 @@ describe('AuditFlow ballot interaction', () => {
       .spyOn(ballotRouteProps.history, 'push')
       .mockImplementation()
     ballotRouteProps.match.url = '/election/1/board/123'
-    const { getByText } = await utilities.asyncActRender(
+    const { getByText } = await asyncActRender(
       <StaticRouter {...staticBallotRouteProps}>
         <AuditFlow {...ballotRouteProps} />
       </StaticRouter>
@@ -227,7 +227,7 @@ describe('AuditFlow ballot interaction', () => {
     )
     const { history, ...staticBallotRouteProps } = ballotRouteProps // eslint-disable-line @typescript-eslint/no-unused-vars
     ballotRouteProps.match.url = '/election/1/board/123'
-    const { getByText, getByTestId } = await utilities.asyncActRender(
+    const { getByText, getByTestId } = await asyncActRender(
       <StaticRouter {...staticBallotRouteProps}>
         <AuditFlow {...ballotRouteProps} />
       </StaticRouter>

--- a/arlo-client/src/components/AuditFlow/index_members.test.tsx
+++ b/arlo-client/src/components/AuditFlow/index_members.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { wait } from '@testing-library/react'
 import { Router } from 'react-router-dom'
-import { routerTestProps } from '../testUtilities'
+import { routerTestProps, asyncActRender } from '../testUtilities'
 import AuditFlow from './index'
 import { dummyBoard, dummyBallots } from './_mocks'
 import { statusStates } from '../AuditForms/_mocks'
@@ -42,7 +42,7 @@ describe('AuditFlow initial load', () => {
   })
 
   it('renders correctly', async () => {
-    const { container } = await utilities.asyncActRender(
+    const { container } = await asyncActRender(
       <Router {...routeProps}>
         <AuditFlow {...routeProps} />
       </Router>
@@ -51,7 +51,7 @@ describe('AuditFlow initial load', () => {
   })
 
   it('fetches initial state from api', async () => {
-    const { container } = await utilities.asyncActRender(
+    const { container } = await asyncActRender(
       <Router {...routeProps}>
         <AuditFlow {...routeProps} />
       </Router>
@@ -63,7 +63,7 @@ describe('AuditFlow initial load', () => {
   })
 
   it('renders member form', async () => {
-    const { container, getByText } = await utilities.asyncActRender(
+    const { container, getByText } = await asyncActRender(
       <Router {...routeProps}>
         <AuditFlow {...routeProps} />
       </Router>

--- a/arlo-client/src/components/AuditForms/CalculateRiskMeasurement.test.tsx
+++ b/arlo-client/src/components/AuditForms/CalculateRiskMeasurement.test.tsx
@@ -5,6 +5,7 @@ import jsPDF from 'jspdf'
 import CalculateRiskMeasurement from './CalculateRiskMeasurement'
 import { statusStates, dummyBallots, incompleteDummyBallots } from './_mocks'
 import * as utilities from '../utilities'
+import { asyncActRender } from '../testUtilities'
 
 statusStates[3].online = false
 statusStates[4].online = false
@@ -468,7 +469,7 @@ describe('CalculateRiskMeasurement', () => {
   it('renders online mode progress bar', async () => {
     statusStates[4].online = true
     apiMock.mockImplementationOnce(async () => incompleteDummyBallots)
-    const { container } = await utilities.asyncActRender(
+    const { container } = await asyncActRender(
       <CalculateRiskMeasurement
         audit={statusStates[4]}
         isLoading
@@ -484,7 +485,7 @@ describe('CalculateRiskMeasurement', () => {
   it('renders online mode progress bar in multiple rounds', async () => {
     statusStates[8].online = true
     apiMock.mockImplementationOnce(async () => incompleteDummyBallots)
-    const { container } = await utilities.asyncActRender(
+    const { container } = await asyncActRender(
       <CalculateRiskMeasurement
         audit={statusStates[8]}
         isLoading

--- a/arlo-client/src/components/AuditForms/index.test.tsx
+++ b/arlo-client/src/components/AuditForms/index.test.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter as Router } from 'react-router-dom'
 import AuditForms from './index'
 import { statusStates, dummyBallots } from './_mocks'
 import * as utilities from '../utilities'
-import { routerTestProps } from '../testUtilities'
+import { routerTestProps, asyncActRender } from '../testUtilities'
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
@@ -27,9 +27,7 @@ afterEach(() => {
 describe('RiskLimitingAuditForm', () => {
   it('fetches initial state from api', async () => {
     apiMock.mockImplementation(async () => statusStates[0])
-    const { container } = await utilities.asyncActRender(
-      <AuditForms {...routeProps} />
-    )
+    const { container } = await asyncActRender(<AuditForms {...routeProps} />)
 
     expect(container).toMatchSnapshot()
     await wait(() => {
@@ -42,21 +40,19 @@ describe('RiskLimitingAuditForm', () => {
   })
 
   it('renders correctly with initialData', async () => {
-    const { container } = await utilities.asyncActRender(
-      <AuditForms {...routeProps} />
-    )
+    const { container } = await asyncActRender(<AuditForms {...routeProps} />)
     expect(container).toMatchSnapshot()
   })
 
   it('still renders if there is a server error', async () => {
     checkAndToastMock.mockReturnValueOnce(true)
-    await utilities.asyncActRender(<AuditForms {...routeProps} />)
+    await asyncActRender(<AuditForms {...routeProps} />)
     expect(checkAndToastMock).toBeCalledTimes(1)
   })
 
   it('does not render SelectBallotsToAudit when /audit/status is processing samplesizes', async () => {
     apiMock.mockImplementation(async () => statusStates[1])
-    const { container, queryByTestId } = await utilities.asyncActRender(
+    const { container, queryByTestId } = await asyncActRender(
       <AuditForms {...routeProps} />
     )
 
@@ -73,7 +69,7 @@ describe('RiskLimitingAuditForm', () => {
 
   it('renders SelectBallotsToAudit when /audit/status returns contest data', async () => {
     apiMock.mockImplementation(async () => statusStates[2])
-    const { container, getByTestId } = await utilities.asyncActRender(
+    const { container, getByTestId } = await asyncActRender(
       <AuditForms {...routeProps} />
     )
 
@@ -94,11 +90,9 @@ describe('RiskLimitingAuditForm', () => {
 
   it('does not render CalculateRiskMeasurement when audit.jurisdictions has length but audit.rounds does not', async () => {
     apiMock.mockImplementation(async () => statusStates[3])
-    const {
-      container,
-      getByTestId,
-      queryByTestId,
-    } = await utilities.asyncActRender(<AuditForms {...routeProps} />) // this one will not have the first empty round
+    const { container, getByTestId, queryByTestId } = await asyncActRender(
+      <AuditForms {...routeProps} />
+    ) // this one will not have the first empty round
 
     const fillFormTwo = await waitForElement(() => getByTestId('form-two'), {
       container,
@@ -120,7 +114,7 @@ describe('RiskLimitingAuditForm', () => {
     apiMock
       .mockImplementationOnce(async () => statusStates[4])
       .mockImplementationOnce(async () => dummyBallots)
-    const { container, getByTestId } = await utilities.asyncActRender(
+    const { container, getByTestId } = await asyncActRender(
       <Router>
         <AuditForms {...routeProps} />
       </Router>

--- a/arlo-client/src/components/testUtilities.ts
+++ b/arlo-client/src/components/testUtilities.ts
@@ -1,3 +1,5 @@
+import React from 'react'
+import { RenderResult, act, render } from '@testing-library/react'
 import { createLocation, createMemoryHistory } from 'history'
 import { match as routerMatch } from 'react-router-dom'
 
@@ -43,6 +45,16 @@ export const routerTestProps = <Params extends MatchParameter<Params> = {}>(
 export const regexpEscape = (s: string) => {
   /* eslint-disable no-useless-escape */
   return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+}
+
+export const asyncActRender = async (
+  component: React.ReactElement
+): Promise<RenderResult> => {
+  let result: RenderResult
+  await act(async () => {
+    result = render(component)
+  })
+  return result!
 }
 
 export default {

--- a/arlo-client/src/components/utilities.ts
+++ b/arlo-client/src/components/utilities.ts
@@ -1,6 +1,4 @@
-import React from 'react'
 import { toast } from 'react-toastify'
-import { RenderResult, act, render } from '@testing-library/react'
 import number from '../utils/number-schema'
 import { IErrorResponse } from '../types'
 
@@ -104,14 +102,4 @@ export const checkAndToast = (
   } else {
     return false
   }
-}
-
-export const asyncActRender = async (
-  component: React.ReactElement
-): Promise<RenderResult> => {
-  let result: RenderResult
-  await act(async () => {
-    result = render(component)
-  })
-  return result!
 }


### PR DESCRIPTION
**DESCRIPTION**

- Moving `asyncActRender` from utilities to testUtilities so that `@testing-library/react` can stay in devDependencies.

EDIT: Still moving it to testUtilities, but evidently it needs to be in regular dependencies regardless. Oh well.

**New Tests**

- N/A

**Checklist**

*Function*

[] Code is fully functional and ready for review (or is tagged WIP)

[] No errors/warnings in the browser console ( ﾟヮﾟ)/

[] package.json is committed if I added or removed any dependencies

[] Tests added as needed to ensure code base still has 100% passing coverage

[] Tests added as needed to cover new functionality

*Style*

[] Passes linter without errors

[] Code is easily understandable and self-documenting (using naming conventions in keeping with the rest of the codebase)

[] Interfaces all have 'I' before their names (as in `IAudit`)

[] Comments are only included as needed to explain the 'why' instead of the 'what'

[] Common standards and coding practices are adhered to

[] DRY: Don't Repeat Yourself. Code is reasonably structured to avoid repetition

[] Code is intuitively structured following a Separation of Concerns

[] No class components; only functional components (using Hooks as needed)

*Workflow*

[] Do an interactive rebase or a rebase 