### PR TITLE
/audit/basic: Require contest.isTargeted

### DIFF
--- a/arlo_server/validation.py
+++ b/arlo_server/validation.py
@@ -1,0 +1,16 @@
+from werkzeug.exceptions import BadRequest
+from typing import List, NoReturn
+
+
+def check_required_fields(json: dict, fields: List[str], prefix: str = "") -> None:
+    missing_field = next((field for field in fields if field not in json), None)
+    if missing_field:
+        raise BadRequest(f"Missing required field {prefix}{missing_field}")
+
+
+def check_required_fields_for_contest(json: dict) -> None:
+    check_required_fields(
+        json,
+        ["id", "name", "isTargeted", "totalBallotsCast", "numWinners", "votesAllowed",],
+        "contest.",
+    )

--- a/tests/test_audit_basic_update.py
+++ b/tests/test_audit_basic_update.py
@@ -42,7 +42,7 @@ def test_audit_basic_update_create_contest(client):
     assert json.loads(rv.data)["status"] == "ok"
 
 
-def test_audit_basic_update_sets_default_for_contest_is_targeted(client):
+def test_audit_basic_update_contest_required_fields(client):
     rv = client.post("/election/new")
     election_id = json.loads(rv.data)["electionId"]
     assert election_id
@@ -51,31 +51,43 @@ def test_audit_basic_update_sets_default_for_contest_is_targeted(client):
     candidate_id_1 = str(uuid.uuid4())
     candidate_id_2 = str(uuid.uuid4())
 
-    rv = post_json(
-        client,
-        f"/election/{election_id}/audit/basic",
-        {
-            "name": "Create Contest",
-            "riskLimit": 10,
-            "randomSeed": "a1234567890987654321b",
-            "online": False,
-            "contests": [
-                {
-                    "id": contest_id,
-                    "name": "Contest 1",
-                    "choices": [
-                        {"id": candidate_id_1, "name": "Candidate 1", "numVotes": 1325},
-                        {"id": candidate_id_2, "name": "Candidate 2", "numVotes": 792},
-                    ],
-                    "totalBallotsCast": 2123,
-                    "numWinners": 1,
-                    "votesAllowed": 1,
-                }
-            ],
-        },
-    )
+    contest = {
+        "id": contest_id,
+        "name": "Contest 1",
+        "choices": [
+            {"id": candidate_id_1, "name": "Candidate 1", "numVotes": 1325},
+            {"id": candidate_id_2, "name": "Candidate 2", "numVotes": 792},
+        ],
+        "totalBallotsCast": 2123,
+        "numWinners": 1,
+        "votesAllowed": 1,
+    }
 
-    assert json.loads(rv.data)["status"] == "ok"
+    for field in contest:
+        contest_missing_field = contest.copy()
+        del contest_missing_field[field]
+
+        rv = post_json(
+            client,
+            f"/election/{election_id}/audit/basic",
+            {
+                "name": "Create Contest",
+                "riskLimit": 10,
+                "randomSeed": "a1234567890987654321b",
+                "online": False,
+                "contests": [contest],
+            },
+        )
+
+        assert rv.status_code == 400
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "message": "Missing required field contest.isTargeted",
+                    "errorType": "BadRequest",
+                }
+            ]
+        }
 
     rv = client.get(f"/election/{election_id}/audit/status")
-    assert json.loads(rv.data)["contests"][0]["isTargeted"] == True
+    assert json.loads(rv.data)["contests"] == []


### PR DESCRIPTION
**Description**

Task: votingworks/arlo#309 

votingworks/arlo#336 added `contest.isTargeted` to `/audit/basic` as an optional field. Once the frontend starts sending the field, this PR will make it required (as well as all the other fields on the contest object).

**Testing**

Added new test for all required fields in the contest object.

**Progress**

Ready for review. Can't be merged til the frontend sends `isTargeted`.