### PR TITLE
Making header logo a link to home

### DIFF
--- a/arlo-client/src/components/Header.test.tsx
+++ b/arlo-client/src/components/Header.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
 import { render } from '@testing-library/react'
+import { BrowserRouter as Router } from 'react-router-dom'
 import Header from './Header'
 
 it('renders correctly', () => {
-  const { container } = render(<Header />)
+  const { container } = render(
+    <Router>
+      <Header />
+    </Router>
+  )
   expect(container).toMatchSnapshot()
 })

--- a/arlo-client/src/components/Header.tsx
+++ b/arlo-client/src/components/Header.tsx
@@ -6,6 +6,7 @@ import {
   NavbarHeading,
   Alignment,
 } from '@blueprintjs/core'
+import { Link } from 'react-router-dom'
 
 const ButtonBar = styled.div`
   display: inline-block;
@@ -25,7 +26,9 @@ const Header: React.FC<{}> = () => (
   <Nav fixedToTop>
     <NavbarGroup align={Alignment.LEFT}>
       <NavbarHeading>
-        <img src="/arlo.png" alt="Arlo, by VotingWorks" />
+        <Link to="/">
+          <img src="/arlo.png" alt="Arlo, by VotingWorks" />
+        </Link>
       </NavbarHeading>
     </NavbarGroup>
     <NavbarGroup align={Alignment.RIGHT}>

--- a/arlo-client/src/components/__snapshots__/Header.test.tsx.snap
+++ b/arlo-client/src/components/__snapshots__/Header.test.tsx.snap
@@ -11,10 +11,14 @@ exports[`renders correctly 1`] = `
       <div
         class="bp3-navbar-heading"
       >
-        <img
-          alt="Arlo, by VotingWorks"
-          src="/arlo.png"
-        />
+        <a
+          href="/"
+        >
+          <img
+            alt="Arlo, by VotingWorks"
+            src="/arlo.png"
+          />
+        </a>
       </div>
     </div>
     <div


### PR DESCRIPTION
**DESCRIPTION**

- The logo in the header now is a link doing to /

**New Tests**

- Snapshots updated

**Checklist**

*Function*

[] Code is fully functional and ready for review (or is tagged WIP)

[] No errors/warnings in the browser console ( ﾟヮﾟ)/

[] package.json is committed if I added or removed any dependencies

[] Tests added as needed to ensure code base still has 100% passing coverage

[] Tests added as needed to cover new functionality

*Style*

[] Passes linter without errors

[] Code is easily understandable and self-documenting (using naming conventions in keeping with the rest of the codebase)

[] Interfaces all have 'I' before their names (as in `IAudit`)

[] Comments are only included as needed to explain the 'why' instead of the 'what'

[] Common standards and coding practices are adhered to

[] DRY: Don't Repeat Yourself. Code is reasonably structured to avoid repetition

[] Code is intuitively structured following a Separation of Concerns

[] No class components; only functional components (using Hooks as needed)

*Workflow*

[] Do an interactive rebase or a rebase 