### PR TITLE
fix: use camel case in JSON APIs

### DIFF
--- a/arlo-client/src/components/CreateAudit.test.tsx
+++ b/arlo-client/src/components/CreateAudit.test.tsx
@@ -93,8 +93,7 @@ describe('CreateAudit', () => {
       expect(apiMock).toBeCalledTimes(2)
       expect(apiMock).toHaveBeenNthCalledWith(2, '/election/new', {
         method: 'POST',
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        body: JSON.stringify({ organization_id: 'org-id' }),
+        body: JSON.stringify({ organizationId: 'org-id' }),
       })
       expect(historySpy).toBeCalledTimes(1)
       expect(historySpy).toHaveBeenNthCalledWith(1, '/election/1')

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -39,8 +39,7 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
     try {
       setLoading(true)
       const data = isAuthenticated
-        ? // eslint-disable-next-line @typescript-eslint/camelcase
-          { organization_id: meta!.organizations[0].id }
+        ? { organizationId: meta!.organizations[0].id }
         : {}
       const response: { electionId: string } | IErrorResponse = await api(
         '/election/new',

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -355,7 +355,7 @@ def require_audit_admin_for_organization(organization_id: Optional[str]):
 def election_new():
     info = request.get_json()
 
-    organization_id = info.get("organization_id", None) if info else None
+    organization_id = info.get("organizationId", None) if info else None
     require_audit_admin_for_organization(organization_id)
 
     election_id = create_election(organization_id=organization_id)

--- a/tests/test_new_election.py
+++ b/tests/test_new_election.py
@@ -30,7 +30,7 @@ def test_without_org_with_anonymous_user(client: FlaskClient):
 
 def test_in_org_with_anonymous_user(client: FlaskClient):
     org = create_organization()
-    rv = post_json(client, "/election/new", {"organization_id": org.id})
+    rv = post_json(client, "/election/new", {"organizationId": org.id})
     assert json.loads(rv.data) == {
         "errors": [
             {
@@ -48,7 +48,7 @@ def test_in_org_with_logged_in_admin(client: FlaskClient):
         client, user_type=UserType.AUDIT_ADMIN, user_email="admin@example.com"
     )
 
-    rv = post_json(client, "/election/new", {"organization_id": org_id})
+    rv = post_json(client, "/election/new", {"organizationId": org_id})
     response = json.loads(rv.data)
     election_id = response.get("electionId", None)
     assert election_id, response
@@ -65,7 +65,7 @@ def test_in_org_with_logged_in_admin_without_access(client: FlaskClient):
         client, user_type=UserType.AUDIT_ADMIN, user_email="admin1@example.com"
     )
 
-    rv = post_json(client, "/election/new", {"organization_id": org2_id})
+    rv = post_json(client, "/election/new", {"organizationId": org2_id})
     assert json.loads(rv.data) == {
         "errors": [
             {
@@ -83,7 +83,7 @@ def test_in_org_with_logged_in_jurisdiction_admin(client: FlaskClient):
         client, user_type=UserType.JURISDICTION_ADMIN, user_email="admin@example.com"
     )
 
-    rv = post_json(client, "/election/new", {"organization_id": org_id})
+    rv = post_json(client, "/election/new", {"organizationId": org_id})
     assert json.loads(rv.data) == {
         "errors": [
             {


### PR DESCRIPTION
**Description**

I noticed a snake-case property snuck in recently, and this fixes it.

**Testing**

Covered by existing tests.

**Progress**

Ideally this would be enforced by a development/test-time wrapper that checks JSON requests & responses for snake casing and raises an error.
