### PR TITLE
Format python with black

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,3 +1,0 @@
-[style]
-based_on_style = pep8
-column_limit = 100

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,5 @@
   "python.pythonPath": "/usr/bin/python3.7",
   "files.exclude": {
     "arlo-client": true
-  },
-  "python.formatting.provider": "yapf"
+  }
 }

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ typecheck:
 	python3 -m pipenv run mypy .
 
 format-python:
-	python3 -m pipenv run yapf --in-place --recursive .
+	python3 -m pipenv run black .
 
 test-client:
 	yarn --cwd arlo-client lint

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,9 @@ mypy = "*"
 numpy-stubs = {git = "https://github.com/numpy/numpy-stubs"}
 sqlalchemy-stubs = "*"
 pytest = "*"
-yapf = "*"
+# black only has pre-releases available, so we have to specify a specific version
+# for now (or enable pre-releases for all packages, which we don't want)
+black = "==19.10b0"
 
 [packages]
 consistent_sampler = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3a3acae2cfe5fda10edb177396efa3efee1eccec93273acfa7d976373c8628d9"
+            "sha256": "bd610e2e25cd3b600601eaa2210178e848a4c0492b83a7419afdd80c536d38be"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -73,10 +73,10 @@
         },
         "click": {
             "hashes": [
-                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
-                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
+                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
             ],
-            "version": "==7.0"
+            "version": "==7.1.1"
         },
         "consistent-sampler": {
             "hashes": [
@@ -278,9 +278,10 @@
         },
         "pycparser": {
             "hashes": [
-                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
+                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
             ],
-            "version": "==2.19"
+            "version": "==2.20"
         },
         "requests": {
             "hashes": [
@@ -325,9 +326,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:64a7b71846db6423807e96820993fa12a03b89127d278290ca25c0b11ed7b4fb"
+                "sha256:b92d2de62e43499d85b1780274d1b562e5159c7996f6f04a9bb46cf681ced45f"
             ],
-            "version": "==1.3.13"
+            "version": "==1.3.14"
         },
         "sqlalchemy-utils": {
             "hashes": [
@@ -366,12 +367,34 @@
         }
     },
     "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
         "attrs": {
             "hashes": [
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
                 "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
             "version": "==19.3.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
+                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+            ],
+            "index": "pypi",
+            "version": "==19.10b0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
+                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+            ],
+            "version": "==7.1.1"
         },
         "importlib-metadata": {
             "hashes": [
@@ -421,10 +444,17 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73",
-                "sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"
+                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
+                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
             ],
-            "version": "==20.1"
+            "version": "==20.3"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:163b0632d4e31cef212976cf57b43d9fd6b0bac6e67c26015d611a647d5e7424",
+                "sha256:562aa70af2e0d434367d9790ad37aed893de47f1693e4201fd1d3dca15d19b96"
+            ],
+            "version": "==0.7.0"
         },
         "pluggy": {
             "hashes": [
@@ -455,6 +485,32 @@
             "index": "pypi",
             "version": "==5.3.5"
         },
+        "regex": {
+            "hashes": [
+                "sha256:01b2d70cbaed11f72e57c1cfbaca71b02e3b98f739ce33f5f26f71859ad90431",
+                "sha256:046e83a8b160aff37e7034139a336b660b01dbfe58706f9d73f5cdc6b3460242",
+                "sha256:113309e819634f499d0006f6200700c8209a2a8bf6bd1bdc863a4d9d6776a5d1",
+                "sha256:200539b5124bc4721247a823a47d116a7a23e62cc6695744e3eb5454a8888e6d",
+                "sha256:25f4ce26b68425b80a233ce7b6218743c71cf7297dbe02feab1d711a2bf90045",
+                "sha256:269f0c5ff23639316b29f31df199f401e4cb87529eafff0c76828071635d417b",
+                "sha256:5de40649d4f88a15c9489ed37f88f053c15400257eeb18425ac7ed0a4e119400",
+                "sha256:7f78f963e62a61e294adb6ff5db901b629ef78cb2a1cfce3cf4eeba80c1c67aa",
+                "sha256:82469a0c1330a4beb3d42568f82dffa32226ced006e0b063719468dcd40ffdf0",
+                "sha256:8c2b7fa4d72781577ac45ab658da44c7518e6d96e2a50d04ecb0fd8f28b21d69",
+                "sha256:974535648f31c2b712a6b2595969f8ab370834080e00ab24e5dbb9d19b8bfb74",
+                "sha256:99272d6b6a68c7ae4391908fc15f6b8c9a6c345a46b632d7fdb7ef6c883a2bbb",
+                "sha256:9b64a4cc825ec4df262050c17e18f60252cdd94742b4ba1286bcfe481f1c0f26",
+                "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5",
+                "sha256:9ff16d994309b26a1cdf666a6309c1ef51ad4f72f99d3392bcd7b7139577a1f2",
+                "sha256:b33ebcd0222c1d77e61dbcd04a9fd139359bded86803063d3d2d197b796c63ce",
+                "sha256:bba52d72e16a554d1894a0cc74041da50eea99a8483e591a9edf1025a66843ab",
+                "sha256:bed7986547ce54d230fd8721aba6fd19459cdc6d315497b98686d0416efaff4e",
+                "sha256:c7f58a0e0e13fb44623b65b01052dae8e820ed9b8b654bb6296bc9c41f571b70",
+                "sha256:d58a4fa7910102500722defbde6e2816b0372a4fcc85c7e239323767c74f5cbc",
+                "sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0"
+            ],
+            "version": "==2020.2.20"
+        },
         "six": {
             "hashes": [
                 "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
@@ -469,6 +525,13 @@
             ],
             "index": "pypi",
             "version": "==0.3"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
         },
         "typed-ast": {
             "hashes": [
@@ -511,20 +574,12 @@
             ],
             "version": "==0.1.8"
         },
-        "yapf": {
-            "hashes": [
-                "sha256:712e23c468506bf12cadd10169f852572ecc61b266258422d45aaf4ad7ef43de",
-                "sha256:cad8a272c6001b3401de3278238fdc54997b6c2e56baa751788915f879a52fca"
-            ],
-            "index": "pypi",
-            "version": "==0.29.0"
-        },
         "zipp": {
             "hashes": [
-                "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2",
-                "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
             ],
-            "version": "==3.0.0"
+            "version": "==3.1.0"
         }
     }
 }

--- a/app.py
+++ b/app.py
@@ -1,5 +1,10 @@
 import os
 from arlo_server import app
 
-if __name__ == '__main__':
-    app.run(use_reloader=True, port=os.environ.get('PORT', 3001), host='0.0.0.0', threaded=True)
+if __name__ == "__main__":
+    app.run(
+        use_reloader=True,
+        port=os.environ.get("PORT", 3001),
+        host="0.0.0.0",
+        threaded=True,
+    )

--- a/arlo.code-workspace
+++ b/arlo.code-workspace
@@ -14,6 +14,7 @@
 				"name": "Arlo Web",
 				"remotePort": 3000
 			}
-		]
+		],
+		"python.formatting.provider": "black"
 	}
 }

--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -18,8 +18,16 @@ from arlo_server.db import db
 from models import *
 
 from config import HTTP_ORIGIN
-from config import AUDITADMIN_AUTH0_BASE_URL, AUDITADMIN_AUTH0_CLIENT_ID, AUDITADMIN_AUTH0_CLIENT_SECRET
-from config import JURISDICTIONADMIN_AUTH0_BASE_URL, JURISDICTIONADMIN_AUTH0_CLIENT_ID, JURISDICTIONADMIN_AUTH0_CLIENT_SECRET
+from config import (
+    AUDITADMIN_AUTH0_BASE_URL,
+    AUDITADMIN_AUTH0_CLIENT_ID,
+    AUDITADMIN_AUTH0_CLIENT_SECRET,
+)
+from config import (
+    JURISDICTIONADMIN_AUTH0_BASE_URL,
+    JURISDICTIONADMIN_AUTH0_CLIENT_ID,
+    JURISDICTIONADMIN_AUTH0_CLIENT_SECRET,
+)
 
 from util.binpacking import Bucket, BalancedBucketList
 from util.jurisdiction_bulk_update import bulk_update_jurisdictions
@@ -29,8 +37,8 @@ WORDS = xp.generate_wordlist(wordfile=xp.locate_wordfile())
 
 
 class UserType(str, Enum):
-    AUDIT_ADMIN = 'audit_admin'
-    JURISDICTION_ADMIN = 'jurisdiction_admin'
+    AUDIT_ADMIN = "audit_admin"
+    JURISDICTION_ADMIN = "jurisdiction_admin"
 
 
 def create_election(election_id=None, organization_id=None):
@@ -63,10 +71,12 @@ def contest_status(election):
     contests = {}
 
     for contest in election.contests:
-        contests[contest.id] = dict([[choice.id, choice.num_votes] for choice in contest.choices])
-        contests[contest.id]['ballots'] = contest.total_ballots_cast
-        contests[contest.id]['numWinners'] = contest.num_winners
-        contests[contest.id]['votesAllowed'] = contest.votes_allowed
+        contests[contest.id] = dict(
+            [[choice.id, choice.num_votes] for choice in contest.choices]
+        )
+        contests[contest.id]["ballots"] = contest.total_ballots_cast
+        contests[contest.id]["numWinners"] = contest.num_winners
+        contests[contest.id]["votesAllowed"] = contest.votes_allowed
 
     return contests
 
@@ -77,8 +87,11 @@ def sample_results(election):
     for contest in election.contests:
         contests[contest.id] = dict([[choice.id, 0] for choice in contest.choices])
 
-        round_contests = RoundContest.query.filter_by(
-            contest_id=contest.id).order_by('round_id').all()
+        round_contests = (
+            RoundContest.query.filter_by(contest_id=contest.id)
+            .order_by("round_id")
+            .all()
+        )
         for round_contest in round_contests:
             for result in round_contest.results:
                 contests[contest.id][result.targeted_contest_choice_id] += result.result
@@ -88,8 +101,12 @@ def sample_results(election):
 
 def get_sampler(election):
     # TODO Change this to audit_type
-    return Sampler('BRAVO', election.random_seed, election.risk_limit / 100,
-                   contest_status(election))
+    return Sampler(
+        "BRAVO",
+        election.random_seed,
+        election.risk_limit / 100,
+        contest_status(election),
+    )
 
 
 def compute_sample_sizes(round_contest):
@@ -98,8 +115,9 @@ def compute_sample_sizes(round_contest):
     sampler = get_sampler(election)
 
     # format the options properly
-    raw_sample_size_options = sampler.get_sample_sizes(
-        sample_results(election))[election.contests[0].id]
+    raw_sample_size_options = sampler.get_sample_sizes(sample_results(election))[
+        election.contests[0].id
+    ]
     sample_size_options = []
     sample_size_90 = None
     sample_size_backup = None
@@ -108,17 +126,17 @@ def compute_sample_sizes(round_contest):
 
         if prob_or_asn == "asn":
             if size["prob"]:
-                prob = round(size["prob"], 2),  # round to the nearest hundreth
-            sample_size_options.append({
-                "type": "ASN",
-                "prob": prob,
-                "size": int(math.ceil(size["size"]))
-            })
+                prob = (round(size["prob"], 2),)  # round to the nearest hundreth
+            sample_size_options.append(
+                {"type": "ASN", "prob": prob, "size": int(math.ceil(size["size"]))}
+            )
             sample_size_backup = int(math.ceil(size["size"]))
 
         else:
             prob = prob_or_asn
-            sample_size_options.append({"type": None, "prob": prob, "size": int(math.ceil(size))})
+            sample_size_options.append(
+                {"type": None, "prob": prob, "size": int(math.ceil(size))}
+            )
 
             # stash this one away for later
             if prob == 0.9:
@@ -142,13 +160,15 @@ def setup_next_round(election):
     if len(election.contests) > 1:
         raise Exception("only supports one contest for now")
 
-    rounds = Round.query.filter_by(election_id=election.id).order_by('round_num').all()
+    rounds = Round.query.filter_by(election_id=election.id).order_by("round_num").all()
 
     print("adding round {:d} for election {:s}".format(len(rounds) + 1, election.id))
-    round = Round(id=str(uuid.uuid4()),
-                  election_id=election.id,
-                  round_num=len(rounds) + 1,
-                  started_at=datetime.datetime.utcnow())
+    round = Round(
+        id=str(uuid.uuid4()),
+        election_id=election.id,
+        round_num=len(rounds) + 1,
+        started_at=datetime.datetime.utcnow(),
+    )
 
     db.session.add(round)
 
@@ -164,8 +184,12 @@ def sample_ballots(election, round):
     round_contest = round.round_contests[0]
     jurisdiction = election.jurisdictions[0]
 
-    num_sampled = db.session.query(SampledBallotDraw).join(
-        SampledBallotDraw.batch).filter_by(jurisdiction_id=jurisdiction.id).count()
+    num_sampled = (
+        db.session.query(SampledBallotDraw)
+        .join(SampledBallotDraw.batch)
+        .filter_by(jurisdiction_id=jurisdiction.id)
+        .count()
+    )
     if not num_sampled:
         num_sampled = 0
 
@@ -195,12 +219,18 @@ def sample_ballots(election, round):
         ticket_number = item[0]
 
         if batch_name in batch_sizes:
-            if sample_number == 1:  # if we've already seen it, it doesn't affect batch size
+            if (
+                sample_number == 1
+            ):  # if we've already seen it, it doesn't affect batch size
                 batch_sizes[batch_name] += 1
-            batches_to_ballots[batch_name].append((ballot_position, ticket_number, sample_number))
+            batches_to_ballots[batch_name].append(
+                (ballot_position, ticket_number, sample_number)
+            )
         else:
             batch_sizes[batch_name] = 1
-            batches_to_ballots[batch_name] = [(ballot_position, ticket_number, sample_number)]
+            batches_to_ballots[batch_name] = [
+                (ballot_position, ticket_number, sample_number)
+            ]
 
     # Create the buckets and initially assign batches
     buckets = [Bucket(audit_board.name) for audit_board in audit_boards]
@@ -224,15 +254,19 @@ def sample_ballots(election, round):
                 batch_id = batch_id_from_name[batch_name]
 
                 if sample_number == 1:
-                    sampled_ballot = SampledBallot(batch_id=batch_id,
-                                                   ballot_position=ballot_position,
-                                                   audit_board_id=audit_board.id)
+                    sampled_ballot = SampledBallot(
+                        batch_id=batch_id,
+                        ballot_position=ballot_position,
+                        audit_board_id=audit_board.id,
+                    )
                     db.session.add(sampled_ballot)
 
-                sampled_ballot_draw = SampledBallotDraw(batch_id=batch_id,
-                                                        ballot_position=ballot_position,
-                                                        round_id=round.id,
-                                                        ticket_number=ticket_number)
+                sampled_ballot_draw = SampledBallotDraw(
+                    batch_id=batch_id,
+                    ballot_position=ballot_position,
+                    round_id=round.id,
+                    ticket_number=ticket_number,
+                )
 
                 db.session.add(sampled_ballot_draw)
 
@@ -249,8 +283,9 @@ def check_round(election, jurisdiction_id, round_id):
     sampler = get_sampler(election)
     current_sample_results = sample_results(election)
 
-    risk, is_complete = sampler.compute_risk(round_contest.contest_id,
-                                             current_sample_results[round_contest.contest_id])
+    risk, is_complete = sampler.compute_risk(
+        round_contest.contest_id, current_sample_results[round_contest.contest_id]
+    )
 
     round.ended_at = datetime.datetime.utcnow()
     # TODO this is a hack, should we report pairwise p-values?
@@ -263,9 +298,9 @@ def check_round(election, jurisdiction_id, round_id):
 
 
 def election_timestamp_name(election) -> str:
-    clean_election_name = re.sub(r'[^a-zA-Z0-9]+', r'-', election.name)
-    now = datetime.datetime.utcnow().isoformat(timespec='minutes')
-    return f'{clean_election_name}-{now}'
+    clean_election_name = re.sub(r"[^a-zA-Z0-9]+", r"-", election.name)
+    now = datetime.datetime.utcnow().isoformat(timespec="minutes")
+    return f"{clean_election_name}-{now}"
 
 
 def serialize_members(audit_board):
@@ -283,7 +318,7 @@ def serialize_members(audit_board):
     return members
 
 
-ADMIN_PASSWORD = os.environ.get('ARLO_ADMIN_PASSWORD', None)
+ADMIN_PASSWORD = os.environ.get("ARLO_ADMIN_PASSWORD", None)
 
 # this is a temporary approach to getting all running audits
 # before we actually tie audits to a single user / login.
@@ -298,44 +333,53 @@ if ADMIN_PASSWORD:
         # https://securitypitfalls.wordpress.com/2018/08/03/constant-time-compare-in-python/
         return password is not None and hmac.compare_digest(password, ADMIN_PASSWORD)
 
-    @app.route('/admin', methods=["GET"])
+    @app.route("/admin", methods=["GET"])
     @auth.login_required
     def admin():
         elections = Election.query.all()
         result = "\n".join(["%s - %s" % (e.id, e.name) for e in elections])
-        return Response(result, content_type='text/plain')
+        return Response(result, content_type="text/plain")
 
 
-@app.route('/election/new', methods=["POST"])
+@app.route("/election/new", methods=["POST"])
 def election_new():
     info = request.get_json()
 
     # TODO: check that the user is an admin of this organization
-    organization_id = info.get('organization_id', None) if info else None
+    organization_id = info.get("organization_id", None) if info else None
     election_id = create_election(organization_id=organization_id)
     return jsonify(electionId=election_id)
 
 
-@app.route('/election/<election_id>/jurisdictions_file', methods=["GET"])
+@app.route("/election/<election_id>/jurisdictions_file", methods=["GET"])
 def get_jurisdictions_file(election_id=None):
     election = get_election(election_id)
-    return jsonify(content=election.jurisdictions_file,
-                   filename=election.jurisdictions_filename,
-                   uploaded_at=election.jurisdictions_file_uploaded_at)
+    return jsonify(
+        content=election.jurisdictions_file,
+        filename=election.jurisdictions_filename,
+        uploaded_at=election.jurisdictions_file_uploaded_at,
+    )
 
 
-@app.route('/election/<election_id>/jurisdictions_file', methods=["POST"])
+@app.route("/election/<election_id>/jurisdictions_file", methods=["POST"])
 def update_jurisdictions_file(election_id=None):
     election = get_election(election_id)
 
-    if 'jurisdictions' not in request.files:
-        return jsonify(errors=[{
-            'message': 'Expected file parameter "jurisdictions" was missing',
-            'errorType': 'MissingFile'
-        }]), 400
+    if "jurisdictions" not in request.files:
+        return (
+            jsonify(
+                errors=[
+                    {
+                        "message": 'Expected file parameter "jurisdictions" was missing',
+                        "errorType": "MissingFile",
+                    }
+                ]
+            ),
+            400,
+        )
 
-    jurisdictions_file = request.files['jurisdictions']
-    jurisdictions_file_string = jurisdictions_file.read().decode('utf-8-sig')
+    jurisdictions_file = request.files["jurisdictions"]
+    jurisdictions_file_string = jurisdictions_file.read().decode("utf-8-sig")
 
     election.jurisdictions_file = jurisdictions_file_string
     election.jurisdictions_filename = jurisdictions_file.filename
@@ -343,146 +387,176 @@ def update_jurisdictions_file(election_id=None):
     db.session.add(election)
 
     jurisdictions_csv = csv.DictReader(io.StringIO(jurisdictions_file_string))
-    JURISDICTION_NAME = 'Jurisdiction'
-    ADMIN_EMAIL = 'Admin Email'
+    JURISDICTION_NAME = "Jurisdiction"
+    ADMIN_EMAIL = "Admin Email"
 
     missing_fields = [
-        field for field in [JURISDICTION_NAME, ADMIN_EMAIL]
+        field
+        for field in [JURISDICTION_NAME, ADMIN_EMAIL]
         if field not in jurisdictions_csv.fieldnames
     ]
 
     if missing_fields:
-        return jsonify(errors=[{
-            'message': f'Missing required CSV field "{field}"',
-            'errorType': 'MissingRequiredCsvField',
-            'fieldName': field
-        } for field in missing_fields]), 400
+        return (
+            jsonify(
+                errors=[
+                    {
+                        "message": f'Missing required CSV field "{field}"',
+                        "errorType": "MissingRequiredCsvField",
+                        "fieldName": field,
+                    }
+                    for field in missing_fields
+                ]
+            ),
+            400,
+        )
 
-    bulk_update_jurisdictions(db.session, election, [(row[JURISDICTION_NAME], row[ADMIN_EMAIL])
-                                                     for row in jurisdictions_csv])
+    bulk_update_jurisdictions(
+        db.session,
+        election,
+        [(row[JURISDICTION_NAME], row[ADMIN_EMAIL]) for row in jurisdictions_csv],
+    )
     db.session.commit()
 
-    return jsonify(status='ok')
+    return jsonify(status="ok")
 
 
-@app.route('/election/<election_id>/audit/status', methods=["GET"])
+@app.route("/election/<election_id>/audit/status", methods=["GET"])
 def audit_status(election_id=None):
     election = get_election(election_id)
 
-    return jsonify(organizationId=election.organization_id,
-                   name=election.name,
-                   online=election.online,
-                   frozenAt=election.frozen_at,
-                   riskLimit=election.risk_limit,
-                   randomSeed=election.random_seed,
-                   contests=[{
-                       "id":
-                       contest.id,
-                       "name":
-                       contest.name,
-                       "choices": [{
-                           "id": choice.id,
-                           "name": choice.name,
-                           "numVotes": choice.num_votes
-                       } for choice in contest.choices],
-                       "totalBallotsCast":
-                       contest.total_ballots_cast,
-                       "numWinners":
-                       contest.num_winners,
-                       "votesAllowed":
-                       contest.votes_allowed
-                   } for contest in election.contests],
-                   jurisdictions=[{
-                       "id":
-                       j.id,
-                       "name":
-                       j.name,
-                       "contests": [c.contest_id for c in j.contests],
-                       "auditBoards": [{
-                           "id": audit_board.id,
-                           "name": audit_board.name,
-                           "members": serialize_members(audit_board),
-                           "passphrase": audit_board.passphrase
-                       } for audit_board in j.audit_boards],
-                       "ballotManifest": {
-                           "filename": j.manifest_filename,
-                           "numBallots": j.manifest_num_ballots,
-                           "numBatches": j.manifest_num_batches,
-                           "uploadedAt": j.manifest_uploaded_at
-                       },
-                       "batches": [{
-                           "id": batch.id,
-                           "name": batch.name,
-                           "numBallots": batch.num_ballots,
-                           "storageLocation": batch.storage_location,
-                           "tabulator": batch.tabulator
-                       } for batch in j.batches]
-                   } for j in election.jurisdictions],
-                   rounds=[{
-                       "id":
-                       round.id,
-                       "startedAt":
-                       round.started_at,
-                       "endedAt":
-                       round.ended_at,
-                       "contests": [{
-                           "id":
-                           round_contest.contest_id,
-                           "endMeasurements": {
-                               "pvalue": round_contest.end_p_value,
-                               "isComplete": round_contest.is_complete
-                           },
-                           "results":
-                           dict([[result.targeted_contest_choice_id, result.result]
-                                 for result in round_contest.results]),
-                           "sampleSizeOptions":
-                           json.loads(round_contest.sample_size_options or 'null'),
-                           "sampleSize":
-                           round_contest.sample_size
-                       } for round_contest in round.round_contests]
-                   } for round in election.rounds])
+    return jsonify(
+        organizationId=election.organization_id,
+        name=election.name,
+        online=election.online,
+        frozenAt=election.frozen_at,
+        riskLimit=election.risk_limit,
+        randomSeed=election.random_seed,
+        contests=[
+            {
+                "id": contest.id,
+                "name": contest.name,
+                "choices": [
+                    {"id": choice.id, "name": choice.name, "numVotes": choice.num_votes}
+                    for choice in contest.choices
+                ],
+                "totalBallotsCast": contest.total_ballots_cast,
+                "numWinners": contest.num_winners,
+                "votesAllowed": contest.votes_allowed,
+            }
+            for contest in election.contests
+        ],
+        jurisdictions=[
+            {
+                "id": j.id,
+                "name": j.name,
+                "contests": [c.contest_id for c in j.contests],
+                "auditBoards": [
+                    {
+                        "id": audit_board.id,
+                        "name": audit_board.name,
+                        "members": serialize_members(audit_board),
+                        "passphrase": audit_board.passphrase,
+                    }
+                    for audit_board in j.audit_boards
+                ],
+                "ballotManifest": {
+                    "filename": j.manifest_filename,
+                    "numBallots": j.manifest_num_ballots,
+                    "numBatches": j.manifest_num_batches,
+                    "uploadedAt": j.manifest_uploaded_at,
+                },
+                "batches": [
+                    {
+                        "id": batch.id,
+                        "name": batch.name,
+                        "numBallots": batch.num_ballots,
+                        "storageLocation": batch.storage_location,
+                        "tabulator": batch.tabulator,
+                    }
+                    for batch in j.batches
+                ],
+            }
+            for j in election.jurisdictions
+        ],
+        rounds=[
+            {
+                "id": round.id,
+                "startedAt": round.started_at,
+                "endedAt": round.ended_at,
+                "contests": [
+                    {
+                        "id": round_contest.contest_id,
+                        "endMeasurements": {
+                            "pvalue": round_contest.end_p_value,
+                            "isComplete": round_contest.is_complete,
+                        },
+                        "results": dict(
+                            [
+                                [result.targeted_contest_choice_id, result.result]
+                                for result in round_contest.results
+                            ]
+                        ),
+                        "sampleSizeOptions": json.loads(
+                            round_contest.sample_size_options or "null"
+                        ),
+                        "sampleSize": round_contest.sample_size,
+                    }
+                    for round_contest in round.round_contests
+                ],
+            }
+            for round in election.rounds
+        ],
+    )
 
 
-@app.route('/election/<election_id>/audit/basic', methods=["POST"])
+@app.route("/election/<election_id>/audit/basic", methods=["POST"])
 def audit_basic_update(election_id):
     election = get_election(election_id)
     info = request.get_json()
-    election.name = info['name']
-    election.risk_limit = info['riskLimit']
-    election.random_seed = info['randomSeed']
-    election.online = info['online']
+    election.name = info["name"]
+    election.risk_limit = info["riskLimit"]
+    election.random_seed = info["randomSeed"]
+    election.online = info["online"]
 
     errors = []
     db.session.query(TargetedContest).filter_by(election_id=election.id).delete()
 
-    for contest in info['contests']:
-        total_allowed_votes_in_contest = contest['totalBallotsCast'] * contest['votesAllowed']
+    for contest in info["contests"]:
+        total_allowed_votes_in_contest = (
+            contest["totalBallotsCast"] * contest["votesAllowed"]
+        )
 
-        contest_obj = TargetedContest(election_id=election.id,
-                                      id=contest['id'],
-                                      name=contest['name'],
-                                      total_ballots_cast=contest['totalBallotsCast'],
-                                      num_winners=contest['numWinners'],
-                                      votes_allowed=contest['votesAllowed'])
+        contest_obj = TargetedContest(
+            election_id=election.id,
+            id=contest["id"],
+            name=contest["name"],
+            total_ballots_cast=contest["totalBallotsCast"],
+            num_winners=contest["numWinners"],
+            votes_allowed=contest["votesAllowed"],
+        )
         db.session.add(contest_obj)
 
         total_votes_in_all_choices = 0
 
-        for choice in contest['choices']:
-            total_votes_in_all_choices += choice['numVotes']
+        for choice in contest["choices"]:
+            total_votes_in_all_choices += choice["numVotes"]
 
-            choice_obj = TargetedContestChoice(id=choice['id'],
-                                               contest_id=contest_obj.id,
-                                               name=choice['name'],
-                                               num_votes=choice['numVotes'])
+            choice_obj = TargetedContestChoice(
+                id=choice["id"],
+                contest_id=contest_obj.id,
+                name=choice["name"],
+                num_votes=choice["numVotes"],
+            )
             db.session.add(choice_obj)
 
         if total_votes_in_all_choices > total_allowed_votes_in_contest:
-            errors.append({
-                'message':
-                f'Too many votes cast in contest: {contest["name"]} ({total_votes_in_all_choices} votes, {total_allowed_votes_in_contest} allowed)',
-                'errorType': 'TooManyVotes'
-            })
+            errors.append(
+                {
+                    "message": f'Too many votes cast in contest: {contest["name"]} ({total_votes_in_all_choices} votes, {total_allowed_votes_in_contest} allowed)',
+                    "errorType": "TooManyVotes",
+                }
+            )
 
     if errors:
         db.session.rollback()
@@ -493,7 +567,7 @@ def audit_basic_update(election_id):
     return jsonify(status="ok")
 
 
-@app.route('/election/<election_id>/audit/sample-size', methods=["POST"])
+@app.route("/election/<election_id>/audit/sample-size", methods=["POST"])
 def samplesize_set(election_id):
     election = get_election(election_id)
 
@@ -502,37 +576,38 @@ def samplesize_set(election_id):
     if len(rounds) > 1:
         return jsonify(status="bad")
 
-    rounds[0].round_contests[0].sample_size = int(request.get_json()['size'])
+    rounds[0].round_contests[0].sample_size = int(request.get_json()["size"])
     db.session.commit()
 
     return jsonify(status="ok")
 
 
-@app.route('/election/<election_id>/audit/jurisdictions', methods=["POST"])
+@app.route("/election/<election_id>/audit/jurisdictions", methods=["POST"])
 def jurisdictions_set(election_id):
     election = get_election(election_id)
-    jurisdictions = request.get_json()['jurisdictions']
+    jurisdictions = request.get_json()["jurisdictions"]
 
     db.session.query(Jurisdiction).filter_by(election_id=election.id).delete()
 
     for jurisdiction in jurisdictions:
-        jurisdiction_obj = Jurisdiction(election_id=election.id,
-                                        id=jurisdiction['id'],
-                                        name=jurisdiction['name'])
+        jurisdiction_obj = Jurisdiction(
+            election_id=election.id, id=jurisdiction["id"], name=jurisdiction["name"]
+        )
         db.session.add(jurisdiction_obj)
 
         for contest_id in jurisdiction["contests"]:
-            jurisdiction_contest = TargetedContestJurisdiction(contest_id=contest_id,
-                                                               jurisdiction_id=jurisdiction_obj.id)
+            jurisdiction_contest = TargetedContestJurisdiction(
+                contest_id=contest_id, jurisdiction_id=jurisdiction_obj.id
+            )
             db.session.add(jurisdiction_contest)
 
         for audit_board in jurisdiction["auditBoards"]:
-            audit_board_obj = AuditBoard(id=audit_board["id"],
-                                         name=audit_board["name"],
-                                         jurisdiction_id=jurisdiction_obj.id,
-                                         passphrase=xp.generate_xkcdpassword(WORDS,
-                                                                             numwords=4,
-                                                                             delimiter="-"))
+            audit_board_obj = AuditBoard(
+                id=audit_board["id"],
+                name=audit_board["name"],
+                jurisdiction_id=jurisdiction_obj.id,
+                passphrase=xp.generate_xkcdpassword(WORDS, numwords=4, delimiter="-"),
+            )
             db.session.add(audit_board_obj)
 
     db.session.commit()
@@ -540,22 +615,33 @@ def jurisdictions_set(election_id):
     return jsonify(status="ok")
 
 
-@app.route('/election/<election_id>/jurisdiction/<jurisdiction_id>/manifest',
-           methods=["DELETE", "POST"])
+@app.route(
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/manifest",
+    methods=["DELETE", "POST"],
+)
 def jurisdiction_manifest(jurisdiction_id, election_id):
-    BATCH_NAME = 'Batch Name'
-    NUMBER_OF_BALLOTS = 'Number of Ballots'
-    STORAGE_LOCATION = 'Storage Location'
-    TABULATOR = 'Tabulator'
+    BATCH_NAME = "Batch Name"
+    NUMBER_OF_BALLOTS = "Number of Ballots"
+    STORAGE_LOCATION = "Storage Location"
+    TABULATOR = "Tabulator"
 
     election = get_election(election_id)
-    jurisdiction = Jurisdiction.query.filter_by(election_id=election.id, id=jurisdiction_id).one()
+    jurisdiction = Jurisdiction.query.filter_by(
+        election_id=election.id, id=jurisdiction_id
+    ).one()
 
     if not jurisdiction:
-        return jsonify(errors=[{
-            'message': f'No jurisdiction found with id: {jurisdiction_id}',
-            'errorType': 'NotFoundError'
-        }]), 404
+        return (
+            jsonify(
+                errors=[
+                    {
+                        "message": f"No jurisdiction found with id: {jurisdiction_id}",
+                        "errorType": "NotFoundError",
+                    }
+                ]
+            ),
+            404,
+        )
 
     if request.method == "DELETE":
         jurisdiction.manifest = None
@@ -570,8 +656,8 @@ def jurisdiction_manifest(jurisdiction_id, election_id):
 
         return jsonify(status="ok")
 
-    manifest = request.files['manifest']
-    manifest_string = manifest.read().decode('utf-8-sig')
+    manifest = request.files["manifest"]
+    manifest_string = manifest.read().decode("utf-8-sig")
     jurisdiction.manifest = manifest_string
 
     jurisdiction.manifest_filename = manifest.filename
@@ -580,15 +666,25 @@ def jurisdiction_manifest(jurisdiction_id, election_id):
     manifest_csv = csv.DictReader(io.StringIO(manifest_string))
 
     missing_fields = [
-        field for field in [BATCH_NAME, NUMBER_OF_BALLOTS] if field not in manifest_csv.fieldnames
+        field
+        for field in [BATCH_NAME, NUMBER_OF_BALLOTS]
+        if field not in manifest_csv.fieldnames
     ]
 
     if missing_fields:
-        return jsonify(errors=[{
-            'message': f'Missing required CSV field "{field}"',
-            'errorType': 'MissingRequiredCsvField',
-            'fieldName': field
-        } for field in missing_fields]), 400
+        return (
+            jsonify(
+                errors=[
+                    {
+                        "message": f'Missing required CSV field "{field}"',
+                        "errorType": "MissingRequiredCsvField",
+                        "fieldName": field,
+                    }
+                    for field in missing_fields
+                ]
+            ),
+            400,
+        )
 
     num_batches = 0
     num_ballots = 0
@@ -598,18 +694,26 @@ def jurisdiction_manifest(jurisdiction_id, election_id):
         try:
             num_ballots_in_batch = locale.atoi(num_ballots_in_batch_csv)
         except ValueError:
-            return jsonify(errors=[{
-                'message':
-                f'Invalid value for "{NUMBER_OF_BALLOTS}" on line {manifest_csv.line_num}: {num_ballots_in_batch_csv}',
-                'errorType': 'InvalidCsvIntegerField'
-            }]), 400
+            return (
+                jsonify(
+                    errors=[
+                        {
+                            "message": f'Invalid value for "{NUMBER_OF_BALLOTS}" on line {manifest_csv.line_num}: {num_ballots_in_batch_csv}',
+                            "errorType": "InvalidCsvIntegerField",
+                        }
+                    ]
+                ),
+                400,
+            )
 
-        batch = Batch(id=str(uuid.uuid4()),
-                      name=row[BATCH_NAME],
-                      jurisdiction_id=jurisdiction.id,
-                      num_ballots=num_ballots_in_batch,
-                      storage_location=row.get(STORAGE_LOCATION, None),
-                      tabulator=row.get(TABULATOR, None))
+        batch = Batch(
+            id=str(uuid.uuid4()),
+            name=row[BATCH_NAME],
+            jurisdiction_id=jurisdiction.id,
+            num_ballots=num_ballots_in_batch,
+            storage_location=row.get(STORAGE_LOCATION, None),
+            tabulator=row.get(TABULATOR, None),
+        )
         db.session.add(batch)
         num_batches += 1
         num_ballots += batch.num_ballots
@@ -624,7 +728,7 @@ def jurisdiction_manifest(jurisdiction_id, election_id):
     return jsonify(status="ok")
 
 
-@app.route('/election/<election_id>/audit/freeze', methods=["POST"])
+@app.route("/election/<election_id>/audit/freeze", methods=["POST"])
 def audit_launch(election_id):
     election = get_election(election_id)
 
@@ -643,12 +747,17 @@ def audit_launch(election_id):
     return jsonify(status="ok")
 
 
-@app.route('/election/<election_id>/jurisdiction/<jurisdiction_id>/audit-board/<audit_board_id>',
-           methods=["GET"])
+@app.route(
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/audit-board/<audit_board_id>",
+    methods=["GET"],
+)
 def audit_board(election_id, jurisdiction_id, audit_board_id):
-    audit_boards = AuditBoard.query.filter_by(id=audit_board_id) \
-        .join(AuditBoard.jurisdiction).filter_by(id=jurisdiction_id, election_id=election_id) \
+    audit_boards = (
+        AuditBoard.query.filter_by(id=audit_board_id)
+        .join(AuditBoard.jurisdiction)
+        .filter_by(id=jurisdiction_id, election_id=election_id)
         .all()
+    )
 
     if not audit_boards:
         return f"no audit board found with id={audit_board_id}", 404
@@ -658,45 +767,74 @@ def audit_board(election_id, jurisdiction_id, audit_board_id):
 
     audit_board = audit_boards[0]
 
-    return jsonify(id=audit_board.id, name=audit_board.name, members=serialize_members(audit_board))
+    return jsonify(
+        id=audit_board.id, name=audit_board.name, members=serialize_members(audit_board)
+    )
 
 
-@app.route('/election/<election_id>/jurisdiction/<jurisdiction_id>/audit-board/<audit_board_id>',
-           methods=["POST"])
+@app.route(
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/audit-board/<audit_board_id>",
+    methods=["POST"],
+)
 def set_audit_board(election_id, jurisdiction_id, audit_board_id):
     attributes = request.get_json()
-    audit_boards = AuditBoard.query.filter_by(id=audit_board_id) \
-        .join(Jurisdiction).filter_by(id=jurisdiction_id, election_id=election_id) \
+    audit_boards = (
+        AuditBoard.query.filter_by(id=audit_board_id)
+        .join(Jurisdiction)
+        .filter_by(id=jurisdiction_id, election_id=election_id)
         .all()
+    )
 
     if not audit_boards:
-        return jsonify(errors=[{
-            'message': f'No audit board found with id={audit_board_id}',
-            'errorType': 'NotFoundError'
-        }]), 404
+        return (
+            jsonify(
+                errors=[
+                    {
+                        "message": f"No audit board found with id={audit_board_id}",
+                        "errorType": "NotFoundError",
+                    }
+                ]
+            ),
+            404,
+        )
 
     if len(audit_boards) > 1:
-        return jsonify(errors=[{
-            'message': f'Found too many audit boards with id={audit_board_id}',
-            'errorType': 'BadRequest'
-        }]), 400
+        return (
+            jsonify(
+                errors=[
+                    {
+                        "message": f"Found too many audit boards with id={audit_board_id}",
+                        "errorType": "BadRequest",
+                    }
+                ]
+            ),
+            400,
+        )
 
     audit_board = audit_boards[0]
-    members = attributes.get('members', None)
+    members = attributes.get("members", None)
 
     if members is not None:
         if len(members) != AUDIT_BOARD_MEMBER_COUNT:
-            return jsonify(errors=[{
-                'message':
-                f'Members must contain exactly {AUDIT_BOARD_MEMBER_COUNT} entries, got {len(members)}',
-                'errorType': 'BadRequest'
-            }]), 400
+            return (
+                jsonify(
+                    errors=[
+                        {
+                            "message": f"Members must contain exactly {AUDIT_BOARD_MEMBER_COUNT} entries, got {len(members)}",
+                            "errorType": "BadRequest",
+                        }
+                    ]
+                ),
+                400,
+            )
 
         for i in range(0, AUDIT_BOARD_MEMBER_COUNT):
-            setattr(audit_board, f"member_{i + 1}", members[i]['name'])
-            setattr(audit_board, f"member_{i + 1}_affiliation", members[i]['affiliation'])
+            setattr(audit_board, f"member_{i + 1}", members[i]["name"])
+            setattr(
+                audit_board, f"member_{i + 1}_affiliation", members[i]["affiliation"]
+            )
 
-    name = attributes.get('name', None)
+    name = attributes.get("name", None)
 
     if name is not None:
         audit_board.name = name
@@ -706,99 +844,143 @@ def set_audit_board(election_id, jurisdiction_id, audit_board_id):
     return jsonify(status="ok")
 
 
-@app.route('/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/ballot-list')
+@app.route(
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/ballot-list"
+)
 def ballot_list(election_id, jurisdiction_id, round_id):
-    query = SampledBallotDraw.query \
-                .join(SampledBallot).join(SampledBallotDraw.batch).join(AuditBoard).join(Round) \
-                .add_entity(SampledBallot).add_entity(Batch).add_entity(AuditBoard) \
-                .filter(Round.id == round_id) \
-                .filter(Batch.jurisdiction_id == jurisdiction_id) \
-                .order_by(AuditBoard.name, Batch.name, SampledBallot.ballot_position, SampledBallotDraw.ticket_number) \
-                .all()
+    query = (
+        SampledBallotDraw.query.join(SampledBallot)
+        .join(SampledBallotDraw.batch)
+        .join(AuditBoard)
+        .join(Round)
+        .add_entity(SampledBallot)
+        .add_entity(Batch)
+        .add_entity(AuditBoard)
+        .filter(Round.id == round_id)
+        .filter(Batch.jurisdiction_id == jurisdiction_id)
+        .order_by(
+            AuditBoard.name,
+            Batch.name,
+            SampledBallot.ballot_position,
+            SampledBallotDraw.ticket_number,
+        )
+        .all()
+    )
 
-    return jsonify(ballots=[{
-        "ticketNumber": ballot_draw.ticket_number,
-        "status": 'AUDITED' if ballot.vote is not None else None,
-        "vote": ballot.vote,
-        "comment": ballot.comment,
-        "position": ballot.ballot_position,
-        "batch": {
-            "id": batch.id,
-            "name": batch.name,
-            "tabulator": batch.tabulator
-        },
-        "auditBoard": {
-            "id": audit_board.id,
-            "name": audit_board.name
-        }
-    } for (ballot_draw, ballot, batch, audit_board) in query])
+    return jsonify(
+        ballots=[
+            {
+                "ticketNumber": ballot_draw.ticket_number,
+                "status": "AUDITED" if ballot.vote is not None else None,
+                "vote": ballot.vote,
+                "comment": ballot.comment,
+                "position": ballot.ballot_position,
+                "batch": {
+                    "id": batch.id,
+                    "name": batch.name,
+                    "tabulator": batch.tabulator,
+                },
+                "auditBoard": {"id": audit_board.id, "name": audit_board.name},
+            }
+            for (ballot_draw, ballot, batch, audit_board) in query
+        ]
+    )
 
 
 @app.route(
-    '/election/<election_id>/jurisdiction/<jurisdiction_id>/audit-board/<audit_board_id>/round/<round_id>/ballot-list'
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/audit-board/<audit_board_id>/round/<round_id>/ballot-list"
 )
 def ballot_list_by_audit_board(election_id, jurisdiction_id, audit_board_id, round_id):
-    query = SampledBallotDraw.query \
-                .join(Round).join(SampledBallot).join(Batch) \
-                .add_entity(SampledBallot).add_entity(Batch) \
-                .filter(Round.id == round_id) \
-                .filter(Batch.jurisdiction_id == jurisdiction_id) \
-                .filter(SampledBallot.audit_board_id == audit_board_id) \
-                .order_by(Batch.name, SampledBallot.ballot_position, SampledBallotDraw.ticket_number)
+    query = (
+        SampledBallotDraw.query.join(Round)
+        .join(SampledBallot)
+        .join(Batch)
+        .add_entity(SampledBallot)
+        .add_entity(Batch)
+        .filter(Round.id == round_id)
+        .filter(Batch.jurisdiction_id == jurisdiction_id)
+        .filter(SampledBallot.audit_board_id == audit_board_id)
+        .order_by(
+            Batch.name, SampledBallot.ballot_position, SampledBallotDraw.ticket_number
+        )
+    )
 
-    return jsonify(ballots=[{
-        "ticketNumber": ballot_draw.ticket_number,
-        "status": 'AUDITED' if ballot.vote is not None else None,
-        "vote": ballot.vote,
-        "comment": ballot.comment,
-        "position": ballot.ballot_position,
-        "batch": {
-            "id": batch.id,
-            "name": batch.name,
-            "tabulator": batch.tabulator
-        }
-    } for (ballot_draw, ballot, batch) in query])
+    return jsonify(
+        ballots=[
+            {
+                "ticketNumber": ballot_draw.ticket_number,
+                "status": "AUDITED" if ballot.vote is not None else None,
+                "vote": ballot.vote,
+                "comment": ballot.comment,
+                "position": ballot.ballot_position,
+                "batch": {
+                    "id": batch.id,
+                    "name": batch.name,
+                    "tabulator": batch.tabulator,
+                },
+            }
+            for (ballot_draw, ballot, batch) in query
+        ]
+    )
 
 
 @app.route(
-    '/election/<election_id>/jurisdiction/<jurisdiction_id>/batch/<batch_id>/ballot/<ballot_position>',
-    methods=["POST"])
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/batch/<batch_id>/ballot/<ballot_position>",
+    methods=["POST"],
+)
 def ballot_set(election_id, jurisdiction_id, batch_id, ballot_position):
     attributes = request.get_json()
-    ballots = SampledBallot.query \
-        .filter_by(batch_id=batch_id, ballot_position=ballot_position) \
-        .join(SampledBallot.batch) \
-        .filter_by(jurisdiction_id=jurisdiction_id) \
+    ballots = (
+        SampledBallot.query.filter_by(
+            batch_id=batch_id, ballot_position=ballot_position
+        )
+        .join(SampledBallot.batch)
+        .filter_by(jurisdiction_id=jurisdiction_id)
         .all()
+    )
 
     if not ballots:
-        return jsonify(errors=[{
-            'message':
-            f'No ballot found with election_id={election_id}, jurisdiction_id={jurisdiction_id}, batch_id={batch_id}, ballot_position={ballot_position}',
-            'errorType': 'NotFoundError'
-        }]), 404
+        return (
+            jsonify(
+                errors=[
+                    {
+                        "message": f"No ballot found with election_id={election_id}, jurisdiction_id={jurisdiction_id}, batch_id={batch_id}, ballot_position={ballot_position}",
+                        "errorType": "NotFoundError",
+                    }
+                ]
+            ),
+            404,
+        )
     elif len(ballots) > 1:
-        return jsonify(errors=[{
-            'message':
-            f'Multiple ballots found with election_id={election_id}, jurisdiction_id={jurisdiction_id}, batch_id={batch_id}, ballot_position={ballot_position}',
-            'errorType': 'BadRequest'
-        }]), 400
+        return (
+            jsonify(
+                errors=[
+                    {
+                        "message": f"Multiple ballots found with election_id={election_id}, jurisdiction_id={jurisdiction_id}, batch_id={batch_id}, ballot_position={ballot_position}",
+                        "errorType": "BadRequest",
+                    }
+                ]
+            ),
+            400,
+        )
 
     ballot = ballots[0]
 
-    if 'vote' in attributes:
-        ballot.vote = attributes['vote']
+    if "vote" in attributes:
+        ballot.vote = attributes["vote"]
 
-    if 'comment' in attributes:
-        ballot.comment = attributes['comment']
+    if "comment" in attributes:
+        ballot.comment = attributes["comment"]
 
     db.session.commit()
 
     return jsonify(status="ok")
 
 
-@app.route('/election/<election_id>/jurisdiction/<jurisdiction_id>/<round_num>/retrieval-list',
-           methods=["GET"])
+@app.route(
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/<round_num>/retrieval-list",
+    methods=["GET"],
+)
 def jurisdiction_retrieval_list(election_id, jurisdiction_id, round_num):
     election = get_election(election_id)
 
@@ -808,48 +990,97 @@ def jurisdiction_retrieval_list(election_id, jurisdiction_id, round_num):
 
     csv_io = io.StringIO()
     retrieval_list_writer = csv.writer(csv_io)
-    retrieval_list_writer.writerow([
-        "Batch Name", "Ballot Number", "Storage Location", "Tabulator", "Ticket Numbers",
-        "Already Audited", "Audit Board"
-    ])
+    retrieval_list_writer.writerow(
+        [
+            "Batch Name",
+            "Ballot Number",
+            "Storage Location",
+            "Tabulator",
+            "Ticket Numbers",
+            "Already Audited",
+            "Audit Board",
+        ]
+    )
 
     # Get previously sampled ballots as a separate query for clarity
     # (self joins are cool but they're not super clear)
-    previous_ballots_query = SampledBallotDraw.query \
-                        .join(SampledBallotDraw.round).filter(Round.round_num < round_num) \
-                        .join(SampledBallotDraw.batch).filter_by(jurisdiction_id = jurisdiction_id)  \
-                        .values(Batch.name, SampledBallotDraw.ballot_position)
-    previous_ballots = {(batch_name, ballot_position)
-                        for batch_name, ballot_position in previous_ballots_query}
+    previous_ballots_query = (
+        SampledBallotDraw.query.join(SampledBallotDraw.round)
+        .filter(Round.round_num < round_num)
+        .join(SampledBallotDraw.batch)
+        .filter_by(jurisdiction_id=jurisdiction_id)
+        .values(Batch.name, SampledBallotDraw.ballot_position)
+    )
+    previous_ballots = {
+        (batch_name, ballot_position)
+        for batch_name, ballot_position in previous_ballots_query
+    }
 
     # Get deduped sampled ballots
-    ballots = SampledBallotDraw.query.filter_by(round_id = round.id) \
-                    .join(SampledBallotDraw.batch).filter_by(jurisdiction_id = jurisdiction_id)  \
-                    .join(SampledBallotDraw.sampled_ballot).join(SampledBallot.audit_board) \
-                    .add_entity(Batch).add_entity(AuditBoard) \
-                    .group_by(Batch.name, Batch.id, Batch.storage_location, Batch.tabulator, AuditBoard.name)\
-                    .group_by(SampledBallotDraw.ballot_position) \
-                    .order_by(AuditBoard.name, Batch.name, SampledBallotDraw.ballot_position) \
-                    .values(Batch.id, SampledBallotDraw.ballot_position, Batch.name,
-                            Batch.storage_location, Batch.tabulator, AuditBoard.name,
-                            func.string_agg(SampledBallotDraw.ticket_number,
-                                            aggregate_order_by(",", SampledBallotDraw.ticket_number)))
+    ballots = (
+        SampledBallotDraw.query.filter_by(round_id=round.id)
+        .join(SampledBallotDraw.batch)
+        .filter_by(jurisdiction_id=jurisdiction_id)
+        .join(SampledBallotDraw.sampled_ballot)
+        .join(SampledBallot.audit_board)
+        .add_entity(Batch)
+        .add_entity(AuditBoard)
+        .group_by(
+            Batch.name,
+            Batch.id,
+            Batch.storage_location,
+            Batch.tabulator,
+            AuditBoard.name,
+        )
+        .group_by(SampledBallotDraw.ballot_position)
+        .order_by(AuditBoard.name, Batch.name, SampledBallotDraw.ballot_position)
+        .values(
+            Batch.id,
+            SampledBallotDraw.ballot_position,
+            Batch.name,
+            Batch.storage_location,
+            Batch.tabulator,
+            AuditBoard.name,
+            func.string_agg(
+                SampledBallotDraw.ticket_number,
+                aggregate_order_by(",", SampledBallotDraw.ticket_number),
+            ),
+        )
+    )
 
-    for _batch_id, position, batch_name, storage_location, tabulator, audit_board, ticket_numbers in ballots:
+    for (
+        _batch_id,
+        position,
+        batch_name,
+        storage_location,
+        tabulator,
+        audit_board,
+        ticket_numbers,
+    ) in ballots:
         previously_audited = "Y" if (batch_name, position) in previous_ballots else "N"
-        retrieval_list_writer.writerow([
-            batch_name, position, storage_location, tabulator, ticket_numbers, previously_audited,
-            audit_board
-        ])
+        retrieval_list_writer.writerow(
+            [
+                batch_name,
+                position,
+                storage_location,
+                tabulator,
+                ticket_numbers,
+                previously_audited,
+                audit_board,
+            ]
+        )
 
     response = Response(csv_io.getvalue())
     response.headers[
-        'Content-Disposition'] = f'attachment; filename="ballot-retrieval-{election_timestamp_name(election)}.csv"'
+        "Content-Disposition"
+    ] = f'attachment; filename="ballot-retrieval-{election_timestamp_name(election)}.csv"'
     return response
 
 
-@app.route('/election/<election_id>/jurisdiction/<jurisdiction_id>/<round_num>/results',
-           methods=["POST"])
+@app.route(
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/<round_num>/results",
+    methods=["POST"],
+)
 def jurisdiction_results(election_id, jurisdiction_id, round_num):
     election = get_election(election_id)
     results = request.get_json()
@@ -859,13 +1090,17 @@ def jurisdiction_results(election_id, jurisdiction_id, round_num):
 
     for contest in results["contests"]:
         RoundContest.query.filter_by(contest_id=contest["id"], round_id=round.id).one()
-        RoundContestResult.query.filter_by(contest_id=contest["id"], round_id=round.id).delete()
+        RoundContestResult.query.filter_by(
+            contest_id=contest["id"], round_id=round.id
+        ).delete()
 
         for choice_id, result in contest["results"].items():
-            contest_result = RoundContestResult(round_id=round.id,
-                                                contest_id=contest["id"],
-                                                targeted_contest_choice_id=choice_id,
-                                                result=result)
+            contest_result = RoundContestResult(
+                round_id=round.id,
+                contest_id=contest["id"],
+                targeted_contest_choice_id=choice_id,
+                result=result,
+            )
             db.session.add(contest_result)
 
     if not check_round(election, jurisdiction_id, round.id):
@@ -876,7 +1111,7 @@ def jurisdiction_results(election_id, jurisdiction_id, round_num):
     return jsonify(status="ok")
 
 
-@app.route('/election/<election_id>/audit/report', methods=["GET"])
+@app.route("/election/<election_id>/audit/report", methods=["GET"])
 def audit_report(election_id):
     election = get_election(election_id)
     jurisdiction = election.jurisdictions[0]
@@ -899,55 +1134,86 @@ def audit_report(election_id):
     report_writer.writerow(["Random Seed", election.random_seed])
 
     for audit_board in jurisdiction.audit_boards:
-        report_writer.writerow([
-            audit_board.name, audit_board.member_1,
-            pretty_affiliation(audit_board.member_1_affiliation)
-        ])
-        report_writer.writerow([
-            audit_board.name, audit_board.member_2,
-            pretty_affiliation(audit_board.member_2_affiliation)
-        ])
+        report_writer.writerow(
+            [
+                audit_board.name,
+                audit_board.member_1,
+                pretty_affiliation(audit_board.member_1_affiliation),
+            ]
+        )
+        report_writer.writerow(
+            [
+                audit_board.name,
+                audit_board.member_2,
+                pretty_affiliation(audit_board.member_2_affiliation),
+            ]
+        )
 
     for round in election.rounds:
         round_contest = round.round_contests[0]
         round_contest_results = round_contest.results
 
         report_writer.writerow(
-            ["Round {:d} Sample Size".format(round.round_num), round_contest.sample_size])
+            [
+                "Round {:d} Sample Size".format(round.round_num),
+                round_contest.sample_size,
+            ]
+        )
 
         for result in round_contest_results:
-            report_writer.writerow([
-                "Round {:d} Audited Votes for {:s}".format(round.round_num,
-                                                           result.targeted_contest_choice.name),
-                result.result
-            ])
+            report_writer.writerow(
+                [
+                    "Round {:d} Audited Votes for {:s}".format(
+                        round.round_num, result.targeted_contest_choice.name
+                    ),
+                    result.result,
+                ]
+            )
 
         report_writer.writerow(
-            ["Round {:d} P-Value".format(round.round_num), round_contest.end_p_value])
-        report_writer.writerow([
-            "Round {:d} Risk Limit Met?".format(round.round_num),
-            'Yes' if round_contest.is_complete else 'No'
-        ])
+            ["Round {:d} P-Value".format(round.round_num), round_contest.end_p_value]
+        )
+        report_writer.writerow(
+            [
+                "Round {:d} Risk Limit Met?".format(round.round_num),
+                "Yes" if round_contest.is_complete else "No",
+            ]
+        )
 
-        report_writer.writerow(["Round {:d} Start".format(round.round_num), round.started_at])
-        report_writer.writerow(["Round {:d} End".format(round.round_num), round.ended_at])
+        report_writer.writerow(
+            ["Round {:d} Start".format(round.round_num), round.started_at]
+        )
+        report_writer.writerow(
+            ["Round {:d} End".format(round.round_num), round.ended_at]
+        )
 
-        ballots = SampledBallotDraw.query \
-                    .filter_by(round_id = round.id) \
-                    .join(SampledBallotDraw.batch).add_entity(Batch) \
-                    .filter_by(jurisdiction_id = jurisdiction.id) \
-                    .order_by('batch_id', 'ballot_position').all()
+        ballots = (
+            SampledBallotDraw.query.filter_by(round_id=round.id)
+            .join(SampledBallotDraw.batch)
+            .add_entity(Batch)
+            .filter_by(jurisdiction_id=jurisdiction.id)
+            .order_by("batch_id", "ballot_position")
+            .all()
+        )
 
-        report_writer.writerow([
-            "Round {:d} Samples".format(round.round_num), " ".join([
-                "(Batch {:s}, #{:d}, Ticket #{:s})".format(batch.name, b.ballot_position,
-                                                           b.ticket_number) for b, batch in ballots
-            ])
-        ])
+        report_writer.writerow(
+            [
+                "Round {:d} Samples".format(round.round_num),
+                " ".join(
+                    [
+                        "(Batch {:s}, #{:d}, Ticket #{:s})".format(
+                            batch.name, b.ballot_position, b.ticket_number
+                        )
+                        for b, batch in ballots
+                    ]
+                ),
+            ]
+        )
 
     response = Response(csv_io.getvalue())
     response.headers[
-        'Content-Disposition'] = f'attachment; filename="audit-report-{election_timestamp_name(election)}.csv"'
+        "Content-Disposition"
+    ] = f'attachment; filename="audit-report-{election_timestamp_name(election)}.csv"'
     return response
 
 
@@ -962,7 +1228,7 @@ def pretty_affiliation(affiliation):
     return mapping.get(affiliation, None)
 
 
-@app.route('/election/<election_id>/audit/reset', methods=["POST"])
+@app.route("/election/<election_id>/audit/reset", methods=["POST"])
 def audit_reset(election_id):
     # deleting the election cascades to all the data structures
     Election.query.filter_by(id=election_id).delete()
@@ -974,64 +1240,66 @@ def audit_reset(election_id):
     return jsonify(status="ok")
 
 
-@app.route('/auditboard/<passphrase>', methods=["GET"])
+@app.route("/auditboard/<passphrase>", methods=["GET"])
 def auditboard_passphrase(passphrase):
     auditboard = AuditBoard.query.filter_by(passphrase=passphrase).one()
-    return redirect("/election/%s/board/%s" % (auditboard.jurisdiction.election.id, auditboard.id))
+    return redirect(
+        "/election/%s/board/%s" % (auditboard.jurisdiction.election.id, auditboard.id)
+    )
 
 
 # Test endpoint for the session.
-@app.route('/incr')
+@app.route("/incr")
 def incr():
-    if 'count' in session:
-        session['count'] += 1
+    if "count" in session:
+        session["count"] += 1
     else:
-        session['count'] = 1
+        session["count"] = 1
 
-    return jsonify(count=session['count'])
+    return jsonify(count=session["count"])
 
 
 ##
 ## Authentication
 ##
 
-AUDITADMIN_OAUTH_CALLBACK_URL = '/auth/auditadmin/callback'
-JURISDICTIONADMIN_OAUTH_CALLBACK_URL = '/auth/jurisdictionadmin/callback'
+AUDITADMIN_OAUTH_CALLBACK_URL = "/auth/auditadmin/callback"
+JURISDICTIONADMIN_OAUTH_CALLBACK_URL = "/auth/jurisdictionadmin/callback"
 
 oauth = OAuth(app)
 
 auth0_aa = oauth.register(
-    'auth0_aa',
+    "auth0_aa",
     client_id=AUDITADMIN_AUTH0_CLIENT_ID,
     client_secret=AUDITADMIN_AUTH0_CLIENT_SECRET,
     api_base_url=AUDITADMIN_AUTH0_BASE_URL,
     access_token_url=f"{AUDITADMIN_AUTH0_BASE_URL}/oauth/token",
     authorize_url=f"{AUDITADMIN_AUTH0_BASE_URL}/authorize",
-    client_kwargs={'scope': 'openid profile email'},
+    client_kwargs={"scope": "openid profile email"},
 )
 
 auth0_ja = oauth.register(
-    'auth0_ja',
+    "auth0_ja",
     client_id=JURISDICTIONADMIN_AUTH0_CLIENT_ID,
     client_secret=JURISDICTIONADMIN_AUTH0_CLIENT_SECRET,
     api_base_url=JURISDICTIONADMIN_AUTH0_BASE_URL,
     access_token_url=f"{JURISDICTIONADMIN_AUTH0_BASE_URL}/oauth/token",
     authorize_url=f"{JURISDICTIONADMIN_AUTH0_BASE_URL}/authorize",
-    client_kwargs={'scope': 'openid profile email'},
+    client_kwargs={"scope": "openid profile email"},
 )
 
 
 def set_loggedin_user(user_type: UserType, user_email: str):
-    session['_user'] = {'type': user_type, 'email': user_email}
+    session["_user"] = {"type": user_type, "email": user_email}
 
 
 def get_loggedin_user():
-    user = session.get('_user', None)
-    return (user['type'], user['email']) if user else (None, None)
+    user = session.get("_user", None)
+    return (user["type"], user["email"]) if user else (None, None)
 
 
 def clear_loggedin_user():
-    session['_user'] = None
+    session["_user"] = None
 
 
 def serialize_election(election):
@@ -1039,32 +1307,36 @@ def serialize_election(election):
         "id": election.id,
         "name": election.name,
         "state": election.state,
-        "election_date": election.election_date
+        "election_date": election.election_date,
     }
 
 
-@app.route('/auth/me')
+@app.route("/auth/me")
 def me():
     user_type, user_email = get_loggedin_user()
     if user_type:
         user = User.query.filter_by(email=user_email).one()
-        return jsonify(type=user_type,
-                       email=user_email,
-                       organizations=[{
-                           "id": org.id,
-                           "name": org.name,
-                           "elections": [serialize_election(e) for e in org.elections]
-                       } for org in user.organizations],
-                       jurisdictions=[{
-                           "id": j.id,
-                           "name": j.name,
-                           "election": serialize_election(j.election)
-                       } for j in user.jurisdictions])
+        return jsonify(
+            type=user_type,
+            email=user_email,
+            organizations=[
+                {
+                    "id": org.id,
+                    "name": org.name,
+                    "elections": [serialize_election(e) for e in org.elections],
+                }
+                for org in user.organizations
+            ],
+            jurisdictions=[
+                {"id": j.id, "name": j.name, "election": serialize_election(j.election)}
+                for j in user.jurisdictions
+            ],
+        )
     else:
         return jsonify()
 
 
-@app.route('/auth/logout')
+@app.route("/auth/logout")
 def logout():
     user_type, _user_email = get_loggedin_user()
     if not user_type:
@@ -1074,57 +1346,64 @@ def logout():
 
     # request auth0 logout and come back here when that's done
     return_url = f"{HTTP_ORIGIN}/"
-    params = urllib.parse.urlencode({'returnTo': return_url})
+    params = urllib.parse.urlencode({"returnTo": return_url})
 
-    base_url = AUDITADMIN_AUTH0_BASE_URL if user_type == UserType.AUDIT_ADMIN else JURISDICTIONADMIN_AUTH0_BASE_URL
+    base_url = (
+        AUDITADMIN_AUTH0_BASE_URL
+        if user_type == UserType.AUDIT_ADMIN
+        else JURISDICTIONADMIN_AUTH0_BASE_URL
+    )
     return redirect(f"{base_url}/v2/logout?{params}")
 
 
-@app.route('/auth/auditadmin/start')
+@app.route("/auth/auditadmin/start")
 def auditadmin_login():
-    return auth0_aa.authorize_redirect(redirect_uri=f"{HTTP_ORIGIN}{AUDITADMIN_OAUTH_CALLBACK_URL}")
+    return auth0_aa.authorize_redirect(
+        redirect_uri=f"{HTTP_ORIGIN}{AUDITADMIN_OAUTH_CALLBACK_URL}"
+    )
 
 
 @app.route(AUDITADMIN_OAUTH_CALLBACK_URL)
 def auditadmin_login_callback():
     auth0_aa.authorize_access_token()
-    resp = auth0_aa.get('userinfo')
+    resp = auth0_aa.get("userinfo")
     userinfo = resp.json()
 
-    if userinfo and userinfo['email']:
-        user = User.query.filter_by(email=userinfo['email']).first()
+    if userinfo and userinfo["email"]:
+        user = User.query.filter_by(email=userinfo["email"]).first()
         if user and len(user.audit_administrations) > 0:
-            set_loggedin_user(UserType.AUDIT_ADMIN, userinfo['email'])
+            set_loggedin_user(UserType.AUDIT_ADMIN, userinfo["email"])
 
-    return redirect('/')
+    return redirect("/")
 
 
-@app.route('/auth/jurisdictionadmin/start')
+@app.route("/auth/jurisdictionadmin/start")
 def jurisdictionadmin_login():
     return auth0_ja.authorize_redirect(
-        redirect_uri=f"{HTTP_ORIGIN}{JURISDICTIONADMIN_OAUTH_CALLBACK_URL}")
+        redirect_uri=f"{HTTP_ORIGIN}{JURISDICTIONADMIN_OAUTH_CALLBACK_URL}"
+    )
 
 
 @app.route(JURISDICTIONADMIN_OAUTH_CALLBACK_URL)
 def jurisdictionadmin_login_callback():
     auth0_ja.authorize_access_token()
-    resp = auth0_ja.get('userinfo')
+    resp = auth0_ja.get("userinfo")
     userinfo = resp.json()
 
-    if userinfo and userinfo['email']:
-        user = User.query.filter_by(email=userinfo['email']).first()
+    if userinfo and userinfo["email"]:
+        user = User.query.filter_by(email=userinfo["email"]).first()
         if user and len(user.jurisdiction_administrations) > 0:
-            set_loggedin_user(UserType.JURISDICTION_ADMIN, userinfo['email'])
+            set_loggedin_user(UserType.JURISDICTION_ADMIN, userinfo["email"])
 
-    return redirect('/')
+    return redirect("/")
 
 
 # React App
-@app.route('/')
-@app.route('/election/<election_id>')
-@app.route('/election/<election_id>/board/<board_id>')
+@app.route("/")
+@app.route("/election/<election_id>")
+@app.route("/election/<election_id>/board/<board_id>")
 def serve(election_id=None, board_id=None):
-    return app.send_static_file('index.html')
+    return app.send_static_file("index.html")
 
 
 @app.errorhandler(InternalServerError)
@@ -1136,4 +1415,9 @@ def handle_500(e):
         return e
 
     # wrapped unhandled error
-    return jsonify(errors=[{'message': str(original), 'errorType': type(original).__name__}]), 500
+    return (
+        jsonify(
+            errors=[{"message": str(original), "errorType": type(original).__name__}]
+        ),
+        500,
+    )

--- a/arlo_server/db.py
+++ b/arlo_server/db.py
@@ -3,6 +3,6 @@ from config import DATABASE_URL
 from arlo_server.base import app
 
 # database config
-app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URL
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db = SQLAlchemy(app)

--- a/audits/audit.py
+++ b/audits/audit.py
@@ -2,9 +2,9 @@ import abc
 
 
 class RiskLimitingAudit(abc.ABC):
-    '''
+    """
     An interface for a Risk Limiting Audit
-    '''
+    """
 
     risk_limit: float
 

--- a/audits/bravo.py
+++ b/audits/bravo.py
@@ -27,21 +27,21 @@ class BRAVO(RiskLimitingAudit):
         asns = {}
         for contest in contests:
             margin = margins[contest]
-            p_w = 10**7
+            p_w = 10 ** 7
             s_w = 0
             p_l = 0
             # Get smallest p_w - p_l
-            for winner in margin['winners']:
-                if margin['winners'][winner]['p_w'] < p_w:
-                    p_w = margin['winners'][winner]['p_w']
+            for winner in margin["winners"]:
+                if margin["winners"][winner]["p_w"] < p_w:
+                    p_w = margin["winners"][winner]["p_w"]
 
-            if not margin['losers']:
+            if not margin["losers"]:
                 asns[contest] = -1
                 continue
 
-            for loser in margin['losers']:
-                if margin['losers'][loser]['p_l'] > p_l:
-                    p_l = margin['losers'][loser]['p_l']
+            for loser in margin["losers"]:
+                if margin["losers"][loser]["p_l"] > p_l:
+                    p_l = margin["losers"][loser]["p_l"]
 
             s_w = p_w / (p_w + p_l)
 
@@ -49,16 +49,21 @@ class BRAVO(RiskLimitingAudit):
                 # Handle single-candidate or crazy landslides
                 asns[contest] = -1
             elif p_w == p_l:
-                asns[contest] = contests[contest]['ballots']
+                asns[contest] = contests[contest]["ballots"]
             else:
                 z_w = math.log(2 * s_w)
                 z_l = math.log(2 - 2 * s_w)
 
                 T = min(
-                    self.get_test_statistics(margins[contest], sample_results[contest]).values())
+                    self.get_test_statistics(
+                        margins[contest], sample_results[contest]
+                    ).values()
+                )
 
                 weighted_alpha = math.log((1.0 / self.risk_limit) / T)
-                asns[contest] = math.ceil((weighted_alpha + (z_w / 2.0)) / (p_w * z_w + p_l * z_l))
+                asns[contest] = math.ceil(
+                    (weighted_alpha + (z_w / 2.0)) / (p_w * z_w + p_l * z_l)
+                )
 
         return asns
 
@@ -115,9 +120,9 @@ class BRAVO(RiskLimitingAudit):
         g = minus / (plus - minus) + p_w2
 
         # The three coefficients of the quadratic:
-        q_a = g**2
-        q_b = -(z**2 * d + 2 * f * g)
-        q_c = f**2
+        q_a = g ** 2
+        q_b = -(z ** 2 * d + 2 * f * g)
+        q_c = f ** 2
 
         # Apply the quadratic formula.
         # We want the larger root for p_completion > 0.5, the
@@ -126,7 +131,7 @@ class BRAVO(RiskLimitingAudit):
         # max here handles cases where, due to rounding error,
         # the base (content) of the radical is trivially
         # negative for p_completion very close to 0.5.
-        radical = math.sqrt(max(0, q_b**2 - 4 * q_a * q_c))
+        radical = math.sqrt(max(0, q_b ** 2 - 4 * q_a * q_c))
 
         if p_completion > 0.5:
             size = math.floor((-q_b + radical) / (2 * q_a))
@@ -151,7 +156,7 @@ class BRAVO(RiskLimitingAudit):
 
         size_adj = math.ceil(size / p_wr)
 
-        return (size_adj)
+        return size_adj
 
     def expected_prob(self, p_w, p_r, sample_w, sample_r, asn):
         """ 
@@ -200,7 +205,7 @@ class BRAVO(RiskLimitingAudit):
 
         R_x = (threshold - minus * n) / (plus - minus)
 
-        print('R_x: {}, n*p_w2: {}'.format(R_x, n * p_w2))
+        print("R_x: {}, n*p_w2: {}".format(R_x, n * p_w2))
 
         z = (R_x - n * p_w2) / math.sqrt(n * p_w2 * p_r2)
 
@@ -228,7 +233,7 @@ class BRAVO(RiskLimitingAudit):
                         ...
                     }
         """
-        quants = [.7, .8, .9]
+        quants = [0.7, 0.8, 0.9]
 
         samples = {}
 
@@ -236,43 +241,46 @@ class BRAVO(RiskLimitingAudit):
         for contest in contests:
             samples[contest] = {}
 
-            p_w = 10**7
+            p_w = 10 ** 7
             p_l = 0
-            best_loser = ''
-            worse_winner = ''
+            best_loser = ""
+            worse_winner = ""
 
             # For multi-winner, do nothing
-            if 'numWinners' not in contests[contest] or contests[contest]['numWinners'] != 1:
-                samples[contest] = {'asn': {'size': asns[contest], 'prob': None}}
+            if (
+                "numWinners" not in contests[contest]
+                or contests[contest]["numWinners"] != 1
+            ):
+                samples[contest] = {"asn": {"size": asns[contest], "prob": None}}
                 return samples
 
             margin = margins[contest]
             # Get smallest p_w - p_l
-            for winner in margin['winners']:
-                if margin['winners'][winner]['p_w'] < p_w:
-                    p_w = margin['winners'][winner]['p_w']
+            for winner in margin["winners"]:
+                if margin["winners"][winner]["p_w"] < p_w:
+                    p_w = margin["winners"][winner]["p_w"]
                     worse_winner = winner
 
-            for loser in margin['losers']:
-                if margin['losers'][loser]['p_l'] > p_l:
-                    p_l = margin['losers'][loser]['p_l']
+            for loser in margin["losers"]:
+                if margin["losers"][loser]["p_l"] > p_l:
+                    p_l = margin["losers"][loser]["p_l"]
                     best_loser = loser
 
             # If we're in a single-candidate race, set sample to 0
-            if not margin['losers']:
-                samples[contest]['asn'] = {'size': -1, 'prob': -1}
+            if not margin["losers"]:
+                samples[contest]["asn"] = {"size": -1, "prob": -1}
                 for quant in quants:
                     samples[contest][quant] = -1
 
                 continue
 
-            num_ballots = contests[contest]['ballots']
+            num_ballots = contests[contest]["ballots"]
 
             # Handles ties
             if p_w == p_l:
-                samples[contest]['asn'] = {
-                    'size': num_ballots,
-                    'prob': 1,
+                samples[contest]["asn"] = {
+                    "size": num_ballots,
+                    "prob": 1,
                 }
 
                 for quant in quants:
@@ -282,14 +290,15 @@ class BRAVO(RiskLimitingAudit):
             sample_w = sample_results[contest][worse_winner]
             sample_l = sample_results[contest][best_loser]
 
-            samples[contest]['asn'] = {
-                'size': asns[contest],
-                'prob': self.expected_prob(p_w, p_l, sample_w, sample_l, asns[contest])
+            samples[contest]["asn"] = {
+                "size": asns[contest],
+                "prob": self.expected_prob(p_w, p_l, sample_w, sample_l, asns[contest]),
             }
 
             for quant in quants:
-                samples[contest][quant] = self.bravo_sample_sizes(p_w, p_l, sample_w, sample_l,
-                                                                  quant)
+                samples[contest][quant] = self.bravo_sample_sizes(
+                    p_w, p_l, sample_w, sample_l, quant
+                )
 
         return samples
 
@@ -312,8 +321,8 @@ class BRAVO(RiskLimitingAudit):
             T - Mapping of (winner, loser) pairs to their test statistic based
                 on sample_results
         """
-        winners = margins['winners']
-        losers = margins['losers']
+        winners = margins["winners"]
+        losers = margins["losers"]
 
         T = {}
 
@@ -325,15 +334,17 @@ class BRAVO(RiskLimitingAudit):
         # Handle the no-losers case
         if not losers:
             for winner in winners:
-                T[(winner, )] = 1
+                T[(winner,)] = 1
 
         for cand, votes in sample_results.items():
             if cand in winners:
                 for loser in losers:
-                    T[(cand, loser)] *= (winners[cand]['swl'][loser] / 0.5)**votes
+                    T[(cand, loser)] *= (winners[cand]["swl"][loser] / 0.5) ** votes
             elif cand in losers:
                 for winner in winners:
-                    T[(winner, cand)] *= ((1 - winners[winner]['swl'][cand]) / 0.5)**votes
+                    T[(winner, cand)] *= (
+                        (1 - winners[winner]["swl"][cand]) / 0.5
+                    ) ** votes
 
         return T
 

--- a/audits/macro.py
+++ b/audits/macro.py
@@ -42,8 +42,8 @@ class MACRO(RiskLimitingAudit):
 
         error = 0
         for contest in self.reported_results[batch_name]:
-            for winner in margins[contest]['winners']:
-                for loser in margins[contest]['losers']:
+            for winner in margins[contest]["winners"]:
+                for loser in margins[contest]["losers"]:
                     v_wp = self.reported_results[batch_name][contest][winner]
                     v_lp = self.reported_results[batch_name][contest][loser]
 
@@ -74,12 +74,12 @@ class MACRO(RiskLimitingAudit):
 
         error = 0
         for contest in self.reported_results[batch_name]:
-            for winner in margins[contest]['winners']:
-                for loser in margins[contest]['losers']:
+            for winner in margins[contest]["winners"]:
+                for loser in margins[contest]["losers"]:
                     v_wp = self.reported_results[batch_name][contest][winner]
                     v_lp = self.reported_results[batch_name][contest][loser]
 
-                    b_cp = self.reported_results[batch_name][contest]['ballots']
+                    b_cp = self.reported_results[batch_name][contest]["ballots"]
 
                     V_wl = contests[contest][winner] - contests[contest][loser]
 
@@ -156,10 +156,7 @@ class MACRO(RiskLimitingAudit):
         U = self.compute_U(contests, margins)
 
         for batch in sample_results:
-            e_p = self.compute_error(batch, \
-                                     contests, \
-                                     margins,  \
-                                     sample_results[batch])
+            e_p = self.compute_error(batch, contests, margins, sample_results[batch])
 
             u_p = self.compute_max_error(batch, contests, margins)
 

--- a/bgcompute.py
+++ b/bgcompute.py
@@ -12,14 +12,21 @@ def bgcompute():
     round_contests = RoundContest.query.filter_by(sample_size_options=None)
 
     for round_contest in round_contests:
-        print("computing sample size options for round {:d} of election ID {:s}".format(
-            round_contest.round.round_num, round_contest.round.election_id))
+        print(
+            "computing sample size options for round {:d} of election ID {:s}".format(
+                round_contest.round.round_num, round_contest.round.election_id
+            )
+        )
 
         compute_sample_sizes(round_contest)
 
-        print("done computing sample size options for round {:d} of election ID {:s}: {:s}".format(
-            round_contest.round.round_num, round_contest.round.election_id,
-            round_contest.sample_size_options))
+        print(
+            "done computing sample size options for round {:d} of election ID {:s}: {:s}".format(
+                round_contest.round.round_num,
+                round_contest.round.election_id,
+                round_contest.sample_size_options,
+            )
+        )
 
 
 def bgcompute_forever():

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -4,54 +4,68 @@ import sys
 
 from typing import Tuple
 
-DEFAULT_DATABASE_URL = 'postgres://postgres@localhost:5432/arlo'
+DEFAULT_DATABASE_URL = "postgres://postgres@localhost:5432/arlo"
 
 
 def read_database_url_config() -> str:
-    environment_database_url = os.environ.get('DATABASE_URL', None)
+    environment_database_url = os.environ.get("DATABASE_URL", None)
 
     if environment_database_url:
         return environment_database_url
 
-    database_cfg_path = os.path.normpath(os.path.join(__file__, '..', 'database.cfg'))
+    database_cfg_path = os.path.normpath(os.path.join(__file__, "..", "database.cfg"))
     database_config = configparser.ConfigParser()
     database_config.read(database_cfg_path)
 
-    flask_env = os.environ.get('FLASK_ENV', 'development')
-    result = database_config.get(flask_env, 'database_url', fallback=None)
+    flask_env = os.environ.get("FLASK_ENV", "development")
+    result = database_config.get(flask_env, "database_url", fallback=None)
 
     if not result:
         print(
-            f'WARNING: no database url was configured, falling back to default: {DEFAULT_DATABASE_URL}',
-            file=sys.stderr)
+            f"WARNING: no database url was configured, falling back to default: {DEFAULT_DATABASE_URL}",
+            file=sys.stderr,
+        )
         print(
-            f'To configure your own database url, either run with a DATABASE_URL environment variable',
-            file=sys.stderr)
+            f"To configure your own database url, either run with a DATABASE_URL environment variable",
+            file=sys.stderr,
+        )
         print(
-            f'or copy `config/database.cfg.example` to `config/database.cfg` and edit it as needed.',
-            file=sys.stderr)
+            f"or copy `config/database.cfg.example` to `config/database.cfg` and edit it as needed.",
+            file=sys.stderr,
+        )
 
     return result or DEFAULT_DATABASE_URL
 
 
 DATABASE_URL = read_database_url_config()
 
-STATIC_FOLDER = os.path.normpath(
-    os.path.join(__file__, '..', '..', 'arlo-client',
-                 'public' if os.environ.get('FLASK_ENV') == 'test' else 'build')) + "/"
+STATIC_FOLDER = (
+    os.path.normpath(
+        os.path.join(
+            __file__,
+            "..",
+            "..",
+            "arlo-client",
+            "public" if os.environ.get("FLASK_ENV") == "test" else "build",
+        )
+    )
+    + "/"
+)
 
 
 def read_session_secret() -> str:
-    session_secret = os.environ.get('ARLO_SESSION_SECRET', None)
+    session_secret = os.environ.get("ARLO_SESSION_SECRET", None)
 
     if not session_secret:
-        flask_env = os.environ.get('FLASK_ENV', 'development')
+        flask_env = os.environ.get("FLASK_ENV", "development")
 
-        if flask_env == 'development' or flask_env == 'test':
+        if flask_env == "development" or flask_env == "test":
             # Allow omitting in development, use a fixed secret instead.
-            session_secret = f'arlo-{flask_env}-session-secret-v1'
+            session_secret = f"arlo-{flask_env}-session-secret-v1"
         else:
-            raise Exception("ARLO_SESSION_SECRET env var for managing sessions is missing")
+            raise Exception(
+                "ARLO_SESSION_SECRET env var for managing sessions is missing"
+            )
 
     return session_secret
 
@@ -60,15 +74,17 @@ SESSION_SECRET = read_session_secret()
 
 
 def read_http_origin() -> str:
-    http_origin = os.environ.get('ARLO_HTTP_ORIGIN', None)
+    http_origin = os.environ.get("ARLO_HTTP_ORIGIN", None)
 
     if not http_origin:
-        flask_env = os.environ.get('FLASK_ENV', 'development')
+        flask_env = os.environ.get("FLASK_ENV", "development")
 
-        if flask_env == 'development' or flask_env == 'test':
-            http_origin = 'http://localhost:3000'
+        if flask_env == "development" or flask_env == "test":
+            http_origin = "http://localhost:3000"
         else:
-            raise Exception("ARLO_HTTP_ORIGIN env var, e.g. https://arlo.example.com, is missing")
+            raise Exception(
+                "ARLO_HTTP_ORIGIN env var, e.g. https://arlo.example.com, is missing"
+            )
 
     return http_origin
 
@@ -77,20 +93,30 @@ HTTP_ORIGIN = read_http_origin()
 
 
 def read_auditadmin_auth0_creds() -> Tuple[str, str, str]:
-    return (os.environ.get('ARLO_AUDITADMIN_AUTH0_BASE_URL',
-                           ''), os.environ.get('ARLO_AUDITADMIN_AUTH0_CLIENT_ID', ''),
-            os.environ.get('ARLO_AUDITADMIN_AUTH0_CLIENT_SECRET', ''))
+    return (
+        os.environ.get("ARLO_AUDITADMIN_AUTH0_BASE_URL", ""),
+        os.environ.get("ARLO_AUDITADMIN_AUTH0_CLIENT_ID", ""),
+        os.environ.get("ARLO_AUDITADMIN_AUTH0_CLIENT_SECRET", ""),
+    )
 
 
-AUDITADMIN_AUTH0_BASE_URL, AUDITADMIN_AUTH0_CLIENT_ID, AUDITADMIN_AUTH0_CLIENT_SECRET = read_auditadmin_auth0_creds(
-)
+(
+    AUDITADMIN_AUTH0_BASE_URL,
+    AUDITADMIN_AUTH0_CLIENT_ID,
+    AUDITADMIN_AUTH0_CLIENT_SECRET,
+) = read_auditadmin_auth0_creds()
 
 
 def read_jurisdictionadmin_auth0_creds() -> Tuple[str, str, str]:
-    return (os.environ.get('ARLO_JURISDICTIONADMIN_AUTH0_BASE_URL',
-                           ''), os.environ.get('ARLO_JURISDICTIONADMIN_AUTH0_CLIENT_ID', ''),
-            os.environ.get('ARLO_JURISDICTIONADMIN_AUTH0_CLIENT_SECRET', ''))
+    return (
+        os.environ.get("ARLO_JURISDICTIONADMIN_AUTH0_BASE_URL", ""),
+        os.environ.get("ARLO_JURISDICTIONADMIN_AUTH0_CLIENT_ID", ""),
+        os.environ.get("ARLO_JURISDICTIONADMIN_AUTH0_CLIENT_SECRET", ""),
+    )
 
 
-JURISDICTIONADMIN_AUTH0_BASE_URL, JURISDICTIONADMIN_AUTH0_CLIENT_ID, JURISDICTIONADMIN_AUTH0_CLIENT_SECRET = read_jurisdictionadmin_auth0_creds(
-)
+(
+    JURISDICTIONADMIN_AUTH0_BASE_URL,
+    JURISDICTIONADMIN_AUTH0_CLIENT_ID,
+    JURISDICTIONADMIN_AUTH0_CLIENT_SECRET,
+) = read_jurisdictionadmin_auth0_creds()

--- a/create-admin.py
+++ b/create-admin.py
@@ -3,7 +3,7 @@ import sys, uuid
 
 from arlo_server import User, AuditAdministration, db
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if len(sys.argv) != 3:
         print("Usage: python create-admin.py <org_id> <user_email>")
         sys.exit(1)

--- a/create-org.py
+++ b/create-org.py
@@ -2,7 +2,7 @@ import sys
 
 from arlo_server import create_organization
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: python create-org.py <org_name>")
         sys.exit(1)

--- a/create.py
+++ b/create.py
@@ -3,17 +3,17 @@ from config import DATABASE_URL
 from sqlalchemy import create_engine
 from sqlalchemy_utils import database_exists, create_database
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     engine = create_engine(DATABASE_URL)
-    print(f'database: {engine.url}')
+    print(f"database: {engine.url}")
 
     try:
         if not database_exists(engine.url):
-            print('creating database…')
+            print("creating database…")
             create_database(engine.url)
     except:
         # sometimes, e.g. on Heroku, you can't even test if the database exists cause permissions
         pass
 
-    print('creating tables…')
+    print("creating tables…")
     init_db()

--- a/models.py
+++ b/models.py
@@ -12,7 +12,7 @@ class Organization(db.Model):
     id = db.Column(db.String(200), primary_key=True)
     name = db.Column(db.String(200), nullable=False)
 
-    elections = relationship('Election', backref='organization', passive_deletes=True)
+    elections = relationship("Election", backref="organization", passive_deletes=True)
 
 
 class Election(db.Model):
@@ -29,27 +29,33 @@ class Election(db.Model):
     online = db.Column(db.Boolean, nullable=False, default=False)
 
     # Who does this election belong to?
-    organization_id = db.Column(db.String(200),
-                                db.ForeignKey('organization.id', ondelete='cascade'),
-                                nullable=False)
+    organization_id = db.Column(
+        db.String(200),
+        db.ForeignKey("organization.id", ondelete="cascade"),
+        nullable=False,
+    )
 
     frozen_at = db.Column(db.DateTime(timezone=False), nullable=True)
 
-    jurisdictions = relationship('Jurisdiction', backref='election', passive_deletes=True)
-    contests = relationship('TargetedContest', backref='election', passive_deletes=True)
-    rounds = relationship('Round', backref='election', passive_deletes=True)
+    jurisdictions = relationship(
+        "Jurisdiction", backref="election", passive_deletes=True
+    )
+    contests = relationship("TargetedContest", backref="election", passive_deletes=True)
+    rounds = relationship("Round", backref="election", passive_deletes=True)
 
     jurisdictions_file = db.Column(db.Text, nullable=True)
     jurisdictions_filename = db.Column(db.String(250), nullable=True)
-    jurisdictions_file_uploaded_at = db.Column(db.DateTime(timezone=False), nullable=True)
+    jurisdictions_file_uploaded_at = db.Column(
+        db.DateTime(timezone=False), nullable=True
+    )
 
 
 # these are typically counties
 class Jurisdiction(db.Model):
     id = db.Column(db.String(200), primary_key=True)
-    election_id = db.Column(db.String(200),
-                            db.ForeignKey('election.id', ondelete='cascade'),
-                            nullable=False)
+    election_id = db.Column(
+        db.String(200), db.ForeignKey("election.id", ondelete="cascade"), nullable=False
+    )
     name = db.Column(db.String(200), nullable=False)
     manifest = db.Column(db.Text, nullable=True)
     manifest_filename = db.Column(db.String(250), nullable=True)
@@ -63,11 +69,13 @@ class Jurisdiction(db.Model):
     # a JSON array of field names that are included in the CSV
     manifest_fields = db.Column(db.Text, nullable=True)
 
-    batches = relationship('Batch', backref='jurisdiction', passive_deletes=True)
-    audit_boards = relationship('AuditBoard', backref='jurisdiction', passive_deletes=True)
-    contests = relationship('TargetedContestJurisdiction',
-                            backref='jurisdiction',
-                            passive_deletes=True)
+    batches = relationship("Batch", backref="jurisdiction", passive_deletes=True)
+    audit_boards = relationship(
+        "AuditBoard", backref="jurisdiction", passive_deletes=True
+    )
+    contests = relationship(
+        "TargetedContestJurisdiction", backref="jurisdiction", passive_deletes=True
+    )
 
 
 class User(db.Model):
@@ -76,101 +84,127 @@ class User(db.Model):
     external_id = db.Column(db.String(200), unique=True, nullable=True)
 
     organizations = relationship("Organization", secondary="audit_administration")
-    jurisdictions = relationship("Jurisdiction", secondary="jurisdiction_administration")
+    jurisdictions = relationship(
+        "Jurisdiction", secondary="jurisdiction_administration"
+    )
 
 
 class AuditAdministration(db.Model):
-    organization_id = db.Column(db.String(200),
-                                db.ForeignKey('organization.id', ondelete='cascade'),
-                                nullable=False)
-    user_id = db.Column(db.String(200),
-                        db.ForeignKey('user.id', ondelete='cascade'),
-                        nullable=False)
+    organization_id = db.Column(
+        db.String(200),
+        db.ForeignKey("organization.id", ondelete="cascade"),
+        nullable=False,
+    )
+    user_id = db.Column(
+        db.String(200), db.ForeignKey("user.id", ondelete="cascade"), nullable=False
+    )
 
-    organization = relationship(Organization,
-                                backref=backref("audit_administrations",
-                                                cascade="all, delete-orphan"))
-    user = relationship(User,
-                        backref=backref("audit_administrations", cascade="all, delete-orphan"))
+    organization = relationship(
+        Organization,
+        backref=backref("audit_administrations", cascade="all, delete-orphan"),
+    )
+    user = relationship(
+        User, backref=backref("audit_administrations", cascade="all, delete-orphan")
+    )
 
-    __table_args__ = (db.PrimaryKeyConstraint('organization_id', 'user_id'), )
+    __table_args__ = (db.PrimaryKeyConstraint("organization_id", "user_id"),)
 
 
 class JurisdictionAdministration(db.Model):
-    user_id = db.Column(db.String(200),
-                        db.ForeignKey('user.id', ondelete='cascade'),
-                        nullable=False)
-    jurisdiction_id = db.Column(db.String(200),
-                                db.ForeignKey('jurisdiction.id', ondelete='cascade'),
-                                nullable=True)
+    user_id = db.Column(
+        db.String(200), db.ForeignKey("user.id", ondelete="cascade"), nullable=False
+    )
+    jurisdiction_id = db.Column(
+        db.String(200),
+        db.ForeignKey("jurisdiction.id", ondelete="cascade"),
+        nullable=True,
+    )
 
-    jurisdiction = relationship(Jurisdiction,
-                                backref=backref("jurisdiction_administrations",
-                                                cascade="all, delete-orphan"))
-    user = relationship(User,
-                        backref=backref("jurisdiction_administrations",
-                                        cascade="all, delete-orphan"))
+    jurisdiction = relationship(
+        Jurisdiction,
+        backref=backref("jurisdiction_administrations", cascade="all, delete-orphan"),
+    )
+    user = relationship(
+        User,
+        backref=backref("jurisdiction_administrations", cascade="all, delete-orphan"),
+    )
 
-    __table_args__ = (db.PrimaryKeyConstraint('user_id', 'jurisdiction_id'), )
+    __table_args__ = (db.PrimaryKeyConstraint("user_id", "jurisdiction_id"),)
 
 
 class Batch(db.Model):
     id = db.Column(db.String(200), primary_key=True)
-    jurisdiction_id = db.Column(db.String(200),
-                                db.ForeignKey('jurisdiction.id', ondelete='cascade'),
-                                nullable=False)
+    jurisdiction_id = db.Column(
+        db.String(200),
+        db.ForeignKey("jurisdiction.id", ondelete="cascade"),
+        nullable=False,
+    )
     name = db.Column(db.String(200), nullable=False)
     num_ballots = db.Column(db.Integer, nullable=False)
     storage_location = db.Column(db.String(200), nullable=True)
     tabulator = db.Column(db.String(200), nullable=True)
 
-    ballots = relationship('SampledBallot', backref='batch', passive_deletes=True)
-    ballot_draws = relationship('SampledBallotDraw', backref='batch', passive_deletes=True)
+    ballots = relationship("SampledBallot", backref="batch", passive_deletes=True)
+    ballot_draws = relationship(
+        "SampledBallotDraw", backref="batch", passive_deletes=True
+    )
 
 
 class TargetedContest(db.Model):
     id = db.Column(db.String(200), primary_key=True)
-    election_id = db.Column(db.String(200),
-                            db.ForeignKey('election.id', ondelete='cascade'),
-                            nullable=False)
+    election_id = db.Column(
+        db.String(200), db.ForeignKey("election.id", ondelete="cascade"), nullable=False
+    )
     name = db.Column(db.String(200), nullable=False)
     total_ballots_cast = db.Column(db.Integer, nullable=False)
     num_winners = db.Column(db.Integer, nullable=False)
     votes_allowed = db.Column(db.Integer, nullable=False)
 
-    choices = relationship('TargetedContestChoice', backref='contest', passive_deletes=True)
-    results = relationship('RoundContestResult', backref='contest', passive_deletes=True)
+    choices = relationship(
+        "TargetedContestChoice", backref="contest", passive_deletes=True
+    )
+    results = relationship(
+        "RoundContestResult", backref="contest", passive_deletes=True
+    )
 
 
 class TargetedContestChoice(db.Model):
     id = db.Column(db.String(200), primary_key=True)
-    contest_id = db.Column(db.String(200),
-                           db.ForeignKey('targeted_contest.id', ondelete='cascade'),
-                           nullable=False)
+    contest_id = db.Column(
+        db.String(200),
+        db.ForeignKey("targeted_contest.id", ondelete="cascade"),
+        nullable=False,
+    )
     name = db.Column(db.String(200), nullable=False)
     num_votes = db.Column(db.Integer, nullable=False)
 
-    results = relationship('RoundContestResult',
-                           backref='targeted_contest_choice',
-                           passive_deletes=True)
+    results = relationship(
+        "RoundContestResult", backref="targeted_contest_choice", passive_deletes=True
+    )
 
 
 class TargetedContestJurisdiction(db.Model):
-    contest_id = db.Column(db.String(200),
-                           db.ForeignKey('targeted_contest.id', ondelete='cascade'),
-                           nullable=False)
-    jurisdiction_id = db.Column(db.String(200),
-                                db.ForeignKey('jurisdiction.id', ondelete='cascade'),
-                                nullable=False)
+    contest_id = db.Column(
+        db.String(200),
+        db.ForeignKey("targeted_contest.id", ondelete="cascade"),
+        nullable=False,
+    )
+    jurisdiction_id = db.Column(
+        db.String(200),
+        db.ForeignKey("jurisdiction.id", ondelete="cascade"),
+        nullable=False,
+    )
 
-    __table_args__ = (db.PrimaryKeyConstraint('contest_id', 'jurisdiction_id'), )
+    __table_args__ = (db.PrimaryKeyConstraint("contest_id", "jurisdiction_id"),)
 
 
 class AuditBoard(db.Model):
     id = db.Column(db.String(200), primary_key=True)
-    jurisdiction_id = db.Column(db.String(200),
-                                db.ForeignKey('jurisdiction.id', ondelete='cascade'),
-                                nullable=False)
+    jurisdiction_id = db.Column(
+        db.String(200),
+        db.ForeignKey("jurisdiction.id", ondelete="cascade"),
+        nullable=False,
+    )
     name = db.Column(db.String(200))
     member_1 = db.Column(db.String(200), nullable=True)
     member_1_affiliation = db.Column(db.String(200), nullable=True)
@@ -178,75 +212,91 @@ class AuditBoard(db.Model):
     member_2_affiliation = db.Column(db.String(200), nullable=True)
     passphrase = db.Column(db.String(1000), unique=True, nullable=True)
 
-    sampled_ballots = relationship('SampledBallot', backref='audit_board', passive_deletes=True)
+    sampled_ballots = relationship(
+        "SampledBallot", backref="audit_board", passive_deletes=True
+    )
 
 
 class Round(db.Model):
     id = db.Column(db.String(200), primary_key=True)
-    election_id = db.Column(db.String(200),
-                            db.ForeignKey('election.id', ondelete='cascade'),
-                            nullable=False)
+    election_id = db.Column(
+        db.String(200), db.ForeignKey("election.id", ondelete="cascade"), nullable=False
+    )
     round_num = db.Column(db.Integer, nullable=False)
     started_at = db.Column(db.DateTime, nullable=False)
     ended_at = db.Column(db.DateTime, nullable=True)
 
-    __table_args__ = (db.UniqueConstraint('election_id', 'round_num'), )
+    __table_args__ = (db.UniqueConstraint("election_id", "round_num"),)
 
-    round_contests = relationship('RoundContest', backref='round', passive_deletes=True)
-    sampled_ballot_draws = relationship('SampledBallotDraw', backref='round', passive_deletes=True)
+    round_contests = relationship("RoundContest", backref="round", passive_deletes=True)
+    sampled_ballot_draws = relationship(
+        "SampledBallotDraw", backref="round", passive_deletes=True
+    )
 
 
 class SampledBallot(db.Model):
-    batch_id = db.Column(db.String(200),
-                         db.ForeignKey('batch.id', ondelete='cascade'),
-                         nullable=False)
+    batch_id = db.Column(
+        db.String(200), db.ForeignKey("batch.id", ondelete="cascade"), nullable=False
+    )
 
     # this ballot position should be 1-indexed
     ballot_position = db.Column(db.Integer, nullable=False)
 
-    __table_args__ = (db.PrimaryKeyConstraint('batch_id', 'ballot_position'), )
+    __table_args__ = (db.PrimaryKeyConstraint("batch_id", "ballot_position"),)
 
-    draws = relationship('SampledBallotDraw', backref='sampled_ballot', passive_deletes=True)
+    draws = relationship(
+        "SampledBallotDraw", backref="sampled_ballot", passive_deletes=True
+    )
 
-    audit_board_id = db.Column(db.String(200),
-                               db.ForeignKey('audit_board.id', ondelete='cascade'),
-                               nullable=False)
+    audit_board_id = db.Column(
+        db.String(200),
+        db.ForeignKey("audit_board.id", ondelete="cascade"),
+        nullable=False,
+    )
     vote = db.Column(db.String(200), nullable=True)
     comment = db.Column(db.Text, nullable=True)
 
 
 class SampledBallotDraw(db.Model):
-    batch_id = db.Column(db.String(200),
-                         db.ForeignKey('batch.id', ondelete='cascade'),
-                         nullable=False)
+    batch_id = db.Column(
+        db.String(200), db.ForeignKey("batch.id", ondelete="cascade"), nullable=False
+    )
     ballot_position = db.Column(db.Integer, nullable=False)
 
-    round_id = db.Column(db.String(200),
-                         db.ForeignKey('round.id', ondelete='cascade'),
-                         nullable=False)
+    round_id = db.Column(
+        db.String(200), db.ForeignKey("round.id", ondelete="cascade"), nullable=False
+    )
     ticket_number = db.Column(db.String(200), nullable=False)
 
-    __table_args__ = (db.PrimaryKeyConstraint('batch_id', 'ballot_position', 'round_id',
-                                              'ticket_number'),
-                      db.ForeignKeyConstraint(
-                          ['batch_id', 'ballot_position'],
-                          ['sampled_ballot.batch_id', 'sampled_ballot.ballot_position'],
-                          ondelete='cascade'))
+    __table_args__ = (
+        db.PrimaryKeyConstraint(
+            "batch_id", "ballot_position", "round_id", "ticket_number"
+        ),
+        db.ForeignKeyConstraint(
+            ["batch_id", "ballot_position"],
+            ["sampled_ballot.batch_id", "sampled_ballot.ballot_position"],
+            ondelete="cascade",
+        ),
+    )
 
 
 class RoundContest(db.Model):
-    round_id = db.Column(db.String(200),
-                         db.ForeignKey('round.id', ondelete='cascade'),
-                         nullable=False)
-    contest_id = db.Column(db.String(200),
-                           db.ForeignKey('targeted_contest.id', ondelete='cascade'),
-                           nullable=False)
+    round_id = db.Column(
+        db.String(200), db.ForeignKey("round.id", ondelete="cascade"), nullable=False
+    )
+    contest_id = db.Column(
+        db.String(200),
+        db.ForeignKey("targeted_contest.id", ondelete="cascade"),
+        nullable=False,
+    )
 
     sample_size_options = db.Column(db.String(1000), nullable=True)
 
-    results = relationship('RoundContestResult', backref='round_contest', passive_deletes=True)
+    results = relationship(
+        "RoundContestResult", backref="round_contest", passive_deletes=True
+    )
 
-    __table_args__ = (db.PrimaryKeyConstraint('round_id', 'contest_id'), )
+    __table_args__ = (db.PrimaryKeyConstraint("round_id", "contest_id"),)
 
     end_p_value = db.Column(db.Float)
     is_complete = db.Column(db.Boolean)
@@ -254,20 +304,26 @@ class RoundContest(db.Model):
 
 
 class RoundContestResult(db.Model):
-    round_id = db.Column(db.String(200),
-                         db.ForeignKey('round.id', ondelete='cascade'),
-                         nullable=False)
-    contest_id = db.Column(db.String(200),
-                           db.ForeignKey('targeted_contest.id', ondelete='cascade'),
-                           nullable=False)
-    __table_args__ = (db.PrimaryKeyConstraint('round_id', 'targeted_contest_choice_id'),
-                      db.ForeignKeyConstraint(
-                          ['round_id', 'contest_id'],
-                          ['round_contest.round_id', 'round_contest.contest_id'],
-                          ondelete='cascade'))
+    round_id = db.Column(
+        db.String(200), db.ForeignKey("round.id", ondelete="cascade"), nullable=False
+    )
+    contest_id = db.Column(
+        db.String(200),
+        db.ForeignKey("targeted_contest.id", ondelete="cascade"),
+        nullable=False,
+    )
+    __table_args__ = (
+        db.PrimaryKeyConstraint("round_id", "targeted_contest_choice_id"),
+        db.ForeignKeyConstraint(
+            ["round_id", "contest_id"],
+            ["round_contest.round_id", "round_contest.contest_id"],
+            ondelete="cascade",
+        ),
+    )
 
-    targeted_contest_choice_id = db.Column(db.String(200),
-                                           db.ForeignKey('targeted_contest_choice.id',
-                                                         ondelete='cascade'),
-                                           nullable=False)
+    targeted_contest_choice_id = db.Column(
+        db.String(200),
+        db.ForeignKey("targeted_contest_choice.id", ondelete="cascade"),
+        nullable=False,
+    )
     result = db.Column(db.Integer)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "prettier --write"
     ],
     "*.py": [
-      "python3 -m pipenv run yapf --in-place"
+      "black"
     ],
     "package.json": [
       "sort-package-json"

--- a/resetdb.py
+++ b/resetdb.py
@@ -5,22 +5,22 @@ from config import DATABASE_URL
 from sqlalchemy import create_engine
 from sqlalchemy_utils import database_exists, create_database, drop_database
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # a simple flag to skip DB creation
-    skip_db_creation = len(sys.argv) > 1 and sys.argv[1] == '--skip-db-creation'
+    skip_db_creation = len(sys.argv) > 1 and sys.argv[1] == "--skip-db-creation"
 
     engine = create_engine(DATABASE_URL)
-    print(f'database: {engine.url}')
+    print(f"database: {engine.url}")
 
     if skip_db_creation:
         print("skipping DB drop/create ...")
     else:
         if database_exists(engine.url):
-            print('dropping database…')
+            print("dropping database…")
             drop_database(engine.url)
 
-        print('creating database…')
+        print("creating database…")
         create_database(engine.url)
 
-    print('creating tables…')
+    print("creating tables…")
     init_db()

--- a/sampler.py
+++ b/sampler.py
@@ -57,10 +57,10 @@ class Sampler:
         self.margins = self.compute_margins()
         self.audit_type = audit_type
 
-        if audit_type == 'BRAVO':
+        if audit_type == "BRAVO":
             self.audit = BRAVO(risk_limit)
-        elif audit_type == 'MACRO':
-            assert self.batch_results, 'Must have batch-level results to use MACRO'
+        elif audit_type == "MACRO":
+            assert self.batch_results, "Must have batch-level results to use MACRO"
             self.audit = MACRO(risk_limit, batch_results)
 
     def compute_margins(self):
@@ -111,46 +111,50 @@ class Sampler:
 
         margins = {}
         for contest in self.contests:
-            margins[contest] = {'winners': {}, 'losers': {}}
+            margins[contest] = {"winners": {}, "losers": {}}
 
             cand_vec = sorted(
-                [(cand, self.contests[contest][cand])
-                 for cand in self.contests[contest] if cand not in ['numWinners', 'ballots']],
+                [
+                    (cand, self.contests[contest][cand])
+                    for cand in self.contests[contest]
+                    if cand not in ["numWinners", "ballots"]
+                ],
                 key=operator.itemgetter(1),
-                reverse=True)
+                reverse=True,
+            )
 
-            if 'numWinners' not in self.contests[contest]:
+            if "numWinners" not in self.contests[contest]:
                 num_winners = 1
             else:
-                num_winners = self.contests[contest]['numWinners']
+                num_winners = self.contests[contest]["numWinners"]
             winners = cand_vec[:num_winners]
             losers = cand_vec[num_winners:]
 
-            ballots = self.contests[contest]['ballots']
+            ballots = self.contests[contest]["ballots"]
 
             v_wl = sum([c[1] for c in winners + losers])
 
-            margins[contest]['winners']: {}
-            margins[contest]['losers']: {}
+            margins[contest]["winners"]: {}
+            margins[contest]["losers"]: {}
 
             for loser in losers:
-                margins[contest]['losers'][loser[0]] = {
-                    'p_l': loser[1] / ballots,
-                    's_l': loser[1] / v_wl
+                margins[contest]["losers"][loser[0]] = {
+                    "p_l": loser[1] / ballots,
+                    "s_l": loser[1] / v_wl,
                 }
 
             for winner in winners:
                 s_w = winner[1] / v_wl
 
                 swl = {}
-                for loser in margins[contest]['losers']:
-                    s_l = margins[contest]['losers'][loser]['s_l']
+                for loser in margins[contest]["losers"]:
+                    s_l = margins[contest]["losers"][loser]["s_l"]
                     swl[loser] = s_w / (s_w + s_l)
 
-                margins[contest]['winners'][winner[0]] = {
-                    'p_w': winner[1] / ballots,
-                    's_w': s_w,
-                    'swl': swl
+                margins[contest]["winners"][winner[0]] = {
+                    "p_w": winner[1] / ballots,
+                    "s_w": s_w,
+                    "swl": swl,
                 }
 
         return margins
@@ -182,7 +186,7 @@ class Sampler:
                     ]
         """
 
-        if self.audit_type == 'MACRO':
+        if self.audit_type == "MACRO":
             # Here we do PPEB.
 
             U = self.audit.compute_U(self.contests, self.margins)
@@ -210,20 +214,23 @@ class Sampler:
                 for i in range(times):
                     # We have to create "unique" records for the sampler, so we add
                     # a '.n' to the batch name so we know which duplicate it is.
-                    sample_from.append('{}.{}'.format(batch, i))
+                    sample_from.append("{}.{}".format(batch, i))
 
             # Now draw the sample
             faux_sample = list(
-                consistent_sampler.sampler(sample_from,
-                                           seed=self.seed,
-                                           take=sample_size + num_sampled,
-                                           with_replacement=True,
-                                           output='tuple'))[num_sampled:]
+                consistent_sampler.sampler(
+                    sample_from,
+                    seed=self.seed,
+                    take=sample_size + num_sampled,
+                    with_replacement=True,
+                    output="tuple",
+                )
+            )[num_sampled:]
 
             # here we take off the decimals.
             sample = []
             for i in faux_sample:
-                sample.append((i[0], i[1].split('.')[0], i[2]))
+                sample.append((i[0], i[1].split(".")[0], i[2]))
         else:
             ballots = []
             # First build a faux list of ballots
@@ -232,11 +239,14 @@ class Sampler:
                     ballots.append((batch, i))
 
             sample = list(
-                consistent_sampler.sampler(ballots,
-                                           seed=self.seed,
-                                           take=sample_size + num_sampled,
-                                           with_replacement=True,
-                                           output='tuple'))[num_sampled:]
+                consistent_sampler.sampler(
+                    ballots,
+                    seed=self.seed,
+                    take=sample_size + num_sampled,
+                    with_replacement=True,
+                    output="tuple",
+                )
+            )[num_sampled:]
 
         return sample
 
@@ -262,13 +272,17 @@ class Sampler:
                     }
         """
         if type(self.audit) == MACRO:
-            return self.audit.get_sample_sizes(contests=self.contests,
-                                               margins=self.margins,
-                                               sample_results=sample_results)
+            return self.audit.get_sample_sizes(
+                contests=self.contests,
+                margins=self.margins,
+                sample_results=sample_results,
+            )
         else:
-            return self.audit.get_sample_sizes(contests=self.contests,
-                                               margins=self.margins,
-                                               sample_results=sample_results)
+            return self.audit.get_sample_sizes(
+                contests=self.contests,
+                margins=self.margins,
+                sample_results=sample_results,
+            )
 
     def compute_risk(self, contest, sample_results):
         """

--- a/stubs/consistent_sampler/__init__.pyi
+++ b/stubs/consistent_sampler/__init__.pyi
@@ -1,4 +1,14 @@
-from typing import Any, Hashable, Iterable, Union, overload, TypeVar, Tuple, NamedTuple, Generic
+from typing import (
+    Any,
+    Hashable,
+    Iterable,
+    Union,
+    overload,
+    TypeVar,
+    Tuple,
+    NamedTuple,
+    Generic,
+)
 from typing_extensions import Literal
 
 # The actual type signature of `sampler` does not seem possible to describe
@@ -7,7 +17,7 @@ from typing_extensions import Literal
 # 1. mypy seems incapable of choosing an overload based on `Literal` types with
 #    the same underlying type, which in this case is `str`. So we get these
 #    errors trying to type check:
-# 
+#
 #      Overloaded function signatures 1 and 2 overlap with incompatible return types
 #      Overloaded function signatures 1 and 3 overlap with incompatible return types
 #      Overloaded function signatures 2 and 3 overlap with incompatible return types
@@ -22,12 +32,12 @@ from typing_extensions import Literal
 # So this is what I'd like to do but can't (yet?):
 #
 #   Id = TypeVar('Id', bound=Hashable)
-# 
+#
 #   class Ticket(NamedTuple, Generic[Id]):
 #     ticket_number: str
 #     id: Id
 #     generation: int
-# 
+#
 #   @overload
 #   def sampler(
 #     id_list: Iterable[Id],
@@ -70,21 +80,20 @@ from typing_extensions import Literal
 # instead of `NamedTuple` and to handle the "named" part ourselves, which is a
 # bit annoying in an interface file but not as bad as the implmentation.
 
-Id = TypeVar('Id', bound=Hashable)
+Id = TypeVar("Id", bound=Hashable)
 
 class Ticket(tuple, Generic[Id]):
-  ticket_number: str
-  id: Id
-  generation: int
-
-  def __new__(cls, ticket_number: str, id: Id, generation: int): ...
+    ticket_number: str
+    id: Id
+    generation: int
+    def __new__(cls, ticket_number: str, id: Id, generation: int): ...
 
 def sampler(
-  id_list: Iterable[Id],
-  seed: Any,
-  with_replacement: bool = ...,
-  drop: int = ...,
-  take: int = ...,
-  output: Literal['id', 'tuple', 'ticket'] = ...,
-  digits: int = ...,
+    id_list: Iterable[Id],
+    seed: Any,
+    with_replacement: bool = ...,
+    drop: int = ...,
+    take: int = ...,
+    output: Literal["id", "tuple", "ticket"] = ...,
+    digits: int = ...,
 ) -> Union[Iterable[Id], Iterable[Tuple[str, str, int]], Iterable[Ticket]]: ...

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,13 +1,23 @@
 import pytest, json, uuid
 from unittest.mock import patch, Mock, MagicMock
 
-from arlo_server import app, set_loggedin_user, clear_loggedin_user, auth0_aa, auth0_ja, db, create_organization, create_election, UserType
+from arlo_server import (
+    app,
+    set_loggedin_user,
+    clear_loggedin_user,
+    auth0_aa,
+    auth0_ja,
+    db,
+    create_organization,
+    create_election,
+    UserType,
+)
 from models import *
 
 
 @pytest.fixture
 def client():
-    app.config['TESTING'] = True
+    app.config["TESTING"] = True
     client = app.test_client()
 
     yield client
@@ -15,7 +25,7 @@ def client():
 
 def _setup_user(client, user_type, user_email):
     with client.session_transaction() as session:
-        session['_user'] = {'type': user_type, 'email': user_email}
+        session["_user"] = {"type": user_type, "email": user_email}
 
 
 def _create_org_and_admin(org_name, user_email):
@@ -32,51 +42,55 @@ def _create_org_and_admin(org_name, user_email):
 def test_auth_me(client):
     org_id, user_id = _create_org_and_admin("Test Org", "admin@example.com")
     election_id = create_election(organization_id=org_id)
-    jurisdiction = Jurisdiction(election_id=election_id,
-                                id=str(uuid.uuid4()),
-                                name='Test Jurisdiction')
-    j_admin = JurisdictionAdministration(user_id=user_id, jurisdiction_id=jurisdiction.id)
+    jurisdiction = Jurisdiction(
+        election_id=election_id, id=str(uuid.uuid4()), name="Test Jurisdiction"
+    )
+    j_admin = JurisdictionAdministration(
+        user_id=user_id, jurisdiction_id=jurisdiction.id
+    )
     j_id = jurisdiction.id
 
     db.session.add(jurisdiction)
     db.session.add(j_admin)
     db.session.commit()
 
-    _setup_user(client, UserType.AUDIT_ADMIN, 'admin@example.com')
+    _setup_user(client, UserType.AUDIT_ADMIN, "admin@example.com")
 
-    rv = client.get('/auth/me')
+    rv = client.get("/auth/me")
     assert json.loads(rv.data) == {
-        'type':
-        UserType.AUDIT_ADMIN,
-        'email':
-        'admin@example.com',
-        'organizations': [{
-            "name":
-            "Test Org",
-            "id":
-            org_id,
-            "elections": [{
-                "id": election_id,
-                "name": "",
-                "state": None,
-                "election_date": None
-            }]
-        }],
-        'jurisdictions': [{
-            "id": j_id,
-            "name": "Test Jurisdiction",
-            "election": {
-                "id": election_id,
-                "name": "",
-                "state": None,
-                "election_date": None
+        "type": UserType.AUDIT_ADMIN,
+        "email": "admin@example.com",
+        "organizations": [
+            {
+                "name": "Test Org",
+                "id": org_id,
+                "elections": [
+                    {
+                        "id": election_id,
+                        "name": "",
+                        "state": None,
+                        "election_date": None,
+                    }
+                ],
             }
-        }]
+        ],
+        "jurisdictions": [
+            {
+                "id": j_id,
+                "name": "Test Jurisdiction",
+                "election": {
+                    "id": election_id,
+                    "name": "",
+                    "state": None,
+                    "election_date": None,
+                },
+            }
+        ],
     }
 
 
 def test_auditadmin_start(client):
-    rv = client.get('/auth/auditadmin/start')
+    rv = client.get("/auth/auditadmin/start")
     assert rv.status_code == 302
 
 
@@ -86,32 +100,34 @@ def test_auditadmin_callback(client):
     auth0_aa.authorize_access_token = MagicMock(return_value=None)
 
     mock_response = Mock()
-    mock_response.json = MagicMock(return_value={'email': 'foo@example.com'})
+    mock_response.json = MagicMock(return_value={"email": "foo@example.com"})
     auth0_aa.get = Mock(return_value=mock_response)
 
-    rv = client.get('/auth/auditadmin/callback?code=foobar')
+    rv = client.get("/auth/auditadmin/callback?code=foobar")
     assert rv.status_code == 302
 
     with client.session_transaction() as session:
-        assert session['_user']['type'] == UserType.AUDIT_ADMIN
-        assert session['_user']['email'] == 'foo@example.com'
+        assert session["_user"]["type"] == UserType.AUDIT_ADMIN
+        assert session["_user"]["email"] == "foo@example.com"
 
     assert auth0_aa.authorize_access_token.called
     assert auth0_aa.get.called
 
 
 def test_jurisdictionadmin_start(client):
-    rv = client.get('/auth/jurisdictionadmin/start')
+    rv = client.get("/auth/jurisdictionadmin/start")
     assert rv.status_code == 302
 
 
 def test_jurisdictionadmin_callback(client):
     org = create_organization("Test Organization")
     election_id = create_election(organization_id=org.id)
-    jurisdiction = Jurisdiction(election_id=election_id,
-                                id=str(uuid.uuid4()),
-                                name='Test Jurisdiction')
-    u = User(id=str(uuid.uuid4()), email='bar@example.com', external_id='bar@example.com')
+    jurisdiction = Jurisdiction(
+        election_id=election_id, id=str(uuid.uuid4()), name="Test Jurisdiction"
+    )
+    u = User(
+        id=str(uuid.uuid4()), email="bar@example.com", external_id="bar@example.com"
+    )
     j_admin = JurisdictionAdministration(user_id=u.id, jurisdiction_id=jurisdiction.id)
 
     db.session.add(jurisdiction)
@@ -122,26 +138,26 @@ def test_jurisdictionadmin_callback(client):
     auth0_ja.authorize_access_token = MagicMock(return_value=None)
 
     mock_response = Mock()
-    mock_response.json = MagicMock(return_value={'email': 'bar@example.com'})
+    mock_response.json = MagicMock(return_value={"email": "bar@example.com"})
     auth0_ja.get = Mock(return_value=mock_response)
 
-    rv = client.get('/auth/jurisdictionadmin/callback?code=foobar')
+    rv = client.get("/auth/jurisdictionadmin/callback?code=foobar")
     assert rv.status_code == 302
 
     with client.session_transaction() as session:
-        assert session['_user']['type'] == UserType.JURISDICTION_ADMIN
-        assert session['_user']['email'] == 'bar@example.com'
+        assert session["_user"]["type"] == UserType.JURISDICTION_ADMIN
+        assert session["_user"]["email"] == "bar@example.com"
 
     assert auth0_ja.authorize_access_token.called
     assert auth0_ja.get.called
 
 
 def test_logout(client):
-    _setup_user(client, UserType.AUDIT_ADMIN, 'admin@example.com')
+    _setup_user(client, UserType.AUDIT_ADMIN, "admin@example.com")
 
-    rv = client.get('/auth/logout')
+    rv = client.get("/auth/logout")
 
     with client.session_transaction() as session:
-        assert session['_user'] is None
+        assert session["_user"] is None
 
     assert rv.status_code == 302

--- a/tests/test_ballot_list.py
+++ b/tests/test_ballot_list.py
@@ -2,28 +2,44 @@ import json
 
 import pytest
 
-from test_app import client, post_json, setup_whole_audit, setup_whole_multi_winner_audit
+from test_app import (
+    client,
+    post_json,
+    setup_whole_audit,
+    setup_whole_multi_winner_audit,
+)
 import bgcompute
 
 
 def test_ballot_list_jurisdiction_two_rounds(client):
-    rv = post_json(client, '/election/new', {})
-    election_id = json.loads(rv.data)['electionId']
+    rv = post_json(client, "/election/new", {})
+    election_id = json.loads(rv.data)["electionId"]
     assert election_id
 
-    url_prefix, contest_id, candidate_id_1, candidate_id_2, jurisdiction_id, audit_board_id_1, audit_board_id_2, num_ballots = setup_whole_audit(
-        client, election_id, "Primary 2019", 10, "12345678901234567890")
+    (
+        url_prefix,
+        contest_id,
+        candidate_id_1,
+        candidate_id_2,
+        jurisdiction_id,
+        audit_board_id_1,
+        audit_board_id_2,
+        num_ballots,
+    ) = setup_whole_audit(
+        client, election_id, "Primary 2019", 10, "12345678901234567890"
+    )
 
     # Get the sample size and round id
-    rv = client.get(f'/election/{election_id}/audit/status')
+    rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
     sample_size = status["rounds"][0]["contests"][0]["sampleSize"]
     round_id = status["rounds"][0]["id"]
 
     # Retrieve the ballot list
     rv = client.get(
-        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/ballot-list")
-    ballot_list = json.loads(rv.data)['ballots']
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/ballot-list"
+    )
+    ballot_list = json.loads(rv.data)["ballots"]
     assert ballot_list
     assert len(ballot_list) == sample_size
 
@@ -31,42 +47,58 @@ def test_ballot_list_jurisdiction_two_rounds(client):
     num_for_winner = int(num_ballots * 0.5)
     num_for_loser = num_ballots - num_for_winner
     rv = post_json(
-        client, '{}/jurisdiction/{}/1/results'.format(url_prefix, jurisdiction_id), {
-            "contests": [{
-                "id": contest_id,
-                "results": {
-                    candidate_id_1: num_for_winner,
-                    candidate_id_2: num_for_loser
+        client,
+        "{}/jurisdiction/{}/1/results".format(url_prefix, jurisdiction_id),
+        {
+            "contests": [
+                {
+                    "id": contest_id,
+                    "results": {
+                        candidate_id_1: num_for_winner,
+                        candidate_id_2: num_for_loser,
+                    },
                 }
-            }]
-        })
-    assert json.loads(rv.data)['status'] == 'ok'
+            ]
+        },
+    )
+    assert json.loads(rv.data)["status"] == "ok"
     bgcompute.bgcompute()
 
     # Get the sample size and round id for the second round
-    rv = client.get(f'/election/{election_id}/audit/status')
+    rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
     sample_size = status["rounds"][1]["contests"][0]["sampleSize"]
     round_id = status["rounds"][1]["id"]
 
     # Retrieve the ballot list
     rv = client.get(
-        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/ballot-list")
-    ballot_list = json.loads(rv.data)['ballots']
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/ballot-list"
+    )
+    ballot_list = json.loads(rv.data)["ballots"]
     assert ballot_list
     assert len(ballot_list) == sample_size
 
 
 def test_ballot_list_audit_board_two_rounds(client):
-    rv = post_json(client, '/election/new', {})
-    election_id = json.loads(rv.data)['electionId']
+    rv = post_json(client, "/election/new", {})
+    election_id = json.loads(rv.data)["electionId"]
     assert election_id
 
-    url_prefix, contest_id, candidate_id_1, candidate_id_2, jurisdiction_id, audit_board_id_1, audit_board_id_2, num_ballots = setup_whole_audit(
-        client, election_id, "Primary 2019", 10, "12345678901234567890")
+    (
+        url_prefix,
+        contest_id,
+        candidate_id_1,
+        candidate_id_2,
+        jurisdiction_id,
+        audit_board_id_1,
+        audit_board_id_2,
+        num_ballots,
+    ) = setup_whole_audit(
+        client, election_id, "Primary 2019", 10, "12345678901234567890"
+    )
 
     # Get the sample size and round id
-    rv = client.get(f'/election/{election_id}/audit/status')
+    rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
     sample_size = status["rounds"][0]["contests"][0]["sampleSize"]
     round_id = status["rounds"][0]["id"]
@@ -77,7 +109,7 @@ def test_ballot_list_audit_board_two_rounds(client):
         rv = client.get(
             f"/election/{election_id}/jurisdiction/{jurisdiction_id}/audit-board/{audit_board_id}/round/{round_id}/ballot-list"
         )
-        board_ballot_list = json.loads(rv.data)['ballots']
+        board_ballot_list = json.loads(rv.data)["ballots"]
         assert board_ballot_list
         ballot_list += board_ballot_list
 
@@ -87,20 +119,25 @@ def test_ballot_list_audit_board_two_rounds(client):
     num_for_winner = int(num_ballots * 0.5)
     num_for_loser = num_ballots - num_for_winner
     rv = post_json(
-        client, '{}/jurisdiction/{}/1/results'.format(url_prefix, jurisdiction_id), {
-            "contests": [{
-                "id": contest_id,
-                "results": {
-                    candidate_id_1: num_for_winner,
-                    candidate_id_2: num_for_loser
+        client,
+        "{}/jurisdiction/{}/1/results".format(url_prefix, jurisdiction_id),
+        {
+            "contests": [
+                {
+                    "id": contest_id,
+                    "results": {
+                        candidate_id_1: num_for_winner,
+                        candidate_id_2: num_for_loser,
+                    },
                 }
-            }]
-        })
-    assert json.loads(rv.data)['status'] == 'ok'
+            ]
+        },
+    )
+    assert json.loads(rv.data)["status"] == "ok"
     bgcompute.bgcompute()
 
     # Get the sample size and round id for the second round
-    rv = client.get(f'/election/{election_id}/audit/status')
+    rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
     sample_size = status["rounds"][1]["contests"][0]["sampleSize"]
     round_id = status["rounds"][1]["id"]
@@ -111,7 +148,7 @@ def test_ballot_list_audit_board_two_rounds(client):
         rv = client.get(
             f"/election/{election_id}/jurisdiction/{jurisdiction_id}/audit-board/{audit_board_id}/round/{round_id}/ballot-list"
         )
-        board_ballot_list = json.loads(rv.data)['ballots']
+        board_ballot_list = json.loads(rv.data)["ballots"]
         assert board_ballot_list
         ballot_list += board_ballot_list
 
@@ -119,49 +156,81 @@ def test_ballot_list_audit_board_two_rounds(client):
 
 
 def test_ballot_list_jurisdiction_ordering(client):
-    rv = post_json(client, '/election/new', {})
-    election_id = json.loads(rv.data)['electionId']
+    rv = post_json(client, "/election/new", {})
+    election_id = json.loads(rv.data)["electionId"]
     assert election_id
 
-    url_prefix, contest_id, candidate_id_1, candidate_id_2, jurisdiction_id, audit_board_id_1, audit_board_id_2, num_ballots = setup_whole_audit(
-        client, election_id, "Primary 2019", 10, "12345678901234567890")
+    (
+        url_prefix,
+        contest_id,
+        candidate_id_1,
+        candidate_id_2,
+        jurisdiction_id,
+        audit_board_id_1,
+        audit_board_id_2,
+        num_ballots,
+    ) = setup_whole_audit(
+        client, election_id, "Primary 2019", 10, "12345678901234567890"
+    )
 
     # Get the round id
-    rv = client.get(f'/election/{election_id}/audit/status')
+    rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
     round_id = status["rounds"][0]["id"]
 
     # Verify that the ballots are ordered correctly
-    rv = client.get('{}/jurisdiction/{}/round/{}/ballot-list'.format(url_prefix, jurisdiction_id,
-                                                                     round_id))
-    unsorted_ballots = json.loads(rv.data)['ballots']
+    rv = client.get(
+        "{}/jurisdiction/{}/round/{}/ballot-list".format(
+            url_prefix, jurisdiction_id, round_id
+        )
+    )
+    unsorted_ballots = json.loads(rv.data)["ballots"]
     sorted_ballots = sorted(
         unsorted_ballots,
-        key=lambda ballot:
-        (ballot['auditBoard']['name'], ballot['batch']['name'], ballot['position']))
+        key=lambda ballot: (
+            ballot["auditBoard"]["name"],
+            ballot["batch"]["name"],
+            ballot["position"],
+        ),
+    )
 
     assert unsorted_ballots == sorted_ballots
 
 
 def test_ballot_list_audit_board_ordering(client):
-    rv = post_json(client, '/election/new', {})
-    election_id = json.loads(rv.data)['electionId']
+    rv = post_json(client, "/election/new", {})
+    election_id = json.loads(rv.data)["electionId"]
     assert election_id
 
-    url_prefix, contest_id, candidate_id_1, candidate_id_2, jurisdiction_id, audit_board_id_1, audit_board_id_2, num_ballots = setup_whole_audit(
-        client, election_id, "Primary 2019", 10, "12345678901234567890")
+    (
+        url_prefix,
+        contest_id,
+        candidate_id_1,
+        candidate_id_2,
+        jurisdiction_id,
+        audit_board_id_1,
+        audit_board_id_2,
+        num_ballots,
+    ) = setup_whole_audit(
+        client, election_id, "Primary 2019", 10, "12345678901234567890"
+    )
 
     # Get the round id
-    rv = client.get(f'/election/{election_id}/audit/status')
+    rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
     round_id = status["rounds"][0]["id"]
 
     # Verify that the ballots are ordered correctly
     for audit_board_id in [audit_board_id_1, audit_board_id_2]:
-        rv = client.get('{}/jurisdiction/{}/audit-board/{}/round/{}/ballot-list'.format(
-            url_prefix, jurisdiction_id, audit_board_id, round_id))
-        unsorted_ballots = json.loads(rv.data)['ballots']
-        sorted_ballots = sorted(unsorted_ballots,
-                                key=lambda ballot: (ballot['batch']['name'], ballot['position']))
+        rv = client.get(
+            "{}/jurisdiction/{}/audit-board/{}/round/{}/ballot-list".format(
+                url_prefix, jurisdiction_id, audit_board_id, round_id
+            )
+        )
+        unsorted_ballots = json.loads(rv.data)["ballots"]
+        sorted_ballots = sorted(
+            unsorted_ballots,
+            key=lambda ballot: (ballot["batch"]["name"], ballot["position"]),
+        )
 
         assert unsorted_ballots == sorted_ballots

--- a/tests/test_binpacking.py
+++ b/tests/test_binpacking.py
@@ -4,31 +4,31 @@ from util.binpacking import Bucket, BucketList, BalancedBucketList
 
 @pytest.fixture
 def bucket():
-    yield Bucket('1')
+    yield Bucket("1")
 
 
 @pytest.fixture
 def bucketlist():
     buckets = []
 
-    b = Bucket('1')
-    b.add_batch('1', 100)
-    b.add_batch('2', 50)
+    b = Bucket("1")
+    b.add_batch("1", 100)
+    b.add_batch("2", 50)
     buckets.append(b)
 
-    b = Bucket('2')
-    b.add_batch('3', 100)
-    b.add_batch('4', 150)
+    b = Bucket("2")
+    b.add_batch("3", 100)
+    b.add_batch("4", 150)
     buckets.append(b)
 
-    b = Bucket('3')
-    b.add_batch('5', 50)
-    b.add_batch('6', 50)
+    b = Bucket("3")
+    b.add_batch("5", 50)
+    b.add_batch("6", 50)
     buckets.append(b)
 
-    b = Bucket('4')
-    b.add_batch('7', 100)
-    b.add_batch('8', 200)
+    b = Bucket("4")
+    b.add_batch("7", 100)
+    b.add_batch("8", 200)
     buckets.append(b)
 
     yield BucketList(buckets)
@@ -38,24 +38,24 @@ def bucketlist():
 def balancedbucketlist():
     buckets = []
 
-    b = Bucket('1')
-    b.add_batch('1', 100)
-    b.add_batch('2', 50)
+    b = Bucket("1")
+    b.add_batch("1", 100)
+    b.add_batch("2", 50)
     buckets.append(b)
 
-    b = Bucket('2')
-    b.add_batch('3', 100)
-    b.add_batch('4', 150)
+    b = Bucket("2")
+    b.add_batch("3", 100)
+    b.add_batch("4", 150)
     buckets.append(b)
 
-    b = Bucket('3')
-    b.add_batch('5', 50)
-    b.add_batch('6', 50)
+    b = Bucket("3")
+    b.add_batch("5", 50)
+    b.add_batch("6", 50)
     buckets.append(b)
 
-    b = Bucket('4')
-    b.add_batch('7', 100)
-    b.add_batch('8', 200)
+    b = Bucket("4")
+    b.add_batch("7", 100)
+    b.add_batch("8", 200)
     buckets.append(b)
 
     yield BalancedBucketList(buckets)
@@ -63,149 +63,231 @@ def balancedbucketlist():
 
 class TestBucket:
     def test_init(self, bucket):
-        assert bucket.name == '1', 'name failed, expected {}, got {}'.format('1', bucket.name)
-        assert not bucket.size, 'Initial bucket size was {}, not 0'.format(bucket.size)
-        assert not bucket.batches, 'Initial batches were non-empty: {}'.format(bucket.batches)
-        assert not bucket.largest_element, 'Initial largest element was not None'.format(
-            bucket.largest_element)
+        assert bucket.name == "1", "name failed, expected {}, got {}".format(
+            "1", bucket.name
+        )
+        assert not bucket.size, "Initial bucket size was {}, not 0".format(bucket.size)
+        assert not bucket.batches, "Initial batches were non-empty: {}".format(
+            bucket.batches
+        )
+        assert (
+            not bucket.largest_element
+        ), "Initial largest element was not None".format(bucket.largest_element)
 
     def test_add_batch(self, bucket):
-        expected_batches = {'1': 100}
-        bucket.add_batch('1', 100)
+        expected_batches = {"1": 100}
+        bucket.add_batch("1", 100)
         expected_size = 100
-        assert bucket.batches == expected_batches, 'add_batch batches failed, got {}, expected {}'.format(
-            bucket.batches, expected_batches)
-        assert bucket.size == expected_size, 'add_batch size failed, got {}, expected {}'.format(
-            bucket.size, expected_size)
-        assert bucket.largest_element == '1', 'add_batch largest_element  failed, got {}, expected {}'.format(
-            bucket.largest_element, '1')
+        assert (
+            bucket.batches == expected_batches
+        ), "add_batch batches failed, got {}, expected {}".format(
+            bucket.batches, expected_batches
+        )
+        assert (
+            bucket.size == expected_size
+        ), "add_batch size failed, got {}, expected {}".format(
+            bucket.size, expected_size
+        )
+        assert (
+            bucket.largest_element == "1"
+        ), "add_batch largest_element  failed, got {}, expected {}".format(
+            bucket.largest_element, "1"
+        )
 
-        expected_batches = {'1': 100, '2': 50}
-        bucket.add_batch('2', 50)
+        expected_batches = {"1": 100, "2": 50}
+        bucket.add_batch("2", 50)
         expected_size += 50
-        assert bucket.batches == expected_batches, 'add_batch batches failed, got {}, expected {}'.format(
-            bucket.batches, expected_batches)
-        assert bucket.size == expected_size, 'add_batch size failed, got {}, expected {}'.format(
-            bucket.size, expected_size)
-        assert bucket.largest_element == '1', 'add_batch largest_element  failed, got {}, expected {}'.format(
-            bucket.largest_element, '1')
+        assert (
+            bucket.batches == expected_batches
+        ), "add_batch batches failed, got {}, expected {}".format(
+            bucket.batches, expected_batches
+        )
+        assert (
+            bucket.size == expected_size
+        ), "add_batch size failed, got {}, expected {}".format(
+            bucket.size, expected_size
+        )
+        assert (
+            bucket.largest_element == "1"
+        ), "add_batch largest_element  failed, got {}, expected {}".format(
+            bucket.largest_element, "1"
+        )
 
-        expected_batches = {'1': 100, '2': 50, '3': 150}
-        bucket.add_batch('3', 150)
+        expected_batches = {"1": 100, "2": 50, "3": 150}
+        bucket.add_batch("3", 150)
         expected_size += 150
-        assert bucket.batches == expected_batches, 'add_batch batches failed, got {}, expected {}'.format(
-            bucket.batches, expected_batches)
-        assert bucket.size == expected_size, 'add_batch size failed, got {}, expected {}'.format(
-            bucket.size, expected_size)
-        assert bucket.largest_element == '3', 'add_batch largest_element  failed, got {}, expected {}'.format(
-            bucket.largest_element, '3')
+        assert (
+            bucket.batches == expected_batches
+        ), "add_batch batches failed, got {}, expected {}".format(
+            bucket.batches, expected_batches
+        )
+        assert (
+            bucket.size == expected_size
+        ), "add_batch size failed, got {}, expected {}".format(
+            bucket.size, expected_size
+        )
+        assert (
+            bucket.largest_element == "3"
+        ), "add_batch largest_element  failed, got {}, expected {}".format(
+            bucket.largest_element, "3"
+        )
 
     def test_remove_batch(self, bucket):
-        bucket.add_batch('1', 100)
-        bucket.add_batch('2', 50)
-        bucket.add_batch('3', 150)
+        bucket.add_batch("1", 100)
+        bucket.add_batch("2", 50)
+        bucket.add_batch("3", 150)
 
-        rem = bucket.remove_batch('1')
+        rem = bucket.remove_batch("1")
 
-        expected_batches = {'2': 50, '3': 150}
+        expected_batches = {"2": 50, "3": 150}
         expected_size = 200
-        expected_rem = {'1': 100}
-        expected_largest = '3'
+        expected_rem = {"1": 100}
+        expected_largest = "3"
 
-        assert rem == expected_rem, 'remove_batch returned {}, expected {}'.format(
-            rem, expected_rem)
-        assert bucket.largest_element == expected_largest, 'remove_batch changed largest to {}, should still be {}'.format(
-            bucket.largest_element, expected_largest)
-        assert bucket.batches == expected_batches, 'remove_batch resulted in batches {}, should be {}'.format(
-            bucket.batches, expected_batches)
-        assert bucket.size == expected_size, 'remove_batch resulted in size {}, expected size{}'.format(
-            bucket.size, expected_size)
+        assert rem == expected_rem, "remove_batch returned {}, expected {}".format(
+            rem, expected_rem
+        )
+        assert (
+            bucket.largest_element == expected_largest
+        ), "remove_batch changed largest to {}, should still be {}".format(
+            bucket.largest_element, expected_largest
+        )
+        assert (
+            bucket.batches == expected_batches
+        ), "remove_batch resulted in batches {}, should be {}".format(
+            bucket.batches, expected_batches
+        )
+        assert (
+            bucket.size == expected_size
+        ), "remove_batch resulted in size {}, expected size{}".format(
+            bucket.size, expected_size
+        )
 
-        rem = bucket.remove_batch('3')
+        rem = bucket.remove_batch("3")
 
-        expected_batches = {'2': 50}
+        expected_batches = {"2": 50}
         expected_size = 50
-        expected_rem = {'3': 150}
-        expected_largest = '2'
+        expected_rem = {"3": 150}
+        expected_largest = "2"
 
-        assert rem == expected_rem, 'remove_batch returned {}, expected {}'.format(
-            rem, expected_rem)
-        assert bucket.largest_element == expected_largest, 'remove_batch changed largest to {}, should still be {}'.format(
-            bucket.largest_element, expected_largest)
-        assert bucket.batches == expected_batches, 'remove_batch resulted in batches {}, should be {}'.format(
-            bucket.batches, expected_batches)
-        assert bucket.size == expected_size, 'remove_batch resulted in size {}, expected size{}'.format(
-            bucket.size, expected_size)
+        assert rem == expected_rem, "remove_batch returned {}, expected {}".format(
+            rem, expected_rem
+        )
+        assert (
+            bucket.largest_element == expected_largest
+        ), "remove_batch changed largest to {}, should still be {}".format(
+            bucket.largest_element, expected_largest
+        )
+        assert (
+            bucket.batches == expected_batches
+        ), "remove_batch resulted in batches {}, should be {}".format(
+            bucket.batches, expected_batches
+        )
+        assert (
+            bucket.size == expected_size
+        ), "remove_batch resulted in size {}, expected size{}".format(
+            bucket.size, expected_size
+        )
 
     def test_repr(self, bucket):
-        expected = {'name': '1', 'size': 0, 'batches': {}, 'largest element': None}
-        assert str(bucket) == str(expected), 'repr failed, expected {}, got {}'.format(
-            str(expected), str(bucket))
+        expected = {"name": "1", "size": 0, "batches": {}, "largest element": None}
+        assert str(bucket) == str(expected), "repr failed, expected {}, got {}".format(
+            str(expected), str(bucket)
+        )
 
-        bucket.add_batch('1', 100)
-        expected = {'name': '1', 'size': 100, 'batches': {'1': 100}, 'largest element': '1'}
-        assert str(bucket) == str(expected), 'repr failed, expected {}, got {}'.format(
-            str(expected), str(bucket))
+        bucket.add_batch("1", 100)
+        expected = {
+            "name": "1",
+            "size": 100,
+            "batches": {"1": 100},
+            "largest element": "1",
+        }
+        assert str(bucket) == str(expected), "repr failed, expected {}, got {}".format(
+            str(expected), str(bucket)
+        )
 
 
 class TestBucketList:
     def test_init(self, bucketlist):
-        assert bucketlist.avg_size == 200, 'Expected avg_size of {}, got {}'.format(
-            200, bucketlist.avg_size)
+        assert bucketlist.avg_size == 200, "Expected avg_size of {}, got {}".format(
+            200, bucketlist.avg_size
+        )
 
     def test_balance(self, bucketlist):
         new_bl = bucketlist.balance()
 
-        assert bucketlist.deviation() >= new_bl.deviation(
-        ), 'Balanced list has higher deviation than original assignment! {} is greater than {}'.format(
-            new_bl.deviation(), bucketlist.deviation())
+        assert (
+            bucketlist.deviation() >= new_bl.deviation()
+        ), "Balanced list has higher deviation than original assignment! {} is greater than {}".format(
+            new_bl.deviation(), bucketlist.deviation()
+        )
 
         num_batches = sum([len(b.batches) for b in bucketlist.buckets])
         balanced_num_batches = sum([len(b.batches) for b in new_bl.buckets])
 
-        assert num_batches == balanced_num_batches, 'New batch has different number of batches than expected! Got {}, expected {}'.format(
-            balanced_num_batches, num_batches)
+        assert (
+            num_batches == balanced_num_batches
+        ), "New batch has different number of batches than expected! Got {}, expected {}".format(
+            balanced_num_batches, num_batches
+        )
 
         batches = set()
         [
             batches.union(s)
-            for s in [set(batch.keys()) for batch in [b.batches for b in bucketlist.buckets]]
+            for s in [
+                set(batch.keys()) for batch in [b.batches for b in bucketlist.buckets]
+            ]
         ]
         new_batches = set()
         [
             new_batches.union(s)
-            for s in [set(batch.keys()) for batch in [b.batches for b in new_bl.buckets]]
+            for s in [
+                set(batch.keys()) for batch in [b.batches for b in new_bl.buckets]
+            ]
         ]
 
-        assert batches == new_batches, 'Balanced batches were not the same as original batches!'
+        assert (
+            batches == new_batches
+        ), "Balanced batches were not the same as original batches!"
 
 
 class TestBalancedBucketList:
     def test_init(self, balancedbucketlist):
-        assert balancedbucketlist.avg_size == 200, 'Expected avg_size of {}, got {}'.format(
-            200, bucketlist.avg_size)
+        assert (
+            balancedbucketlist.avg_size == 200
+        ), "Expected avg_size of {}, got {}".format(200, bucketlist.avg_size)
 
     def test_is_balanced(self, bucketlist, balancedbucketlist):
         new_bl = bucketlist.balance()
-        bbl = balancedbucketlist  #for convenience
+        bbl = balancedbucketlist  # for convenience
 
-        assert new_bl.avg_size == bbl.avg_size, 'BalancedBucketList average size not the same! got {}, expected {}'.format(
-            bbl.avg_size, new_bl.avg_size)
+        assert (
+            new_bl.avg_size == bbl.avg_size
+        ), "BalancedBucketList average size not the same! got {}, expected {}".format(
+            bbl.avg_size, new_bl.avg_size
+        )
 
-        assert new_bl.deviation() == bbl.deviation(
-        ), 'BalancedBucketList has a different deviation! got {}, expected {}'.format(
-            bbl.deviation, new_bl.deviation)
+        assert (
+            new_bl.deviation() == bbl.deviation()
+        ), "BalancedBucketList has a different deviation! got {}, expected {}".format(
+            bbl.deviation, new_bl.deviation
+        )
 
         num_batches = sum([len(b.batches) for b in bucketlist.buckets])
         balanced_num_batches = sum([len(b.batches) for b in bbl.buckets])
 
-        assert num_batches == balanced_num_batches, 'BalancedBucketList has different number of batches than expected! Got {}, expected {}'.format(
-            balanced_num_batches, num_batches)
+        assert (
+            num_batches == balanced_num_batches
+        ), "BalancedBucketList has different number of batches than expected! Got {}, expected {}".format(
+            balanced_num_batches, num_batches
+        )
 
         batches = set()
         [
             batches.union(s)
-            for s in [set(batch.keys()) for batch in [b.batches for b in bucketlist.buckets]]
+            for s in [
+                set(batch.keys()) for batch in [b.batches for b in bucketlist.buckets]
+            ]
         ]
         new_batches = set()
         [
@@ -213,4 +295,6 @@ class TestBalancedBucketList:
             for s in [set(batch.keys()) for batch in [b.batches for b in bbl.buckets]]
         ]
 
-        assert batches == new_batches, 'Balanced batches were not the same as original batches!'
+        assert (
+            batches == new_batches
+        ), "Balanced batches were not the same as original batches!"

--- a/tests/test_bravo.py
+++ b/tests/test_bravo.py
@@ -7,135 +7,120 @@ from sampler import Sampler
 
 @pytest.fixture
 def sampler():
-    seed = '12345678901234567890abcdefghijklmnopqrstuvwxyz😊'
+    seed = "12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
 
-    risk_limit = .1
+    risk_limit = 0.1
     contests = {
-        'test1': {
-            'cand1': 600,
-            'cand2': 400,
-            'ballots': 1000,
-            'numWinners': 1
+        "test1": {"cand1": 600, "cand2": 400, "ballots": 1000, "numWinners": 1},
+        "test2": {
+            "cand1": 600,
+            "cand2": 200,
+            "cand3": 100,
+            "ballots": 900,
+            "numWinners": 1,
         },
-        'test2': {
-            'cand1': 600,
-            'cand2': 200,
-            'cand3': 100,
-            'ballots': 900,
-            'numWinners': 1
+        "test3": {"cand1": 100, "ballots": 100, "numWinners": 1},
+        "test4": {"cand1": 100, "ballots": 100, "numWinners": 1},
+        "test5": {"cand1": 500, "cand2": 500, "ballots": 1000, "numWinners": 1},
+        "test6": {
+            "cand1": 300,
+            "cand2": 200,
+            "cand3": 200,
+            "ballots": 1000,
+            "numWinners": 1,
         },
-        'test3': {
-            'cand1': 100,
-            'ballots': 100,
-            'numWinners': 1
+        "test7": {
+            "cand1": 300,
+            "cand2": 200,
+            "cand3": 100,
+            "ballots": 700,
+            "numWinners": 2,
         },
-        'test4': {
-            'cand1': 100,
-            'ballots': 100,
-            'numWinners': 1
+        "test7": {
+            "cand1": 300,
+            "cand2": 200,
+            "cand3": 100,
+            "ballots": 700,
+            "numWinners": 2,
         },
-        'test5': {
-            'cand1': 500,
-            'cand2': 500,
-            'ballots': 1000,
-            'numWinners': 1
+        "test8": {
+            "cand1": 300,
+            "cand2": 300,
+            "cand3": 100,
+            "ballots": 700,
+            "numWinners": 2,
         },
-        'test6': {
-            'cand1': 300,
-            'cand2': 200,
-            'cand3': 200,
-            'ballots': 1000,
-            'numWinners': 1
-        },
-        'test7': {
-            'cand1': 300,
-            'cand2': 200,
-            'cand3': 100,
-            'ballots': 700,
-            'numWinners': 2
-        },
-        'test7': {
-            'cand1': 300,
-            'cand2': 200,
-            'cand3': 100,
-            'ballots': 700,
-            'numWinners': 2
-        },
-        'test8': {
-            'cand1': 300,
-            'cand2': 300,
-            'cand3': 100,
-            'ballots': 700,
-            'numWinners': 2
-        },
-        'test9': {
-            'cand1': 300,
-            'cand2': 200,
-            'ballots': 700,
-            'numWinners': 2
-        },
-        'test10': {
-            'cand1': 600,
-            'cand2': 300,
-            'cand3': 100,
-            'ballots': 1000,
-            'numWinners': 2
+        "test9": {"cand1": 300, "cand2": 200, "ballots": 700, "numWinners": 2},
+        "test10": {
+            "cand1": 600,
+            "cand2": 300,
+            "cand3": 100,
+            "ballots": 1000,
+            "numWinners": 2,
         },
     }
 
-    yield Sampler('BRAVO', seed, risk_limit, contests)
+    yield Sampler("BRAVO", seed, risk_limit, contests)
 
 
 def test_expected_sample_sizes(sampler):
     # Test expected sample sizes computation
 
     true_asns = {
-        'test1': 119,
-        'test2': 22,
-        'test3': -1,
-        'test4': -1,
-        'test5': 1000,
-        'test6': 238,
-        'test7': 101,
-        'test8': 34,
-        'test9': -1,
-        'test10': 48,
+        "test1": 119,
+        "test2": 22,
+        "test3": -1,
+        "test4": -1,
+        "test5": 1000,
+        "test6": 238,
+        "test7": 101,
+        "test8": 34,
+        "test9": -1,
+        "test10": 48,
     }
 
-    computed_asns = sampler.audit.get_expected_sample_sizes(sampler.margins, sampler.contests,
-                                                            round0_sample_results)
+    computed_asns = sampler.audit.get_expected_sample_sizes(
+        sampler.margins, sampler.contests, round0_sample_results
+    )
     for contest in true_asns:
         expected = true_asns[contest]
         computed = computed_asns[contest]
 
-        assert expected == computed, 'get_expected_sample_sizes failed in {}: got {}, expected {}'.format(
-            contest, computed, expected)
+        assert (
+            expected == computed
+        ), "get_expected_sample_sizes failed in {}: got {}, expected {}".format(
+            contest, computed, expected
+        )
 
 
 def test_expected_sample_sizes_second_round(sampler):
     # Test expected sample sizes computation
 
     true_asns = {
-        'test1': -12,
-        'test2': 42,
-        'test3': -1,
-        'test4': -1,
-        'test5': 1000,
-        'test6': -2,
-        'test7': -28,
-        'test8': 14,
-        'test9': -1,
-        'test10': -52,
+        "test1": -12,
+        "test2": 42,
+        "test3": -1,
+        "test4": -1,
+        "test5": 1000,
+        "test6": -2,
+        "test7": -28,
+        "test8": 14,
+        "test9": -1,
+        "test10": -52,
     }
 
-    computed_asns = sampler.audit.get_expected_sample_sizes(sampler.margins, sampler.contests,
-                                                            round1_sample_results)
+    computed_asns = sampler.audit.get_expected_sample_sizes(
+        sampler.margins, sampler.contests, round1_sample_results
+    )
     for contest in true_asns:
         expected = true_asns[contest]
         computed = computed_asns[contest]
 
-        assert expected == computed, 'get_expected_sample_sizes failed in {}: got {}, expected {}'.format(
-            contest, computed, expected)
+        assert (
+            expected == computed
+        ), "get_expected_sample_sizes failed in {}: got {}, expected {}".format(
+            contest, computed, expected
+        )
 
 
 def test_bravo_sample_sizes(sampler):
@@ -146,54 +131,70 @@ def test_bravo_sample_sizes(sampler):
     r0_sample_rup = 0
 
     computed_size1 = math.ceil(
-        sampler.audit.bravo_sample_sizes(p_w=.4,
-                                         p_r=.32,
-                                         sample_w=r0_sample_win,
-                                         sample_r=r0_sample_rup,
-                                         p_completion=.9))
+        sampler.audit.bravo_sample_sizes(
+            p_w=0.4,
+            p_r=0.32,
+            sample_w=r0_sample_win,
+            sample_r=r0_sample_rup,
+            p_completion=0.9,
+        )
+    )
     delta = expected_size1 - computed_size1
 
-    assert not delta, 'bravo_sample_sizes failed: got {}, expected {}'.format(
-        computed_size1, expected_size1)
+    assert not delta, "bravo_sample_sizes failed: got {}, expected {}".format(
+        computed_size1, expected_size1
+    )
 
     expected_size1 = 6067
 
     computed_size1 = math.ceil(
-        sampler.audit.bravo_sample_sizes(p_w=.36,
-                                         p_r=.32,
-                                         sample_w=r0_sample_win,
-                                         sample_r=r0_sample_rup,
-                                         p_completion=.9))
+        sampler.audit.bravo_sample_sizes(
+            p_w=0.36,
+            p_r=0.32,
+            sample_w=r0_sample_win,
+            sample_r=r0_sample_rup,
+            p_completion=0.9,
+        )
+    )
     delta = expected_size1 - computed_size1
 
-    assert not delta, 'bravo_sample_sizes failed: got {}, expected {}'.format(
-        computed_size1, expected_size1)
+    assert not delta, "bravo_sample_sizes failed: got {}, expected {}".format(
+        computed_size1, expected_size1
+    )
 
     expected_size1 = 2475
 
     computed_size1 = math.ceil(
-        sampler.audit.bravo_sample_sizes(p_w=.36,
-                                         p_r=.32,
-                                         sample_w=r0_sample_win,
-                                         sample_r=r0_sample_rup,
-                                         p_completion=.6))
+        sampler.audit.bravo_sample_sizes(
+            p_w=0.36,
+            p_r=0.32,
+            sample_w=r0_sample_win,
+            sample_r=r0_sample_rup,
+            p_completion=0.6,
+        )
+    )
     delta = expected_size1 - computed_size1
 
-    assert not delta, 'bravo_sample_sizes failed: got {}, expected {}'.format(
-        computed_size1, expected_size1)
+    assert not delta, "bravo_sample_sizes failed: got {}, expected {}".format(
+        computed_size1, expected_size1
+    )
 
     expected_size1 = 5657
 
     computed_size1 = math.ceil(
-        sampler.audit.bravo_sample_sizes(p_w=.52,
-                                         p_r=.47,
-                                         sample_w=r0_sample_win,
-                                         sample_r=r0_sample_rup,
-                                         p_completion=.9))
+        sampler.audit.bravo_sample_sizes(
+            p_w=0.52,
+            p_r=0.47,
+            sample_w=r0_sample_win,
+            sample_r=r0_sample_rup,
+            p_completion=0.9,
+        )
+    )
     delta = expected_size1 - computed_size1
 
-    assert not delta, 'bravo_sample_sizes failed: got {}, expected {}'.format(
-        computed_size1, expected_size1)
+    assert not delta, "bravo_sample_sizes failed: got {}, expected {}".format(
+        computed_size1, expected_size1
+    )
 
 
 def test_bravo_sample_sizes_round1_finish(sampler):
@@ -203,15 +204,19 @@ def test_bravo_sample_sizes_round1_finish(sampler):
     expected_size1 = 0
 
     computed_size1 = math.ceil(
-        sampler.audit.bravo_sample_sizes(p_w=.52,
-                                         p_r=.47,
-                                         sample_w=r0_sample_win,
-                                         sample_r=r0_sample_rup,
-                                         p_completion=.9))
+        sampler.audit.bravo_sample_sizes(
+            p_w=0.52,
+            p_r=0.47,
+            sample_w=r0_sample_win,
+            sample_r=r0_sample_rup,
+            p_completion=0.9,
+        )
+    )
     delta = expected_size1 - computed_size1
 
-    assert not delta, 'bravo_sample_sizes failed: got {}, expected {}'.format(
-        computed_size1, expected_size1)
+    assert not delta, "bravo_sample_sizes failed: got {}, expected {}".format(
+        computed_size1, expected_size1
+    )
 
 
 def test_bravo_sample_sizes_round1_incomplete(sampler):
@@ -220,34 +225,39 @@ def test_bravo_sample_sizes_round1_incomplete(sampler):
     r0_sample_rup = 2735
 
     computed_size1 = math.ceil(
-        sampler.audit.bravo_sample_sizes(p_w=.52,
-                                         p_r=.47,
-                                         sample_w=r0_sample_win,
-                                         sample_r=r0_sample_rup,
-                                         p_completion=.9))
+        sampler.audit.bravo_sample_sizes(
+            p_w=0.52,
+            p_r=0.47,
+            sample_w=r0_sample_win,
+            sample_r=r0_sample_rup,
+            p_completion=0.9,
+        )
+    )
     delta = expected_size1 - computed_size1
 
-    assert not delta, 'bravo_sample_sizes failed: got {}, expected {}'.format(
-        computed_size1, expected_size1)
+    assert not delta, "bravo_sample_sizes failed: got {}, expected {}".format(
+        computed_size1, expected_size1
+    )
 
 
 def test_bravo_expected_prob(sampler):
     # Test bravo sample simulator
     # Test without sample
-    expected_prob1 = .52
-    r0_sample_win = round0_sample_results['test1']['cand1']
-    r0_sample_rup = round0_sample_results['test1']['cand2']
+    expected_prob1 = 0.52
+    r0_sample_win = round0_sample_results["test1"]["cand1"]
+    r0_sample_rup = round0_sample_results["test1"]["cand2"]
 
     computed_prob1 = round(
-        sampler.audit.expected_prob(p_w=.6,
-                                    p_r=.4,
-                                    sample_w=r0_sample_win,
-                                    sample_r=r0_sample_rup,
-                                    asn=119), 2)
+        sampler.audit.expected_prob(
+            p_w=0.6, p_r=0.4, sample_w=r0_sample_win, sample_r=r0_sample_rup, asn=119
+        ),
+        2,
+    )
     delta = expected_prob1 - computed_prob1
 
-    assert not delta, 'bravo_simulator failed: got {}, expected {}'.format(
-        computed_prob1, expected_prob1)
+    assert not delta, "bravo_simulator failed: got {}, expected {}".format(
+        computed_prob1, expected_prob1
+    )
 
 
 def test_bravo_sample_sizes(sampler):
@@ -256,214 +266,121 @@ def test_bravo_sample_sizes(sampler):
     print(computed_samples)
     for contest in computed_samples:
         for key in true_sample_sizes[contest]:
-            if key == 'asn':
+            if key == "asn":
                 # Check probs:
-                if sampler.contests[contest]['numWinners'] == 1:
-                    expected_prob = true_sample_sizes[contest][key]['prob']
-                    computed_prob = round(computed_samples[contest][key]['prob'], 2)
+                if sampler.contests[contest]["numWinners"] == 1:
+                    expected_prob = true_sample_sizes[contest][key]["prob"]
+                    computed_prob = round(computed_samples[contest][key]["prob"], 2)
 
-                    assert expected_prob == computed_prob, '{} expected_sample_size probabability check for {} failed: got {}, expected {}'.format(
-                        key, contest, computed_prob, expected_prob)
+                    assert (
+                        expected_prob == computed_prob
+                    ), "{} expected_sample_size probabability check for {} failed: got {}, expected {}".format(
+                        key, contest, computed_prob, expected_prob
+                    )
 
-                expected = true_sample_sizes[contest][key]['size']
-                computed = computed_samples[contest][key]['size']
+                expected = true_sample_sizes[contest][key]["size"]
+                computed = computed_samples[contest][key]["size"]
             else:
                 expected = true_sample_sizes[contest][key]
                 computed = computed_samples[contest][key]
             diff = expected - computed
 
-            assert not diff, '{} sample size for {} failed: got {}, expected {}'.format(
-                key, contest, computed, expected)
+            assert not diff, "{} sample size for {} failed: got {}, expected {}".format(
+                key, contest, computed, expected
+            )
 
 
 def test_compute_margins(sampler):
     # Test margins
     true_margins = {
-        'test1': {
-            'winners': {
-                'cand1': {
-                    'p_w': .6,
-                    's_w': .6,
-                    'swl': {
-                        'cand2': .6
-                    }
-                }
-            },
-            'losers': {
-                'cand2': {
-                    'p_l': .4,
-                    's_l': .4
-                }
-            }
+        "test1": {
+            "winners": {"cand1": {"p_w": 0.6, "s_w": 0.6, "swl": {"cand2": 0.6}}},
+            "losers": {"cand2": {"p_l": 0.4, "s_l": 0.4}},
         },
-        'test2': {
-            'winners': {
-                'cand1': {
-                    'p_w': 2 / 3,
-                    's_w': 2 / 3,
-                    'swl': {
-                        'cand2': 6 / 8,
-                        'cand3': 6 / 7
-                    }
+        "test2": {
+            "winners": {
+                "cand1": {
+                    "p_w": 2 / 3,
+                    "s_w": 2 / 3,
+                    "swl": {"cand2": 6 / 8, "cand3": 6 / 7},
                 }
             },
-            'losers': {
-                'cand2': {
-                    'p_l': 2 / 9,
-                    's_l': 2 / 9
+            "losers": {
+                "cand2": {"p_l": 2 / 9, "s_l": 2 / 9},
+                "cand3": {"p_l": 1 / 9, "s_l": 1 / 9},
+            },
+        },
+        "test3": {"winners": {"cand1": {"p_w": 1, "s_w": 1, "swl": {}}}, "losers": {}},
+        "test4": {"winners": {"cand1": {"p_w": 1, "s_w": 1, "swl": {}}}, "losers": {}},
+        "test5": {
+            "winners": {"cand1": {"p_w": 0.5, "s_w": 0.5, "swl": {"cand2": 0.5}}},
+            "losers": {"cand2": {"p_l": 0.5, "s_l": 0.5}},
+        },
+        "test6": {
+            "winners": {
+                "cand1": {
+                    "p_w": 0.3,
+                    "s_w": 300 / 700,
+                    "swl": {"cand2": 300 / (300 + 200), "cand3": 300 / (300 + 200)},
+                }
+            },
+            "losers": {
+                "cand2": {"p_l": 0.2, "s_l": 200 / 700},
+                "cand3": {"p_l": 0.2, "s_l": 200 / 700},
+            },
+        },
+        "test7": {
+            "winners": {
+                "cand1": {
+                    "p_w": 300 / 700,
+                    "s_w": 300 / 600,
+                    "swl": {"cand3": 300 / (300 + 100)},
                 },
-                'cand3': {
-                    'p_l': 1 / 9,
-                    's_l': 1 / 9
-                }
-            }
-        },
-        'test3': {
-            'winners': {
-                'cand1': {
-                    'p_w': 1,
-                    's_w': 1,
-                    'swl': {}
-                }
-            },
-            'losers': {}
-        },
-        'test4': {
-            'winners': {
-                'cand1': {
-                    'p_w': 1,
-                    's_w': 1,
-                    'swl': {}
-                }
-            },
-            'losers': {}
-        },
-        'test5': {
-            'winners': {
-                'cand1': {
-                    'p_w': .5,
-                    's_w': .5,
-                    'swl': {
-                        'cand2': .5
-                    }
-                }
-            },
-            'losers': {
-                'cand2': {
-                    'p_l': .5,
-                    's_l': .5
-                }
-            }
-        },
-        'test6': {
-            'winners': {
-                'cand1': {
-                    'p_w': .3,
-                    's_w': 300 / 700,
-                    'swl': {
-                        'cand2': 300 / (300 + 200),
-                        'cand3': 300 / (300 + 200)
-                    }
-                }
-            },
-            'losers': {
-                'cand2': {
-                    'p_l': .2,
-                    's_l': 200 / 700
+                "cand2": {
+                    "p_w": 200 / 700,
+                    "s_w": 200 / 600,
+                    "swl": {"cand3": 200 / (200 + 100)},
                 },
-                'cand3': {
-                    'p_l': .2,
-                    's_l': 200 / 700
-                }
-            }
-        },
-        'test7': {
-            'winners': {
-                'cand1': {
-                    'p_w': 300 / 700,
-                    's_w': 300 / 600,
-                    'swl': {
-                        'cand3': 300 / (300 + 100)
-                    }
-                },
-                'cand2': {
-                    'p_w': 200 / 700,
-                    's_w': 200 / 600,
-                    'swl': {
-                        'cand3': 200 / (200 + 100)
-                    }
-                }
             },
-            'losers': {
-                'cand3': {
-                    'p_l': 100 / 700,
-                    's_l': 100 / 600
-                }
-            }
+            "losers": {"cand3": {"p_l": 100 / 700, "s_l": 100 / 600}},
         },
-        'test8': {
-            'winners': {
-                'cand1': {
-                    'p_w': 300 / 700,
-                    's_w': 300 / 700,
-                    'swl': {
-                        'cand3': 300 / (300 + 100)
-                    }
+        "test8": {
+            "winners": {
+                "cand1": {
+                    "p_w": 300 / 700,
+                    "s_w": 300 / 700,
+                    "swl": {"cand3": 300 / (300 + 100)},
                 },
-                'cand2': {
-                    'p_w': 300 / 700,
-                    's_w': 300 / 700,
-                    'swl': {
-                        'cand3': 300 / (300 + 100)
-                    }
-                }
+                "cand2": {
+                    "p_w": 300 / 700,
+                    "s_w": 300 / 700,
+                    "swl": {"cand3": 300 / (300 + 100)},
+                },
             },
-            'losers': {
-                'cand3': {
-                    'p_l': 100 / 700,
-                    's_l': 100 / 700
-                }
-            }
+            "losers": {"cand3": {"p_l": 100 / 700, "s_l": 100 / 700}},
         },
-        'test9': {
-            'winners': {
-                'cand1': {
-                    'p_w': 300 / 700,
-                    's_w': 300 / 500,
-                    'swl': {}
-                },
-                'cand2': {
-                    'p_w': 200 / 700,
-                    's_w': 200 / 500,
-                    'swl': {}
-                }
+        "test9": {
+            "winners": {
+                "cand1": {"p_w": 300 / 700, "s_w": 300 / 500, "swl": {}},
+                "cand2": {"p_w": 200 / 700, "s_w": 200 / 500, "swl": {}},
             },
-            'losers': {}
+            "losers": {},
         },
-        'test10': {
-            'winners': {
-                'cand1': {
-                    'p_w': 600 / 1000,
-                    's_w': 600 / 1000,
-                    'swl': {
-                        'cand3': 600 / 700
-                    }
+        "test10": {
+            "winners": {
+                "cand1": {
+                    "p_w": 600 / 1000,
+                    "s_w": 600 / 1000,
+                    "swl": {"cand3": 600 / 700},
                 },
-                'cand2': {
-                    'p_w': 300 / 1000,
-                    's_w': 300 / 1000,
-                    'swl': {
-                        'cand3': 300 / 400
-                    }
-                }
+                "cand2": {
+                    "p_w": 300 / 1000,
+                    "s_w": 300 / 1000,
+                    "swl": {"cand3": 300 / 400},
+                },
             },
-            'losers': {
-                'cand3': {
-                    'p_l': 100 / 1000,
-                    's_l': 100 / 1000
-                }
-            }
-        }
+            "losers": {"cand3": {"p_l": 100 / 1000, "s_l": 100 / 1000}},
+        },
     }
 
     margins = sampler.compute_margins()
@@ -471,87 +388,72 @@ def test_compute_margins(sampler):
         true_margins_for_contest = true_margins[contest]
         computed_margins_for_contest = margins[contest]
 
-        for winner in true_margins_for_contest['winners']:
-            expected = round(true_margins_for_contest['winners'][winner]['p_w'], 5)
-            computed = round(computed_margins_for_contest['winners'][winner]['p_w'], 5)
-            assert expected == computed, '{} p_w failed: got {}, expected {}'.format(
-                contest, computed, expected)
+        for winner in true_margins_for_contest["winners"]:
+            expected = round(true_margins_for_contest["winners"][winner]["p_w"], 5)
+            computed = round(computed_margins_for_contest["winners"][winner]["p_w"], 5)
+            assert expected == computed, "{} p_w failed: got {}, expected {}".format(
+                contest, computed, expected
+            )
 
-            expected = round(true_margins_for_contest['winners'][winner]['s_w'], 5)
-            computed = round(computed_margins_for_contest['winners'][winner]['s_w'], 5)
-            assert expected == computed, '{} s_w failed: got {}, expected {}'.format(
-                contest, computed, expected)
+            expected = round(true_margins_for_contest["winners"][winner]["s_w"], 5)
+            computed = round(computed_margins_for_contest["winners"][winner]["s_w"], 5)
+            assert expected == computed, "{} s_w failed: got {}, expected {}".format(
+                contest, computed, expected
+            )
 
-            for cand in true_margins_for_contest['winners'][winner]['swl']:
-                expected = round(true_margins_for_contest['winners'][winner]['swl'][cand], 5)
-                computed = round(computed_margins_for_contest['winners'][winner]['swl'][cand], 5)
-                assert expected == computed, '{} swl failed: got {}, expected {}'.format(
-                    contest, computed, expected)
+            for cand in true_margins_for_contest["winners"][winner]["swl"]:
+                expected = round(
+                    true_margins_for_contest["winners"][winner]["swl"][cand], 5
+                )
+                computed = round(
+                    computed_margins_for_contest["winners"][winner]["swl"][cand], 5
+                )
+                assert (
+                    expected == computed
+                ), "{} swl failed: got {}, expected {}".format(
+                    contest, computed, expected
+                )
 
-        for loser in true_margins_for_contest['losers']:
-            expected = round(true_margins_for_contest['losers'][loser]['p_l'], 5)
-            computed = round(computed_margins_for_contest['losers'][loser]['p_l'], 5)
-            assert expected == computed, '{} p_l failed: got {}, expected {}'.format(
-                contest, computed, expected)
+        for loser in true_margins_for_contest["losers"]:
+            expected = round(true_margins_for_contest["losers"][loser]["p_l"], 5)
+            computed = round(computed_margins_for_contest["losers"][loser]["p_l"], 5)
+            assert expected == computed, "{} p_l failed: got {}, expected {}".format(
+                contest, computed, expected
+            )
 
-            expected = round(true_margins_for_contest['losers'][loser]['s_l'], 5)
-            computed = round(computed_margins_for_contest['losers'][loser]['s_l'], 5)
-            assert expected == computed, '{} s_l failed: got {}, expected {}'.format(
-                contest, computed, expected)
+            expected = round(true_margins_for_contest["losers"][loser]["s_l"], 5)
+            computed = round(computed_margins_for_contest["losers"][loser]["s_l"], 5)
+            assert expected == computed, "{} s_l failed: got {}, expected {}".format(
+                contest, computed, expected
+            )
 
 
 def test_compute_risk(sampler):
     # Test computing sample
     expected_Ts = {
-        'test1': {
-            ('cand1', 'cand2'): .07
-        },
-        'test2': {
-            ('cand1', 'cand2'): 10.38,
-            ('cand1', 'cand3'): 0,
-        },
-        'test3': {
-            ('cand1', ): 1
-        },
-        'test4': {
-            ('cand1', ): 1
-        },
-        'test5': {
-            ('cand1', 'cand2'): 1
-        },
-        'test6': {
-            ('cand1', 'cand2'): 0.08,
-            ('cand1', 'cand3'): 0.08,
-        },
-        'test7': {
-            ('cand1', 'cand3'): 0.01,
-            ('cand2', 'cand3'): 0.04,
-        },
-        'test8': {
-            ('cand1', 'cand3'): 0.0,
-            ('cand2', 'cand3'): 0.22,
-        },
-        'test9': {
-            ('cand1', ): 1,
-            ('cand2', ): 1,
-        },
-        'test10': {
-            ('cand1', 'cand3'): 0,
-            ('cand2', 'cand3'): 0.01,
-        },
+        "test1": {("cand1", "cand2"): 0.07},
+        "test2": {("cand1", "cand2"): 10.38, ("cand1", "cand3"): 0,},
+        "test3": {("cand1",): 1},
+        "test4": {("cand1",): 1},
+        "test5": {("cand1", "cand2"): 1},
+        "test6": {("cand1", "cand2"): 0.08, ("cand1", "cand3"): 0.08,},
+        "test7": {("cand1", "cand3"): 0.01, ("cand2", "cand3"): 0.04,},
+        "test8": {("cand1", "cand3"): 0.0, ("cand2", "cand3"): 0.22,},
+        "test9": {("cand1",): 1, ("cand2",): 1,},
+        "test10": {("cand1", "cand3"): 0, ("cand2", "cand3"): 0.01,},
     }
 
     expected_decisions = {
-        'test1': True,
-        'test2': False,
-        'test3': False,
-        'test4': False,
-        'test5': False,
-        'test6': True,
-        'test7': True,
-        'test8': False,
-        'test9': False,
-        'test10': True,
+        "test1": True,
+        "test2": False,
+        "test3": False,
+        "test4": False,
+        "test5": False,
+        "test6": True,
+        "test7": True,
+        "test8": False,
+        "test9": False,
+        "test10": True,
     }
 
     for contest, sample in round1_sample_results.items():
@@ -559,185 +461,56 @@ def test_compute_risk(sampler):
         expected_T = expected_Ts[contest]
         for pair in expected_T:
             diff = T[pair] - expected_T[pair]
-            assert abs(diff) < .01, 'Risk compute for {} failed! Expected {}, got {}'.format(
-                contest, expected_Ts[contest][pair], T[pair])
+            assert (
+                abs(diff) < 0.01
+            ), "Risk compute for {} failed! Expected {}, got {}".format(
+                contest, expected_Ts[contest][pair], T[pair]
+            )
 
         expected_decision = expected_decisions[contest]
-        assert decision == expected_decision, 'Risk decision for {} failed! Expected {}, got{}'.format(
-            contest, expected_decision, decision)
+        assert (
+            decision == expected_decision
+        ), "Risk decision for {} failed! Expected {}, got{}".format(
+            contest, expected_decision, decision
+        )
 
 
 # Useful test data
 round0_sample_results = {
-    'test1': {
-        'cand1': 0,
-        'cand2': 0,
-    },
-    'test2': {
-        'cand1': 0,
-        'cand2': 0,
-        'cand3': 0,
-    },
-    'test3': {
-        'cand1': 0,
-    },
-    'test4': {
-        'cand1': 0,
-    },
-    'test5': {
-        'cand1': 0,
-        'cand2': 0,
-    },
-    'test6': {
-        'cand1': 0,
-        'cand2': 0,
-        'cand3': 0
-    },
-    'test7': {
-        'cand1': 0,
-        'cand2': 0,
-        'cand3': 0
-    },
-    'test8': {
-        'cand1': 0,
-        'cand2': 0,
-        'cand3': 0
-    },
-    'test9': {
-        'cand1': 0,
-        'cand2': 0,
-        'cand3': 0
-    },
-    'test10': {
-        'cand1': 0,
-        'cand2': 0,
-        'cand3': 0
-    },
+    "test1": {"cand1": 0, "cand2": 0,},
+    "test2": {"cand1": 0, "cand2": 0, "cand3": 0,},
+    "test3": {"cand1": 0,},
+    "test4": {"cand1": 0,},
+    "test5": {"cand1": 0, "cand2": 0,},
+    "test6": {"cand1": 0, "cand2": 0, "cand3": 0},
+    "test7": {"cand1": 0, "cand2": 0, "cand3": 0},
+    "test8": {"cand1": 0, "cand2": 0, "cand3": 0},
+    "test9": {"cand1": 0, "cand2": 0, "cand3": 0},
+    "test10": {"cand1": 0, "cand2": 0, "cand3": 0},
 }
 
 round1_sample_results = {
-    'test1': {
-        'cand1': 72,
-        'cand2': 47
-    },
-    'test2': {
-        'cand1': 25,
-        'cand2': 18,
-        'cand3': 5,
-    },
-    'test3': {
-        'cand1': 0
-    },
-    'test4': {
-        'cand1': 100
-    },
-    'test5': {
-        'cand1': 500,
-        'cand2': 500,
-    },
-    'test6': {
-        'cand1': 72,
-        'cand2': 48,
-        'cand3': 48
-    },
-    'test7': {
-        'cand1': 30,
-        'cand2': 25,
-        'cand3': 10
-    },
-    'test8': {
-        'cand1': 72,
-        'cand2': 55,
-        'cand3': 30
-    },
-    'test9': {
-        'cand1': 1,
-        'cand2': 1,
-    },
-    'test10': {
-        'cand1': 60,
-        'cand2': 30,
-        'cand3': 10
-    },
+    "test1": {"cand1": 72, "cand2": 47},
+    "test2": {"cand1": 25, "cand2": 18, "cand3": 5,},
+    "test3": {"cand1": 0},
+    "test4": {"cand1": 100},
+    "test5": {"cand1": 500, "cand2": 500,},
+    "test6": {"cand1": 72, "cand2": 48, "cand3": 48},
+    "test7": {"cand1": 30, "cand2": 25, "cand3": 10},
+    "test8": {"cand1": 72, "cand2": 55, "cand3": 30},
+    "test9": {"cand1": 1, "cand2": 1,},
+    "test10": {"cand1": 60, "cand2": 30, "cand3": 10},
 }
 
 true_sample_sizes = {
-    'test1': {
-        'asn': {
-            'size': 119,
-            'prob': .52
-        },
-        .7: 184,
-        .8: 244,
-        .9: 351,
-    },
-    'test2': {
-        'asn': {
-            'size': 22,
-            'prob': .6
-        },
-        .7: 32,
-        .8: 41,
-        .9: 57,
-    },
-    'test3': {
-        'asn': {
-            'size': -1,
-            'prob': -1
-        },
-        .7: -1,
-        .8: -1,
-        .9: -1,
-    },
-    'test4': {
-        'asn': {
-            'size': -1,
-            'prob': -1
-        },
-        .7: -1,
-        .8: -1,
-        .9: -1,
-    },
-    'test5': {
-        'asn': {
-            'size': 1000,
-            'prob': 1
-        },
-        .7: 1000,
-        .8: 1000,
-        .9: 1000
-    },
-    'test6': {
-        'asn': {
-            'size': 238,
-            'prob': .79
-        },
-        .7: 368,
-        .8: 488,
-        .9: 702
-    },
-    'test7': {
-        'asn': {
-            'size': 101,
-            'prob': None,
-        },
-    },
-    'test8': {
-        'asn': {
-            'size': 59,
-            'prob': None,
-        },
-    },
-    'test9': {
-        'asn': {
-            'size': -1,
-            'prob': None,
-        },
-    },
-    'test10': {
-        'asn': {
-            'size': 48,
-            'prob': None,
-        },
-    },
+    "test1": {"asn": {"size": 119, "prob": 0.52}, 0.7: 184, 0.8: 244, 0.9: 351,},
+    "test2": {"asn": {"size": 22, "prob": 0.6}, 0.7: 32, 0.8: 41, 0.9: 57,},
+    "test3": {"asn": {"size": -1, "prob": -1}, 0.7: -1, 0.8: -1, 0.9: -1,},
+    "test4": {"asn": {"size": -1, "prob": -1}, 0.7: -1, 0.8: -1, 0.9: -1,},
+    "test5": {"asn": {"size": 1000, "prob": 1}, 0.7: 1000, 0.8: 1000, 0.9: 1000},
+    "test6": {"asn": {"size": 238, "prob": 0.79}, 0.7: 368, 0.8: 488, 0.9: 702},
+    "test7": {"asn": {"size": 101, "prob": None,},},
+    "test8": {"asn": {"size": 59, "prob": None,},},
+    "test9": {"asn": {"size": -1, "prob": None,},},
+    "test10": {"asn": {"size": 48, "prob": None,},},
 }

--- a/tests/test_jurisdiction_bulk_update.py
+++ b/tests/test_jurisdiction_bulk_update.py
@@ -17,14 +17,16 @@ def db():
 
 
 def test_first_update(db):
-    org = Organization(id=str(uuid.uuid4()), name='Test Org')
+    org = Organization(id=str(uuid.uuid4()), name="Test Org")
     election = Election(id=str(uuid.uuid4()), organization=org)
-    new_admins = bulk_update_jurisdictions(db.session, election,
-                                           [('Jurisdiction #1', 'bob.harris@ca.gov')])
+    new_admins = bulk_update_jurisdictions(
+        db.session, election, [("Jurisdiction #1", "bob.harris@ca.gov")]
+    )
     db.session.commit()
 
-    assert [(admin.jurisdiction.name, admin.user.email)
-            for admin in new_admins] == [('Jurisdiction #1', 'bob.harris@ca.gov')]
+    assert [(admin.jurisdiction.name, admin.user.email) for admin in new_admins] == [
+        ("Jurisdiction #1", "bob.harris@ca.gov")
+    ]
 
     assert User.query.count() == 1
     assert Jurisdiction.query.count() == 1
@@ -32,29 +34,35 @@ def test_first_update(db):
 
 
 def test_idempotent(db):
-    org = Organization(id=str(uuid.uuid4()), name='Test Org')
+    org = Organization(id=str(uuid.uuid4()), name="Test Org")
     election = Election(id=str(uuid.uuid4()), organization=org)
 
     # Do it once.
-    bulk_update_jurisdictions(db.session, election, [('Jurisdiction #1', 'bob.harris@ca.gov')])
+    bulk_update_jurisdictions(
+        db.session, election, [("Jurisdiction #1", "bob.harris@ca.gov")]
+    )
     db.session.commit()
 
     user = User.query.one()
     jurisdiction = Jurisdiction.query.one()
 
     # Do the same thing again.
-    bulk_update_jurisdictions(db.session, election, [('Jurisdiction #1', 'bob.harris@ca.gov')])
+    bulk_update_jurisdictions(
+        db.session, election, [("Jurisdiction #1", "bob.harris@ca.gov")]
+    )
 
     assert User.query.one() == user
     assert Jurisdiction.query.one() == jurisdiction
 
 
 def test_remove_outdated_jurisdictions(db):
-    org = Organization(id=str(uuid.uuid4()), name='Test Org')
+    org = Organization(id=str(uuid.uuid4()), name="Test Org")
     election = Election(id=str(uuid.uuid4()), organization=org)
 
     # Add jurisdictions.
-    bulk_update_jurisdictions(db.session, election, [('Jurisdiction #1', 'bob.harris@ca.gov')])
+    bulk_update_jurisdictions(
+        db.session, election, [("Jurisdiction #1", "bob.harris@ca.gov")]
+    )
     db.session.commit()
 
     # Delete jurisdictions.

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -7,93 +7,83 @@ from sampler import Sampler
 
 @pytest.fixture
 def sampler():
-    seed = '12345678901234567890abcdefghijklmnopqrstuvwxyz😊'
+    seed = "12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
 
-    risk_limit = .25
+    risk_limit = 0.25
     contests = {
-        'Contest A': {
-            'winner': 60000,
-            'loser': 54000,
-            'ballots': 120000,
-            'numWinners': 1,
+        "Contest A": {
+            "winner": 60000,
+            "loser": 54000,
+            "ballots": 120000,
+            "numWinners": 1,
         },
-        'Contest B': {
-            'winner': 30000,
-            'loser': 24000,
-            'ballots': 60000,
-            'numWinners': 1,
+        "Contest B": {
+            "winner": 30000,
+            "loser": 24000,
+            "ballots": 60000,
+            "numWinners": 1,
         },
-        'Contest C': {
-            'winner': 18000,
-            'loser': 12600,
-            'ballots': 36000,
-            'numWinners': 1,
+        "Contest C": {
+            "winner": 18000,
+            "loser": 12600,
+            "ballots": 36000,
+            "numWinners": 1,
         },
     }
 
     batches = {}
     for i in range(200):
-        batches['Batch {}'.format(i)] = {
-            'Contest A': {
-                'winner': 200,
-                'loser': 180,
-                'ballots': 400,
-                'numWinners': 1
-            },
+        batches["Batch {}".format(i)] = {
+            "Contest A": {"winner": 200, "loser": 180, "ballots": 400, "numWinners": 1},
         }
 
-        batches['Batch {} AV'.format(i)] = {
-            'Contest A': {
-                'winner': 100,
-                'loser': 90,
-                'ballots': 200,
-                'numWinners': 1
-            },
+        batches["Batch {} AV".format(i)] = {
+            "Contest A": {"winner": 100, "loser": 90, "ballots": 200, "numWinners": 1},
         }
 
     for i in range(100):
-        batches['Batch {}'.format(i)]['Contest B'] = {
-            'winner': 200,
-            'loser': 160,
-            'ballots': 400,
-            'numWinners': 1
+        batches["Batch {}".format(i)]["Contest B"] = {
+            "winner": 200,
+            "loser": 160,
+            "ballots": 400,
+            "numWinners": 1,
         }
-        batches['Batch {} AV'.format(i)]['Contest B'] = {
-            'winner': 100,
-            'loser': 80,
-            'ballots': 200,
-            'numWinners': 1
+        batches["Batch {} AV".format(i)]["Contest B"] = {
+            "winner": 100,
+            "loser": 80,
+            "ballots": 200,
+            "numWinners": 1,
         }
 
     for i in range(30):
-        batches['Batch {}'.format(i)]['Contest C'] = {
-            'winner': 200,
-            'loser': 140,
-            'ballots': 400,
-            'numWinners': 1
+        batches["Batch {}".format(i)]["Contest C"] = {
+            "winner": 200,
+            "loser": 140,
+            "ballots": 400,
+            "numWinners": 1,
         }
-        batches['Batch {} AV'.format(i)]['Contest C'] = {
-            'winner': 100,
-            'loser': 70,
-            'ballots': 200,
-            'numWinners': 1
+        batches["Batch {} AV".format(i)]["Contest C"] = {
+            "winner": 100,
+            "loser": 70,
+            "ballots": 200,
+            "numWinners": 1,
         }
 
     for i in range(100, 130):
-        batches['Batch {}'.format(i)]['Contest C'] = {
-            'winner': 200,
-            'loser': 140,
-            'ballots': 400,
-            'numWinners': 1
+        batches["Batch {}".format(i)]["Contest C"] = {
+            "winner": 200,
+            "loser": 140,
+            "ballots": 400,
+            "numWinners": 1,
         }
-        batches['Batch {} AV'.format(i)]['Contest C'] = {
-            'winner': 100,
-            'loser': 70,
-            'ballots': 200,
-            'numWinners': 1
+        batches["Batch {} AV".format(i)]["Contest C"] = {
+            "winner": 100,
+            "loser": 70,
+            "ballots": 200,
+            "numWinners": 1,
         }
 
-    yield Sampler('MACRO', seed, risk_limit, contests, batches)
+    yield Sampler("MACRO", seed, risk_limit, contests, batches)
 
 
 def test_max_error(sampler):
@@ -101,35 +91,41 @@ def test_max_error(sampler):
     # this is kind of a hacky way to do this but ¯\_(ツ)_/¯
     expected_ups = {}
     for i in range(200):
-        expected_ups['Batch {}'.format(i)] = 0.0700
-        expected_ups['Batch {} AV'.format(i)] = 0.035
+        expected_ups["Batch {}".format(i)] = 0.0700
+        expected_ups["Batch {} AV".format(i)] = 0.035
 
     for i in range(100):
-        expected_ups['Batch {}'.format(i)] = 0.0733
-        expected_ups['Batch {} AV'.format(i)] = 0.0367
+        expected_ups["Batch {}".format(i)] = 0.0733
+        expected_ups["Batch {} AV".format(i)] = 0.0367
 
     for i in range(30):
-        expected_ups['Batch {}'.format(i)] = 0.0852
-        expected_ups['Batch {} AV'.format(i)] = 0.0426
+        expected_ups["Batch {}".format(i)] = 0.0852
+        expected_ups["Batch {} AV".format(i)] = 0.0426
 
     for i in range(100, 130):
-        expected_ups['Batch {}'.format(i)] = 0.0852
-        expected_ups['Batch {} AV'.format(i)] = 0.0426
+        expected_ups["Batch {}".format(i)] = 0.0852
+        expected_ups["Batch {} AV".format(i)] = 0.0426
 
     for batch in sampler.batch_results:
         expected_up = expected_ups[batch]
-        computed_up = sampler.audit.compute_max_error(batch, sampler.contests, sampler.margins)
+        computed_up = sampler.audit.compute_max_error(
+            batch, sampler.contests, sampler.margins
+        )
 
         delta = abs(computed_up - expected_up)
-        assert delta < 0.001, \
-                'Got an incorrect maximum possible overstatement: {} should be {}'.format(computed_up, expected_up)
+        assert (
+            delta < 0.001
+        ), "Got an incorrect maximum possible overstatement: {} should be {}".format(
+            computed_up, expected_up
+        )
 
 
 def test_get_sample_sizes(sampler):
     expected = 31
     computed = sampler.get_sample_sizes({})
-    assert computed == expected, 'Failed to compute sample sized: got {}, expected {}'.format(
-        computed, expected)
+    assert (
+        computed == expected
+    ), "Failed to compute sample sized: got {}, expected {}".format(computed, expected)
 
 
 def test_compute_risk(sampler):
@@ -138,44 +134,30 @@ def test_compute_risk(sampler):
 
     # Draws with taint of 0
     for i in range(31):
-        sample['Batch {}'.format(i)] = {
-            'Contest A': {
-                'winner': 200,
-                'loser': 180,
-            },
-            'Contest B': {
-                'winner': 200,
-                'loser': 160,
-            },
-            'Contest C': {
-                'winner': 200,
-                'loser': 140,
-            }
+        sample["Batch {}".format(i)] = {
+            "Contest A": {"winner": 200, "loser": 180,},
+            "Contest B": {"winner": 200, "loser": 160,},
+            "Contest C": {"winner": 200, "loser": 140,},
         }
 
     # draws with taint of 0.04047619
     for i in range(100, 106):
-        sample['Batch {}'.format(i)] = {
-            'Contest A': {
-                'winner': 190,
-                'loser': 190,
-            },
-            'Contest B': {
-                'winner': 200,
-                'loser': 160,
-            },
-            'Contest C': {
-                'winner': 200,
-                'loser': 140,
-            }
+        sample["Batch {}".format(i)] = {
+            "Contest A": {"winner": 190, "loser": 190,},
+            "Contest B": {"winner": 200, "loser": 160,},
+            "Contest C": {"winner": 200, "loser": 140,},
         }
 
-    computed_p, result = sampler.audit.compute_risk(sampler.contests, sampler.margins, sample)
+    computed_p, result = sampler.audit.compute_risk(
+        sampler.contests, sampler.margins, sample
+    )
 
     expected_p = 0.247688222
 
     delta = abs(expected_p - computed_p)
 
-    assert delta < 10**-4, 'Incorrect p-value: Got {}, expected {}'.format(computed_p, expected_p)
+    assert delta < 10 ** -4, "Incorrect p-value: Got {}, expected {}".format(
+        computed_p, expected_p
+    )
 
-    assert result, 'Audit did not terminate but should have'
+    assert result, "Audit did not terminate but should have"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -6,15 +6,17 @@ from test_app import client, post_json, run_whole_audit_flow
 
 
 def test_basic_report(client):
-    rv = post_json(client, '/election/new', {})
-    election_id = json.loads(rv.data)['electionId']
+    rv = post_json(client, "/election/new", {})
+    election_id = json.loads(rv.data)["electionId"]
     assert election_id
 
     print("running whole audit flow " + election_id)
-    run_whole_audit_flow(client, election_id, "Primary 2019", 10, "12345678901234567890")
+    run_whole_audit_flow(
+        client, election_id, "Primary 2019", 10, "12345678901234567890"
+    )
 
-    rv = client.get(f'/election/{election_id}/audit/report')
-    lines = rv.data.decode('utf-8').splitlines()
+    rv = client.get(f"/election/{election_id}/audit/report")
+    lines = rv.data.decode("utf-8").splitlines()
     for line in EXPECTED_BASIC_REPORT:
         assert line in lines
     assert any(line.startswith("Round 1 Start,") for line in lines)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -7,159 +7,143 @@ from sampler import Sampler
 
 @pytest.fixture
 def bravo_sampler():
-    seed = '12345678901234567890abcdefghijklmnopqrstuvwxyz😊'
+    seed = "12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
 
-    risk_limit = .1
+    risk_limit = 0.1
     contests = {
-        'test1': {
-            'cand1': 600,
-            'cand2': 400,
-            'ballots': 1000,
-            'numWinners': 1
+        "test1": {"cand1": 600, "cand2": 400, "ballots": 1000, "numWinners": 1},
+        "test2": {
+            "cand1": 600,
+            "cand2": 200,
+            "cand3": 100,
+            "ballots": 900,
+            "numWinners": 1,
         },
-        'test2': {
-            'cand1': 600,
-            'cand2': 200,
-            'cand3': 100,
-            'ballots': 900,
-            'numWinners': 1
+        "test3": {"cand1": 100, "ballots": 100, "numWinners": 1},
+        "test4": {"cand1": 100, "ballots": 100, "numWinners": 1},
+        "test5": {"cand1": 500, "cand2": 500, "ballots": 1000, "numWinners": 1},
+        "test6": {
+            "cand1": 300,
+            "cand2": 200,
+            "cand3": 200,
+            "ballots": 1000,
+            "numWinners": 1,
         },
-        'test3': {
-            'cand1': 100,
-            'ballots': 100,
-            'numWinners': 1
+        "test7": {
+            "cand1": 300,
+            "cand2": 200,
+            "cand3": 100,
+            "ballots": 700,
+            "numWinners": 2,
         },
-        'test4': {
-            'cand1': 100,
-            'ballots': 100,
-            'numWinners': 1
+        "test7": {
+            "cand1": 300,
+            "cand2": 200,
+            "cand3": 100,
+            "ballots": 700,
+            "numWinners": 2,
         },
-        'test5': {
-            'cand1': 500,
-            'cand2': 500,
-            'ballots': 1000,
-            'numWinners': 1
+        "test8": {
+            "cand1": 300,
+            "cand2": 300,
+            "cand3": 100,
+            "ballots": 700,
+            "numWinners": 2,
         },
-        'test6': {
-            'cand1': 300,
-            'cand2': 200,
-            'cand3': 200,
-            'ballots': 1000,
-            'numWinners': 1
-        },
-        'test7': {
-            'cand1': 300,
-            'cand2': 200,
-            'cand3': 100,
-            'ballots': 700,
-            'numWinners': 2
-        },
-        'test7': {
-            'cand1': 300,
-            'cand2': 200,
-            'cand3': 100,
-            'ballots': 700,
-            'numWinners': 2
-        },
-        'test8': {
-            'cand1': 300,
-            'cand2': 300,
-            'cand3': 100,
-            'ballots': 700,
-            'numWinners': 2
-        },
-        'test9': {
-            'cand1': 300,
-            'cand2': 200,
-            'ballots': 700,
-            'numWinners': 2
-        },
-        'test10': {
-            'cand1': 600,
-            'cand2': 300,
-            'cand3': 100,
-            'ballots': 1000,
-            'numWinners': 2
+        "test9": {"cand1": 300, "cand2": 200, "ballots": 700, "numWinners": 2},
+        "test10": {
+            "cand1": 600,
+            "cand2": 300,
+            "cand3": 100,
+            "ballots": 1000,
+            "numWinners": 2,
         },
     }
 
-    yield Sampler('BRAVO', seed, risk_limit, contests)
+    yield Sampler("BRAVO", seed, risk_limit, contests)
 
 
 @pytest.fixture
 def macro_sampler():
-    seed = '12345678901234567890abcdefghijklmnopqrstuvwxyz😊'
+    seed = "12345678901234567890abcdefghijklmnopqrstuvwxyz😊"
 
-    risk_limit = .1
+    risk_limit = 0.1
     contests = {
-        'test1': {
-            'cand1': 600,
-            'cand2': 400,
-            'ballots': 1000,
-            'numWinners': 1
-        },
+        "test1": {"cand1": 600, "cand2": 400, "ballots": 1000, "numWinners": 1},
     }
 
     batches = {}
 
     # 10 batches will have max error of .08
     for i in range(10):
-        batches['pct {}'.format(i)] = {'test1': {'cand1': 40, 'cand2': 10, 'ballots': 50}}
+        batches["pct {}".format(i)] = {
+            "test1": {"cand1": 40, "cand2": 10, "ballots": 50}
+        }
         # 10 batches will have max error of .04
     for i in range(11, 20):
-        batches['pct {}'.format(i)] = {'test1': {'cand1': 20, 'cand2': 30, 'ballots': 50}}
+        batches["pct {}".format(i)] = {
+            "test1": {"cand1": 20, "cand2": 30, "ballots": 50}
+        }
 
-    yield Sampler('MACRO', seed, risk_limit, contests, batches)
+    yield Sampler("MACRO", seed, risk_limit, contests, batches)
 
 
 def test_macro_error():
     with pytest.raises(Exception) as e:
-        Sampler('MACRO', 0, 0, {})
+        Sampler("MACRO", 0, 0, {})
 
-        assert 'Must have batch-level results to use MACRO' in e.value
+        assert "Must have batch-level results to use MACRO" in e.value
 
 
 def test_draw_sample(bravo_sampler):
     # Test getting a sample
     manifest = {
-        'pct 1': 25,
-        'pct 2': 25,
-        'pct 3': 25,
-        'pct 4': 25,
+        "pct 1": 25,
+        "pct 2": 25,
+        "pct 3": 25,
+        "pct 4": 25,
     }
 
     sample = bravo_sampler.draw_sample(manifest, 20)
 
     for i, item in enumerate(sample):
         expected = expected_sample[i]
-        assert item == expected, 'Draw sample failed: got {}, expected {}'.format(item, expected)
+        assert item == expected, "Draw sample failed: got {}, expected {}".format(
+            item, expected
+        )
 
 
 def test_draw_more_samples(bravo_sampler):
     # Test getting a sample
     manifest = {
-        'pct 1': 25,
-        'pct 2': 25,
-        'pct 3': 25,
-        'pct 4': 25,
+        "pct 1": 25,
+        "pct 2": 25,
+        "pct 3": 25,
+        "pct 4": 25,
     }
 
     samp_size = 10
     sample = bravo_sampler.draw_sample(manifest, 10)
-    assert samp_size == len(sample), 'Received sample of size {}, expected {}'.format(
-        samp_size, len(sample))
+    assert samp_size == len(sample), "Received sample of size {}, expected {}".format(
+        samp_size, len(sample)
+    )
 
     for i, item in enumerate(sample):
         expected = expected_first_sample[i]
-        assert item == expected, 'Draw sample failed: got {}, expected {}'.format(item, expected)
+        assert item == expected, "Draw sample failed: got {}, expected {}".format(
+            item, expected
+        )
 
     samp_size = 10
     sample = bravo_sampler.draw_sample(manifest, 10, 10)
-    assert samp_size == len(sample), 'Received sample of size {}, expected {}'.format(
-        samp_size, len(sample))
+    assert samp_size == len(sample), "Received sample of size {}, expected {}".format(
+        samp_size, len(sample)
+    )
     for i, item in enumerate(sample):
         expected = expected_second_sample[i]
-        assert item == expected, 'Draw sample failed: got {}, expected {}'.format(item, expected)
+        assert item == expected, "Draw sample failed: got {}, expected {}".format(
+            item, expected
+        )
 
 
 def test_draw_macro_sample(macro_sampler):
@@ -168,73 +152,111 @@ def test_draw_macro_sample(macro_sampler):
 
     for i, item in enumerate(sample):
         expected = expected_macro_sample[i]
-        assert item == expected, 'Draw sample failed: got {}, expected {}'.format(item, expected)
+        assert item == expected, "Draw sample failed: got {}, expected {}".format(
+            item, expected
+        )
 
 
 def test_draw_more_macro_samples(macro_sampler):
     # Test getting a sample
     samp_size = 5
     sample = macro_sampler.draw_sample({}, 5)
-    assert samp_size == len(sample), 'Received sample of size {}, expected {}'.format(
-        samp_size, len(sample))
+    assert samp_size == len(sample), "Received sample of size {}, expected {}".format(
+        samp_size, len(sample)
+    )
 
     for i, item in enumerate(sample):
         expected = expected_first_macro_sample[i]
-        assert item == expected, 'Draw sample failed: got {}, expected {}'.format(item, expected)
+        assert item == expected, "Draw sample failed: got {}, expected {}".format(
+            item, expected
+        )
 
     samp_size = 5
     sample = macro_sampler.draw_sample({}, 5, 5)
-    assert samp_size == len(sample), 'Received sample of size {}, expected {}'.format(
-        samp_size, len(sample))
+    assert samp_size == len(sample), "Received sample of size {}, expected {}".format(
+        samp_size, len(sample)
+    )
     for i, item in enumerate(sample):
         expected = expected_second_macro_sample[i]
-        assert item == expected, 'Draw sample failed: got {}, expected {}'.format(item, expected)
+        assert item == expected, "Draw sample failed: got {}, expected {}".format(
+            item, expected
+        )
 
 
-expected_sample = [('0.000617786', ('pct 2', 3), 1), ('0.002991631', ('pct 3', 24), 1),
-                   ('0.017930028', ('pct 4', 19), 1), ('0.025599454', ('pct 3', 15), 1),
-                   ('0.045351055', ('pct 1', 7), 1), ('0.063913979', ('pct 1', 8), 1),
-                   ('0.064553852', ('pct 1', 22), 1), ('0.078998835', ('pct 1', 20), 1),
-                   ('0.090240829', ('pct 3', 12), 1), ('0.096136506', ('pct 1', 20), 2),
-                   ('0.104280162', ('pct 4', 17), 1), ('0.111195681', ('pct 1', 4), 1),
-                   ('0.114438612', ('pct 4', 3), 1), ('0.130457464', ('pct 2', 1), 1),
-                   ('0.133484785', ('pct 1', 12), 1), ('0.134519219', ('pct 3', 20), 1),
-                   ('0.135840440', ('pct 3', 10), 1), ('0.138772253', ('pct 4', 20), 1),
-                   ('0.145377629', ('pct 2', 9), 1), ('0.146681466', ('pct 1', 20), 3)]
+expected_sample = [
+    ("0.000617786", ("pct 2", 3), 1),
+    ("0.002991631", ("pct 3", 24), 1),
+    ("0.017930028", ("pct 4", 19), 1),
+    ("0.025599454", ("pct 3", 15), 1),
+    ("0.045351055", ("pct 1", 7), 1),
+    ("0.063913979", ("pct 1", 8), 1),
+    ("0.064553852", ("pct 1", 22), 1),
+    ("0.078998835", ("pct 1", 20), 1),
+    ("0.090240829", ("pct 3", 12), 1),
+    ("0.096136506", ("pct 1", 20), 2),
+    ("0.104280162", ("pct 4", 17), 1),
+    ("0.111195681", ("pct 1", 4), 1),
+    ("0.114438612", ("pct 4", 3), 1),
+    ("0.130457464", ("pct 2", 1), 1),
+    ("0.133484785", ("pct 1", 12), 1),
+    ("0.134519219", ("pct 3", 20), 1),
+    ("0.135840440", ("pct 3", 10), 1),
+    ("0.138772253", ("pct 4", 20), 1),
+    ("0.145377629", ("pct 2", 9), 1),
+    ("0.146681466", ("pct 1", 20), 3),
+]
 
-expected_macro_sample = [('0.003875995', 'pct 16', 1), ('0.011835450', 'pct 2', 1),
-                         ('0.022865957', 'pct 2', 2), ('0.035732442', 'pct 3', 1),
-                         ('0.125751540', 'pct 2', 3), ('0.136070319', 'pct 18', 1),
-                         ('0.150306323', 'pct 6', 1), ('0.176060218', 'pct 4', 1),
-                         ('0.183200120', 'pct 13', 1), ('0.191343085', 'pct 18', 2)]
+expected_macro_sample = [
+    ("0.003875995", "pct 16", 1),
+    ("0.011835450", "pct 2", 1),
+    ("0.022865957", "pct 2", 2),
+    ("0.035732442", "pct 3", 1),
+    ("0.125751540", "pct 2", 3),
+    ("0.136070319", "pct 18", 1),
+    ("0.150306323", "pct 6", 1),
+    ("0.176060218", "pct 4", 1),
+    ("0.183200120", "pct 13", 1),
+    ("0.191343085", "pct 18", 2),
+]
 
 expected_first_sample = [
-    ('0.000617786', ('pct 2', 3), 1),
-    ('0.002991631', ('pct 3', 24), 1),
-    ('0.017930028', ('pct 4', 19), 1),
-    ('0.025599454', ('pct 3', 15), 1),
-    ('0.045351055', ('pct 1', 7), 1),
-    ('0.063913979', ('pct 1', 8), 1),
-    ('0.064553852', ('pct 1', 22), 1),
-    ('0.078998835', ('pct 1', 20), 1),
-    ('0.090240829', ('pct 3', 12), 1),
-    ('0.096136506', ('pct 1', 20), 2),
+    ("0.000617786", ("pct 2", 3), 1),
+    ("0.002991631", ("pct 3", 24), 1),
+    ("0.017930028", ("pct 4", 19), 1),
+    ("0.025599454", ("pct 3", 15), 1),
+    ("0.045351055", ("pct 1", 7), 1),
+    ("0.063913979", ("pct 1", 8), 1),
+    ("0.064553852", ("pct 1", 22), 1),
+    ("0.078998835", ("pct 1", 20), 1),
+    ("0.090240829", ("pct 3", 12), 1),
+    ("0.096136506", ("pct 1", 20), 2),
 ]
 
-expected_second_sample = [('0.104280162', ('pct 4', 17), 1), ('0.111195681', ('pct 1', 4), 1),
-                          ('0.114438612', ('pct 4', 3), 1), ('0.130457464', ('pct 2', 1), 1),
-                          ('0.133484785', ('pct 1', 12), 1), ('0.134519219', ('pct 3', 20), 1),
-                          ('0.135840440', ('pct 3', 10), 1), ('0.138772253', ('pct 4', 20), 1),
-                          ('0.145377629', ('pct 2', 9), 1), ('0.146681466', ('pct 1', 20), 3)]
+expected_second_sample = [
+    ("0.104280162", ("pct 4", 17), 1),
+    ("0.111195681", ("pct 1", 4), 1),
+    ("0.114438612", ("pct 4", 3), 1),
+    ("0.130457464", ("pct 2", 1), 1),
+    ("0.133484785", ("pct 1", 12), 1),
+    ("0.134519219", ("pct 3", 20), 1),
+    ("0.135840440", ("pct 3", 10), 1),
+    ("0.138772253", ("pct 4", 20), 1),
+    ("0.145377629", ("pct 2", 9), 1),
+    ("0.146681466", ("pct 1", 20), 3),
+]
 
 expected_first_macro_sample = [
-    ('0.003875995', 'pct 16', 1),
-    ('0.011835450', 'pct 2', 1),
-    ('0.022865957', 'pct 2', 2),
-    ('0.035732442', 'pct 3', 1),
-    ('0.125751540', 'pct 2', 3),
+    ("0.003875995", "pct 16", 1),
+    ("0.011835450", "pct 2", 1),
+    ("0.022865957", "pct 2", 2),
+    ("0.035732442", "pct 3", 1),
+    ("0.125751540", "pct 2", 3),
 ]
 
-expected_second_macro_sample = [('0.136070319', 'pct 18', 1), ('0.150306323', 'pct 6', 1),
-                                ('0.176060218', 'pct 4', 1), ('0.183200120', 'pct 13', 1),
-                                ('0.191343085', 'pct 18', 2)]
+expected_second_macro_sample = [
+    ("0.136070319", "pct 18", 1),
+    ("0.150306323", "pct 6", 1),
+    ("0.176060218", "pct 4", 1),
+    ("0.183200120", "pct 13", 1),
+    ("0.191343085", "pct 18", 2),
+]

--- a/util/binpacking.py
+++ b/util/binpacking.py
@@ -27,20 +27,22 @@ class Bucket:
         if not self.size:
             self.largest_element = None
         elif batch_name == self.largest_element:
-            self.largest_element = max(self.batches.items(), key=operator.itemgetter(1))[0]
+            self.largest_element = max(
+                self.batches.items(), key=operator.itemgetter(1)
+            )[0]
 
-        return ({batch_name: taken})
+        return {batch_name: taken}
 
     def __repr__(self) -> str:
         ret_str = {
-            'name': self.name,
-            'size': self.size,
-            'batches': self.batches,
-            'largest element': self.largest_element
+            "name": self.name,
+            "size": self.size,
+            "batches": self.batches,
+            "largest element": self.largest_element,
         }
         return str(ret_str)
 
-    def __gt__(self, other: 'Bucket') -> bool:
+    def __gt__(self, other: "Bucket") -> bool:
         return self.size > other.size
 
     def __eq__(self, other: object) -> bool:
@@ -50,10 +52,11 @@ class Bucket:
 
 
 class BucketList:
-    '''
+    """
     A list of buckets that doesn't self-balance. For use in testing balancing
     algorithms.
-    '''
+    """
+
     def __init__(self, buckets: List[Bucket]):
         self.buckets = buckets
         self.avg_size = self.get_avg_size()
@@ -64,13 +67,13 @@ class BucketList:
     def deviation(self) -> float:
         return sum([abs(self.avg_size - b.size) for b in self.buckets]) / self.avg_size
 
-    def balance(self) -> 'BucketList':
-        '''
+    def balance(self) -> "BucketList":
+        """
         Assign all batches that are bigger than the average size to buckets, 
         minimizing the amount of size deviation from the average.
         Then iterate through all the rest of the batches and add them to the 
         buckets, minimizing the deviation from the average.
-        '''
+        """
 
         # first get all the batches in a list
         batches: List[Tuple[str, int]] = []
@@ -94,9 +97,15 @@ class BucketList:
             # Find the least-full bucket and assign this batch
             if batch[1] > self.avg_size:
                 # Find the least-bad bucket
-                (min_idx, _min_del) = min(enumerate(
-                    map(lambda bucket: bucket.size + batch[1] - self.avg_size, new_buckets)),
-                                          key=operator.itemgetter(1))
+                (min_idx, _min_del) = min(
+                    enumerate(
+                        map(
+                            lambda bucket: bucket.size + batch[1] - self.avg_size,
+                            new_buckets,
+                        )
+                    ),
+                    key=operator.itemgetter(1),
+                )
 
                 # Now add to the least-bad bucket
                 new_buckets[min_idx].add_batch(batch[0], batch[1])
@@ -109,9 +118,15 @@ class BucketList:
         # that will be _least_ over the average
         for batch in left_overs:
             # Find the least-bad bucket
-            (min_idx, _min_del) = min(enumerate(
-                map(lambda bucket: bucket.size + batch[1] - self.avg_size, new_buckets)),
-                                      key=operator.itemgetter(1))
+            (min_idx, _min_del) = min(
+                enumerate(
+                    map(
+                        lambda bucket: bucket.size + batch[1] - self.avg_size,
+                        new_buckets,
+                    )
+                ),
+                key=operator.itemgetter(1),
+            )
 
             # Now add to the least-bad bucket
             new_buckets[min_idx].add_batch(batch[0], batch[1])
@@ -125,25 +140,25 @@ class BucketList:
         for bucket in self.buckets:
             print(bucket.name, bucket.size)
             for batch in bucket.batches:
-                print('\t', batch, bucket.batches[batch])
+                print("\t", batch, bucket.batches[batch])
 
 
 class BalancedBucketList:
-    '''
+    """
     A balanced list of buckets.
-    '''
+    """
 
     avg_size: float
     buckets: List[Bucket]
 
     def __init__(self, buckets):
-        '''
+        """
         Assign all batches that are bigger than the average size to buckets, 
         minimizing the amount of size deviation from the average.
 
         Then iterate through all the rest of the batches and add them to the 
         buckets, minimizing the deviation from the average.
-        '''
+        """
 
         self.avg_size = numpy.mean([s.size for s in buckets])
 
@@ -167,9 +182,15 @@ class BalancedBucketList:
             # Find the least-full bucket and assign this batch
             if batch[1] > self.avg_size:
                 # Find the least-bad bucket
-                (min_idx, _min_del) = min(enumerate(
-                    map(lambda bucket: bucket.size + batch[1] - self.avg_size, self.buckets)),
-                                          key=operator.itemgetter(1))
+                (min_idx, _min_del) = min(
+                    enumerate(
+                        map(
+                            lambda bucket: bucket.size + batch[1] - self.avg_size,
+                            self.buckets,
+                        )
+                    ),
+                    key=operator.itemgetter(1),
+                )
 
                 # Now add to the least-bad bucket
                 self.buckets[min_idx].add_batch(batch[0], batch[1])
@@ -182,9 +203,15 @@ class BalancedBucketList:
         # that will be _least_ over the average
         for batch in left_overs:
             # Find the least-bad bucket
-            (min_idx, _min_del) = min(enumerate(
-                map(lambda bucket: bucket.size + batch[1] - self.avg_size, self.buckets)),
-                                      key=operator.itemgetter(1))
+            (min_idx, _min_del) = min(
+                enumerate(
+                    map(
+                        lambda bucket: bucket.size + batch[1] - self.avg_size,
+                        self.buckets,
+                    )
+                ),
+                key=operator.itemgetter(1),
+            )
 
             # Now add to the least-bad bucket
             self.buckets[min_idx].add_batch(batch[0], batch[1])
@@ -202,10 +229,10 @@ class BalancedBucketList:
         for bucket in self.buckets:
             print(bucket.name, bucket.size)
             for batch in bucket.batches:
-                print('\t', batch, bucket.batches[batch])
+                print("\t", batch, bucket.batches[batch])
 
 
-'''
+"""
 batches = {}
 for line in csv.DictReader(open('washtenaw-retrieval.csv')):
     if line['Batch Name'] in batches:
@@ -248,4 +275,4 @@ print('////////')
 print(len(batches), bl_batches, nnew_bl_batches) 
 print(bl.deviation(), new_bl.deviation())
 print(len(new_bl_batches.intersection(set(batches.keys()))))
-'''
+"""

--- a/util/jurisdiction_bulk_update.py
+++ b/util/jurisdiction_bulk_update.py
@@ -5,8 +5,8 @@ from sqlalchemy import func
 
 
 def bulk_update_jurisdictions(
-        session, election: Election,
-        name_and_admin_email_pairs: List[Tuple[str, str]]) -> List[JurisdictionAdministration]:
+    session, election: Election, name_and_admin_email_pairs: List[Tuple[str, str]]
+) -> List[JurisdictionAdministration]:
     """
     Updates the jurisdictions for an election all at once. Requires a SQLAlchemy session to use,
     and uses a nested transaction to ensure the changes made are atomic. Depending on your
@@ -15,8 +15,9 @@ def bulk_update_jurisdictions(
     """
     with session.begin_nested():
         # Clear existing admins.
-        session.query(JurisdictionAdministration).filter(Jurisdiction.election == election).delete(
-            synchronize_session='fetch')
+        session.query(JurisdictionAdministration).filter(
+            Jurisdiction.election == election
+        ).delete(synchronize_session="fetch")
         new_admins: List[JurisdictionAdministration] = []
 
         for (name, email) in name_and_admin_email_pairs:
@@ -28,10 +29,14 @@ def bulk_update_jurisdictions(
                 session.add(user)
 
             # Find or create the jurisdiction by name.
-            jurisdiction = Jurisdiction.query.filter_by(election=election, name=name).one_or_none()
+            jurisdiction = Jurisdiction.query.filter_by(
+                election=election, name=name
+            ).one_or_none()
 
             if not jurisdiction:
-                jurisdiction = Jurisdiction(id=str(uuid.uuid4()), election=election, name=name)
+                jurisdiction = Jurisdiction(
+                    id=str(uuid.uuid4()), election=election, name=name
+                )
                 session.add(jurisdiction)
 
             # Link the user to the jurisdiction as an admin.
@@ -40,13 +45,19 @@ def bulk_update_jurisdictions(
             new_admins.append(admin)
 
         # Delete unmanaged jurisdictions.
-        unmanaged_admin_id_records = session.query(
-            Jurisdiction).outerjoin(JurisdictionAdministration).filter(
+        unmanaged_admin_id_records = (
+            session.query(Jurisdiction)
+            .outerjoin(JurisdictionAdministration)
+            .filter(
                 Jurisdiction.election == election,
-                JurisdictionAdministration.jurisdiction_id == None).with_entities(
-                    Jurisdiction.id).all()
-        unmanaged_admin_ids = [id for (id, ) in unmanaged_admin_id_records]
+                JurisdictionAdministration.jurisdiction_id == None,
+            )
+            .with_entities(Jurisdiction.id)
+            .all()
+        )
+        unmanaged_admin_ids = [id for (id,) in unmanaged_admin_id_records]
         session.query(Jurisdiction).filter(
-            Jurisdiction.id.in_(unmanaged_admin_ids)).delete(synchronize_session='fetch')
+            Jurisdiction.id.in_(unmanaged_admin_ids)
+        ).delete(synchronize_session="fetch")
 
         return new_admins


### PR DESCRIPTION
**Description**

Switches from `yapf` to `black` for Python formatting. `black` is waaay faster and also doesn't have some of the weird line-breaking quirks that `yapf` had.

I separated the configuration changes from the actual reformatting of all the code into separate commits, so may be easier to review commit by commit.

**Testing**

N/A

**Progress**

Ready for review