### PR TITLE
Toggle online/offline repositioning

### DIFF
--- a/arlo-client/src/components/AuditForms/EstimateSampleSize.test.tsx
+++ b/arlo-client/src/components/AuditForms/EstimateSampleSize.test.tsx
@@ -342,41 +342,6 @@ describe('EstimateSampleSize', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('changes audits to be offline and online', () => {
-    const { getByLabelText } = render(
-      <EstimateSampleSize
-        audit={statusStates[0]}
-        isLoading={false}
-        setIsLoading={jest.fn()}
-        updateAudit={jest.fn()}
-        getStatus={jest.fn()}
-        electionId="1"
-      />
-    )
-
-    const auditToggleOffline = getByLabelText(
-      new RegExp(regexpEscape('Offline')),
-      {
-        selector: 'select',
-      }
-    )
-    expect(auditToggleOffline).toBeInstanceOf(HTMLInputElement)
-    if (auditToggleOffline instanceof HTMLInputElement) {
-      fireEvent.click(auditToggleOffline, { bubbles: true })
-    }
-
-    const auditToggleOnline = getByLabelText(
-      new RegExp(regexpEscape('Online')),
-      {
-        selector: 'select',
-      }
-    )
-    expect(auditToggleOnline).toBeInstanceOf(HTMLInputElement)
-    if (auditToggleOnline instanceof HTMLInputElement) {
-      fireEvent.click(auditToggleOnline, { bubbles: true })
-    }
-  })
-
   it.skip('adds and removes contests', async () => {
     // skip until feature is complete in backend
     const { getByText, getAllByText, queryByText } = render(

--- a/arlo-client/src/components/AuditForms/EstimateSampleSize.tsx
+++ b/arlo-client/src/components/AuditForms/EstimateSampleSize.tsx
@@ -11,13 +11,7 @@ import {
 } from 'formik'
 import * as Yup from 'yup'
 import uuidv4 from 'uuidv4'
-import {
-  HTMLSelect,
-  Label,
-  Spinner,
-  RadioGroup,
-  Radio,
-} from '@blueprintjs/core'
+import { HTMLSelect, Label, Spinner } from '@blueprintjs/core'
 import FormSection, { FormSectionDescription } from '../Form/FormSection'
 import FormWrapper from '../Form/FormWrapper'
 import FormTitle from '../Form/FormTitle'
@@ -100,7 +94,6 @@ interface IContestValues {
 
 interface IEstimateSampleSizeValues {
   name: string
-  online: boolean
   randomSeed: string
   riskLimit: string
   contests: IContestValues[]
@@ -183,7 +176,7 @@ const EstimateSampleSize: React.FC<IProps> = ({
   const handlePost = async (values: IEstimateSampleSizeValues) => {
     const data = {
       name: values.name,
-      online: values.online,
+      online: true, // hardcoded here, is updated in form two if needed
       randomSeed: values.randomSeed,
       riskLimit: parseNumber(values.riskLimit),
       contests: values.contests.map(contest => ({
@@ -268,7 +261,6 @@ const EstimateSampleSize: React.FC<IProps> = ({
     randomSeed: audit.randomSeed || '',
     riskLimit: audit.riskLimit || '10',
     name: audit.name || '',
-    online: audit.online,
     contests: audit.contests.length ? audit.contests : contestValues,
   }
 
@@ -462,19 +454,6 @@ const EstimateSampleSize: React.FC<IProps> = ({
                 )}
               />
               <FormTitle>Audit Settings</FormTitle>
-              <FormSection>
-                <RadioGroup
-                  name="online"
-                  onChange={e =>
-                    setFieldValue('online', e.currentTarget.value === 'online')
-                  }
-                  selectedValue={values.online ? 'online' : 'offline'}
-                  disabled={!canEstimateSampleSize}
-                >
-                  <Radio value="online">Online</Radio>
-                  <Radio value="offline">Offline</Radio>
-                </RadioGroup>
-              </FormSection>
               <FormSection label="Desired Risk Limit">
                 <label htmlFor="risk-limit">
                   Set the risk for the audit as a percentage (e.g. &quot;5&quot;

--- a/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
+++ b/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
@@ -121,8 +121,11 @@ const SelectBallotsToAudit: React.FC<IProps> = ({
 
       // update 'online' for audit
       const auditData = {
-        ...audit,
+        contests: [], // empty because we don't want to recreate them
         online: values.online,
+        name: audit.name,
+        riskLimit: audit.riskLimit,
+        randomSeed: audit.randomSeed,
       }
       const basicResponse: IErrorResponse = await api(
         `/election/${electionId}/audit/basic`,

--- a/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
+++ b/arlo-client/src/components/AuditForms/SelectBallotsToAudit.tsx
@@ -70,6 +70,7 @@ interface IProps {
 }
 
 interface ISelectBallotsToAuditValues {
+  online: boolean
   auditBoards: string
   auditNames: string[]
   manifest: File | null
@@ -117,6 +118,23 @@ const SelectBallotsToAudit: React.FC<IProps> = ({
           members: [],
         }
       })
+
+      // update 'online' for audit
+      const auditData = {
+        ...audit,
+        online: values.online,
+      }
+      const basicResponse: IErrorResponse = await api(
+        `/election/${electionId}/audit/basic`,
+        {
+          method: 'POST',
+          body: JSON.stringify(auditData),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+      if (checkAndToast(basicResponse)) return
 
       // upload jurisdictions
       const data: IJurisdiction[] = [
@@ -194,6 +212,7 @@ const SelectBallotsToAudit: React.FC<IProps> = ({
         )
       : Array(numberOfBoards).fill('')
   const initialState: ISelectBallotsToAuditValues = {
+    online: true,
     auditBoards: `${numberOfBoards}`,
     auditNames,
     manifest: null,
@@ -376,6 +395,22 @@ const SelectBallotsToAudit: React.FC<IProps> = ({
                     </label>
                     <FormSectionDescription>
                       Audit boards will enter data about each ballot:
+                      <FormSection>
+                        <RadioGroup
+                          name="online"
+                          onChange={e =>
+                            setFieldValue(
+                              'online',
+                              e.currentTarget.value === 'online'
+                            )
+                          }
+                          selectedValue={values.online ? 'online' : 'offline'}
+                          disabled={sampleSizeSelected}
+                        >
+                          <Radio value="online">Online</Radio>
+                          <Radio value="offline">Offline</Radio>
+                        </RadioGroup>
+                      </FormSection>
                     </FormSectionDescription>
                     <AuditBoardsWrapper>
                       {values.auditNames.map((name, i) => (

--- a/arlo-client/src/components/AuditForms/__snapshots__/EstimateSampleSize.test.tsx.snap
+++ b/arlo-client/src/components/AuditForms/__snapshots__/EstimateSampleSize.test.tsx.snap
@@ -294,41 +294,6 @@ exports[`EstimateSampleSize renders after contests creation correctly 1`] = `
       <div
         class="sc-bdVaJa fdbLH"
       >
-        <div>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              checked=""
-              disabled=""
-              name="online"
-              type="radio"
-              value="online"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Online
-          </label>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              disabled=""
-              name="online"
-              type="radio"
-              value="offline"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Offline
-          </label>
-        </div>
-      </div>
-      <div
-        class="sc-bdVaJa fdbLH"
-      >
         <h3
           class="bp3-heading sc-htpNat cNFUHJ"
         >
@@ -751,41 +716,6 @@ exports[`EstimateSampleSize renders after contests creation correctly 2`] = `
       >
         Audit Settings
       </h2>
-      <div
-        class="sc-bdVaJa fdbLH"
-      >
-        <div>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              checked=""
-              disabled=""
-              name="online"
-              type="radio"
-              value="online"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Online
-          </label>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              disabled=""
-              name="online"
-              type="radio"
-              value="offline"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Offline
-          </label>
-        </div>
-      </div>
       <div
         class="sc-bdVaJa fdbLH"
       >
@@ -1240,41 +1170,6 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 1`] = `
       <div
         class="sc-bdVaJa fdbLH"
       >
-        <div>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              checked=""
-              disabled=""
-              name="online"
-              type="radio"
-              value="online"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Online
-          </label>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              disabled=""
-              name="online"
-              type="radio"
-              value="offline"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Offline
-          </label>
-        </div>
-      </div>
-      <div
-        class="sc-bdVaJa fdbLH"
-      >
         <h3
           class="bp3-heading sc-htpNat cNFUHJ"
         >
@@ -1697,41 +1592,6 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 2`] = `
       >
         Audit Settings
       </h2>
-      <div
-        class="sc-bdVaJa fdbLH"
-      >
-        <div>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              checked=""
-              disabled=""
-              name="online"
-              type="radio"
-              value="online"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Online
-          </label>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              disabled=""
-              name="online"
-              type="radio"
-              value="offline"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Offline
-          </label>
-        </div>
-      </div>
       <div
         class="sc-bdVaJa fdbLH"
       >
@@ -2186,41 +2046,6 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 1`]
       <div
         class="sc-bdVaJa fdbLH"
       >
-        <div>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              checked=""
-              disabled=""
-              name="online"
-              type="radio"
-              value="online"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Online
-          </label>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              disabled=""
-              name="online"
-              type="radio"
-              value="offline"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Offline
-          </label>
-        </div>
-      </div>
-      <div
-        class="sc-bdVaJa fdbLH"
-      >
         <h3
           class="bp3-heading sc-htpNat cNFUHJ"
         >
@@ -2643,41 +2468,6 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 2`]
       >
         Audit Settings
       </h2>
-      <div
-        class="sc-bdVaJa fdbLH"
-      >
-        <div>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              checked=""
-              disabled=""
-              name="online"
-              type="radio"
-              value="online"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Online
-          </label>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              disabled=""
-              name="online"
-              type="radio"
-              value="offline"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Offline
-          </label>
-        </div>
-      </div>
       <div
         class="sc-bdVaJa fdbLH"
       >
@@ -3132,41 +2922,6 @@ exports[`EstimateSampleSize renders during rounds stage correctly 1`] = `
       <div
         class="sc-bdVaJa fdbLH"
       >
-        <div>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              checked=""
-              disabled=""
-              name="online"
-              type="radio"
-              value="online"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Online
-          </label>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              disabled=""
-              name="online"
-              type="radio"
-              value="offline"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Offline
-          </label>
-        </div>
-      </div>
-      <div
-        class="sc-bdVaJa fdbLH"
-      >
         <h3
           class="bp3-heading sc-htpNat cNFUHJ"
         >
@@ -3589,41 +3344,6 @@ exports[`EstimateSampleSize renders during rounds stage correctly 2`] = `
       >
         Audit Settings
       </h2>
-      <div
-        class="sc-bdVaJa fdbLH"
-      >
-        <div>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              checked=""
-              disabled=""
-              name="online"
-              type="radio"
-              value="online"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Online
-          </label>
-          <label
-            class="bp3-control bp3-radio bp3-disabled"
-          >
-            <input
-              disabled=""
-              name="online"
-              type="radio"
-              value="offline"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Offline
-          </label>
-        </div>
-      </div>
       <div
         class="sc-bdVaJa fdbLH"
       >
@@ -4074,39 +3794,6 @@ exports[`EstimateSampleSize renders empty state correctly 1`] = `
       <div
         class="sc-bdVaJa fdbLH"
       >
-        <div>
-          <label
-            class="bp3-control bp3-radio"
-          >
-            <input
-              checked=""
-              name="online"
-              type="radio"
-              value="online"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Online
-          </label>
-          <label
-            class="bp3-control bp3-radio"
-          >
-            <input
-              name="online"
-              type="radio"
-              value="offline"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Offline
-          </label>
-        </div>
-      </div>
-      <div
-        class="sc-bdVaJa fdbLH"
-      >
         <h3
           class="bp3-heading sc-htpNat cNFUHJ"
         >
@@ -4537,39 +4224,6 @@ exports[`EstimateSampleSize renders empty state correctly 2`] = `
       >
         Audit Settings
       </h2>
-      <div
-        class="sc-bdVaJa fdbLH"
-      >
-        <div>
-          <label
-            class="bp3-control bp3-radio"
-          >
-            <input
-              checked=""
-              name="online"
-              type="radio"
-              value="online"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Online
-          </label>
-          <label
-            class="bp3-control bp3-radio"
-          >
-            <input
-              name="online"
-              type="radio"
-              value="offline"
-            />
-            <span
-              class="bp3-control-indicator"
-            />
-            Offline
-          </label>
-        </div>
-      </div>
       <div
         class="sc-bdVaJa fdbLH"
       >

--- a/arlo-client/src/components/AuditForms/__snapshots__/SelectBallotsToAudit.test.tsx.snap
+++ b/arlo-client/src/components/AuditForms/__snapshots__/SelectBallotsToAudit.test.tsx.snap
@@ -109,6 +109,39 @@ exports[`SelectBallotsToAudit changes number of audits 1`] = `
           class="sc-bwzfXH izcbHX"
         >
           Audit boards will enter data about each ballot:
+          <div
+            class="sc-bdVaJa fdbLH"
+          >
+            <div>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  checked=""
+                  name="online"
+                  type="radio"
+                  value="online"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Online
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="online"
+                  type="radio"
+                  value="offline"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Offline
+              </label>
+            </div>
+          </div>
         </div>
         <div
           class="sc-jTzLTM jLWsng"
@@ -280,6 +313,39 @@ exports[`SelectBallotsToAudit changes number of audits 2`] = `
           class="sc-bwzfXH izcbHX"
         >
           Audit boards will enter data about each ballot:
+          <div
+            class="sc-bdVaJa fdbLH"
+          >
+            <div>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  checked=""
+                  name="online"
+                  type="radio"
+                  value="online"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Online
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="online"
+                  type="radio"
+                  value="offline"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Offline
+              </label>
+            </div>
+          </div>
         </div>
         <div
           class="sc-jTzLTM jLWsng"
@@ -448,6 +514,39 @@ exports[`SelectBallotsToAudit renders correctly 1`] = `
           class="sc-bwzfXH izcbHX"
         >
           Audit boards will enter data about each ballot:
+          <div
+            class="sc-bdVaJa fdbLH"
+          >
+            <div>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  checked=""
+                  name="online"
+                  type="radio"
+                  value="online"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Online
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="online"
+                  type="radio"
+                  value="offline"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Offline
+              </label>
+            </div>
+          </div>
         </div>
         <div
           class="sc-jTzLTM jLWsng"
@@ -613,6 +712,39 @@ exports[`SelectBallotsToAudit renders correctly 2`] = `
           class="sc-bwzfXH izcbHX"
         >
           Audit boards will enter data about each ballot:
+          <div
+            class="sc-bdVaJa fdbLH"
+          >
+            <div>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  checked=""
+                  name="online"
+                  type="radio"
+                  value="online"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Online
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="online"
+                  type="radio"
+                  value="offline"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Offline
+              </label>
+            </div>
+          </div>
         </div>
         <div
           class="sc-jTzLTM jLWsng"

--- a/arlo-client/src/components/AuditForms/__snapshots__/index.test.tsx.snap
+++ b/arlo-client/src/components/AuditForms/__snapshots__/index.test.tsx.snap
@@ -289,41 +289,6 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
         <div
           class="sc-bdVaJa fdbLH"
         >
-          <div>
-            <label
-              class="bp3-control bp3-radio bp3-disabled"
-            >
-              <input
-                checked=""
-                disabled=""
-                name="online"
-                type="radio"
-                value="online"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Online
-            </label>
-            <label
-              class="bp3-control bp3-radio bp3-disabled"
-            >
-              <input
-                disabled=""
-                name="online"
-                type="radio"
-                value="offline"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Offline
-            </label>
-          </div>
-        </div>
-        <div
-          class="sc-bdVaJa fdbLH"
-        >
           <h3
             class="bp3-heading sc-htpNat cNFUHJ"
           >
@@ -646,6 +611,39 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
             class="sc-bwzfXH izcbHX"
           >
             Audit boards will enter data about each ballot:
+            <div
+              class="sc-bdVaJa fdbLH"
+            >
+              <div>
+                <label
+                  class="bp3-control bp3-radio"
+                >
+                  <input
+                    checked=""
+                    name="online"
+                    type="radio"
+                    value="online"
+                  />
+                  <span
+                    class="bp3-control-indicator"
+                  />
+                  Online
+                </label>
+                <label
+                  class="bp3-control bp3-radio"
+                >
+                  <input
+                    name="online"
+                    type="radio"
+                    value="offline"
+                  />
+                  <span
+                    class="bp3-control-indicator"
+                  />
+                  Offline
+                </label>
+              </div>
+            </div>
           </div>
           <div
             class="sc-kGXeez bMTBGr"
@@ -989,41 +987,6 @@ exports[`RiskLimitingAuditForm does not render SelectBallotsToAudit when /audit/
         >
           Audit Settings
         </h2>
-        <div
-          class="sc-bdVaJa fdbLH"
-        >
-          <div>
-            <label
-              class="bp3-control bp3-radio bp3-disabled"
-            >
-              <input
-                checked=""
-                disabled=""
-                name="online"
-                type="radio"
-                value="online"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Online
-            </label>
-            <label
-              class="bp3-control bp3-radio bp3-disabled"
-            >
-              <input
-                disabled=""
-                name="online"
-                type="radio"
-                value="offline"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Offline
-            </label>
-          </div>
-        </div>
         <div
           class="sc-bdVaJa fdbLH"
         >
@@ -1449,39 +1412,6 @@ exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
         >
           Audit Settings
         </h2>
-        <div
-          class="sc-bdVaJa fdbLH"
-        >
-          <div>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                checked=""
-                name="online"
-                type="radio"
-                value="online"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Online
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="online"
-                type="radio"
-                value="offline"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Offline
-            </label>
-          </div>
-        </div>
         <div
           class="sc-bdVaJa fdbLH"
         >
@@ -1926,41 +1856,6 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
         <div
           class="sc-bdVaJa fdbLH"
         >
-          <div>
-            <label
-              class="bp3-control bp3-radio bp3-disabled"
-            >
-              <input
-                checked=""
-                disabled=""
-                name="online"
-                type="radio"
-                value="online"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Online
-            </label>
-            <label
-              class="bp3-control bp3-radio bp3-disabled"
-            >
-              <input
-                disabled=""
-                name="online"
-                type="radio"
-                value="offline"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Offline
-            </label>
-          </div>
-        </div>
-        <div
-          class="sc-bdVaJa fdbLH"
-        >
           <h3
             class="bp3-heading sc-htpNat cNFUHJ"
           >
@@ -2288,6 +2183,41 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
             class="sc-bwzfXH izcbHX"
           >
             Audit boards will enter data about each ballot:
+            <div
+              class="sc-bdVaJa fdbLH"
+            >
+              <div>
+                <label
+                  class="bp3-control bp3-radio bp3-disabled"
+                >
+                  <input
+                    checked=""
+                    disabled=""
+                    name="online"
+                    type="radio"
+                    value="online"
+                  />
+                  <span
+                    class="bp3-control-indicator"
+                  />
+                  Online
+                </label>
+                <label
+                  class="bp3-control bp3-radio bp3-disabled"
+                >
+                  <input
+                    disabled=""
+                    name="online"
+                    type="radio"
+                    value="offline"
+                  />
+                  <span
+                    class="bp3-control-indicator"
+                  />
+                  Offline
+                </label>
+              </div>
+            </div>
           </div>
           <div
             class="sc-kGXeez bMTBGr"
@@ -2782,41 +2712,6 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
         <div
           class="sc-bdVaJa fdbLH"
         >
-          <div>
-            <label
-              class="bp3-control bp3-radio bp3-disabled"
-            >
-              <input
-                checked=""
-                disabled=""
-                name="online"
-                type="radio"
-                value="online"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Online
-            </label>
-            <label
-              class="bp3-control bp3-radio bp3-disabled"
-            >
-              <input
-                disabled=""
-                name="online"
-                type="radio"
-                value="offline"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Offline
-            </label>
-          </div>
-        </div>
-        <div
-          class="sc-bdVaJa fdbLH"
-        >
           <h3
             class="bp3-heading sc-htpNat cNFUHJ"
           >
@@ -3139,6 +3034,39 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
             class="sc-bwzfXH izcbHX"
           >
             Audit boards will enter data about each ballot:
+            <div
+              class="sc-bdVaJa fdbLH"
+            >
+              <div>
+                <label
+                  class="bp3-control bp3-radio"
+                >
+                  <input
+                    checked=""
+                    name="online"
+                    type="radio"
+                    value="online"
+                  />
+                  <span
+                    class="bp3-control-indicator"
+                  />
+                  Online
+                </label>
+                <label
+                  class="bp3-control bp3-radio"
+                >
+                  <input
+                    name="online"
+                    type="radio"
+                    value="offline"
+                  />
+                  <span
+                    class="bp3-control-indicator"
+                  />
+                  Offline
+                </label>
+              </div>
+            </div>
           </div>
           <div
             class="sc-kGXeez bMTBGr"
@@ -3478,39 +3406,6 @@ exports[`RiskLimitingAuditForm renders correctly with initialData 1`] = `
         >
           Audit Settings
         </h2>
-        <div
-          class="sc-bdVaJa fdbLH"
-        >
-          <div>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                checked=""
-                name="online"
-                type="radio"
-                value="online"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Online
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="online"
-                type="radio"
-                value="offline"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Offline
-            </label>
-          </div>
-        </div>
         <div
           class="sc-bdVaJa fdbLH"
         >

--- a/arlo-client/src/test/specs/auditFlow.ts
+++ b/arlo-client/src/test/specs/auditFlow.ts
@@ -54,9 +54,9 @@ const memberFill = () => {
 
 beforeEach(() => {
   start()
-  fillFormOne(true)
+  fillFormOne()
   submitFormOne()
-  fillFormTwo()
+  fillFormTwo(false)
   submitFormTwo()
   $('a=Audit Board #1').click()
   memberFill()

--- a/arlo-client/src/test/specs/createAudit.ts
+++ b/arlo-client/src/test/specs/createAudit.ts
@@ -25,7 +25,7 @@ describe('create audit page', () => {
 describe('form one', () => {
   it('should submit', () => {
     start()
-    fillFormOne(false)
+    fillFormOne()
     submitFormOne()
   })
 })
@@ -33,17 +33,17 @@ describe('form one', () => {
 describe('form two', () => {
   it('should submit', () => {
     start()
-    fillFormOne(false)
+    fillFormOne()
     submitFormOne()
-    fillFormTwo()
+    fillFormTwo(true)
     submitFormTwo()
   })
 
   // it('should accept custom audit board names', () => { // commented out until we decide to add it back in again
   //   start()
-  //   fillFormOne(false)
+  //   fillFormOne()
   //   submitFormOne()
-  //   fillFormTwo()
+  //   fillFormTwo(true)
   //   $('input[name="auditNames[0]"]').addValue('First Audit Board')
   //   submitFormTwo()
   //   expect($('a=First Audit Board')).toBeTruthy()
@@ -53,18 +53,18 @@ describe('form two', () => {
 describe('form three', () => {
   it('should go to the next round', () => {
     start()
-    fillFormOne(false)
+    fillFormOne()
     submitFormOne()
-    fillFormTwo()
+    fillFormTwo(true)
     submitFormTwo()
     formThreeNext()
   })
 
   it('should cycle through several rounds', () => {
     start()
-    fillFormOne(false)
+    fillFormOne()
     submitFormOne()
-    fillFormTwo()
+    fillFormTwo(true)
     submitFormTwo()
     formThreeNext()
     formThreeNext()
@@ -73,9 +73,9 @@ describe('form three', () => {
 
   it('should complete the audit', () => {
     start()
-    fillFormOne(false)
+    fillFormOne()
     submitFormOne()
-    fillFormTwo()
+    fillFormTwo(true)
     submitFormTwo()
     formThreeNext()
     const inputs = $$('.bp3-input')
@@ -87,13 +87,13 @@ describe('form three', () => {
 
   it('should display the same candidates/choices entered in form one', () => {
     start()
-    fillFormOne(false)
+    fillFormOne()
     $('p=Add a new candidate/choice').click()
     $('input[name="contests[0].totalBallotsCast"]').setValue('2436')
     $('input[name="contests[0].choices[2].name"]').addValue('Choice Three')
     $('input[name="contests[0].choices[2].numVotes"]').addValue('313')
     submitFormOne()
-    fillFormTwo()
+    fillFormTwo(true)
     submitFormTwo()
     expect($('label=Choice One')).toBeTruthy()
     expect($('label=Choice Two')).toBeTruthy()

--- a/arlo-client/src/test/specs/helpers.ts
+++ b/arlo-client/src/test/specs/helpers.ts
@@ -10,7 +10,7 @@ export const start = () => {
   $('.bp3-button-text=Create a New Audit').click()
   $('#audit-name').waitForExist(5000)
 }
-export const fillFormOne = (online: boolean) => {
+export const fillFormOne = () => {
   $('#audit-name').addValue('Election Name')
   $('input[name="contests[0].name"]').addValue('Contest Name')
   $('input[name="contests[0].choices[0].name"]').addValue('Choice One')
@@ -19,7 +19,6 @@ export const fillFormOne = (online: boolean) => {
   $('input[name="contests[0].choices[1].numVotes"]').addValue('1325')
   $('input[name="contests[0].totalBallotsCast"]').addValue('2123')
   $('#random-seed').addValue('1234567890')
-  if (online) $('label.bp3-radio*=Online').click()
 }
 
 export const submitFormOne = () => {
@@ -27,8 +26,9 @@ export const submitFormOne = () => {
   $('.bp3-heading=Select Ballots to Audit').waitForExist(10000)
 }
 
-export const fillFormTwo = () => {
+export const fillFormTwo = (offline: boolean) => {
   $('input[name="manifest"]').setValue(filePath)
+  if (offline) $('label.bp3-radio*=Offline').click()
 }
 
 export const submitFormTwo = () => {

--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -398,7 +398,8 @@ def audit_basic_update(election_id):
     election.online = info['online']
 
     errors = []
-    db.session.query(TargetedContest).filter_by(election_id=election.id).delete()
+    if info['contests']:
+        db.session.query(TargetedContest).filter_by(election_id=election.id).delete()
 
     for contest in info['contests']:
         total_allowed_votes_in_contest = contest['totalBallotsCast'] * contest['votesAllowed']


### PR DESCRIPTION
**Description**

- Moves the form element from the first form to the second form
- Sends `true` as the default value from the first form so the backend doesn't freak out
- Sends an empty array for `contests` when it POSTs to the `/audit/basic` endpoint a second time, so that the backend doesn't freak out
- Adds an if condition to the backend so that it doesn't delete the contests if no new ones are passed back

**New Tests**

- Updates snapshots
- Adjusts all the api mock tests to account for a new api call in the second form
- Tests for server and api errors on the new api call in the second form
- Updates the end to end tests to reflect the change as well

**Notes**

I have no idea if the stuff changed on the backend will affect the backend tests, or if they should. I also am not sure if my backend tweaks were done properly. It works with my manual testing, but someone more familiar back there should triple check everything, haha.