### PR TITLE
build(docker): fixes `docker-compose up`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
-version: '3'
+# NOTE: This file is intended for using Docker for development, not to deploy
+# Arlo in a production environment.
+
+version: "3"
 services:
   # standard postgres instance to store application data
   db:
@@ -6,6 +9,8 @@ services:
     ports:
       - 5432:5432
     restart: on-failure
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   # creates the initial database and, maybe later, runs migrations
   migrate:


### PR DESCRIPTION
The `db` container failed to start because the `9.6` image changed (presumably to the most recent `9.6.x` version) and now wants a password. Since we're only using this for development, I added the environment variable that makes postgres trust incoming requests. This is not suitable for a production environment, so I added a comment to make it clear what this file is for.