### PR TITLE
Freeze flag and API

### DIFF
--- a/arlo-client/src/components/AuditForms/EstimateSampleSize.test.tsx
+++ b/arlo-client/src/components/AuditForms/EstimateSampleSize.test.tsx
@@ -475,9 +475,12 @@ describe('EstimateSampleSize', () => {
     await wait(() => {
       const { body } = apiMock.mock.calls[0][1] as { body: string }
       expect(setIsLoadingMock).toBeCalledTimes(2)
-      expect(apiMock).toBeCalledTimes(1)
+      expect(apiMock).toBeCalledTimes(2)
       expect(apiMock.mock.calls[0][0]).toMatch(
         /\/election\/[^/]+\/audit\/basic/
+      )
+      expect(apiMock.mock.calls[1][0]).toMatch(
+        /\/election\/[^/]+\/audit\/freeze/
       )
       expect(JSON.parse(body)).toMatchObject(estimateSampleSizeMocks.post.body)
       expect(getStatusMock).toBeCalledTimes(3)

--- a/arlo-client/src/components/AuditForms/EstimateSampleSize.test.tsx
+++ b/arlo-client/src/components/AuditForms/EstimateSampleSize.test.tsx
@@ -715,7 +715,7 @@ describe('EstimateSampleSize', () => {
 
   it('handles errors from the server side', async () => {
     apiMock.mockReset()
-    checkAndToastMock.mockReturnValueOnce(true) // checkAndToast returns true if there's an error from the server
+    checkAndToastMock.mockReturnValueOnce(true)
     const updateAuditMock = jest.fn()
     const { getByLabelText, getByText } = render(
       <EstimateSampleSize
@@ -741,6 +741,39 @@ describe('EstimateSampleSize', () => {
     await wait(() => {
       expect(checkAndToastMock).toBeCalledTimes(1)
       expect(apiMock).toBeCalledTimes(1)
+      expect(toastSpy).toBeCalledTimes(0)
+      expect(updateAuditMock).toBeCalledTimes(0)
+    })
+  })
+
+  it('handles errors from server side on freeze call', async () => {
+    apiMock.mockReset()
+    checkAndToastMock.mockReturnValueOnce(false).mockReturnValueOnce(true)
+    const updateAuditMock = jest.fn()
+    const { getByLabelText, getByText } = render(
+      <EstimateSampleSize
+        audit={statusStates[0]}
+        isLoading={false}
+        setIsLoading={jest.fn()}
+        updateAudit={updateAuditMock}
+        getStatus={jest.fn()}
+        electionId="1"
+      />
+    )
+
+    estimateSampleSizeMocks.inputs.forEach(inputData => {
+      const input = getByLabelText(new RegExp(regexpEscape(inputData.key)), {
+        selector: 'input',
+      }) as HTMLInputElement
+      fireEvent.change(input, { target: { value: inputData.value } })
+      expect(input.value).toBe(inputData.value)
+    })
+
+    fireEvent.click(getByText('Estimate Sample Size'), { bubbles: true })
+
+    await wait(() => {
+      expect(checkAndToastMock).toBeCalledTimes(2)
+      expect(apiMock).toBeCalledTimes(2)
       expect(toastSpy).toBeCalledTimes(0)
       expect(updateAuditMock).toBeCalledTimes(0)
     })

--- a/arlo-client/src/components/AuditForms/EstimateSampleSize.tsx
+++ b/arlo-client/src/components/AuditForms/EstimateSampleSize.tsx
@@ -215,6 +215,18 @@ const EstimateSampleSize: React.FC<IProps> = ({
         setIsLoading(false)
         return
       }
+
+      const freezeResponse: IErrorResponse = await api(
+        `/election/${electionId}/audit/freeze`,
+        {
+          method: 'POST',
+        }
+      )
+      if (checkAndToast(freezeResponse)) {
+        setIsLoading(false)
+        return
+      }
+
       const condition = async () => {
         const { rounds } = await getStatus()
         return (

--- a/models.py
+++ b/models.py
@@ -31,6 +31,8 @@ class Election(db.Model):
                                 db.ForeignKey('organization.id', ondelete='cascade'),
                                 nullable=False)
 
+    frozen_at = db.Column(db.DateTime(timezone=False), nullable=True)
+
     jurisdictions = relationship('Jurisdiction', backref='election', passive_deletes=True)
     contests = relationship('TargetedContest', backref='election', passive_deletes=True)
     rounds = relationship('Round', backref='election', passive_deletes=True)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -508,8 +508,17 @@ def test_small_election(client):
 
     assert json.loads(rv.data)['status'] == "ok"
 
+    # not yet frozen
+    rv = client.get(f'/election/{election_id}/audit/status')
+    assert not json.loads(rv.data)["frozenAt"]
+
     rv = post_json(client, f"/election/{election_id}/audit/freeze", {})
     assert json.loads(rv.data)['status'] == "ok"
+
+    # now frozen
+    rv = client.get(f'/election/{election_id}/audit/status')
+    assert json.loads(rv.data)["frozenAt"]
+
     bgcompute.bgcompute()
 
     rv = client.get(f'/election/{election_id}/audit/status')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -517,7 +517,15 @@ def test_small_election(client):
 
     # now frozen
     rv = client.get(f'/election/{election_id}/audit/status')
-    assert json.loads(rv.data)["frozenAt"]
+    frozen_at = json.loads(rv.data)["frozenAt"]
+    assert frozen_at
+
+    # make sure freezing twice doesn't change frozen date
+    rv = post_json(client, f"/election/{election_id}/audit/freeze", {})
+    rv = client.get(f'/election/{election_id}/audit/status')
+    frozen_at_2 = json.loads(rv.data)["frozenAt"]
+
+    assert frozen_at == frozen_at_2
 
     bgcompute.bgcompute()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -122,6 +122,9 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed):
 
     assert json.loads(rv.data)['status'] == "ok"
 
+    rv = post_json(client, f"{url_prefix}/audit/freeze", {})
+    assert json.loads(rv.data)['status'] == "ok"
+
     # before background compute, should be null sample size options
     rv = client.get('{}/audit/status'.format(url_prefix))
     status = json.loads(rv.data)
@@ -288,6 +291,9 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
             }]
         })
 
+    assert json.loads(rv.data)['status'] == "ok"
+
+    rv = post_json(client, f"{url_prefix}/audit/freeze", {})
     assert json.loads(rv.data)['status'] == "ok"
 
     # before background compute, should be null sample size options
@@ -502,7 +508,10 @@ def test_small_election(client):
 
     assert json.loads(rv.data)['status'] == "ok"
 
+    rv = post_json(client, f"/election/{election_id}/audit/freeze", {})
+    assert json.loads(rv.data)['status'] == "ok"
     bgcompute.bgcompute()
+
     rv = client.get(f'/election/{election_id}/audit/status')
     status = json.loads(rv.data)
 
@@ -816,7 +825,6 @@ def test_multi_winner_election(client):
 
     assert json.loads(rv.data)['status'] == "ok"
 
-    bgcompute.bgcompute()
     rv = client.get(f'/election/{election_id}/audit/status')
     status = json.loads(rv.data)
 
@@ -847,6 +855,10 @@ def test_multi_winner_election(client):
         })
 
     assert json.loads(rv.data)['status'] == 'ok'
+
+    rv = post_json(client, f"/election/{election_id}/audit/freeze", {})
+    assert json.loads(rv.data)['status'] == "ok"
+    bgcompute.bgcompute()
 
     rv = client.get(f'/election/{election_id}/audit/status')
     status = json.loads(rv.data)


### PR DESCRIPTION
addresses #301, see that ticket for motivation.

@MorganLove this tweaks the API calls so that `/audit/basic` no longer starts the first round. It just updates the data. You have to explicitly call `/audit/freeze` to mark the audit frozen, and then the `rounds` property appears and the sample set sizes are computed.
