### PR TITLE
List audits on create audit view [wip]

### DIFF
--- a/app.py
+++ b/app.py
@@ -299,7 +299,7 @@ if ADMIN_PASSWORD:
 
 @app.route('/elections', methods=["GET"])
 def audits_list():
-    elections_list = Election.query.all()
+    elections_list = Election.query.order_by(Election.created_at).all()
 
     return jsonify(
         elections = [

--- a/app.py
+++ b/app.py
@@ -297,6 +297,21 @@ if ADMIN_PASSWORD:
         result = "\n".join(["%s - %s" % (e.id, e.name) for e in elections])
         return Response(result, content_type='text/plain')
 
+@app.route('/elections', methods=["GET"])
+def audits_list():
+    elections_list = Election.query.all()
+
+    return jsonify(
+        elections = [
+            {
+                "id": e.id,
+                "name": e.name,
+                "date": e.created_at
+            }
+            for e in elections_list
+        ]
+    )
+
 @app.route('/election/new', methods=["POST"])
 def election_new():
     election_id = create_election()

--- a/arlo-client/package.json
+++ b/arlo-client/package.json
@@ -41,6 +41,7 @@
     "http-proxy-middleware": "^0.19.1",
     "jsdom": "^15.1.1",
     "jspdf": "^1.5.3",
+    "moment": "^2.24.0",
     "qrcode.react": "^0.9.3",
     "react": "16.9.0",
     "react-app-polyfill": "^1.0.1",

--- a/arlo-client/src/__snapshots__/App.test.tsx.snap
+++ b/arlo-client/src/__snapshots__/App.test.tsx.snap
@@ -26,6 +26,19 @@ exports[`App renders properly 1`] = `
           Create a New Audit
         </span>
       </button>
+      <div>
+        <label
+          class="bp3-label"
+        >
+          Select an existing audit:
+        </label>
+      </div>
+      <a
+        class="bp3-button bp3-intent-primary"
+        href="/election/"
+      >
+        View Audit
+      </a>
     </div>
   </div>
 </div>

--- a/arlo-client/src/__snapshots__/App.test.tsx.snap
+++ b/arlo-client/src/__snapshots__/App.test.tsx.snap
@@ -26,19 +26,9 @@ exports[`App renders properly 1`] = `
           Create a New Audit
         </span>
       </button>
-      <div>
-        <label
-          class="bp3-label"
-        >
-          Select an existing audit:
-        </label>
-      </div>
-      <a
-        class="bp3-button bp3-intent-primary"
-        href="/election/"
-      >
-        View Audit
-      </a>
+      <p>
+        Yo do not have any audits currently associated with your account.
+      </p>
     </div>
   </div>
 </div>

--- a/arlo-client/src/components/AuditFlow/index.test.tsx
+++ b/arlo-client/src/components/AuditFlow/index.test.tsx
@@ -242,7 +242,7 @@ describe('AuditFlow ballot interaction', () => {
     })
 
     await wait(() => {
-      expect(apiMock).toBeCalledTimes(4)
+      expect(apiMock).toBeCalledTimes(6)
     })
   })
 })

--- a/arlo-client/src/components/CreateAudit.test.tsx
+++ b/arlo-client/src/components/CreateAudit.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { render, fireEvent, wait } from '@testing-library/react'
+import { fireEvent, wait } from '@testing-library/react'
 import { toast } from 'react-toastify'
 import { RouteComponentProps, BrowserRouter as Router } from 'react-router-dom'
 import CreateAudit, { IElections } from './CreateAudit'
 import { ICreateAuditParams } from '../types'
-import { routerTestProps } from './testUtilities'
+import { routerTestProps, asyncActRender } from './testUtilities'
 import * as utilities from './utilities'
 
 const apiMock: jest.SpyInstance<
@@ -21,8 +21,13 @@ const apiMock: jest.SpyInstance<
         return {
           elections: [
             {
-              name: 'Election One',
+              name: '',
               id: 'election-1',
+              date: 'Thu, 18 Jul 2019 16:34:07 GMT',
+            },
+            {
+              name: 'Election Two',
+              id: 'election-2',
               date: 'Thu, 18 Jul 2019 16:34:07 GMT',
             },
           ],
@@ -58,8 +63,8 @@ afterEach(() => {
 })
 
 describe('CreateAudit', () => {
-  it('renders correctly', () => {
-    const { container } = render(
+  it('renders correctly', async () => {
+    const { container } = await asyncActRender(
       <Router>
         <CreateAudit {...routeProps} />
       </Router>
@@ -68,7 +73,7 @@ describe('CreateAudit', () => {
   })
 
   it('calls the /election/new endpoint', async () => {
-    const { getByText } = render(
+    const { getByText } = await asyncActRender(
       <Router>
         <CreateAudit {...routeProps} />
       </Router>
@@ -85,9 +90,23 @@ describe('CreateAudit', () => {
     })
   })
 
+  it('selects a different election', async () => {
+    const { getByLabelText, container } = await asyncActRender(
+      <Router>
+        <CreateAudit {...routeProps} />
+      </Router>
+    )
+
+    fireEvent.click(getByLabelText('Election Two', { exact: false }), {
+      bubbles: true,
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
   it('handles error responses from server', async () => {
     checkAndToastMock.mockReturnValue(true)
-    const { getByText } = render(
+    const { getByText } = await asyncActRender(
       <Router>
         <CreateAudit {...routeProps} />
       </Router>
@@ -110,7 +129,7 @@ describe('CreateAudit', () => {
       throw new Error('404')
     })
     checkAndToastMock.mockReturnValue(true)
-    const { getByText } = render(
+    const { getByText } = await asyncActRender(
       <Router>
         <CreateAudit {...routeProps} />
       </Router>

--- a/arlo-client/src/components/CreateAudit.test.tsx
+++ b/arlo-client/src/components/CreateAudit.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { render, fireEvent, wait } from '@testing-library/react'
 import { toast } from 'react-toastify'
-import { RouteComponentProps } from 'react-router-dom'
-import CreateAudit from './CreateAudit'
+import { RouteComponentProps, BrowserRouter as Router } from 'react-router-dom'
+import CreateAudit, { IElections } from './CreateAudit'
 import { ICreateAuditParams } from '../types'
 import { routerTestProps } from './testUtilities'
 import * as utilities from './utilities'
@@ -10,7 +10,28 @@ import * as utilities from './utilities'
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
   Parameters<typeof utilities.api>
-> = jest.spyOn(utilities, 'api').mockImplementation()
+> = jest.spyOn(utilities, 'api').mockImplementation(
+  async (
+    endpoint: string
+  ): Promise<IElections | { electionId: string } | undefined> => {
+    switch (endpoint) {
+      case '/election/new':
+        return { electionId: '1' }
+      case '/elections':
+        return {
+          elections: [
+            {
+              name: 'Election One',
+              id: 'election-1',
+              date: 'Thu, 18 Jul 2019 16:34:07 GMT',
+            },
+          ],
+        }
+      default:
+        return undefined
+    }
+  }
+)
 const checkAndToastMock: jest.SpyInstance<
   ReturnType<typeof utilities.checkAndToast>,
   Parameters<typeof utilities.checkAndToast>
@@ -38,35 +59,47 @@ afterEach(() => {
 
 describe('CreateAudit', () => {
   it('renders correctly', () => {
-    const { container } = render(<CreateAudit {...routeProps} />)
+    const { container } = render(
+      <Router>
+        <CreateAudit {...routeProps} />
+      </Router>
+    )
     expect(container).toMatchSnapshot()
   })
 
   it('calls the /election/new endpoint', async () => {
-    apiMock.mockImplementation(async () => ({ electionId: '1' }))
-    const { getByText } = render(<CreateAudit {...routeProps} />)
+    const { getByText } = render(
+      <Router>
+        <CreateAudit {...routeProps} />
+      </Router>
+    )
 
     fireEvent.click(getByText('Create a New Audit'), { bubbles: true })
 
     await wait(() => {
-      expect(apiMock).toBeCalledTimes(1)
-      expect(apiMock.mock.calls[0][0]).toBe('/election/new')
+      expect(apiMock).toBeCalledTimes(2)
+      expect(apiMock.mock.calls[0][0]).toBe('/elections')
+      expect(apiMock.mock.calls[1][0]).toBe('/election/new')
       expect(historySpy).toBeCalledTimes(1)
       expect(historySpy.mock.calls[0][0]).toBe('/election/1')
     })
   })
 
   it('handles error responses from server', async () => {
-    apiMock.mockImplementation(async () => ({ electionId: '1' }))
     checkAndToastMock.mockReturnValue(true)
-    const { getByText } = render(<CreateAudit {...routeProps} />)
+    const { getByText } = render(
+      <Router>
+        <CreateAudit {...routeProps} />
+      </Router>
+    )
 
     fireEvent.click(getByText('Create a New Audit'), { bubbles: true })
 
     await wait(() => {
-      expect(apiMock).toBeCalledTimes(1)
-      expect(apiMock.mock.calls[0][0]).toBe('/election/new')
-      expect(checkAndToastMock).toBeCalledTimes(1)
+      expect(apiMock).toBeCalledTimes(2)
+      expect(apiMock.mock.calls[0][0]).toBe('/elections')
+      expect(apiMock.mock.calls[1][0]).toBe('/election/new')
+      expect(checkAndToastMock).toBeCalledTimes(2)
       expect(historySpy).toBeCalledTimes(0)
       expect(toastSpy).toBeCalledTimes(0)
     })
@@ -77,16 +110,21 @@ describe('CreateAudit', () => {
       throw new Error('404')
     })
     checkAndToastMock.mockReturnValue(true)
-    const { getByText } = render(<CreateAudit {...routeProps} />)
+    const { getByText } = render(
+      <Router>
+        <CreateAudit {...routeProps} />
+      </Router>
+    )
 
     fireEvent.click(getByText('Create a New Audit'), { bubbles: true })
 
     await wait(() => {
-      expect(apiMock).toBeCalledTimes(1)
-      expect(apiMock.mock.calls[0][0]).toBe('/election/new')
+      expect(apiMock).toBeCalledTimes(2)
+      expect(apiMock.mock.calls[0][0]).toBe('/elections')
+      expect(apiMock.mock.calls[1][0]).toBe('/election/new')
       expect(checkAndToastMock).toBeCalledTimes(0)
       expect(historySpy).toBeCalledTimes(0)
-      expect(toastSpy).toBeCalledTimes(1)
+      expect(toastSpy).toBeCalledTimes(2)
     })
   })
 })

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import styled from 'styled-components'
+import moment from 'moment'
 import { toast } from 'react-toastify'
-import { RouteComponentProps } from 'react-router-dom'
+import { RouteComponentProps, Link } from 'react-router-dom'
+import { RadioGroup, Radio } from '@blueprintjs/core'
 import FormButton from './Form/FormButton'
 import { api, checkAndToast } from './utilities'
 import { ICreateAuditParams, IErrorResponse } from '../types'
@@ -32,6 +34,8 @@ interface IElections {
 
 const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
   const [loading, setLoading] = useState(false)
+  const [electionId, setElectionId] = useState('')
+
   const onClick = async () => {
     try {
       setLoading(true)
@@ -66,6 +70,7 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
     const list = await getStatus()
     setLoading(true)
     setElections(list)
+    setElectionId(list.elections[0].id)
     setLoading(false)
   }, [getStatus])
 
@@ -87,13 +92,24 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
       >
         Create a New Audit
       </Button>
-      <div>
+      <RadioGroup
+        label="Select an existing audit:"
+        selectedValue={electionId}
+        onChange={e => setElectionId(e.currentTarget.value)}
+      >
         {elections.elections.map(e => (
-          <div key={e.id}>
-            {e.name} ({e.date})
-          </div>
+          <Radio key={e.id} value={e.id}>
+            {e.name || <i>Not named yet</i>} (Created&nbsp;
+            {moment(e.date).format('MM/DD/YYYY')})
+          </Radio>
         ))}
-      </div>
+      </RadioGroup>
+      <Link
+        to={`/election/${electionId}`}
+        className="bp3-button bp3-intent-primary"
+      >
+        View Audit
+      </Link>
     </Wrapper>
   )
 }

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import styled from 'styled-components'
 import { toast } from 'react-toastify'
 import { RouteComponentProps } from 'react-router-dom'
@@ -21,6 +21,15 @@ const Wrapper = styled.div`
   }
 `
 
+interface IElection {
+  id: string
+  name: string
+  date: string
+}
+interface IElections {
+  elections: IElection[]
+}
+
 const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
   const [loading, setLoading] = useState(false)
   const onClick = async () => {
@@ -41,6 +50,29 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
       toast.error(err.message)
     }
   }
+
+  const [elections, setElections] = useState<IElections>({ elections: [] })
+
+  const getStatus = useCallback(async (): Promise<IElections> => {
+    const list: IElections | IErrorResponse = await api(`/elections`)
+    if (checkAndToast(list)) {
+      return { elections: [] }
+    } else {
+      return list
+    }
+  }, [])
+
+  const updateElections = useCallback(async () => {
+    const list = await getStatus()
+    setLoading(true)
+    setElections(list)
+    setLoading(false)
+  }, [getStatus])
+
+  useEffect(() => {
+    updateElections()
+  }, [updateElections])
+
   return (
     <Wrapper>
       <img height="50px" src="/arlo.png" alt="Arlo, by VotingWorks" />
@@ -55,6 +87,13 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
       >
         Create a New Audit
       </Button>
+      <div>
+        {elections.elections.map(e => (
+          <div key={e.id}>
+            {e.name} ({e.date})
+          </div>
+        ))}
+      </div>
     </Wrapper>
   )
 }

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -97,24 +97,32 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
       >
         Create a New Audit
       </Button>
-      <RadioGroup
-        label="Select an existing audit:"
-        selectedValue={electionId}
-        onChange={e => setElectionId(e.currentTarget.value)}
-      >
-        {elections.elections.map(e => (
-          <Radio key={e.id} value={e.id}>
-            {e.name || <i>Not named yet</i>} (Created&nbsp;
-            {moment(e.date).format('MM/DD/YYYY')})
-          </Radio>
-        ))}
-      </RadioGroup>
-      <Link
-        to={`/election/${electionId}`}
-        className="bp3-button bp3-intent-primary"
-      >
-        View Audit
-      </Link>
+      {elections.elections.length > 0 ? (
+        <>
+          <RadioGroup
+            label="Select an existing audit:"
+            selectedValue={electionId}
+            onChange={e => setElectionId(e.currentTarget.value)}
+          >
+            {elections.elections.map(e => (
+              <Radio key={e.id} value={e.id}>
+                {e.name || <i>Not named yet</i>} (Created&nbsp;
+                {moment(e.date).format('MM/DD/YYYY')})
+              </Radio>
+            ))}
+          </RadioGroup>
+          <Link
+            to={`/election/${electionId}`}
+            className="bp3-button bp3-intent-primary"
+          >
+            View Audit
+          </Link>
+        </>
+      ) : (
+        <p>
+          You do not have any audits currently associated with your account.
+        </p>
+      )}
     </Wrapper>
   )
 }

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -28,7 +28,7 @@ interface IElection {
   name: string
   date: string
 }
-interface IElections {
+export interface IElections {
   elections: IElection[]
 }
 
@@ -58,19 +58,24 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
   const [elections, setElections] = useState<IElections>({ elections: [] })
 
   const getStatus = useCallback(async (): Promise<IElections> => {
-    const list: IElections | IErrorResponse = await api(`/elections`)
-    if (checkAndToast(list)) {
-      return { elections: [] }
-    } else {
-      return list
+    try {
+      const list: IElections | IErrorResponse = await api(`/elections`)
+      if (checkAndToast(list)) {
+        return { elections: [] }
+      } else {
+        return list
+      }
+    } catch (err) {
+      toast.error(err.message)
     }
+    return { elections: [] }
   }, [])
 
   const updateElections = useCallback(async () => {
     const list = await getStatus()
     setLoading(true)
     setElections(list)
-    setElectionId(list.elections[0].id)
+    setElectionId(list.elections.length ? list.elections[0].id : '')
     setLoading(false)
   }, [getStatus])
 

--- a/arlo-client/src/components/__snapshots__/CreateAudit.test.tsx.snap
+++ b/arlo-client/src/components/__snapshots__/CreateAudit.test.tsx.snap
@@ -26,10 +26,115 @@ exports[`CreateAudit renders correctly 1`] = `
       >
         Select an existing audit:
       </label>
+      <label
+        class="bp3-control bp3-radio"
+      >
+        <input
+          name="Blueprint3.RadioGroup-0"
+          type="radio"
+          value="election-1"
+        />
+        <span
+          class="bp3-control-indicator"
+        />
+        <i>
+          Not named yet
+        </i>
+         (Created 
+        07/18/2019
+        )
+      </label>
+      <label
+        class="bp3-control bp3-radio"
+      >
+        <input
+          name="Blueprint3.RadioGroup-0"
+          type="radio"
+          value="election-2"
+        />
+        <span
+          class="bp3-control-indicator"
+        />
+        Election Two
+         (Created 
+        07/18/2019
+        )
+      </label>
     </div>
     <a
       class="bp3-button bp3-intent-primary"
-      href="/election/"
+      href="/election/election-1"
+    >
+      View Audit
+    </a>
+  </div>
+</div>
+`;
+
+exports[`CreateAudit selects a different election 1`] = `
+<div>
+  <div
+    class="sc-htpNat dgtpPg"
+  >
+    <img
+      alt="Arlo, by VotingWorks"
+      height="50px"
+      src="/arlo.png"
+    />
+    <button
+      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-bwzfXH iEhHA sc-bdVaJa gLVjYw"
+      type="button"
+    >
+      <span
+        class="bp3-button-text"
+      >
+        Create a New Audit
+      </span>
+    </button>
+    <div>
+      <label
+        class="bp3-label"
+      >
+        Select an existing audit:
+      </label>
+      <label
+        class="bp3-control bp3-radio"
+      >
+        <input
+          name="Blueprint3.RadioGroup-2"
+          type="radio"
+          value="election-1"
+        />
+        <span
+          class="bp3-control-indicator"
+        />
+        <i>
+          Not named yet
+        </i>
+         (Created 
+        07/18/2019
+        )
+      </label>
+      <label
+        class="bp3-control bp3-radio"
+      >
+        <input
+          name="Blueprint3.RadioGroup-2"
+          type="radio"
+          value="election-2"
+        />
+        <span
+          class="bp3-control-indicator"
+        />
+        Election Two
+         (Created 
+        07/18/2019
+        )
+      </label>
+    </div>
+    <a
+      class="bp3-button bp3-intent-primary"
+      href="/election/election-2"
     >
       View Audit
     </a>

--- a/arlo-client/src/components/__snapshots__/CreateAudit.test.tsx.snap
+++ b/arlo-client/src/components/__snapshots__/CreateAudit.test.tsx.snap
@@ -20,6 +20,19 @@ exports[`CreateAudit renders correctly 1`] = `
         Create a New Audit
       </span>
     </button>
+    <div>
+      <label
+        class="bp3-label"
+      >
+        Select an existing audit:
+      </label>
+    </div>
+    <a
+      class="bp3-button bp3-intent-primary"
+      href="/election/"
+    >
+      View Audit
+    </a>
   </div>
 </div>
 `;

--- a/arlo-client/src/setupProxy.js
+++ b/arlo-client/src/setupProxy.js
@@ -13,6 +13,7 @@ const target = process.env.ARLO_BACKEND_URL || 'http://localhost:3001/'
 module.exports = function(app) {
   app.use(proxy('/admin', { target }))
   app.use(proxy('/election/new', { target }))
+  app.use(proxy('/elections', { target }))
   app.use(proxy('/election/*/audit/**', { target }))
   app.use(proxy('/election/*/jurisdiction/**', { target }))
   app.use(proxy('/election/*/admin/**', { target }))

--- a/arlo-client/yarn.lock
+++ b/arlo-client/yarn.lock
@@ -8503,6 +8503,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"

--- a/models.py
+++ b/models.py
@@ -2,6 +2,7 @@
 from app import db
 from sqlalchemy.orm import relationship
 from typing import Union, List
+import datetime
 
 # on-delete-cascade is done in SQLAlchemy like this:
 # https://stackoverflow.com/questions/5033547/sqlalchemy-cascade-delete
@@ -13,6 +14,7 @@ class Election(db.Model):
     name = db.Column(db.String(200), nullable=True)
     state = db.Column(db.String(100), nullable=True)
     election_date = db.Column(db.Date, nullable=True)
+    created_at = db.Column(db.Date, nullable=True, default=datetime.datetime.now())
     election_type = db.Column(db.String(200), nullable=True)
     meeting_date = db.Column(db.Date, nullable=True)
     risk_limit = db.Column(db.Integer, nullable=True)


### PR DESCRIPTION
**DESCRIPTION**

- Adds a simple (temporary) route for fetching all the elections and lists them on the Create Audit view so you can select one and view it instead of creating a new audit.
- Adds `created_at` to the Elections model so we can sort them by creation time.

Notes:

This is an initial setup. When we have users linked to elections on #248 we can filter these elections by user.

**New Tests**

- TODO

**Checklist**

*Function*

[] Code is fully functional and ready for review (or is tagged WIP)

[] No errors/warnings in the browser console ( ﾟヮﾟ)/

[] package.json is committed if I added or removed any dependencies

[] Tests added as needed to ensure code base still has 100% passing coverage

[] Tests added as needed to cover new functionality

*Style*

[] Passes linter without errors

[] Code is easily understandable and self-documenting (using naming conventions in keeping with the rest of the codebase)

[] Interfaces all have 'I' before their names (as in `IAudit`)

[] Comments are only included as needed to explain the 'why' instead of the 'what'

[] Common standards and coding practices are adhered to

[] DRY: Don't Repeat Yourself. Code is reasonably structured to avoid repetition

[] Code is intuitively structured following a Separation of Concerns

[] No class components; only functional components (using Hooks as needed)

*Workflow*

[] Do an interactive rebase or a rebase 