### PR TITLE
feat: enable sessions

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -1,5 +1,5 @@
 import os, datetime, csv, io, math, json, uuid, locale, re, hmac
-from flask import Flask, jsonify, request, Response, redirect
+from flask import Flask, jsonify, request, Response, redirect, session
 from flask_httpauth import HTTPBasicAuth
 
 from sampler import Sampler
@@ -883,6 +883,17 @@ def audit_reset(election_id):
 def auditboard_passphrase(passphrase):
     auditboard = AuditBoard.query.filter_by(passphrase=passphrase).one()
     return redirect("/election/%s/board/%s" % (auditboard.jurisdiction.election.id, auditboard.id))
+
+
+# Test endpoint for the session.
+@app.route('/incr')
+def incr():
+    if 'count' in session:
+        session['count'] += 1
+    else:
+        session['count'] = 1
+
+    return jsonify(count=session['count'])
 
 
 # React App

--- a/arlo_server/base.py
+++ b/arlo_server/base.py
@@ -1,4 +1,5 @@
 from flask import Flask
-from config import STATIC_FOLDER
+from config import STATIC_FOLDER, SESSION_SECRET
 
 app = Flask(__name__, static_folder=STATIC_FOLDER)
+app.secret_key = SESSION_SECRET

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -37,3 +37,21 @@ DATABASE_URL = read_database_url_config()
 STATIC_FOLDER = os.path.normpath(
     os.path.join(__file__, '..', '..', 'arlo-client',
                  'public' if os.environ.get('FLASK_ENV') == 'test' else 'build'))
+
+
+def read_session_secret() -> str:
+    session_secret = os.environ.get('ARLO_SESSION_SECRET', None)
+
+    if not session_secret:
+        flask_env = os.environ.get('FLASK_ENV', 'development')
+
+        if flask_env == 'development' or flask_env == 'test':
+            # Allow omitting in development, use a fixed secret instead.
+            session_secret = f'arlo-{flask_env}-session-secret-v1'
+        else:
+            raise Exception("ARLO_SESSION_SECRET env var for managing sessions is missing")
+
+    return session_secret
+
+
+SESSION_SECRET = read_session_secret()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -41,6 +41,14 @@ def test_index(client):
     assert b'Arlo (by VotingWorks)' in rv.data
 
 
+def test_session(client):
+    rv = client.get('/incr')
+    assert json.loads(rv.data) == {'count': 1}
+
+    rv = client.get('/incr')
+    assert json.loads(rv.data) == {'count': 2}
+
+
 def test_whole_audit_flow(client):
     rv = post_json(client, '/election/new', {})
     election_id_1 = json.loads(rv.data)['electionId']


### PR DESCRIPTION
This provides a cookie-based application session with a secret key from `ARLO_SESSION_SECRET`. If not provided in development or test, a fixed one will be used instead.
