### PR TITLE
[WIP] make audit boards round-specific

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -140,12 +140,7 @@ def setup_next_round(election):
     rounds = Round.query.filter_by(election_id=election.id).order_by("round_num").all()
 
     print("adding round {:d} for election {:s}".format(len(rounds) + 1, election.id))
-    round = Round(
-        id=str(uuid.uuid4()),
-        election_id=election.id,
-        round_num=len(rounds) + 1,
-        started_at=datetime.datetime.utcnow(),
-    )
+    round = Round(id=str(uuid.uuid4()), election_id=election.id, round_num=len(rounds) + 1)
 
     db.session.add(round)
 

--- a/models.py
+++ b/models.py
@@ -201,9 +201,9 @@ class AuditBoard(db.Model):
         db.ForeignKey("jurisdiction.id", ondelete="cascade"),
         nullable=False,
     )
-    round_id = db.Column(db.String(200),
-                         db.ForeignKey('round.id', ondelete='cascade'),
-                         nullable=False)
+    round_id = db.Column(
+        db.String(200), db.ForeignKey("round.id", ondelete="cascade"), nullable=False
+    )
 
     name = db.Column(db.String(200))
     member_1 = db.Column(db.String(200), nullable=True)
@@ -223,12 +223,12 @@ class Round(db.Model):
         db.String(200), db.ForeignKey("election.id", ondelete="cascade"), nullable=False
     )
     round_num = db.Column(db.Integer, nullable=False)
-    started_at = db.Column(db.DateTime, nullable=False)
+    started_at = db.Column(db.DateTime, nullable=True)
     ended_at = db.Column(db.DateTime, nullable=True)
 
     __table_args__ = (db.UniqueConstraint("election_id", "round_num"),)
 
-    audit_boards = relationship('AuditBoard', backref='round', passive_deletes=True)
+    audit_boards = relationship("AuditBoard", backref="round", passive_deletes=True)
     round_contests = relationship("RoundContest", backref="round", passive_deletes=True)
     sampled_ballot_draws = relationship(
         "SampledBallotDraw", backref="round", passive_deletes=True

--- a/models.py
+++ b/models.py
@@ -201,6 +201,10 @@ class AuditBoard(db.Model):
         db.ForeignKey("jurisdiction.id", ondelete="cascade"),
         nullable=False,
     )
+    round_id = db.Column(db.String(200),
+                         db.ForeignKey('round.id', ondelete='cascade'),
+                         nullable=False)
+
     name = db.Column(db.String(200))
     member_1 = db.Column(db.String(200), nullable=True)
     member_1_affiliation = db.Column(db.String(200), nullable=True)
@@ -224,6 +228,7 @@ class Round(db.Model):
 
     __table_args__ = (db.UniqueConstraint("election_id", "round_num"),)
 
+    audit_boards = relationship('AuditBoard', backref='round', passive_deletes=True)
     round_contests = relationship("RoundContest", backref="round", passive_deletes=True)
     sampled_ballot_draws = relationship(
         "SampledBallotDraw", backref="round", passive_deletes=True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -171,19 +171,7 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
                 {
                     "id": jurisdiction_id,
                     "name": "adams county",
-                    "contests": [contest_id],
-                    "auditBoards": [
-                        {
-                            "id": audit_board_id_1,
-                            "name": "audit board #1",
-                            "members": [],
-                        },
-                        {
-                            "id": audit_board_id_2,
-                            "name": "audit board #2",
-                            "members": [],
-                        },
-                    ],
+                    "contests": [contest_id]
                 }
             ]
         },
@@ -197,7 +185,6 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
     assert len(status["jurisdictions"]) == 1
     jurisdiction = status["jurisdictions"][0]
     assert jurisdiction["name"] == "adams county"
-    assert jurisdiction["auditBoards"][1]["name"] == "audit board #2"
     assert jurisdiction["contests"] == [contest_id]
 
     # choose a sample size
@@ -260,7 +247,23 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
 
     assert json.loads(rv.data)["status"] == "ok"
 
+    rv = post_json(
+        client, f"{url_prefix}/jurisdiction/{jurisdiction_id}/round/1/audit-board/", {
+            "auditBoards": [{
+                "id": audit_board_id_1,
+                "name": "audit board #1"
+            }, {
+                "id": audit_board_id_2,
+                "name": "audit board #2"
+            }]
+        })
+
     setup_audit_board(client, election_id, jurisdiction_id, audit_board_id_1)
+
+    rv = client.get('{}/audit/status'.format(url_prefix))
+    status = json.loads(rv.data)
+    jurisdiction = status["jurisdictions"][0]
+    assert jurisdiction["auditBoards"][1]["name"] == "audit board #2"
 
     # get the retrieval list for round 1
     rv = client.get(
@@ -391,7 +394,7 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
     assert len(status["jurisdictions"]) == 1
     jurisdiction = status["jurisdictions"][0]
     assert jurisdiction["name"] == "adams county"
-    assert jurisdiction["auditBoards"][1]["name"] == "audit board #2"
+    #assert jurisdiction["auditBoards"][1]["name"] == "audit board #2"
     assert jurisdiction["contests"] == [contest_id]
 
     # choose a sample size

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -171,7 +171,7 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
                 {
                     "id": jurisdiction_id,
                     "name": "adams county",
-                    "contests": [contest_id]
+                    "contests": [contest_id],
                 }
             ]
         },
@@ -248,19 +248,19 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
     assert json.loads(rv.data)["status"] == "ok"
 
     rv = post_json(
-        client, f"{url_prefix}/jurisdiction/{jurisdiction_id}/round/1/audit-board/", {
-            "auditBoards": [{
-                "id": audit_board_id_1,
-                "name": "audit board #1"
-            }, {
-                "id": audit_board_id_2,
-                "name": "audit board #2"
-            }]
-        })
+        client,
+        f"{url_prefix}/jurisdiction/{jurisdiction_id}/round/1/audit-board/",
+        {
+            "auditBoards": [
+                {"id": audit_board_id_1, "name": "audit board #1"},
+                {"id": audit_board_id_2, "name": "audit board #2"},
+            ]
+        },
+    )
 
     setup_audit_board(client, election_id, jurisdiction_id, audit_board_id_1)
 
-    rv = client.get('{}/audit/status'.format(url_prefix))
+    rv = client.get("{}/audit/status".format(url_prefix))
     status = json.loads(rv.data)
     jurisdiction = status["jurisdictions"][0]
     assert jurisdiction["auditBoards"][1]["name"] == "audit board #2"
@@ -394,7 +394,7 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
     assert len(status["jurisdictions"]) == 1
     jurisdiction = status["jurisdictions"][0]
     assert jurisdiction["name"] == "adams county"
-    #assert jurisdiction["auditBoards"][1]["name"] == "audit board #2"
+    # assert jurisdiction["auditBoards"][1]["name"] == "audit board #2"
     assert jurisdiction["contests"] == [contest_id]
 
     # choose a sample size


### PR DESCRIPTION
This is a medium-to-big lift, so right now it's a WIP. See #299 

Done so far:
- new APIs for audit-boards that are round-specific
- beginning of updating tests <-- this is non-trivial

What still needs to be done:
- fully updating all backend tests to match new APIs
- including splitting up when the audit boards are created, since that's now the jurisdiction's job at each round, and not part of the creation of the jurisdiction.
- including considering when `setup_next_round` and `sample_ballots` should be called in the server logic. I *think* `setup_next_round` shouldn't set the start time of the round, and setting the sample size should set the start time and call `sample_ballots`, but I'm not 100% sure, so check me.
- update the single-page flow front-end to match these new calls.