### PR TITLE
add optional round_id to AuditBoard

### DIFF
--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -203,6 +203,10 @@ class AuditBoard(db.Model):
         db.ForeignKey("jurisdiction.id", ondelete="cascade"),
         nullable=False,
     )
+    round_id = db.Column(
+        db.String(200), db.ForeignKey("round.id", ondelete="cascade"), nullable=True
+    )
+
     name = db.Column(db.String(200))
     member_1 = db.Column(db.String(200), nullable=True)
     member_1_affiliation = db.Column(db.String(200), nullable=True)
@@ -230,6 +234,7 @@ class Round(db.Model):
     sampled_ballot_draws = relationship(
         "SampledBallotDraw", backref="round", passive_deletes=True
     )
+    audit_boards = relationship("AuditBoard", backref="round", passive_deletes=True)
 
 
 class SampledBallot(db.Model):

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -866,8 +866,8 @@ def ballot_list(election_id, jurisdiction_id, round_id):
     query = (
         SampledBallotDraw.query.join(SampledBallot)
         .join(SampledBallotDraw.batch)
-        .join(AuditBoard)
         .join(Round)
+        .join(AuditBoard, AuditBoard.id == SampledBallot.audit_board_id)
         .add_entity(SampledBallot)
         .add_entity(Batch)
         .add_entity(AuditBoard)


### PR DESCRIPTION
Following the direction of a new, separate API for multi-jurisdiction, this PR makes it possible to map an audit board to a round, without requiring it. Much simpler change that lets the current flow work with no front-end changes and only minor backend changes.

Then, the new API calls that @jonahkagan is planning can map audit boards to an explicit round. This might require some slightly more complicated JOINs on API calls that are shared between both flows, but that should be trivial compared to trying to remap the single workflow onto the new data model.

Addresses votingworks/arlo#299 