### PR TITLE
Home list of audits

### DIFF
--- a/arlo-client/src/__snapshots__/App.test.tsx.snap
+++ b/arlo-client/src/__snapshots__/App.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`App renders properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-fBuWsC eQKFyT"
+    class="sc-fMiknA bGVoxC"
   >
     <div
       class="bp3-navbar bp3-fixed-top sc-htpNat ocefa"

--- a/arlo-client/src/components/CreateAudit.test.tsx
+++ b/arlo-client/src/components/CreateAudit.test.tsx
@@ -93,7 +93,8 @@ describe('CreateAudit', () => {
       expect(apiMock).toBeCalledTimes(2)
       expect(apiMock).toHaveBeenNthCalledWith(2, '/election/new', {
         method: 'POST',
-        body: JSON.stringify({ organization: 'org-id' }),
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        body: JSON.stringify({ organization_id: 'org-id' }),
       })
       expect(historySpy).toBeCalledTimes(1)
       expect(historySpy).toHaveBeenNthCalledWith(1, '/election/1')

--- a/arlo-client/src/components/CreateAudit.test.tsx
+++ b/arlo-client/src/components/CreateAudit.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { render, fireEvent, wait } from '@testing-library/react'
 import { toast } from 'react-toastify'
-import { RouteComponentProps } from 'react-router-dom'
+import { RouteComponentProps, BrowserRouter as Router } from 'react-router-dom'
 import CreateAudit from './CreateAudit'
 import { ICreateAuditParams } from '../types'
 import { routerTestProps } from './testUtilities'
 import * as utilities from './utilities'
+import AuthDataProvider from './UserContext'
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
@@ -42,7 +43,7 @@ describe('CreateAudit', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('calls the /election/new endpoint', async () => {
+  it('calls the /election/new endpoint for nonauthenticated user', async () => {
     apiMock.mockImplementation(async () => ({ electionId: '1' }))
     const { getByText } = render(<CreateAudit {...routeProps} />)
 
@@ -50,9 +51,144 @@ describe('CreateAudit', () => {
 
     await wait(() => {
       expect(apiMock).toBeCalledTimes(1)
-      expect(apiMock.mock.calls[0][0]).toBe('/election/new')
+      expect(apiMock).toHaveBeenNthCalledWith(1, '/election/new', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      })
       expect(historySpy).toBeCalledTimes(1)
-      expect(historySpy.mock.calls[0][0]).toBe('/election/1')
+      expect(historySpy).toHaveBeenNthCalledWith(1, '/election/1')
+    })
+  })
+
+  it('calls the /election/new endpoint for authenticated user', async () => {
+    apiMock
+      .mockImplementationOnce(async () => ({
+        type: 'audit_admin',
+        name: 'Joe',
+        email: 'test@email.org',
+        jurisdictions: [],
+        organizations: [
+          {
+            id: 'org-id',
+            name: 'State',
+            elections: [],
+          },
+        ],
+      }))
+      .mockImplementationOnce(async () => ({ electionId: '1' }))
+    const { getByText } = render(
+      <AuthDataProvider>
+        <CreateAudit {...routeProps} />
+      </AuthDataProvider>
+    )
+
+    await wait(() => {
+      expect(apiMock).toBeCalledTimes(1)
+      expect(apiMock).toHaveBeenNthCalledWith(1, '/auth/me')
+    })
+
+    fireEvent.click(getByText('Create a New Audit'), { bubbles: true })
+
+    await wait(() => {
+      expect(apiMock).toBeCalledTimes(2)
+      expect(apiMock).toHaveBeenNthCalledWith(2, '/election/new', {
+        method: 'POST',
+        body: JSON.stringify({ organization: 'org-id' }),
+      })
+      expect(historySpy).toBeCalledTimes(1)
+      expect(historySpy).toHaveBeenNthCalledWith(1, '/election/1')
+    })
+  })
+
+  it('lists associated elections for authenticated AA user', async () => {
+    apiMock.mockImplementationOnce(async () => ({
+      type: 'audit_admin',
+      name: 'Joe',
+      email: 'test@email.org',
+      jurisdictions: [],
+      organizations: [
+        {
+          id: 'org-id',
+          name: 'State',
+          elections: [
+            {
+              id: 'election-1',
+              name: '',
+              state: 'NY',
+            },
+            {
+              id: 'election-2',
+              name: 'Election Two',
+              state: 'FL',
+            },
+            {
+              id: 'election-3',
+              name: 'Election Three',
+              state: '',
+            },
+            {
+              id: 'election-4',
+              name: 'Election Four',
+              state: 'WA',
+            },
+          ],
+        },
+      ],
+    }))
+    const { container } = render(
+      <Router>
+        <AuthDataProvider>
+          <CreateAudit {...routeProps} />
+        </AuthDataProvider>
+      </Router>
+    )
+
+    await wait(() => {
+      expect(apiMock).toBeCalledTimes(1)
+      expect(apiMock).toHaveBeenNthCalledWith(1, '/auth/me')
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  it('lists associated elections for authenticated JA user', async () => {
+    apiMock.mockImplementationOnce(async () => ({
+      type: 'audit_admin',
+      name: 'Joe',
+      email: 'test@email.org',
+      jurisdictions: [
+        {
+          id: 'jurisdiction-1',
+          name: 'County One',
+          election: {
+            id: 'election-1',
+            name: 'Election One',
+            state: 'NY',
+          },
+        },
+        {
+          id: 'jurisdiction-2',
+          name: 'County Two',
+          election: {
+            id: 'election-2',
+            name: '',
+            state: '',
+          },
+        },
+      ],
+      organizations: [],
+    }))
+    const { container } = render(
+      <Router>
+        <AuthDataProvider>
+          <CreateAudit {...routeProps} />
+        </AuthDataProvider>
+      </Router>
+    )
+
+    await wait(() => {
+      expect(apiMock).toBeCalledTimes(1)
+      expect(apiMock).toHaveBeenNthCalledWith(1, '/auth/me')
+      expect(container).toMatchSnapshot()
     })
   })
 

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 import { toast } from 'react-toastify'
-import { RouteComponentProps } from 'react-router-dom'
+import { RouteComponentProps, Link } from 'react-router-dom'
 import FormButton from './Form/FormButton'
 import { api, checkAndToast } from './utilities'
-import { ICreateAuditParams, IErrorResponse } from '../types'
+import { ICreateAuditParams, IErrorResponse, IOrganizationMeta } from '../types'
 import { useAuthDataContext } from './UserContext'
 
 const Button = styled(FormButton)`
@@ -22,8 +22,17 @@ const Wrapper = styled.div`
   }
 `
 
+const AuditLink = styled(Link)`
+  display: block;
+  margin: 10px;
+
+  &:first-of-type {
+    margin-top: 30px;
+  }
+`
+
 const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
-  const { isAuthenticated } = useAuthDataContext()
+  const { isAuthenticated, meta } = useAuthDataContext()
 
   const [loading, setLoading] = useState(false)
   const onClick = async () => {
@@ -58,7 +67,7 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
       >
         Create a New Audit
       </Button>
-      {!isAuthenticated && (
+      {!isAuthenticated ? (
         <>
           <Button
             type="button"
@@ -88,6 +97,51 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
           >
             Log in as a Jurisdiction Admin
           </Button>
+        </>
+      ) : (
+        <>
+          {meta!.organizations.length > 0 &&
+            [
+              ...meta!.organizations,
+              {
+                id: 'oID',
+                name: 'Organization name',
+                elections: [
+                  {
+                    id: '542e2803-bd10-44d6-af1e-0858cda23432',
+                    name: 'Election name 1',
+                    state: 'WA',
+                  },
+                  {
+                    id: '542e2803-bd10-44d6-af1e-0858cda23432',
+                    name: 'Election name 2',
+                    state: '',
+                  },
+                ],
+              } as IOrganizationMeta,
+            ].map(o =>
+              o.elections.map(election => (
+                <AuditLink
+                  to={`/election/${election.id}`}
+                  key={election.id}
+                  className="bp3-button bp3-intent-primary"
+                >
+                  {election.name || 'Not named yet'}
+                  {election.state && ` (${election.state})`}
+                </AuditLink>
+              ))
+            )}
+          {meta!.jurisdictions.length > 0 &&
+            meta!.jurisdictions.map(({ election }) => (
+              <AuditLink
+                to={`/election/${election.id}`}
+                key={election.id}
+                className="bp3-button bp3-intent-primary"
+              >
+                {election.name || 'Not named yet'}
+                {election.state && ` (${election.state})`}
+              </AuditLink>
+            ))}
         </>
       )}
     </Wrapper>

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -39,7 +39,8 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
     try {
       setLoading(true)
       const data = isAuthenticated
-        ? { organization: meta!.organizations[0].id }
+        ? // eslint-disable-next-line @typescript-eslint/camelcase
+          { organization_id: meta!.organizations[0].id }
         : {}
       const response: { electionId: string } | IErrorResponse = await api(
         '/election/new',

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -38,10 +38,14 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
   const onClick = async () => {
     try {
       setLoading(true)
+      const data = isAuthenticated
+        ? { organization: meta!.organizations[0].id }
+        : {}
       const response: { electionId: string } | IErrorResponse = await api(
         '/election/new',
         {
           method: 'POST',
+          body: JSON.stringify(data),
         }
       )
       if (checkAndToast(response)) {

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -4,7 +4,7 @@ import { toast } from 'react-toastify'
 import { RouteComponentProps, Link } from 'react-router-dom'
 import FormButton from './Form/FormButton'
 import { api, checkAndToast } from './utilities'
-import { ICreateAuditParams, IErrorResponse, IOrganizationMeta } from '../types'
+import { ICreateAuditParams, IErrorResponse } from '../types'
 import { useAuthDataContext } from './UserContext'
 
 const Button = styled(FormButton)`
@@ -105,25 +105,7 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
       ) : (
         <>
           {meta!.organizations.length > 0 &&
-            [
-              ...meta!.organizations,
-              {
-                id: 'oID',
-                name: 'Organization name',
-                elections: [
-                  {
-                    id: '542e2803-bd10-44d6-af1e-0858cda23432',
-                    name: 'Election name 1',
-                    state: 'WA',
-                  },
-                  {
-                    id: '542e2803-bd10-44d6-af1e-0858cda23432',
-                    name: 'Election name 2',
-                    state: '',
-                  },
-                ],
-              } as IOrganizationMeta,
-            ].map(o =>
+            meta!.organizations.map(o =>
               o.elections.map(election => (
                 <AuditLink
                   to={`/election/${election.id}`}

--- a/arlo-client/src/components/__snapshots__/CreateAudit.test.tsx.snap
+++ b/arlo-client/src/components/__snapshots__/CreateAudit.test.tsx.snap
@@ -1,5 +1,95 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CreateAudit lists associated elections for authenticated AA user 1`] = `
+<div>
+  <div
+    class="sc-htpNat dgtpPg"
+  >
+    <img
+      alt="Arlo, by VotingWorks"
+      height="50px"
+      src="/arlo.png"
+    />
+    <button
+      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-bwzfXH fdlCQb sc-bdVaJa gLVjYw"
+      type="button"
+    >
+      <span
+        class="bp3-button-text"
+      >
+        Create a New Audit
+      </span>
+    </button>
+    <a
+      class="bp3-button bp3-intent-primary sc-bxivhb cQgiba"
+      href="/election/election-1"
+    >
+      Not named yet
+       (NY)
+    </a>
+    <a
+      class="bp3-button bp3-intent-primary sc-bxivhb cQgiba"
+      href="/election/election-2"
+    >
+      Election Two
+       (FL)
+    </a>
+    <a
+      class="bp3-button bp3-intent-primary sc-bxivhb cQgiba"
+      href="/election/election-3"
+    >
+      Election Three
+      
+    </a>
+    <a
+      class="bp3-button bp3-intent-primary sc-bxivhb cQgiba"
+      href="/election/election-4"
+    >
+      Election Four
+       (WA)
+    </a>
+  </div>
+</div>
+`;
+
+exports[`CreateAudit lists associated elections for authenticated JA user 1`] = `
+<div>
+  <div
+    class="sc-htpNat dgtpPg"
+  >
+    <img
+      alt="Arlo, by VotingWorks"
+      height="50px"
+      src="/arlo.png"
+    />
+    <button
+      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-bwzfXH fdlCQb sc-bdVaJa gLVjYw"
+      type="button"
+    >
+      <span
+        class="bp3-button-text"
+      >
+        Create a New Audit
+      </span>
+    </button>
+    <a
+      class="bp3-button bp3-intent-primary sc-bxivhb cQgiba"
+      href="/election/election-1"
+    >
+      Election One
+       (NY)
+    </a>
+    <a
+      class="bp3-button bp3-intent-primary sc-bxivhb cQgiba"
+      href="/election/election-2"
+    >
+      Not named yet
+      
+    </a>
+  </div>
+</div>
+`;
+
 exports[`CreateAudit renders correctly 1`] = `
 <div>
   <div

--- a/arlo-client/src/types.ts
+++ b/arlo-client/src/types.ts
@@ -129,16 +129,24 @@ export interface IAudit {
   rounds: IRound[]
 }
 
+export interface IElectionMeta {
+  id: string
+  name: string
+  state: string
+  // eslint-disable-next-line camelcase
+  election_date: string
+}
+
 export interface IOrganizationMeta {
   id: string
   name: string
+  elections: IElectionMeta[]
 }
 
 export interface IJurisdictionMeta {
   id: string
   name: string
-  // eslint-disable-next-line camelcase
-  election_id: string
+  election: IElectionMeta
 }
 
 export interface IUserMeta {


### PR DESCRIPTION
**Description**

- lists the audits currently associated with the authenticated user on the home page as link buttons
- POSTs the organization ID of an authenticated AA user to the `/election/new` endpoint so it can be associated with it

**New Tests**

- Testing of new endpoint usage
- Updated snapshots

**Notes**

- When new audits are created, they aren't associated with the authenticated user, so that needs to be done on this PR for it to be functional. @benadida can you do that? EDIT: this will take place on the backend in another PR to match up with this one.

-As it is currently, I am injecting dummy data in to demonstrate the styling. That will be removed before this is merged. EDIT: now cleaned up.