### PR TITLE
fix: add authorization to a few endpoints

### DIFF
--- a/models.py
+++ b/models.py
@@ -32,7 +32,7 @@ class Election(db.Model):
     organization_id = db.Column(
         db.String(200),
         db.ForeignKey("organization.id", ondelete="cascade"),
-        nullable=False,
+        nullable=True,
     )
 
     frozen_at = db.Column(db.DateTime(timezone=False), nullable=True)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,39 @@
+import uuid
+import json
+from arlo_server import create_organization, db, UserType
+from models import AuditAdministration, User  # type: ignore
+from typing import Any, Optional
+from flask.testing import FlaskClient
+
+DEFAULT_USER_EMAIL = "admin@example.com"
+
+
+def post_json(client: FlaskClient, url: str, obj) -> Any:
+    return client.post(
+        url, headers={"Content-Type": "application/json"}, data=json.dumps(obj)
+    )
+
+
+def set_logged_in_user(
+    client: FlaskClient, user_type: UserType, user_email=DEFAULT_USER_EMAIL
+):
+    with client.session_transaction() as session:
+        session["_user"] = {"type": user_type, "email": user_email}
+
+
+def create_user(email=DEFAULT_USER_EMAIL):
+    user = User(id=str(uuid.uuid4()), email=email, external_id=email)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def create_org_and_admin(org_name="Test Org", user_email=DEFAULT_USER_EMAIL):
+    org = create_organization(org_name)
+    u = create_user(user_email)
+    db.session.add(u)
+    admin = AuditAdministration(organization_id=org.id, user_id=u.id)
+    db.session.add(admin)
+    db.session.commit()
+
+    return org.id, u.id

--- a/tests/test_app_upload_jurisdictions_file.py
+++ b/tests/test_app_upload_jurisdictions_file.py
@@ -2,20 +2,16 @@ import os, math, uuid
 import tempfile
 import json, csv, io
 
+from flask.testing import FlaskClient
+from tests.helpers import post_json
 import pytest
 
 from models import Election, JurisdictionAdministration, User
 from arlo_server import app, db
 
 
-def post_json(client, url, obj):
-    return client.post(
-        url, headers={"Content-Type": "application/json"}, data=json.dumps(obj)
-    )
-
-
 @pytest.fixture
-def client():
+def client() -> FlaskClient:
     app.config["TESTING"] = True
     client = app.test_client()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -13,6 +13,7 @@ from arlo_server import (
     UserType,
 )
 from models import *
+from tests.helpers import create_org_and_admin
 
 
 @pytest.fixture
@@ -28,19 +29,8 @@ def _setup_user(client, user_type, user_email):
         session["_user"] = {"type": user_type, "email": user_email}
 
 
-def _create_org_and_admin(org_name, user_email):
-    org = create_organization(org_name)
-    u = User(id=str(uuid.uuid4()), email=user_email, external_id=user_email)
-    db.session.add(u)
-    admin = AuditAdministration(organization_id=org.id, user_id=u.id)
-    db.session.add(admin)
-    db.session.commit()
-
-    return org.id, u.id
-
-
 def test_auth_me(client):
-    org_id, user_id = _create_org_and_admin("Test Org", "admin@example.com")
+    org_id, user_id = create_org_and_admin("Test Org", "admin@example.com")
     election_id = create_election(organization_id=org_id)
     jurisdiction = Jurisdiction(
         election_id=election_id, id=str(uuid.uuid4()), name="Test Jurisdiction"
@@ -95,7 +85,7 @@ def test_auditadmin_start(client):
 
 
 def test_auditadmin_callback(client):
-    org_id, user_id = _create_org_and_admin("Test Organization", "foo@example.com")
+    create_org_and_admin("Test Organization", "foo@example.com")
 
     auth0_aa.authorize_access_token = MagicMock(return_value=None)
 

--- a/tests/test_new_election.py
+++ b/tests/test_new_election.py
@@ -1,0 +1,94 @@
+import json
+import pytest
+from flask.testing import FlaskClient
+from typing import Any
+
+from arlo_server import app, db, create_organization, UserType
+from tests.helpers import create_org_and_admin, set_logged_in_user, post_json
+
+
+@pytest.fixture
+def client() -> FlaskClient:
+    app.config["TESTING"] = True
+    client = app.test_client()
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+    yield client
+
+    db.session.commit()
+
+
+def test_without_org_with_anonymous_user(client: FlaskClient):
+    rv = client.post("/election/new")
+    assert json.loads(rv.data)["electionId"]
+    assert rv.status_code == 200
+
+
+def test_in_org_with_anonymous_user(client: FlaskClient):
+    org = create_organization()
+    rv = post_json(client, "/election/new", {"organization_id": org.id})
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": f"Anonymous users do not have access to organization {org.id}",
+                "errorType": "Unauthorized",
+            }
+        ]
+    }
+    assert rv.status_code == 401
+
+
+def test_in_org_with_logged_in_admin(client: FlaskClient):
+    org_id, _user_id = create_org_and_admin(user_email="admin@example.com")
+    set_logged_in_user(
+        client, user_type=UserType.AUDIT_ADMIN, user_email="admin@example.com"
+    )
+
+    rv = post_json(client, "/election/new", {"organization_id": org_id})
+    response = json.loads(rv.data)
+    election_id = response.get("electionId", None)
+    assert election_id, response
+
+    rv = client.get(f"/election/{election_id}/audit/status")
+
+    assert json.loads(rv.data)["organizationId"] == org_id
+
+
+def test_in_org_with_logged_in_admin_without_access(client: FlaskClient):
+    _org1_id, _user1_id = create_org_and_admin(user_email="admin1@example.com")
+    org2_id, _user2_id = create_org_and_admin(user_email="admin2@example.com")
+    set_logged_in_user(
+        client, user_type=UserType.AUDIT_ADMIN, user_email="admin1@example.com"
+    )
+
+    rv = post_json(client, "/election/new", {"organization_id": org2_id})
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": f"admin1@example.com does not have access to organization {org2_id}",
+                "errorType": "Forbidden",
+            }
+        ]
+    }
+    assert rv.status_code == 403
+
+
+def test_in_org_with_logged_in_jurisdiction_admin(client: FlaskClient):
+    org_id, _user_id = create_org_and_admin(user_email="admin@example.com")
+    set_logged_in_user(
+        client, user_type=UserType.JURISDICTION_ADMIN, user_email="admin@example.com"
+    )
+
+    rv = post_json(client, "/election/new", {"organization_id": org_id})
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": f"admin@example.com is not logged in as an audit admin and so does not have access to organization {org_id}",
+                "errorType": "Forbidden",
+            }
+        ]
+    }
+    assert rv.status_code == 403


### PR DESCRIPTION
**Description**

This restricts creating elections within an organization to audit admins in that organization. It also restricts the jurisdiction file upload API to audit admins for the election.

This also changes the data model to _not_ require an organization for each election. Any elections without an organization are accessible as they were before: by knowing the URL.

Refs #290 

**Testing**

Pulls tests specifically around `/election/new` into their own file and adds tests for various logged-in user scenarios.

**Progress**

There's still more to go to add authorization for all the endpoints that require them. We can use the new `require_audit_admin_for_organization` and `set_logged_in_user` helpers to make this fairly easy, though we'll need another helper for jurisdiction admins.