### PR TITLE
Fix ballot-list endpoints to filter by round

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -711,6 +711,7 @@ def ballot_list(election_id, jurisdiction_id, round_id):
     query = SampledBallotDraw.query \
                 .join(SampledBallot).join(SampledBallotDraw.batch).join(AuditBoard).join(Round) \
                 .add_entity(SampledBallot).add_entity(Batch).add_entity(AuditBoard) \
+                .filter(Round.id == round_id) \
                 .filter(Batch.jurisdiction_id == jurisdiction_id) \
                 .order_by(AuditBoard.name, Batch.name, SampledBallot.ballot_position, SampledBallotDraw.ticket_number) \
                 .all()
@@ -740,6 +741,7 @@ def ballot_list_by_audit_board(election_id, jurisdiction_id, audit_board_id, rou
     query = SampledBallotDraw.query \
                 .join(Round).join(SampledBallot).join(Batch) \
                 .add_entity(SampledBallot).add_entity(Batch) \
+                .filter(Round.id == round_id) \
                 .filter(Batch.jurisdiction_id == jurisdiction_id) \
                 .filter(SampledBallot.audit_board_id == audit_board_id) \
                 .order_by(Batch.name, SampledBallot.ballot_position, SampledBallotDraw.ticket_number)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1100,62 +1100,6 @@ def test_ballot_set(client):
     assert ballot['comment'] == 'This one had a hanging chad.'
 
 
-def test_ballot_list_ordering(client):
-    ## setup
-    rv = client.post('/election/new')
-    election_id = json.loads(rv.data)['electionId']
-
-    url_prefix, contest_id, candidate_id_1, candidate_id_2, candidate_id_3, jurisdiction_id, audit_board_id_1, audit_board_id_2, num_ballots = setup_whole_multi_winner_audit(
-        client, election_id, 'Multi-Round Multi-winner Audit', 10, '32423432423432')
-
-    ## find all rounds for this jurisdiction
-    rv = client.get('{}/audit/status'.format(url_prefix))
-    response = json.loads(rv.data)
-    assert [j for j in response['jurisdictions'] if j['id'] == jurisdiction_id][0]
-    rounds = response['rounds']
-
-    ## verify order of all returned ballots
-    for round in rounds:
-        rv = client.get('{}/jurisdiction/{}/round/{}/ballot-list'.format(
-            url_prefix, jurisdiction_id, round['id']))
-        response = json.loads(rv.data)
-
-        unsorted_ballots = response['ballots']
-        sorted_ballots = sorted(
-            unsorted_ballots,
-            key=lambda ballot:
-            (ballot['auditBoard']['name'], ballot['batch']['name'], ballot['position']))
-
-        assert unsorted_ballots == sorted_ballots
-
-
-def test_ballot_list_ordering_by_audit_board(client):
-    ## setup
-    rv = client.post('/election/new')
-    election_id = json.loads(rv.data)['electionId']
-
-    url_prefix, contest_id, candidate_id_1, candidate_id_2, candidate_id_3, jurisdiction_id, audit_board_id_1, audit_board_id_2, num_ballots = setup_whole_multi_winner_audit(
-        client, election_id, 'Multi-Round Multi-winner Audit', 10, '32423432423432')
-
-    ## find all rounds for this jurisdiction
-    rv = client.get('{}/audit/status'.format(url_prefix))
-    response = json.loads(rv.data)
-    jurisdiction = [j for j in response['jurisdictions'] if j['id'] == jurisdiction_id][0]
-    rounds = response['rounds']
-
-    ## verify order of all returned ballots
-    for round in rounds:
-        rv = client.get('{}/jurisdiction/{}/audit-board/{}/round/{}/ballot-list'.format(
-            url_prefix, jurisdiction_id, audit_board_id_1, round['id']))
-        response = json.loads(rv.data)
-
-        unsorted_ballots = response['ballots']
-        sorted_ballots = sorted(unsorted_ballots,
-                                key=lambda ballot: (ballot['batch']['name'], ballot['position']))
-
-        assert unsorted_ballots == sorted_ballots
-
-
 def test_audit_board(client):
     ## setup
     rv = client.post('/election/new')

--- a/tests/test_ballot_list.py
+++ b/tests/test_ballot_list.py
@@ -1,0 +1,167 @@
+import json
+
+import pytest
+
+from test_app import client, post_json, setup_whole_audit, setup_whole_multi_winner_audit
+import bgcompute
+
+
+def test_ballot_list_jurisdiction_two_rounds(client):
+    rv = post_json(client, '/election/new', {})
+    election_id = json.loads(rv.data)['electionId']
+    assert election_id
+
+    url_prefix, contest_id, candidate_id_1, candidate_id_2, jurisdiction_id, audit_board_id_1, audit_board_id_2, num_ballots = setup_whole_audit(
+        client, election_id, "Primary 2019", 10, "12345678901234567890")
+
+    # Get the sample size and round id
+    rv = client.get(f'/election/{election_id}/audit/status')
+    status = json.loads(rv.data)
+    sample_size = status["rounds"][0]["contests"][0]["sampleSize"]
+    round_id = status["rounds"][0]["id"]
+
+    # Retrieve the ballot list
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/ballot-list")
+    ballot_list = json.loads(rv.data)['ballots']
+    assert ballot_list
+    assert len(ballot_list) == sample_size
+
+    # Post results for round 1 with 50/50 split, which should trigger a second round.
+    num_for_winner = int(num_ballots * 0.5)
+    num_for_loser = num_ballots - num_for_winner
+    rv = post_json(
+        client, '{}/jurisdiction/{}/1/results'.format(url_prefix, jurisdiction_id), {
+            "contests": [{
+                "id": contest_id,
+                "results": {
+                    candidate_id_1: num_for_winner,
+                    candidate_id_2: num_for_loser
+                }
+            }]
+        })
+    assert json.loads(rv.data)['status'] == 'ok'
+    bgcompute.bgcompute()
+
+    # Get the sample size and round id for the second round
+    rv = client.get(f'/election/{election_id}/audit/status')
+    status = json.loads(rv.data)
+    sample_size = status["rounds"][1]["contests"][0]["sampleSize"]
+    round_id = status["rounds"][1]["id"]
+
+    # Retrieve the ballot list
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/ballot-list")
+    ballot_list = json.loads(rv.data)['ballots']
+    assert ballot_list
+    assert len(ballot_list) == sample_size
+
+
+def test_ballot_list_audit_board_two_rounds(client):
+    rv = post_json(client, '/election/new', {})
+    election_id = json.loads(rv.data)['electionId']
+    assert election_id
+
+    url_prefix, contest_id, candidate_id_1, candidate_id_2, jurisdiction_id, audit_board_id_1, audit_board_id_2, num_ballots = setup_whole_audit(
+        client, election_id, "Primary 2019", 10, "12345678901234567890")
+
+    # Get the sample size and round id
+    rv = client.get(f'/election/{election_id}/audit/status')
+    status = json.loads(rv.data)
+    sample_size = status["rounds"][0]["contests"][0]["sampleSize"]
+    round_id = status["rounds"][0]["id"]
+
+    # Retrieve the ballot lists (the ballots should be split b/w audit boards)
+    ballot_list = []
+    for audit_board_id in [audit_board_id_1, audit_board_id_2]:
+        rv = client.get(
+            f"/election/{election_id}/jurisdiction/{jurisdiction_id}/audit-board/{audit_board_id}/round/{round_id}/ballot-list"
+        )
+        board_ballot_list = json.loads(rv.data)['ballots']
+        assert board_ballot_list
+        ballot_list += board_ballot_list
+
+    assert len(ballot_list) == sample_size
+
+    # Post results for round 1 with 50/50 split, which should trigger a second round.
+    num_for_winner = int(num_ballots * 0.5)
+    num_for_loser = num_ballots - num_for_winner
+    rv = post_json(
+        client, '{}/jurisdiction/{}/1/results'.format(url_prefix, jurisdiction_id), {
+            "contests": [{
+                "id": contest_id,
+                "results": {
+                    candidate_id_1: num_for_winner,
+                    candidate_id_2: num_for_loser
+                }
+            }]
+        })
+    assert json.loads(rv.data)['status'] == 'ok'
+    bgcompute.bgcompute()
+
+    # Get the sample size and round id for the second round
+    rv = client.get(f'/election/{election_id}/audit/status')
+    status = json.loads(rv.data)
+    sample_size = status["rounds"][1]["contests"][0]["sampleSize"]
+    round_id = status["rounds"][1]["id"]
+
+    # Retrieve the ballot lists (the ballots should be split b/w audit boards)
+    ballot_list = []
+    for audit_board_id in [audit_board_id_1, audit_board_id_2]:
+        rv = client.get(
+            f"/election/{election_id}/jurisdiction/{jurisdiction_id}/audit-board/{audit_board_id}/round/{round_id}/ballot-list"
+        )
+        board_ballot_list = json.loads(rv.data)['ballots']
+        assert board_ballot_list
+        ballot_list += board_ballot_list
+
+    assert len(ballot_list) == sample_size
+
+
+def test_ballot_list_jurisdiction_ordering(client):
+    rv = post_json(client, '/election/new', {})
+    election_id = json.loads(rv.data)['electionId']
+    assert election_id
+
+    url_prefix, contest_id, candidate_id_1, candidate_id_2, jurisdiction_id, audit_board_id_1, audit_board_id_2, num_ballots = setup_whole_audit(
+        client, election_id, "Primary 2019", 10, "12345678901234567890")
+
+    # Get the round id
+    rv = client.get(f'/election/{election_id}/audit/status')
+    status = json.loads(rv.data)
+    round_id = status["rounds"][0]["id"]
+
+    # Verify that the ballots are ordered correctly
+    rv = client.get('{}/jurisdiction/{}/round/{}/ballot-list'.format(url_prefix, jurisdiction_id,
+                                                                     round_id))
+    unsorted_ballots = json.loads(rv.data)['ballots']
+    sorted_ballots = sorted(
+        unsorted_ballots,
+        key=lambda ballot:
+        (ballot['auditBoard']['name'], ballot['batch']['name'], ballot['position']))
+
+    assert unsorted_ballots == sorted_ballots
+
+
+def test_ballot_list_audit_board_ordering(client):
+    rv = post_json(client, '/election/new', {})
+    election_id = json.loads(rv.data)['electionId']
+    assert election_id
+
+    url_prefix, contest_id, candidate_id_1, candidate_id_2, jurisdiction_id, audit_board_id_1, audit_board_id_2, num_ballots = setup_whole_audit(
+        client, election_id, "Primary 2019", 10, "12345678901234567890")
+
+    # Get the round id
+    rv = client.get(f'/election/{election_id}/audit/status')
+    status = json.loads(rv.data)
+    round_id = status["rounds"][0]["id"]
+
+    # Verify that the ballots are ordered correctly
+    for audit_board_id in [audit_board_id_1, audit_board_id_2]:
+        rv = client.get('{}/jurisdiction/{}/audit-board/{}/round/{}/ballot-list'.format(
+            url_prefix, jurisdiction_id, audit_board_id, round_id))
+        unsorted_ballots = json.loads(rv.data)['ballots']
+        sorted_ballots = sorted(unsorted_ballots,
+                                key=lambda ballot: (ballot['batch']['name'], ballot['position']))
+
+        assert unsorted_ballots == sorted_ballots


### PR DESCRIPTION
**Description**

In both ballot-list endpoints (per audit board and per jurisdiction),
the round_id parameter was being ignored, so all ballots for all rounds
of the audits were being returned. This adds a filter to the database
query to restrict results to the specified round.

**Testing**

This commit adds a new test for each endpoint with two audit rounds to
ensure this behavior.

It also updates some existing tests that tested the ordering of the
ballot lists. These tests tried to test across multiple rounds of the
audit when there was only one round, so here they are simplified to be
clearer.

**Progress**

Ready for review
