### PR TITLE
Add contest.isTargeted to /audit/basic and /audit/status

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -450,6 +450,7 @@ def audit_status(election_id=None):
             {
                 "id": contest.id,
                 "name": contest.name,
+                "isTargeted": contest.is_targeted,
                 "choices": [
                     {"id": choice.id, "name": choice.name, "numVotes": choice.num_votes}
                     for choice in contest.choices
@@ -545,7 +546,7 @@ def audit_basic_update(election_id):
             election_id=election.id,
             id=contest["id"],
             name=contest["name"],
-            is_targeted=True,
+            is_targeted=contest.get("isTargeted", True),
             total_ballots_cast=contest["totalBallotsCast"],
             num_winners=contest["numWinners"],
             votes_allowed=contest["votesAllowed"],

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,9 +1,10 @@
-import uuid
-import json
-from arlo_server import create_organization, db, UserType
-from models import AuditAdministration, User  # type: ignore
+import uuid, json, re
+from email.utils import parsedate_to_datetime
 from typing import Any, Optional
 from flask.testing import FlaskClient
+
+from arlo_server import create_organization, db, UserType
+from models import AuditAdministration, User  # type: ignore
 
 DEFAULT_USER_EMAIL = "admin@example.com"
 
@@ -37,3 +38,37 @@ def create_org_and_admin(org_name="Test Org", user_email=DEFAULT_USER_EMAIL):
     db.session.commit()
 
     return org.id, u.id
+
+
+def assert_is_id(x):
+    assert isinstance(x, str)
+    uuid.UUID(x, version=4)  # Will raise exception on non-UUID strings
+
+
+def assert_is_date(x):
+    assert isinstance(x, str)
+    parsedate_to_datetime(x)  # Will raise exception on non-HTTP-date strings
+
+
+def assert_is_passphrase(x):
+    assert isinstance(x, str)
+    assert re.match(r"[a-z]+-[a-z]+-[a-z]+-[a-z]+", x)
+
+
+# Checks that a json blob (represented as a Python dict) is equal-ish to an expected
+# dict. The expected dict can contain assertion functions in place of any non-deterministic values.
+def compare_json(actual_json, expected_json):
+    if isinstance(expected_json, dict):
+        assert isinstance(actual_json, dict)
+        for k, v in expected_json.items():
+            compare_json(actual_json[k], v)
+        assert actual_json.keys() == expected_json.keys()
+    elif isinstance(expected_json, list):
+        assert isinstance(actual_json, list)
+        for i, v in enumerate(expected_json):
+            compare_json(actual_json[i], v)
+        assert len(actual_json) == len(expected_json)
+    elif callable(expected_json):
+        expected_json(actual_json)
+    else:
+        assert actual_json == expected_json

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -118,6 +118,7 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
                 {
                     "id": contest_id,
                     "name": "contest 1",
+                    "isTargeted": True,
                     "choices": [
                         {
                             "id": candidate_id_1,
@@ -310,6 +311,7 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
                 {
                     "id": contest_id,
                     "name": "contest 1",
+                    "isTargeted": True,
                     "choices": [
                         {
                             "id": candidate_id_1,
@@ -568,6 +570,7 @@ def test_small_election(client):
                 {
                     "id": contest_id,
                     "name": "Contest 1",
+                    "isTargeted": True,
                     "choices": [
                         {"id": candidate_id_1, "name": "Candidate 1", "numVotes": 1325},
                         {"id": candidate_id_2, "name": "Candidate 2", "numVotes": 792},
@@ -757,6 +760,7 @@ def test_contest_choices_cannot_have_more_votes_than_allowed(client):
                 {
                     "id": contest_id,
                     "name": "Contest 1",
+                    "isTargeted": True,
                     "choices": [
                         {"id": candidate_id_1, "name": "Candidate 1", "numVotes": 21},
                         {"id": candidate_id_2, "name": "Candidate 2", "numVotes": 40},
@@ -792,6 +796,7 @@ def test_contest_choices_cannot_have_more_votes_than_allowed(client):
                 {
                     "id": contest_id,
                     "name": "Contest 1",
+                    "isTargeted": True,
                     "choices": [
                         {"id": candidate_id_1, "name": "Candidate 1", "numVotes": 20},
                         {"id": candidate_id_2, "name": "Candidate 2", "numVotes": 40},
@@ -909,6 +914,7 @@ def test_multi_winner_election(client):
                 {
                     "id": contest_id,
                     "name": "Contest 1",
+                    "isTargeted": True,
                     "choices": [
                         {"id": candidate_id_1, "name": "Candidate 1", "numVotes": 1000},
                         {"id": candidate_id_2, "name": "Candidate 2", "numVotes": 792},

--- a/tests/test_audit_basic_update.py
+++ b/tests/test_audit_basic_update.py
@@ -1,0 +1,81 @@
+import json, uuid
+import pytest
+
+from helpers import post_json
+from test_app import client
+
+
+def test_audit_basic_update_create_contest(client):
+    rv = client.post("/election/new")
+    election_id = json.loads(rv.data)["electionId"]
+    assert election_id
+
+    contest_id = str(uuid.uuid4())
+    candidate_id_1 = str(uuid.uuid4())
+    candidate_id_2 = str(uuid.uuid4())
+
+    rv = post_json(
+        client,
+        f"/election/{election_id}/audit/basic",
+        {
+            "name": "Create Contest",
+            "riskLimit": 10,
+            "randomSeed": "a1234567890987654321b",
+            "online": False,
+            "contests": [
+                {
+                    "id": contest_id,
+                    "name": "Contest 1",
+                    "isTargeted": True,
+                    "choices": [
+                        {"id": candidate_id_1, "name": "Candidate 1", "numVotes": 1325},
+                        {"id": candidate_id_2, "name": "Candidate 2", "numVotes": 792},
+                    ],
+                    "totalBallotsCast": 2123,
+                    "numWinners": 1,
+                    "votesAllowed": 1,
+                }
+            ],
+        },
+    )
+
+    assert json.loads(rv.data)["status"] == "ok"
+
+
+def test_audit_basic_update_sets_default_for_contest_is_targeted(client):
+    rv = client.post("/election/new")
+    election_id = json.loads(rv.data)["electionId"]
+    assert election_id
+
+    contest_id = str(uuid.uuid4())
+    candidate_id_1 = str(uuid.uuid4())
+    candidate_id_2 = str(uuid.uuid4())
+
+    rv = post_json(
+        client,
+        f"/election/{election_id}/audit/basic",
+        {
+            "name": "Create Contest",
+            "riskLimit": 10,
+            "randomSeed": "a1234567890987654321b",
+            "online": False,
+            "contests": [
+                {
+                    "id": contest_id,
+                    "name": "Contest 1",
+                    "choices": [
+                        {"id": candidate_id_1, "name": "Candidate 1", "numVotes": 1325},
+                        {"id": candidate_id_2, "name": "Candidate 2", "numVotes": 792},
+                    ],
+                    "totalBallotsCast": 2123,
+                    "numWinners": 1,
+                    "votesAllowed": 1,
+                }
+            ],
+        },
+    )
+
+    assert json.loads(rv.data)["status"] == "ok"
+
+    rv = client.get(f"/election/{election_id}/audit/status")
+    assert json.loads(rv.data)["contests"][0]["isTargeted"] == True

--- a/tests/test_audit_status.py
+++ b/tests/test_audit_status.py
@@ -1,0 +1,120 @@
+import json
+import pytest
+
+from helpers import (
+    post_json,
+    compare_json,
+    assert_is_id,
+    assert_is_date,
+    assert_is_passphrase,
+)
+from test_app import (
+    client,
+    setup_whole_audit,
+)
+
+
+def test_audit_status(client):
+    rv = client.post("/election/new")
+    election_id = json.loads(rv.data)["electionId"]
+    assert election_id
+
+    (
+        url_prefix,
+        contest_id,
+        candidate_id_1,
+        candidate_id_2,
+        jurisdiction_id,
+        audit_board_id_1,
+        audit_board_id_2,
+        num_ballots,
+    ) = setup_whole_audit(client, election_id, "Audit Status Test", 10, "1234567890")
+
+    rv = client.get(f"/election/{election_id}/audit/status")
+    status = json.loads(rv.data)
+
+    compare_json(
+        status,
+        {
+            "contests": [
+                {
+                    "choices": [
+                        {
+                            "id": candidate_id_1,
+                            "name": "candidate 1",
+                            "numVotes": 48121,
+                        },
+                        {
+                            "id": candidate_id_2,
+                            "name": "candidate 2",
+                            "numVotes": 38026,
+                        },
+                    ],
+                    "id": contest_id,
+                    "isTargeted": True,
+                    "name": "contest 1",
+                    "numWinners": 1,
+                    "totalBallotsCast": 86147,
+                    "votesAllowed": 1,
+                }
+            ],
+            "frozenAt": assert_is_date,
+            "jurisdictions": [
+                {
+                    "auditBoards": [
+                        {
+                            "id": audit_board_id_2,
+                            "members": [],
+                            "name": "audit board #2",
+                            "passphrase": assert_is_passphrase,
+                        },
+                        {
+                            "id": audit_board_id_1,
+                            "members": [
+                                {"affiliation": "REP", "name": "Joe Schmo"},
+                                {"affiliation": "", "name": "Jane Plain"},
+                            ],
+                            "name": "Audit Board #1",
+                            "passphrase": assert_is_passphrase,
+                        },
+                    ],
+                    "ballotManifest": {
+                        "filename": "manifest.csv",
+                        "numBallots": 86147,
+                        "numBatches": 484,
+                        "uploadedAt": assert_is_date,
+                    },
+                    "batches": lambda x: x,  # pass
+                    "contests": [contest_id],
+                    "id": assert_is_id,
+                    "name": "adams county",
+                }
+            ],
+            "name": "Audit Status Test",
+            "online": False,
+            "organizationId": None,
+            "randomSeed": "1234567890",
+            "riskLimit": 10,
+            "rounds": [
+                {
+                    "contests": [
+                        {
+                            "endMeasurements": {"isComplete": None, "pvalue": None},
+                            "id": contest_id,
+                            "results": {},
+                            "sampleSize": 1035,
+                            "sampleSizeOptions": [
+                                {"prob": [0.51], "size": 343, "type": "ASN"},
+                                {"prob": 0.7, "size": 542, "type": None},
+                                {"prob": 0.8, "size": 718, "type": None},
+                                {"prob": 0.9, "size": 1035, "type": None},
+                            ],
+                        }
+                    ],
+                    "endedAt": None,
+                    "id": assert_is_id,
+                    "startedAt": assert_is_date,
+                }
+            ],
+        },
+    )


### PR DESCRIPTION
**Description**

Task: #309 

Adds `contest.isTargeted` to two endpoints:
- `/audit/basic` for creating contests
- `/audit/status` for reading contests

`contest.isTargeted` should be `true` for targeted contests, and `false`
for opportunistic contests.

To maintain backwards compatibility, `/audit/basic` does not require
`contest.isTargeted` yet. It defaults to `true`.

Once the frontend starts sending `isTargeted`, it will become required.

**Testing**

Adds two new tests for `/audit/basic`:
- Creating a contest (happy path)
- Creating a contest without specifying `isTargeted` defaults it to true

Adds one test for `/audit/status` that checks the entire response body in a basic audit.

Also adds some test helpers to facilitate comparing large JSON blobs.

**Progress**

Ready for review.