### PR TITLE
refactor: extract `File` from `Election` jurisdictions file

### DIFF
--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -45,11 +45,10 @@ class Election(db.Model):
     contests = relationship("Contest", backref="election", passive_deletes=True)
     rounds = relationship("Round", backref="election", passive_deletes=True)
 
-    jurisdictions_file = db.Column(db.Text, nullable=True)
-    jurisdictions_filename = db.Column(db.String(250), nullable=True)
-    jurisdictions_file_uploaded_at = db.Column(
-        db.DateTime(timezone=False), nullable=True
+    jurisdictions_file_id = db.Column(
+        db.String(200), db.ForeignKey("file.id", ondelete="set null"), nullable=True
     )
+    jurisdictions_file = relationship("File")
 
 
 # these are typically counties
@@ -326,3 +325,10 @@ class RoundContestResult(db.Model):
         nullable=False,
     )
     result = db.Column(db.Integer)
+
+
+class File(db.Model):
+    id = db.Column(db.String(200), primary_key=True)
+    name = db.Column(db.String(250), nullable=False)
+    contents = db.Column(db.Text, nullable=False)
+    uploaded_at = db.Column(db.DateTime(timezone=False), nullable=False)

--- a/tests/test_app_upload_jurisdictions_file.py
+++ b/tests/test_app_upload_jurisdictions_file.py
@@ -107,15 +107,15 @@ def test_metadata(client):
     assert json.loads(rv.data) == {"status": "ok"}
 
     election = Election.query.filter_by(id=election_id).one()
-    assert election.jurisdictions_file == "Jurisdiction,Admin Email"
-    assert election.jurisdictions_filename == "jurisdictions.csv"
-    assert election.jurisdictions_file_uploaded_at
+    assert election.jurisdictions_file.contents == "Jurisdiction,Admin Email"
+    assert election.jurisdictions_file.name == "jurisdictions.csv"
+    assert election.jurisdictions_file.uploaded_at
 
     rv = client.get(f"/election/{election_id}/jurisdictions_file")
-    jurisdictions_file = json.loads(rv.data)
-    assert jurisdictions_file["content"] == "Jurisdiction,Admin Email"
-    assert jurisdictions_file["filename"] == "jurisdictions.csv"
-    assert jurisdictions_file["uploaded_at"]
+    jurisdictions_file = json.loads(rv.data)["file"]
+    assert jurisdictions_file["contents"] == "Jurisdiction,Admin Email"
+    assert jurisdictions_file["name"] == "jurisdictions.csv"
+    assert jurisdictions_file["uploadedAt"]
 
 
 def test_no_jurisdiction(client):


### PR DESCRIPTION
**Description**

Since it seems likely we're going to have more "file" objects we're going to have to keep track of, this codifies that into a model.

**Testing**

Covered by existing tests.

**Progress**

This was an opportunistic refactor on the road to making the bulk jurisdictions file upload async.