### PR TITLE
Add GET /election/<election_id>/jurisdiction

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -13,3 +13,4 @@ db.init_app(app)
 
 import arlo_server.routes
 import arlo_server.contests
+import arlo_server.jurisdictions

--- a/arlo_server/jurisdictions.py
+++ b/arlo_server/jurisdictions.py
@@ -1,0 +1,32 @@
+from flask import jsonify
+
+from arlo_server import app, db
+from arlo_server.routes import get_election, require_audit_admin_for_organization
+from arlo_server.models import Jurisdiction
+
+
+def serialize_jurisdiction(db_jurisdiction: Jurisdiction) -> dict:
+    return {
+        "id": db_jurisdiction.id,
+        "name": db_jurisdiction.name,
+        "ballotManifest": {
+            "filename": db_jurisdiction.manifest_filename,
+            "numBallots": db_jurisdiction.manifest_num_ballots,
+            "numBatches": db_jurisdiction.manifest_num_batches,
+            "uploadedAt": db_jurisdiction.manifest_uploaded_at,
+        },
+    }
+
+
+@app.route("/election/<election_id>/jurisdiction", methods=["GET"])
+def list_jurisdictions(election_id: str = None):
+    election = get_election(election_id)
+    require_audit_admin_for_organization(election.organization_id)
+
+    jurisdictions = (
+        Jurisdiction.query.filter_by(election_id=election.id)
+        .order_by(Jurisdiction.name)
+        .all()
+    )
+
+    return jsonify([serialize_jurisdiction(j) for j in jurisdictions])

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -753,8 +753,12 @@ def jurisdiction_manifest(jurisdiction_id, election_id):
     jurisdiction.manifest_num_batches = num_batches
     db.session.commit()
 
-    # draw the sample
-    sample_ballots(election, election.rounds[0])
+    # If we're in the single-jurisdiction flow, posting the ballot manifest
+    # starts the first round, so we need to sample the ballots.
+    # In the multi-jurisdiction flow, this happens after all jurisdictions
+    # upload manifests, and is triggered by a different endpoint.
+    if not election.organization_id:
+        sample_ballots(election, election.rounds[0])
 
     return jsonify(status="ok")
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -77,4 +77,6 @@ def compare_json(actual_json, expected_json):
     elif callable(expected_json):
         expected_json(actual_json)
     else:
-        assert actual_json == expected_json
+        assert (
+            actual_json == expected_json
+        ), f"Actual: {actual_json}\nExpected: {expected_json}"

--- a/tests/test_jurisdictions.py
+++ b/tests/test_jurisdictions.py
@@ -1,0 +1,145 @@
+import pytest
+
+import json, io, uuid
+from typing import List
+
+from helpers import post_json, compare_json, assert_is_date, create_org_and_admin
+from test_app import client
+from arlo_server.routes import create_election, UserType
+from arlo_server.models import Jurisdiction
+
+
+@pytest.fixture()
+def audit_admin_email(client) -> str:
+    user_email = "admin@example.com"
+    with client.session_transaction() as session:
+        session["_user"] = {"type": UserType.AUDIT_ADMIN, "email": user_email}
+    return user_email
+
+
+@pytest.fixture()
+def election_id(client, audit_admin_email) -> str:
+    org_id, _ = create_org_and_admin("Test Org", audit_admin_email)
+    election_id = create_election(organization_id=org_id)
+    yield election_id
+
+
+@pytest.fixture()
+def jurisdiction_ids(client, election_id: str) -> List[str]:
+    # We expect the list endpoint to order the jurisdictions by name, so we
+    # upload them out of order.
+    rv = client.put(
+        f"/election/{election_id}/jurisdictions/file",
+        data={
+            "jurisdictions": (
+                io.BytesIO(
+                    b"Jurisdiction,Admin Email\n"
+                    b"J2,a2@example.com\n"
+                    b"J3,a3@example.com\n"
+                    b"J1,a1@example.com"
+                ),
+                "jurisdictions.csv",
+            )
+        },
+    )
+    assert json.loads(rv.data) == {"status": "ok"}
+    jurisdictions = Jurisdiction.query.filter_by(election_id=election_id).all()
+    yield [j.id for j in jurisdictions]
+
+
+def test_jurisdictions_list_empty(client, election_id):
+    rv = client.get(f"/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)
+    assert jurisdictions == []
+
+
+def test_jurisdictions_list_no_manifest(client, election_id, jurisdiction_ids):
+    rv = client.get(f"/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)
+    assert jurisdictions == [
+        {
+            "id": jurisdiction_ids[2],
+            "name": "J1",
+            "ballotManifest": {
+                "filename": None,
+                "numBallots": None,
+                "numBatches": None,
+                "uploadedAt": None,
+            },
+        },
+        {
+            "id": jurisdiction_ids[0],
+            "name": "J2",
+            "ballotManifest": {
+                "filename": None,
+                "numBallots": None,
+                "numBatches": None,
+                "uploadedAt": None,
+            },
+        },
+        {
+            "id": jurisdiction_ids[1],
+            "name": "J3",
+            "ballotManifest": {
+                "filename": None,
+                "numBallots": None,
+                "numBatches": None,
+                "uploadedAt": None,
+            },
+        },
+    ]
+
+
+def test_jurisdictions_list_with_manifest(client, election_id, jurisdiction_ids):
+    rv = client.post(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[2]}/manifest",
+        data={
+            "manifest": (
+                io.BytesIO(
+                    b"Batch Name,Number of Ballots\n"
+                    b"1,23\n"
+                    b"2,101\n"
+                    b"3,122\n"
+                    b"4,400"
+                ),
+                "manifest.csv",
+            )
+        },
+    )
+    assert json.loads(rv.data) == {"status": "ok"}
+
+    rv = client.get(f"/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)
+    expected = [
+        {
+            "id": jurisdiction_ids[2],
+            "name": "J1",
+            "ballotManifest": {
+                "filename": "manifest.csv",
+                "numBallots": 23 + 101 + 122 + 400,
+                "numBatches": 4,
+                "uploadedAt": assert_is_date,
+            },
+        },
+        {
+            "id": jurisdiction_ids[0],
+            "name": "J2",
+            "ballotManifest": {
+                "filename": None,
+                "numBallots": None,
+                "numBatches": None,
+                "uploadedAt": None,
+            },
+        },
+        {
+            "id": jurisdiction_ids[1],
+            "name": "J3",
+            "ballotManifest": {
+                "filename": None,
+                "numBallots": None,
+                "numBatches": None,
+                "uploadedAt": None,
+            },
+        },
+    ]
+    compare_json(jurisdictions, expected)


### PR DESCRIPTION
**Description**

Task: #343 

An endpoint to list all of the jurisdictions in an election, including details about their ballot manifest upload.

Also tweaks the existing /election/<election_id>/jurisdiction/<jurisdiction_id>/manifest endpoint to only initiate ballot sampling when used by the single-jurisdiction flow.

**Testing**

Added new test file testing the endpoint with and without uploading the manifest.

**Progress**

Ready to review.
