### PR TITLE
Add /election/<election_id>/contest API

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -26,6 +26,7 @@ xkcdpass = "*"
 psycopg2-binary = "*"
 authlib = "*"
 requests = "*"
+jsonschema = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bd610e2e25cd3b600601eaa2210178e848a4c0492b83a7419afdd80c536d38be"
+            "sha256": "ab0c8a8e5077f662a71e2a41af2fa6db02510fde63c23dc7ed317048f568e943"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
         "authlib": {
             "hashes": [
                 "sha256:89d55b14362f8acee450f9d153645e438e3a38be99b599190718c4406f575b05",
@@ -151,6 +158,14 @@
             ],
             "version": "==2.9"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
+                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==1.5.0"
+        },
         "itsdangerous": {
             "hashes": [
                 "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
@@ -172,6 +187,14 @@
             ],
             "index": "pypi",
             "version": "==0.14.1"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163",
+                "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
+            ],
+            "index": "pypi",
+            "version": "==3.2.0"
         },
         "markupsafe": {
             "hashes": [
@@ -283,6 +306,12 @@
             ],
             "version": "==2.20"
         },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:cdc7b5e3ed77bed61270a47d35434a30617b9becdf2478af76ad2c6ade307280"
+            ],
+            "version": "==0.15.7"
+        },
         "requests": {
             "hashes": [
                 "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
@@ -326,16 +355,16 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:b92d2de62e43499d85b1780274d1b562e5159c7996f6f04a9bb46cf681ced45f"
+                "sha256:c4cca4aed606297afbe90d4306b49ad3a4cd36feb3f87e4bfd655c57fd9ef445"
             ],
-            "version": "==1.3.14"
+            "version": "==1.3.15"
         },
         "sqlalchemy-utils": {
             "hashes": [
-                "sha256:4e637c88bf3ac5f99b7d72342092a1f636bea1287b2e3e17d441b0413771f86e"
+                "sha256:7b6601b1d4c19dcdcd9fb0a6c39bc2a2cabf29ca47d137c8b6216d1055cc5547"
             ],
             "index": "pypi",
-            "version": "==0.36.1"
+            "version": "==0.36.2"
         },
         "urllib3": {
             "hashes": [
@@ -364,6 +393,13 @@
             ],
             "index": "pypi",
             "version": "==1.17.3"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+            ],
+            "version": "==3.1.0"
         }
     },
     "develop": {
@@ -413,23 +449,23 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0a9a45157e532da06fe56adcfef8a74629566b607fa2c1ac0122d1ff995c748a",
-                "sha256:2c35cae79ceb20d47facfad51f952df16c2ae9f45db6cb38405a3da1cf8fc0a7",
-                "sha256:4b9365ade157794cef9685791032521233729cb00ce76b0ddc78749abea463d2",
-                "sha256:53ea810ae3f83f9c9b452582261ea859828a9ed666f2e1ca840300b69322c474",
-                "sha256:634aef60b4ff0f650d3e59d4374626ca6153fcaff96ec075b215b568e6ee3cb0",
-                "sha256:7e396ce53cacd5596ff6d191b47ab0ea18f8e0ec04e15d69728d530e86d4c217",
-                "sha256:7eadc91af8270455e0d73565b8964da1642fe226665dd5c9560067cd64d56749",
-                "sha256:7f672d02fffcbace4db2b05369142e0506cdcde20cea0e07c7c2171c4fd11dd6",
-                "sha256:85baab8d74ec601e86134afe2bcccd87820f79d2f8d5798c889507d1088287bf",
-                "sha256:87c556fb85d709dacd4b4cb6167eecc5bbb4f0a9864b69136a0d4640fdc76a36",
-                "sha256:a6bd44efee4dc8c3324c13785a9dc3519b3ee3a92cada42d2b57762b7053b49b",
-                "sha256:c6d27bd20c3ba60d5b02f20bd28e20091d6286a699174dfad515636cb09b5a72",
-                "sha256:e2bb577d10d09a2d8822a042a23b8d62bc3b269667c9eb8e60a6edfa000211b1",
-                "sha256:f97a605d7c8bc2c6d1172c2f0d5a65b24142e11a58de689046e62c2d632ca8c1"
+                "sha256:15b948e1302682e3682f11f50208b726a246ab4e6c1b39f9264a8796bb416aa2",
+                "sha256:219a3116ecd015f8dca7b5d2c366c973509dfb9a8fc97ef044a36e3da66144a1",
+                "sha256:3b1fc683fb204c6b4403a1ef23f0b1fac8e4477091585e0c8c54cbdf7d7bb164",
+                "sha256:3beff56b453b6ef94ecb2996bea101a08f1f8a9771d3cbf4988a61e4d9973761",
+                "sha256:7687f6455ec3ed7649d1ae574136835a4272b65b3ddcf01ab8704ac65616c5ce",
+                "sha256:7ec45a70d40ede1ec7ad7f95b3c94c9cf4c186a32f6bacb1795b60abd2f9ef27",
+                "sha256:86c857510a9b7c3104cf4cde1568f4921762c8f9842e987bc03ed4f160925754",
+                "sha256:8a627507ef9b307b46a1fea9513d5c98680ba09591253082b4c48697ba05a4ae",
+                "sha256:8dfb69fbf9f3aeed18afffb15e319ca7f8da9642336348ddd6cab2713ddcf8f9",
+                "sha256:a34b577cdf6313bf24755f7a0e3f3c326d5c1f4fe7422d1d06498eb25ad0c600",
+                "sha256:a8ffcd53cb5dfc131850851cc09f1c44689c2812d0beb954d8138d4f5fc17f65",
+                "sha256:b90928f2d9eb2f33162405f32dde9f6dcead63a0971ca8a1b50eb4ca3e35ceb8",
+                "sha256:c56ffe22faa2e51054c5f7a3bc70a370939c2ed4de308c690e7949230c995913",
+                "sha256:f91c7ae919bbc3f96cd5e5b2e786b2b108343d1d7972ea130f7de27fdd547cf3"
             ],
             "index": "pypi",
-            "version": "==0.761"
+            "version": "==0.770"
         },
         "mypy-extensions": {
             "hashes": [
@@ -479,11 +515,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d",
-                "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"
+                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
+                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
             ],
             "index": "pypi",
-            "version": "==5.3.5"
+            "version": "==5.4.1"
         },
         "regex": {
             "hashes": [

--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -12,3 +12,4 @@ db.app = app
 db.init_app(app)
 
 import arlo_server.routes
+import arlo_server.contests

--- a/arlo_server/contests.py
+++ b/arlo_server/contests.py
@@ -1,0 +1,139 @@
+from typing import List
+from flask import request, jsonify
+from jsonschema import validate
+from werkzeug.exceptions import BadRequest
+
+from arlo_server import app, db
+from arlo_server.routes import get_election, require_audit_admin_for_organization
+from arlo_server.models import Contest, ContestChoice, Jurisdiction
+
+contest_choice_schema = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "numVotes": {"type": "integer", "minimum": 0},
+    },
+    "required": ["id", "name", "numVotes"],
+}
+
+contest_schema = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "isTargeted": {"type": "boolean"},
+        "choices": {"type": "array", "items": contest_choice_schema},
+        "totalBallotsCast": {"type": "integer", "minimum": 0},
+        "numWinners": {"type": "integer", "minimum": 1},
+        "votesAllowed": {"type": "integer", "minimum": 1},
+        "jurisdictionIds": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": [
+        "id",
+        "name",
+        "isTargeted",
+        "choices",
+        "totalBallotsCast",
+        "numWinners",
+        "votesAllowed",
+        "jurisdictionIds",
+    ],
+}
+
+
+def serialize_contest_choice(db_contest_choice: ContestChoice) -> dict:
+    return {
+        "id": db_contest_choice.id,
+        "name": db_contest_choice.name,
+        "numVotes": db_contest_choice.num_votes,
+    }
+
+
+def serialize_contest(db_contest: Contest) -> dict:
+    return {
+        "id": db_contest.id,
+        "name": db_contest.name,
+        "isTargeted": db_contest.is_targeted,
+        "choices": [serialize_contest_choice(c) for c in db_contest.choices],
+        "totalBallotsCast": db_contest.total_ballots_cast,
+        "numWinners": db_contest.num_winners,
+        "votesAllowed": db_contest.votes_allowed,
+        "jurisdictionIds": [j.id for j in db_contest.jurisdictions],
+    }
+
+
+def deserialize_contest_choice(json_contest_choice: dict, contest_id: str) -> Contest:
+    return ContestChoice(
+        id=json_contest_choice["id"],
+        contest_id=contest_id,
+        name=json_contest_choice["name"],
+        num_votes=json_contest_choice["numVotes"],
+    )
+
+
+def deserialize_contest(json_contest: dict, election_id: str) -> Contest:
+    jurisdictions = (
+        db.session.query(Jurisdiction)
+        .filter_by(election_id=election_id)
+        .filter(Jurisdiction.id.in_(json_contest["jurisdictionIds"]))
+        .all()
+    )
+    choices = [
+        deserialize_contest_choice(c, json_contest["id"])
+        for c in json_contest["choices"]
+    ]
+    return Contest(
+        election_id=election_id,
+        id=json_contest["id"],
+        name=json_contest["name"],
+        is_targeted=json_contest["isTargeted"],
+        choices=choices,
+        total_ballots_cast=json_contest["totalBallotsCast"],
+        num_winners=json_contest["numWinners"],
+        votes_allowed=json_contest["votesAllowed"],
+        jurisdictions=jurisdictions,
+    )
+
+
+# Raises if invalid
+def validate_contests(json_contests: List[dict]) -> None:
+    validate(json_contests, {"type": "array", "items": contest_schema})
+
+    for contest in json_contests:
+        total_votes = sum(c["numVotes"] for c in contest["choices"])
+        total_allowed_votes = contest["totalBallotsCast"] * contest["votesAllowed"]
+        if total_votes > total_allowed_votes:
+            raise BadRequest(
+                f"Too many votes cast in contest: {contest['name']}"
+                f" ({total_votes} votes, {total_allowed_votes} allowed)"
+            )
+
+
+@app.route("/election/<election_id>/contest", methods=["PUT"])
+def create_or_update_all_contests(election_id: str = None):
+    election = get_election(election_id)
+    require_audit_admin_for_organization(election.organization_id)
+
+    json_contests = request.get_json()
+    validate_contests(json_contests)
+
+    db.session.query(Contest).filter_by(election_id=election.id).delete()
+
+    for json_contest in json_contests:
+        contest = deserialize_contest(json_contest, election.id)
+        db.session.add(contest)
+
+    db.session.commit()
+
+    return jsonify(status="ok")
+
+
+@app.route("/election/<election_id>/contest", methods=["GET"])
+def list_contests(election_id: str = None):
+    election = get_election(election_id)
+    require_audit_admin_for_organization(election.organization_id)
+
+    contests = Contest.query.filter_by(election_id=election_id).all()
+
+    return jsonify([serialize_contest(c) for c in contests])

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -79,7 +79,10 @@ class Jurisdiction(BaseModel):
         "AuditBoard", backref="jurisdiction", passive_deletes=True
     )
     contests = relationship(
-        "ContestJurisdiction", backref="jurisdiction", passive_deletes=True
+        "Contest",
+        secondary="contest_jurisdiction",
+        backref="jurisdictions",
+        passive_deletes=True,
     )
 
 
@@ -186,17 +189,21 @@ class ContestChoice(BaseModel):
     )
 
 
-class ContestJurisdiction(db.Model):
-    contest_id = db.Column(
-        db.String(200), db.ForeignKey("contest.id", ondelete="cascade"), nullable=False,
-    )
-    jurisdiction_id = db.Column(
+contest_jurisdiction = db.Table(
+    "contest_jurisdiction",
+    db.Column(
+        "contest_id",
         db.String(200),
-        db.ForeignKey("jurisdiction.id", ondelete="cascade"),
+        db.ForeignKey("contest.id", primary_key=True, ondelete="cascade"),
         nullable=False,
-    )
-
-    __table_args__ = (db.PrimaryKeyConstraint("contest_id", "jurisdiction_id"),)
+    ),
+    db.Column(
+        "jurisdiction_id",
+        db.String(200),
+        db.ForeignKey("jurisdiction.id", primary_key=True, ondelete="cascade"),
+        nullable=False,
+    ),
+)
 
 
 class AuditBoard(BaseModel):

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -1,23 +1,27 @@
-# type: ignore
 from sqlalchemy.orm import relationship, backref
 from typing import Union, List
 from enum import Enum
 from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy.model import DefaultMeta
+
 
 db = SQLAlchemy()
+
+# Typing workaround from https://github.com/dropbox/sqlalchemy-stubs/issues/76#issuecomment-595839159
+BaseModel: DefaultMeta = db.Model
 
 # on-delete-cascade is done in SQLAlchemy like this:
 # https://stackoverflow.com/questions/5033547/sqlalchemy-cascade-delete
 
 
-class Organization(db.Model):
+class Organization(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
     name = db.Column(db.String(200), nullable=False)
 
     elections = relationship("Election", backref="organization", passive_deletes=True)
 
 
-class Election(db.Model):
+class Election(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
     name = db.Column(db.String(200), nullable=True)
     state = db.Column(db.String(100), nullable=True)
@@ -52,7 +56,7 @@ class Election(db.Model):
 
 
 # these are typically counties
-class Jurisdiction(db.Model):
+class Jurisdiction(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
     election_id = db.Column(
         db.String(200), db.ForeignKey("election.id", ondelete="cascade"), nullable=False
@@ -79,7 +83,7 @@ class Jurisdiction(db.Model):
     )
 
 
-class User(db.Model):
+class User(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
     email = db.Column(db.String(200), unique=True, nullable=False)
     external_id = db.Column(db.String(200), unique=True, nullable=True)
@@ -90,7 +94,7 @@ class User(db.Model):
     )
 
 
-class AuditAdministration(db.Model):
+class AuditAdministration(BaseModel):
     organization_id = db.Column(
         db.String(200),
         db.ForeignKey("organization.id", ondelete="cascade"),
@@ -111,7 +115,7 @@ class AuditAdministration(db.Model):
     __table_args__ = (db.PrimaryKeyConstraint("organization_id", "user_id"),)
 
 
-class JurisdictionAdministration(db.Model):
+class JurisdictionAdministration(BaseModel):
     user_id = db.Column(
         db.String(200), db.ForeignKey("user.id", ondelete="cascade"), nullable=False
     )
@@ -133,7 +137,7 @@ class JurisdictionAdministration(db.Model):
     __table_args__ = (db.PrimaryKeyConstraint("user_id", "jurisdiction_id"),)
 
 
-class Batch(db.Model):
+class Batch(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
     jurisdiction_id = db.Column(
         db.String(200),
@@ -151,7 +155,7 @@ class Batch(db.Model):
     )
 
 
-class Contest(db.Model):
+class Contest(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
     election_id = db.Column(
         db.String(200), db.ForeignKey("election.id", ondelete="cascade"), nullable=False
@@ -169,7 +173,7 @@ class Contest(db.Model):
     )
 
 
-class ContestChoice(db.Model):
+class ContestChoice(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
     contest_id = db.Column(
         db.String(200), db.ForeignKey("contest.id", ondelete="cascade"), nullable=False,
@@ -195,7 +199,7 @@ class ContestJurisdiction(db.Model):
     __table_args__ = (db.PrimaryKeyConstraint("contest_id", "jurisdiction_id"),)
 
 
-class AuditBoard(db.Model):
+class AuditBoard(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
     jurisdiction_id = db.Column(
         db.String(200),
@@ -218,7 +222,7 @@ class AuditBoard(db.Model):
     )
 
 
-class Round(db.Model):
+class Round(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
     election_id = db.Column(
         db.String(200), db.ForeignKey("election.id", ondelete="cascade"), nullable=False
@@ -236,7 +240,7 @@ class Round(db.Model):
     audit_boards = relationship("AuditBoard", backref="round", passive_deletes=True)
 
 
-class SampledBallot(db.Model):
+class SampledBallot(BaseModel):
     batch_id = db.Column(
         db.String(200), db.ForeignKey("batch.id", ondelete="cascade"), nullable=False
     )
@@ -259,7 +263,7 @@ class SampledBallot(db.Model):
     comment = db.Column(db.Text, nullable=True)
 
 
-class SampledBallotDraw(db.Model):
+class SampledBallotDraw(BaseModel):
     batch_id = db.Column(
         db.String(200), db.ForeignKey("batch.id", ondelete="cascade"), nullable=False
     )
@@ -282,7 +286,7 @@ class SampledBallotDraw(db.Model):
     )
 
 
-class RoundContest(db.Model):
+class RoundContest(BaseModel):
     round_id = db.Column(
         db.String(200), db.ForeignKey("round.id", ondelete="cascade"), nullable=False
     )
@@ -303,7 +307,7 @@ class RoundContest(db.Model):
     sample_size = db.Column(db.Integer)
 
 
-class RoundContestResult(db.Model):
+class RoundContestResult(BaseModel):
     round_id = db.Column(
         db.String(200), db.ForeignKey("round.id", ondelete="cascade"), nullable=False
     )
@@ -327,7 +331,7 @@ class RoundContestResult(db.Model):
     result = db.Column(db.Integer)
 
 
-class File(db.Model):
+class File(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
     name = db.Column(db.String(250), nullable=False)
     contents = db.Column(db.Text, nullable=False)

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -477,7 +477,7 @@ def audit_status(election_id=None):
             {
                 "id": j.id,
                 "name": j.name,
-                "contests": [c.contest_id for c in j.contests],
+                "contests": [c.id for c in j.contests],
                 "auditBoards": [
                     {
                         "id": audit_board.id,
@@ -618,16 +618,18 @@ def jurisdictions_set(election_id):
     db.session.query(Jurisdiction).filter_by(election_id=election.id).delete()
 
     for jurisdiction in jurisdictions:
+        contests = (
+            Contest.query.filter_by(election_id=election.id)
+            .filter(Contest.id.in_(jurisdiction["contests"]))
+            .all()
+        )
         jurisdiction_obj = Jurisdiction(
-            election_id=election.id, id=jurisdiction["id"], name=jurisdiction["name"]
+            election_id=election.id,
+            id=jurisdiction["id"],
+            name=jurisdiction["name"],
+            contests=contests,
         )
         db.session.add(jurisdiction_obj)
-
-        for contest_id in jurisdiction["contests"]:
-            jurisdiction_contest = ContestJurisdiction(
-                contest_id=contest_id, jurisdiction_id=jurisdiction_obj.id
-            )
-            db.session.add(jurisdiction_contest)
 
         for audit_board in jurisdiction["auditBoards"]:
             audit_board_obj = AuditBoard(

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,3 +25,9 @@ ignore_missing_imports = True
 
 [mypy-authlib.flask.client]
 ignore_missing_imports = True
+
+[mypy-jsonschema]
+ignore_missing_imports = True
+
+[mypy-jsonschema.exceptions]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,11 +3,15 @@ python_version = 3.7
 warn_return_any = True
 warn_unused_configs = True
 mypy_path = stubs
+plugins = sqlmypy
 
 [mypy-xkcdpass]
 ignore_missing_imports = True
 
 [mypy-flask_sqlalchemy]
+ignore_missing_imports = True
+
+[mypy-flask_sqlalchemy.model]
 ignore_missing_imports = True
 
 [mypy-flask_httpauth]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,6 +15,12 @@ def post_json(client: FlaskClient, url: str, obj) -> Any:
     )
 
 
+def put_json(client: FlaskClient, url: str, obj) -> Any:
+    return client.put(
+        url, headers={"Content-Type": "application/json"}, data=json.dumps(obj)
+    )
+
+
 def set_logged_in_user(
     client: FlaskClient, user_type: UserType, user_email=DEFAULT_USER_EMAIL
 ):

--- a/tests/test_contests.py
+++ b/tests/test_contests.py
@@ -1,0 +1,242 @@
+import pytest
+
+import json, uuid, io
+from typing import List
+
+from helpers import post_json, put_json
+from test_app import client
+from arlo_server.models import Jurisdiction
+
+
+@pytest.fixture()
+def election_id(client) -> str:
+    rv = post_json(client, "/election/new", {})
+    election_id = json.loads(rv.data)["electionId"]
+    assert election_id
+    yield election_id
+
+
+@pytest.fixture()
+def jurisdiction_ids(client, election_id: str) -> List[str]:
+    rv = client.put(
+        f"/election/{election_id}/jurisdictions/file",
+        data={
+            "jurisdictions": (
+                io.BytesIO(
+                    b"Jurisdiction,Admin Email\n"
+                    b"J1,a1@example.com\n"
+                    b"J2,a2@example.com\n"
+                    b"J3,a3@example.com"
+                ),
+                "jurisdictions.csv",
+            )
+        },
+    )
+    assert json.loads(rv.data) == {"status": "ok"}
+    # TODO use the /elections/<election_id>/jurisdictions endpoint here once it's built
+    jurisdictions = Jurisdiction.query.filter_by(election_id=election_id).all()
+    yield [j.id for j in jurisdictions]
+
+
+def test_contests_list_empty(client, election_id):
+    rv = client.get(f"/election/{election_id}/contest")
+    contests = json.loads(rv.data)
+    assert contests == []
+
+
+def test_contests_create_get_update_one(client, election_id, jurisdiction_ids):
+    contest = {
+        "id": str(uuid.uuid4()),
+        "name": "Contest 1",
+        "isTargeted": True,
+        "choices": [
+            {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 48121,},
+            {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 38026,},
+        ],
+        "totalBallotsCast": 86147,
+        "numWinners": 1,
+        "votesAllowed": 1,
+        "jurisdictionIds": jurisdiction_ids,
+    }
+    rv = put_json(client, f"/election/{election_id}/contest", [contest])
+    assert json.loads(rv.data) == {"status": "ok"}
+
+    rv = client.get(f"/election/{election_id}/contest")
+    contests = json.loads(rv.data)
+    assert contests == [contest]
+
+    contest["totalBallotsCast"] = contest["totalBallotsCast"] + 21
+    contest["numWinners"] = 2
+    contest["choices"].append(
+        {"id": str(uuid.uuid4()), "name": "candidate 3", "numVotes": 21,}
+    )
+
+    rv = put_json(client, f"/election/{election_id}/contest", [contest])
+    print(json.loads(rv.data))
+    assert json.loads(rv.data) == {"status": "ok"}
+
+    rv = client.get(f"/election/{election_id}/contest")
+    contests = json.loads(rv.data)
+    assert contests == [contest]
+
+
+def test_contests_create_get_update_multiple(client, election_id, jurisdiction_ids):
+    contests = [
+        {
+            "id": str(uuid.uuid4()),
+            "name": "Contest 1",
+            "isTargeted": True,
+            "choices": [
+                {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 48121,},
+                {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 38026,},
+            ],
+            "totalBallotsCast": 86147,
+            "numWinners": 1,
+            "votesAllowed": 1,
+            "jurisdictionIds": [],
+        },
+        {
+            "id": str(uuid.uuid4()),
+            "name": "Contest 2",
+            "isTargeted": False,
+            "choices": [
+                {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 200,},
+                {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 300,},
+            ],
+            "totalBallotsCast": 500,
+            "numWinners": 1,
+            "votesAllowed": 1,
+            "jurisdictionIds": jurisdiction_ids,
+        },
+        {
+            "id": str(uuid.uuid4()),
+            "name": "Contest 3",
+            "isTargeted": False,
+            "choices": [
+                {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 200,},
+                {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 400,},
+                {"id": str(uuid.uuid4()), "name": "candidate 3", "numVotes": 600,},
+            ],
+            "totalBallotsCast": 700,
+            "numWinners": 2,
+            "votesAllowed": 2,
+            "jurisdictionIds": jurisdiction_ids[:1],
+        },
+    ]
+    rv = put_json(client, f"/election/{election_id}/contest", contests)
+    assert json.loads(rv.data) == {"status": "ok"}
+
+    rv = client.get(f"/election/{election_id}/contest")
+    json_contests = json.loads(rv.data)
+    assert contests == json_contests
+
+    contests[0]["name"] = "Changed name"
+    contests[1]["isTargeted"] = True
+    contests[2]["jurisdictionIds"] = jurisdiction_ids[1:]
+
+    rv = put_json(client, f"/election/{election_id}/contest", contests)
+    assert json.loads(rv.data) == {"status": "ok"}
+
+    rv = client.get(f"/election/{election_id}/contest")
+    json_contests = json.loads(rv.data)
+    assert contests == json_contests
+
+
+def test_contests_missing_field(client, election_id, jurisdiction_ids):
+    contest = {
+        "id": str(uuid.uuid4()),
+        "name": "Contest 1",
+        "isTargeted": True,
+        "choices": [
+            {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 48121,},
+            {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 38026,},
+        ],
+        "totalBallotsCast": 86147,
+        "numWinners": 1,
+        "votesAllowed": 1,
+        "jurisdictionIds": jurisdiction_ids,
+    }
+
+    for field in contest:
+        invalid_contest = contest.copy()
+        del invalid_contest[field]
+
+        rv = put_json(client, f"/election/{election_id}/contest", [invalid_contest])
+        assert rv.status_code == 400
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "message": f"'{field}' is a required property",
+                    "errorType": "Bad Request",
+                }
+            ]
+        }
+
+    for field in contest["choices"][0]:
+        invalid_contest = contest.copy()
+        invalid_contest_choice = invalid_contest["choices"][0].copy()
+        del invalid_contest_choice[field]
+        invalid_contest["choices"] = [invalid_contest_choice]
+
+        rv = put_json(client, f"/election/{election_id}/contest", [invalid_contest])
+        assert rv.status_code == 400
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "message": f"'{field}' is a required property",
+                    "errorType": "Bad Request",
+                }
+            ]
+        }
+
+
+def test_contest_too_many_votes(client, election_id):
+    contest = {
+        "id": str(uuid.uuid4()),
+        "name": "Contest 1",
+        "isTargeted": True,
+        "choices": [
+            {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 400,},
+            {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 101,},
+        ],
+        "totalBallotsCast": 500,
+        "numWinners": 1,
+        "votesAllowed": 1,
+        "jurisdictionIds": [],
+    }
+
+    rv = put_json(client, f"/election/{election_id}/contest", [contest])
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": f"Too many votes cast in contest: Contest 1 (501 votes, 500 allowed)",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+
+    contest = {
+        "id": str(uuid.uuid4()),
+        "name": "Contest 1",
+        "isTargeted": True,
+        "choices": [
+            {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 700,},
+            {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 301,},
+        ],
+        "totalBallotsCast": 500,
+        "numWinners": 1,
+        "votesAllowed": 2,
+        "jurisdictionIds": [],
+    }
+
+    rv = put_json(client, f"/election/{election_id}/contest", [contest])
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": f"Too many votes cast in contest: Contest 1 (1001 votes, 1000 allowed)",
+                "errorType": "Bad Request",
+            }
+        ]
+    }


### PR DESCRIPTION
**Description**

Task: #309, #326 

Adds new endpoints for getting and creating/updating contests when setting up an audit:
- `GET /election/<election_id>/contest` - gets a list of all contests for the audit
- `PUT /election/<election_id>/contest` - sets the contests for the audit, overwriting any existing contests

Notably, this new API includes a `jurisdictionIds` field to set the contest universe.

The new endpoints use JSON schema to validate the contests.

**Testing**

Added a new test file with quite a few cases.

**Progress**

Ready for review. Left some open questions as PR comments.