### PR TITLE
Audit name

### DIFF
--- a/arlo-client/src/__snapshots__/App.test.tsx.snap
+++ b/arlo-client/src/__snapshots__/App.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`App renders properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-fAjcbJ dUOePp"
+    class="sc-caSCKo brQMae"
   >
     <div
       class="bp3-navbar bp3-fixed-top sc-bxivhb dGpCch"
@@ -44,8 +44,34 @@ exports[`App renders properly 1`] = `
         height="50px"
         src="/arlo.png"
       />
+      <div
+        class="sc-ifAKCX iKQdjg"
+      >
+        <label
+          for="audit-name"
+          id="audit-name-label"
+        >
+          Give your new audit a unique name.
+          <div
+            class="sc-fAjcbJ gSXBFL sc-dnqmqq dOkpOn"
+          >
+            <div
+              class="bp3-input-group sc-iwsKbI hebCva"
+            >
+              <input
+                aria-labelledby="audit-name-label"
+                class="bp3-input"
+                id="audit-name"
+                name="auditName"
+                style="padding-right: 10px;"
+                value=""
+              />
+            </div>
+          </div>
+        </label>
+      </div>
       <button
-        class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-fMiknA hoQSCm sc-bdVaJa gLVjYw"
+        class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-fMiknA hoQSCm sc-bwzfXH eBfcXh"
         type="button"
       >
         <span

--- a/arlo-client/src/components/Audit/Setup/Contests/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Contests/index.tsx
@@ -63,6 +63,7 @@ const Contests: React.FC<IProps> = ({
       validationSchema={schema}
       onSubmit={v => {
         setIsLoading(true)
+        // eslint-disable-next-line no-console
         console.log(v)
         nextStage()
       }}

--- a/arlo-client/src/components/Audit/Setup/Participants/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Participants/index.tsx
@@ -33,6 +33,7 @@ const Participants: React.FC<IProps> = ({ audit, nextStage }: IProps) => {
       validationSchema={schema}
       onSubmit={v => {
         setIsLoading(true)
+        // eslint-disable-next-line no-console
         console.log(v)
         nextStage()
       }}

--- a/arlo-client/src/components/CreateAudit.test.tsx
+++ b/arlo-client/src/components/CreateAudit.test.tsx
@@ -45,7 +45,13 @@ describe('CreateAudit', () => {
 
   it('calls the /election/new endpoint for nonauthenticated user', async () => {
     apiMock.mockImplementation(async () => ({ electionId: '1' }))
-    const { getByText } = render(<CreateAudit {...routeProps} />)
+    const { getByText, getByLabelText } = render(
+      <CreateAudit {...routeProps} />
+    )
+
+    fireEvent.change(getByLabelText('Give your new audit a unique name.'), {
+      target: { value: 'Audit Name' },
+    })
 
     fireEvent.click(getByText('Create a New Audit'), { bubbles: true })
 
@@ -53,10 +59,22 @@ describe('CreateAudit', () => {
       expect(apiMock).toBeCalledTimes(1)
       expect(apiMock).toHaveBeenNthCalledWith(1, '/election/new', {
         method: 'POST',
-        body: JSON.stringify({}),
+        body: JSON.stringify({ auditName: 'Audit Name' }),
       })
       expect(historySpy).toBeCalledTimes(1)
       expect(historySpy).toHaveBeenNthCalledWith(1, '/election/1')
+    })
+  })
+
+  it('requires an audit name', async () => {
+    apiMock.mockImplementation(async () => ({ electionId: '1' }))
+    const { getByText } = render(<CreateAudit {...routeProps} />)
+
+    fireEvent.click(getByText('Create a New Audit'), { bubbles: true })
+
+    await wait(() => {
+      expect(getByText('Required')).toBeTruthy()
+      expect(apiMock).toBeCalledTimes(0)
     })
   })
 
@@ -76,7 +94,7 @@ describe('CreateAudit', () => {
         ],
       }))
       .mockImplementationOnce(async () => ({ electionId: '1' }))
-    const { getByText } = render(
+    const { getByText, getByLabelText } = render(
       <AuthDataProvider>
         <CreateAudit {...routeProps} />
       </AuthDataProvider>
@@ -86,14 +104,19 @@ describe('CreateAudit', () => {
       expect(apiMock).toBeCalledTimes(1)
       expect(apiMock).toHaveBeenNthCalledWith(1, '/auth/me')
     })
-
+    fireEvent.change(getByLabelText('Give your new audit a unique name.'), {
+      target: { value: 'Audit Name' },
+    })
     fireEvent.click(getByText('Create a New Audit'), { bubbles: true })
 
     await wait(() => {
       expect(apiMock).toBeCalledTimes(2)
       expect(apiMock).toHaveBeenNthCalledWith(2, '/election/new', {
         method: 'POST',
-        body: JSON.stringify({ organizationId: 'org-id' }),
+        body: JSON.stringify({
+          organizationId: 'org-id',
+          auditName: 'Audit Name',
+        }),
       })
       expect(historySpy).toBeCalledTimes(1)
       expect(historySpy).toHaveBeenNthCalledWith(1, '/election/1')
@@ -195,8 +218,13 @@ describe('CreateAudit', () => {
   it('handles error responses from server', async () => {
     apiMock.mockImplementation(async () => ({ electionId: '1' }))
     checkAndToastMock.mockReturnValue(true)
-    const { getByText } = render(<CreateAudit {...routeProps} />)
+    const { getByText, getByLabelText } = render(
+      <CreateAudit {...routeProps} />
+    )
 
+    fireEvent.change(getByLabelText('Give your new audit a unique name.'), {
+      target: { value: 'Audit Name' },
+    })
     fireEvent.click(getByText('Create a New Audit'), { bubbles: true })
 
     await wait(() => {
@@ -213,8 +241,13 @@ describe('CreateAudit', () => {
       throw new Error('404')
     })
     checkAndToastMock.mockReturnValue(true)
-    const { getByText } = render(<CreateAudit {...routeProps} />)
+    const { getByText, getByLabelText } = render(
+      <CreateAudit {...routeProps} />
+    )
 
+    fireEvent.change(getByLabelText('Give your new audit a unique name.'), {
+      target: { value: 'Audit Name' },
+    })
     fireEvent.click(getByText('Create a New Audit'), { bubbles: true })
 
     await wait(() => {

--- a/arlo-client/src/components/CreateAudit.test.tsx
+++ b/arlo-client/src/components/CreateAudit.test.tsx
@@ -60,6 +60,9 @@ describe('CreateAudit', () => {
       expect(apiMock).toHaveBeenNthCalledWith(1, '/election/new', {
         method: 'POST',
         body: JSON.stringify({ auditName: 'Audit Name' }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
       })
       expect(historySpy).toBeCalledTimes(1)
       expect(historySpy).toHaveBeenNthCalledWith(1, '/election/1')
@@ -117,6 +120,9 @@ describe('CreateAudit', () => {
           organizationId: 'org-id',
           auditName: 'Audit Name',
         }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
       })
       expect(historySpy).toBeCalledTimes(1)
       expect(historySpy).toHaveBeenNthCalledWith(1, '/election/1')

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -57,6 +57,9 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
         {
           method: 'POST',
           body: JSON.stringify(data),
+          headers: {
+            'Content-Type': 'application/json',
+          },
         }
       )
       if (checkAndToast(response)) {

--- a/arlo-client/src/components/__snapshots__/CreateAudit.test.tsx.snap
+++ b/arlo-client/src/components/__snapshots__/CreateAudit.test.tsx.snap
@@ -3,15 +3,41 @@
 exports[`CreateAudit lists associated elections for authenticated AA user 1`] = `
 <div>
   <div
-    class="sc-bxivhb jKhLAa"
+    class="sc-gZMcBi coLhGN"
   >
     <img
       alt="Arlo, by VotingWorks"
       height="50px"
       src="/arlo.png"
     />
+    <div
+      class="sc-htpNat kLGmUl"
+    >
+      <label
+        for="audit-name"
+        id="audit-name-label"
+      >
+        Give your new audit a unique name.
+        <div
+          class="sc-VigVT kxLHnZ sc-EHOje bXavad"
+        >
+          <div
+            class="bp3-input-group sc-bZQynM fFGKEg"
+          >
+            <input
+              aria-labelledby="audit-name-label"
+              class="bp3-input"
+              id="audit-name"
+              name="auditName"
+              style="padding-right: 10px;"
+              value=""
+            />
+          </div>
+        </div>
+      </label>
+    </div>
     <button
-      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-htpNat grdNVh sc-bdVaJa gLVjYw"
+      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-iwsKbI kljBkO sc-bwzfXH eBfcXh"
       type="button"
     >
       <span
@@ -21,28 +47,28 @@ exports[`CreateAudit lists associated elections for authenticated AA user 1`] = 
       </span>
     </button>
     <a
-      class="bp3-button bp3-intent-primary sc-ifAKCX ebxkuH"
+      class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
       href="/election/election-1"
     >
       Not named yet
        (NY)
     </a>
     <a
-      class="bp3-button bp3-intent-primary sc-ifAKCX ebxkuH"
+      class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
       href="/election/election-2"
     >
       Election Two
        (FL)
     </a>
     <a
-      class="bp3-button bp3-intent-primary sc-ifAKCX ebxkuH"
+      class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
       href="/election/election-3"
     >
       Election Three
       
     </a>
     <a
-      class="bp3-button bp3-intent-primary sc-ifAKCX ebxkuH"
+      class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
       href="/election/election-4"
     >
       Election Four
@@ -55,15 +81,41 @@ exports[`CreateAudit lists associated elections for authenticated AA user 1`] = 
 exports[`CreateAudit lists associated elections for authenticated JA user 1`] = `
 <div>
   <div
-    class="sc-bxivhb jKhLAa"
+    class="sc-gZMcBi coLhGN"
   >
     <img
       alt="Arlo, by VotingWorks"
       height="50px"
       src="/arlo.png"
     />
+    <div
+      class="sc-htpNat kLGmUl"
+    >
+      <label
+        for="audit-name"
+        id="audit-name-label"
+      >
+        Give your new audit a unique name.
+        <div
+          class="sc-VigVT kxLHnZ sc-EHOje bXavad"
+        >
+          <div
+            class="bp3-input-group sc-bZQynM fFGKEg"
+          >
+            <input
+              aria-labelledby="audit-name-label"
+              class="bp3-input"
+              id="audit-name"
+              name="auditName"
+              style="padding-right: 10px;"
+              value=""
+            />
+          </div>
+        </div>
+      </label>
+    </div>
     <button
-      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-htpNat grdNVh sc-bdVaJa gLVjYw"
+      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-iwsKbI kljBkO sc-bwzfXH eBfcXh"
       type="button"
     >
       <span
@@ -73,14 +125,14 @@ exports[`CreateAudit lists associated elections for authenticated JA user 1`] = 
       </span>
     </button>
     <a
-      class="bp3-button bp3-intent-primary sc-ifAKCX ebxkuH"
+      class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
       href="/election/election-1"
     >
       Election One
        (NY)
     </a>
     <a
-      class="bp3-button bp3-intent-primary sc-ifAKCX ebxkuH"
+      class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
       href="/election/election-2"
     >
       Not named yet
@@ -93,15 +145,41 @@ exports[`CreateAudit lists associated elections for authenticated JA user 1`] = 
 exports[`CreateAudit renders correctly 1`] = `
 <div>
   <div
-    class="sc-bxivhb jKhLAa"
+    class="sc-gZMcBi coLhGN"
   >
     <img
       alt="Arlo, by VotingWorks"
       height="50px"
       src="/arlo.png"
     />
+    <div
+      class="sc-htpNat kLGmUl"
+    >
+      <label
+        for="audit-name"
+        id="audit-name-label"
+      >
+        Give your new audit a unique name.
+        <div
+          class="sc-VigVT kxLHnZ sc-EHOje bXavad"
+        >
+          <div
+            class="bp3-input-group sc-bZQynM fFGKEg"
+          >
+            <input
+              aria-labelledby="audit-name-label"
+              class="bp3-input"
+              id="audit-name"
+              name="auditName"
+              style="padding-right: 10px;"
+              value=""
+            />
+          </div>
+        </div>
+      </label>
+    </div>
     <button
-      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-htpNat grdNVh sc-bdVaJa gLVjYw"
+      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-iwsKbI kljBkO sc-bwzfXH eBfcXh"
       type="button"
     >
       <span
@@ -111,7 +189,7 @@ exports[`CreateAudit renders correctly 1`] = `
       </span>
     </button>
     <button
-      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-htpNat grdNVh sc-bdVaJa gLVjYw"
+      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-iwsKbI kljBkO sc-bdVaJa gLVjYw"
       type="button"
     >
       <span
@@ -121,7 +199,7 @@ exports[`CreateAudit renders correctly 1`] = `
       </span>
     </button>
     <button
-      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-htpNat grdNVh sc-bdVaJa gLVjYw"
+      class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-iwsKbI kljBkO sc-bdVaJa gLVjYw"
       type="button"
     >
       <span

--- a/arlo-client/src/test/specs/helpers.ts
+++ b/arlo-client/src/test/specs/helpers.ts
@@ -7,6 +7,7 @@ const filePath = path.join(
 
 export const start = () => {
   browser.url('/')
+  $('#audit-name').addValue('Audit Name')
   $('.bp3-button-text=Create a New Audit').click()
   $('#audit-name').waitForExist(5000)
 }

--- a/arlo-client/src/types.ts
+++ b/arlo-client/src/types.ts
@@ -139,8 +139,7 @@ export interface IElectionMeta {
   id: string
   name: string
   state: string
-  // eslint-disable-next-line camelcase
-  election_date: string
+  electionDate: string
 }
 
 export interface IOrganizationMeta {

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -21,9 +21,13 @@ class Organization(BaseModel):
     elections = relationship("Election", backref="organization", passive_deletes=True)
 
 
+# Election is a slight misnomer - this model represents an audit.
 class Election(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
-    name = db.Column(db.String(200), nullable=True)
+    # audit_name must be unique within each Organization
+    audit_name = db.Column(db.String(200), nullable=False)
+    # election_name can be the same across audits
+    election_name = db.Column(db.String(200), nullable=True)
     state = db.Column(db.String(100), nullable=True)
     election_date = db.Column(db.Date, nullable=True)
     election_type = db.Column(db.String(200), nullable=True)
@@ -53,6 +57,8 @@ class Election(BaseModel):
         db.String(200), db.ForeignKey("file.id", ondelete="set null"), nullable=True
     )
     jurisdictions_file = relationship("File")
+
+    __table_args__ = (db.UniqueConstraint("organization_id", "audit_name"),)
 
 
 # these are typically counties

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -1,17 +1,25 @@
 import os, datetime, csv, io, math, json, uuid, locale, re, hmac, urllib.parse, itertools
 from enum import Enum, auto
 from typing import Optional, Tuple, Union
+from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
 from flask import Flask, jsonify, request, Response, redirect, session
 from flask_httpauth import HTTPBasicAuth
 
 from audits import sampler, bravo, sampler_contest
-from werkzeug.exceptions import InternalServerError, Unauthorized, Forbidden, BadRequest
+from werkzeug.exceptions import (
+    InternalServerError,
+    Unauthorized,
+    Forbidden,
+    BadRequest,
+    Conflict,
+)
 from xkcdpass import xkcd_password as xp
 
 from sqlalchemy import event, func
 from sqlalchemy.dialects.postgresql import aggregate_order_by
+from sqlalchemy.exc import IntegrityError
 
 from authlib.flask.client import OAuth
 
@@ -46,13 +54,9 @@ AUDIT_BOARD_MEMBER_COUNT = 2
 WORDS = xp.generate_wordlist(wordfile=xp.locate_wordfile())
 
 
-def create_election(election_id=None, organization_id=None):
-    if not election_id:
-        election_id = str(uuid.uuid4())
-    e = Election(id=election_id, organization_id=organization_id, name="")
-    db.session.add(e)
-    db.session.commit()
-    return election_id
+class UserType(str, Enum):
+    AUDIT_ADMIN = "audit_admin"
+    JURISDICTION_ADMIN = "jurisdiction_admin"
 
 
 def create_organization(name=""):
@@ -289,7 +293,7 @@ def check_round(election, jurisdiction_id, round_id):
 
 
 def election_timestamp_name(election) -> str:
-    clean_election_name = re.sub(r"[^a-zA-Z0-9]+", r"-", election.name)
+    clean_election_name = re.sub(r"[^a-zA-Z0-9]+", r"-", election.election_name)
     now = datetime.datetime.utcnow().isoformat(timespec="minutes")
     return f"{clean_election_name}-{now}"
 
@@ -309,7 +313,9 @@ def serialize_members(audit_board):
     return members
 
 
-def isoformat(datetime: Optional[datetime.datetime]) -> Optional[str]:
+def isoformat(
+    datetime: Optional[Union[datetime.datetime, datetime.date]]
+) -> Optional[str]:
     if datetime is not None:
         return datetime.isoformat()
     else:
@@ -339,15 +345,42 @@ if ADMIN_PASSWORD:
         return Response(result, content_type="text/plain")
 
 
+ELECTION_NEW_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "auditName": {"type": "string"},
+        "organizationId": {"type": "string"},
+    },
+    "required": ["auditName"],
+}
+
+
 @app.route("/election/new", methods=["POST"])
 def election_new():
-    info = request.get_json()
+    election = request.get_json()
+    validate(election, ELECTION_NEW_SCHEMA)
 
-    organization_id = info.get("organizationId", None) if info else None
+    organization_id = election.get("organizationId", None)
     require_audit_admin_for_organization(organization_id)
 
-    election_id = create_election(organization_id=organization_id)
-    return jsonify(electionId=election_id)
+    election = Election(
+        id=str(uuid.uuid4()),
+        audit_name=election["auditName"],
+        organization_id=organization_id,
+    )
+    db.session.add(election)
+
+    try:
+        db.session.commit()
+    except IntegrityError as e:
+        if e.orig.diag.constraint_name == "election_organization_id_audit_name_key":
+            raise Conflict(
+                f"An audit with name '{election.audit_name}' already exists within your organization"
+            )
+        else:
+            raise e
+
+    return jsonify(electionId=election.id)
 
 
 @app.route("/election/<election_id>/jurisdictions/file", methods=["GET"])
@@ -451,7 +484,7 @@ def audit_status(election_id=None):
 
     return jsonify(
         organizationId=election.organization_id,
-        name=election.name,
+        name=election.election_name,
         online=election.online,
         frozenAt=election.frozen_at,
         riskLimit=election.risk_limit,
@@ -539,7 +572,7 @@ def audit_status(election_id=None):
 def audit_basic_update(election_id):
     election = get_election(election_id)
     info = request.get_json()
-    election.name = info["name"]
+    election.election_name = info["name"]
     election.risk_limit = info["riskLimit"]
     election.random_seed = info["randomSeed"]
     election.online = info["online"]
@@ -1311,11 +1344,17 @@ def pretty_affiliation(affiliation):
 
 @app.route("/election/<election_id>/audit/reset", methods=["POST"])
 def audit_reset(election_id):
+    election = Election.query.get_or_404(election_id)
     # deleting the election cascades to all the data structures
-    Election.query.filter_by(id=election_id).delete()
+    db.session.delete(election)
     db.session.commit()
 
-    create_election(election_id)
+    election = Election(
+        id=election_id,
+        audit_name=election.audit_name,
+        organization_id=election.organization_id,
+    )
+    db.session.add(election)
     db.session.commit()
 
     return jsonify(status="ok")
@@ -1373,9 +1412,10 @@ auth0_ja = oauth.register(
 def serialize_election(election):
     return {
         "id": election.id,
-        "name": election.name,
+        "auditName": election.audit_name,
+        "electionName": election.election_name,
         "state": election.state,
-        "election_date": election.election_date,
+        "electionDate": isoformat(election.election_date),
     }
 
 
@@ -1494,6 +1534,14 @@ def handle_401(e):
     return (
         jsonify(errors=[{"message": e.description, "errorType": type(e).__name__}]),
         Unauthorized.code,
+    )
+
+
+@app.errorhandler(Conflict)
+def handle_409(e):
+    return (
+        jsonify(errors=[{"message": e.description, "errorType": type(e).__name__}]),
+        Conflict.code,
     )
 
 

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -54,11 +54,6 @@ AUDIT_BOARD_MEMBER_COUNT = 2
 WORDS = xp.generate_wordlist(wordfile=xp.locate_wordfile())
 
 
-class UserType(str, Enum):
-    AUDIT_ADMIN = "audit_admin"
-    JURISDICTION_ADMIN = "jurisdiction_admin"
-
-
 def create_organization(name=""):
     org = Organization(id=str(uuid.uuid4()), name=name)
     db.session.add(org)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+import pytest
+import json
+from flask.testing import FlaskClient
+
+from arlo_server import app, db
+from helpers import post_json
+
+# The fixtures in this module are available in any test via dependency
+# injection.
+
+
+@pytest.fixture
+def client() -> FlaskClient:
+    app.config["TESTING"] = True
+    client = app.test_client()
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+    yield client
+
+    db.session.commit()
+
+
+@pytest.fixture
+def election_id(client: FlaskClient, request) -> str:
+    rv = post_json(
+        client,
+        "/election/new",
+        {"auditName": f"Test Audit {request.function.__name__}"},
+    )
+    election_id = json.loads(rv.data)["electionId"]
+    yield election_id

--- a/tests/test_app_upload_jurisdictions_file.py
+++ b/tests/test_app_upload_jurisdictions_file.py
@@ -17,24 +17,7 @@ from arlo_server.models import (
 from bgcompute import bgcompute_update_election_jurisdictions_file
 
 
-@pytest.fixture
-def client() -> FlaskClient:
-    app.config["TESTING"] = True
-    client = app.test_client()
-
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-
-    yield client
-
-    db.session.commit()
-
-
-def test_missing_file(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_missing_file(client, election_id):
     rv = client.put(f"/election/{election_id}/jurisdictions/file")
     assert rv.status_code == 400
     assert json.loads(rv.data) == {
@@ -47,10 +30,7 @@ def test_missing_file(client):
     }
 
 
-def test_bad_csv_file(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_bad_csv_file(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={"jurisdictions": (io.BytesIO(b"not a CSV file"), "random.txt")},
@@ -72,10 +52,7 @@ def test_bad_csv_file(client):
     }
 
 
-def test_missing_one_csv_field(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_missing_one_csv_field(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={
@@ -97,10 +74,7 @@ def test_missing_one_csv_field(client):
     }
 
 
-def test_metadata(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_metadata(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={
@@ -148,10 +122,7 @@ def test_metadata(client):
     assert processing["error"] == None
 
 
-def test_replace_jurisdictions_file(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_replace_jurisdictions_file(client, election_id):
     # Create the initial file.
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
@@ -181,10 +152,7 @@ def test_replace_jurisdictions_file(client):
     assert File.query.count() == 1, "the old file should have been deleted"
 
 
-def test_no_jurisdiction(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_no_jurisdiction(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={
@@ -206,10 +174,7 @@ def test_no_jurisdiction(client):
     assert User.query.count() == 0
 
 
-def test_single_jurisdiction_single_admin(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_single_jurisdiction_single_admin(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={
@@ -234,10 +199,7 @@ def test_single_jurisdiction_single_admin(client):
     ]
 
 
-def test_single_jurisdiction_multiple_admins(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_single_jurisdiction_multiple_admins(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={
@@ -265,10 +227,7 @@ def test_single_jurisdiction_multiple_admins(client):
     ]
 
 
-def test_multiple_jurisdictions_single_admin(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_multiple_jurisdictions_single_admin(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={

--- a/tests/test_audit_basic_update.py
+++ b/tests/test_audit_basic_update.py
@@ -2,14 +2,9 @@ import json, uuid
 import pytest
 
 from helpers import post_json
-from test_app import client
 
 
-def test_audit_basic_update_create_contest(client):
-    rv = client.post("/election/new")
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_audit_basic_update_create_contest(client, election_id):
     contest_id = str(uuid.uuid4())
     candidate_id_1 = str(uuid.uuid4())
     candidate_id_2 = str(uuid.uuid4())
@@ -42,11 +37,7 @@ def test_audit_basic_update_create_contest(client):
     assert json.loads(rv.data)["status"] == "ok"
 
 
-def test_audit_basic_update_sets_default_for_contest_is_targeted(client):
-    rv = client.post("/election/new")
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_audit_basic_update_sets_default_for_contest_is_targeted(client, election_id):
     contest_id = str(uuid.uuid4())
     candidate_id_1 = str(uuid.uuid4())
     candidate_id_2 = str(uuid.uuid4())

--- a/tests/test_audit_status.py
+++ b/tests/test_audit_status.py
@@ -8,17 +8,10 @@ from helpers import (
     assert_is_date,
     assert_is_passphrase,
 )
-from test_app import (
-    client,
-    setup_whole_audit,
-)
+from test_app import setup_whole_audit
 
 
-def test_audit_status(client):
-    rv = client.post("/election/new")
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_audit_status(client, election_id):
     (
         url_prefix,
         contest_id,

--- a/tests/test_ballot_list.py
+++ b/tests/test_ballot_list.py
@@ -3,7 +3,6 @@ import json
 import pytest
 
 from test_app import (
-    client,
     post_json,
     setup_whole_audit,
     setup_whole_multi_winner_audit,
@@ -11,11 +10,7 @@ from test_app import (
 import bgcompute
 
 
-def test_ballot_list_jurisdiction_two_rounds(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_ballot_list_jurisdiction_two_rounds(client, election_id):
     (
         url_prefix,
         contest_id,
@@ -79,11 +74,7 @@ def test_ballot_list_jurisdiction_two_rounds(client):
     assert len(ballot_list) == sample_size
 
 
-def test_ballot_list_audit_board_two_rounds(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_ballot_list_audit_board_two_rounds(client, election_id):
     (
         url_prefix,
         contest_id,
@@ -155,11 +146,7 @@ def test_ballot_list_audit_board_two_rounds(client):
     assert len(ballot_list) == sample_size
 
 
-def test_ballot_list_jurisdiction_ordering(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_ballot_list_jurisdiction_ordering(client, election_id):
     (
         url_prefix,
         contest_id,
@@ -197,11 +184,7 @@ def test_ballot_list_jurisdiction_ordering(client):
     assert unsorted_ballots == sorted_ballots
 
 
-def test_ballot_list_audit_board_ordering(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_ballot_list_audit_board_ordering(client, election_id):
     (
         url_prefix,
         contest_id,

--- a/tests/test_contests.py
+++ b/tests/test_contests.py
@@ -1,23 +1,15 @@
 import pytest
+from flask.testing import FlaskClient
 
 import json, uuid, io
 from typing import List
 
 from helpers import post_json, put_json
-from test_app import client
 from arlo_server.models import Jurisdiction
 
 
 @pytest.fixture()
-def election_id(client) -> str:
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-    yield election_id
-
-
-@pytest.fixture()
-def jurisdiction_ids(client, election_id: str) -> List[str]:
+def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={

--- a/tests/test_jurisdiction_bulk_update.py
+++ b/tests/test_jurisdiction_bulk_update.py
@@ -24,7 +24,7 @@ def db():
 
 def test_first_update(db):
     org = Organization(id=str(uuid.uuid4()), name="Test Org")
-    election = Election(id=str(uuid.uuid4()), organization=org)
+    election = Election(id=str(uuid.uuid4()), audit_name="Test Audit", organization=org)
     new_admins = bulk_update_jurisdictions(
         db.session, election, [("Jurisdiction #1", "bob.harris@ca.gov")]
     )
@@ -41,7 +41,7 @@ def test_first_update(db):
 
 def test_idempotent(db):
     org = Organization(id=str(uuid.uuid4()), name="Test Org")
-    election = Election(id=str(uuid.uuid4()), organization=org)
+    election = Election(id=str(uuid.uuid4()), audit_name="Test Audit", organization=org)
 
     # Do it once.
     bulk_update_jurisdictions(
@@ -63,7 +63,7 @@ def test_idempotent(db):
 
 def test_remove_outdated_jurisdictions(db):
     org = Organization(id=str(uuid.uuid4()), name="Test Org")
-    election = Election(id=str(uuid.uuid4()), organization=org)
+    election = Election(id=str(uuid.uuid4()), audit_name="Test Audit", organization=org)
 
     # Add jurisdictions.
     bulk_update_jurisdictions(

--- a/tests/test_jurisdictions.py
+++ b/tests/test_jurisdictions.py
@@ -1,18 +1,17 @@
 import pytest
+from flask.testing import FlaskClient
 
 import json, io, uuid
 from typing import List
 
 from helpers import post_json, compare_json, assert_is_date, create_org_and_admin
-from test_app import client
 from arlo_server.auth import UserType
-from arlo_server.routes import create_election
 from arlo_server.models import Jurisdiction
 from bgcompute import bgcompute_update_election_jurisdictions_file
 
 
 @pytest.fixture()
-def audit_admin_email(client) -> str:
+def audit_admin_email(client: FlaskClient) -> str:
     user_email = "admin@example.com"
     with client.session_transaction() as session:
         session["_user"] = {"type": UserType.AUDIT_ADMIN, "email": user_email}
@@ -20,14 +19,17 @@ def audit_admin_email(client) -> str:
 
 
 @pytest.fixture()
-def election_id(client, audit_admin_email) -> str:
+def election_id(client: FlaskClient, audit_admin_email: str) -> str:
     org_id, _ = create_org_and_admin("Test Org", audit_admin_email)
-    election_id = create_election(organization_id=org_id)
+    rv = post_json(
+        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id}
+    )
+    election_id = json.loads(rv.data)["electionId"]
     yield election_id
 
 
 @pytest.fixture()
-def jurisdiction_ids(client, election_id: str) -> List[str]:
+def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
     # We expect the list endpoint to order the jurisdictions by name, so we
     # upload them out of order.
     rv = client.put(

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -3,7 +3,7 @@ import json, random
 import pytest
 
 from helpers import post_json
-from test_app import client, setup_whole_audit, run_whole_audit_flow
+from test_app import setup_whole_audit, run_whole_audit_flow
 import bgcompute
 
 
@@ -62,11 +62,7 @@ def run_audit_round(
     return len(ballot_list)
 
 
-def test_offline_audit_report(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_offline_audit_report(client, election_id):
     run_whole_audit_flow(
         client, election_id, "Primary 2019", 10, "12345678901234567890"
     )
@@ -104,11 +100,7 @@ def test_offline_audit_report(client):
     assert len(lines) == len(expected) + 3
 
 
-def test_one_round_audit_report(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_one_round_audit_report(client, election_id):
     (
         url_prefix,
         contest_id,
@@ -201,11 +193,7 @@ def test_one_round_audit_report(client):
     assert len(lines) == len(expected) + 3 + num_ballots - NUM_BALLOTS_SAMPLED_TWICE
 
 
-def test_two_round_audit_report(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_two_round_audit_report(client, election_id):
     (
         url_prefix,
         contest_id,


### PR DESCRIPTION
**Description**

- Has the front end post an `auditName` field to the `/election/new` endpoint

**Testing**

- Tests that it passes as expected for both authenticated and unauthenticated users, and is required
- Updates snapshots

**Progress**

- Do we need to verify the uniqueness of the audit name at this time?
- The back end needs to use the value as passed back when creating an audit, still

![image](https://user-images.githubusercontent.com/1938/76870789-683c0a80-6827-11ea-8ed1-97aaa911d821.png)
