### PR TITLE
Switch all python3 commands to python3.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 deps:
 	sudo apt install python3.7 python3-pip nodejs libpython3.7-dev libpq-dev
-	python3 -m pip install pipenv
+	python3.7 -m pip install pipenv
 	sudo npm install -g yarn
 	sudo apt install postgresql
 
@@ -11,13 +11,13 @@ initdevdb:
 	sudo -u postgres psql -c "create database arlo with owner arlo;"
 
 install:
-	python3 -m pipenv install
+	python3.7 -m pipenv install
 	yarn install
 	yarn --cwd arlo-client install
 	yarn --cwd arlo-client build
 
 install-development:
-	python3 -m pipenv install --dev
+	python3.7 -m pipenv install --dev
 	yarn install
 	yarn --cwd arlo-client install
 
@@ -25,15 +25,15 @@ resettestdb:
 	FLASK_ENV=test make resetdb
 
 resetdb:
-	python3 -m pipenv run python resetdb.py
+	python3.7 -m pipenv run python resetdb.py
 
 dev-environment: deps initdevdb install-development resetdb
 
 typecheck:
-	python3 -m pipenv run mypy .
+	python3.7 -m pipenv run mypy .
 
 format-python:
-	python3 -m pipenv run black .
+	python3.7 -m pipenv run black .
 
 test-client:
 	yarn --cwd arlo-client lint
@@ -41,4 +41,4 @@ test-client:
 
 # To run a specific test: TEST=<test name> make test-server
 test-server:
-	FLASK_ENV=test python3 -m pipenv run python -m pytest -k '${TEST}' --ignore=arlo-client
+	FLASK_ENV=test python3.7 -m pipenv run python -m pytest -k '${TEST}' --ignore=arlo-client

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For testing:
 
 1. Download [`python-dev`](https://www.python.org/) >3.7
 2. Download [`pip`](https://pypi.org/project/pip/)
-3. Install `pipenv` (note: run `python3 -m pip install pipenv` to get a version that's compatible with your local python install if your system defaults to a python other than >3.7).
+3. Install `pipenv` (note: run `python3.7 -m pip install pipenv` to get a version that's compatible with your local python install if your system defaults to a python other than >3.7).
 4. Install [`yarn`](https://yarnpkg.com/en/docs/install) and [nodejs](https://github.com/nodesource/distributions/blob/master/README.md).
 5. Install `postgres-client` and `postgresql-dev`, see https://www.postgresql.org/download.
 6. Install dependencies with `make install` or `make install-development` depending on your use-case

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-(trap 'kill 0' SIGINT SIGHUP; python3 -m pipenv run python app.py & python3 -m pipenv run python bgcompute.py & yarn --cwd arlo-client start)
+(trap 'kill 0' SIGINT SIGHUP; python3.7 -m pipenv run python app.py & python3.7 -m pipenv run python bgcompute.py & yarn --cwd arlo-client start)


### PR DESCRIPTION
**Description**

I discovered that in my Ubuntu dev environment, `python3` is by default
`3.6.9`. To be safe, let's use `python3.7` explicitly.

**Testing**

N/A

**Progress**

Ready for review.
Note: needs to be merged after #327 because it assumes we've switched to black for `make format-python`