### PR TITLE
feat: process jurisdiction file uploads in the background

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from config import STATIC_FOLDER, SESSION_SECRET, DATABASE_URL
-from arlo_server.models import db  # type: ignore
+from arlo_server.models import db
 
 print("serving static files from " + STATIC_FOLDER)
 app = Flask(__name__, static_folder=STATIC_FOLDER)

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -343,3 +343,15 @@ class File(BaseModel):
     name = db.Column(db.String(250), nullable=False)
     contents = db.Column(db.Text, nullable=False)
     uploaded_at = db.Column(db.DateTime(timezone=False), nullable=False)
+
+    # Metadata for processing files in the background.
+    processing_started_at = db.Column(db.DateTime(timezone=False), nullable=True)
+    processing_completed_at = db.Column(db.DateTime(timezone=False), nullable=True)
+    processing_error = db.Column(db.Text, nullable=True)
+
+
+class ProcessingStatus(str, Enum):
+    READY_TO_PROCESS = "READY_TO_PROCESS"
+    PROCESSING = "PROCESSING"
+    PROCESSED = "PROCESSED"
+    ERRORED = "ERRORED"

--- a/bgcompute.py
+++ b/bgcompute.py
@@ -2,13 +2,20 @@
 import time, json
 
 from flask import Flask
+from sqlalchemy.orm import joinedload
 
 from arlo_server import app, db
-from arlo_server.models import RoundContest
+from arlo_server.models import Election, File, RoundContest
 from arlo_server.routes import compute_sample_sizes
+from util.jurisdiction_bulk_update import process_jurisdictions_file
 
 
 def bgcompute():
+    bgcompute_compute_round_contests_sample_sizes()
+    bgcompute_update_election_jurisdictions_file()
+
+
+def bgcompute_compute_round_contests_sample_sizes():
     # round contests that don't have sample_size_options
     round_contests = RoundContest.query.filter_by(sample_size_options=None)
 
@@ -28,6 +35,22 @@ def bgcompute():
                 round_contest.sample_size_options,
             )
         )
+
+
+def bgcompute_update_election_jurisdictions_file() -> int:
+    files = (
+        File.query.join(Election, File.id == Election.jurisdictions_file_id)
+        .filter(File.processing_started_at == None)
+        .all()
+    )
+
+    for file in files:
+        election = Election.query.filter_by(jurisdictions_file_id=file.id).one()
+        print(f"updating jurisdictions file for election ID {election.id}")
+        process_jurisdictions_file(db.session, election, file)
+        print(f"done updating jurisdictions file for election ID {election.id}")
+
+    return len(files)
 
 
 def bgcompute_forever():

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 from flask.testing import FlaskClient
 
 from arlo_server.routes import create_organization, UserType
-from arlo_server.models import db, AuditAdministration, User  # type: ignore
+from arlo_server.models import db, AuditAdministration, User
 
 DEFAULT_USER_EMAIL = "admin@example.com"
 

--- a/tests/test_jurisdiction_bulk_update.py
+++ b/tests/test_jurisdiction_bulk_update.py
@@ -1,5 +1,11 @@
 from util.jurisdiction_bulk_update import bulk_update_jurisdictions
-from arlo_server.models import Election, Jurisdiction, JurisdictionAdministration, Organization, User  # type: ignore
+from arlo_server.models import (
+    Election,
+    Jurisdiction,
+    JurisdictionAdministration,
+    Organization,
+    User,
+)
 import arlo_server
 import pytest
 import uuid

--- a/tests/test_process_file.py
+++ b/tests/test_process_file.py
@@ -1,0 +1,100 @@
+import datetime
+import pytest
+import uuid
+from typing import Optional
+
+import arlo_server
+from arlo_server.models import File
+from util.process_file import process_file
+
+
+@pytest.fixture
+def db():
+    with arlo_server.app.app_context():
+        arlo_server.db.drop_all()
+        arlo_server.db.create_all()
+
+    yield arlo_server.db
+
+    arlo_server.db.session.commit()
+
+
+def test_success(db):
+    file = File(
+        id=str(uuid.uuid4()),
+        name="Test File",
+        contents="abcdefg",
+        uploaded_at=datetime.datetime.utcnow(),
+    )
+    db.session.add(file)
+    db.session.commit()
+
+    while_processing_started_at: Optional[datetime.datetime] = None
+    while_processing_completed_at: Optional[datetime.datetime] = None
+    while_processing_error: Optional[str] = None
+
+    def process():
+        nonlocal while_processing_started_at
+        nonlocal while_processing_completed_at
+        nonlocal while_processing_error
+
+        while_processing_started_at = file.processing_started_at
+        while_processing_completed_at = file.processing_completed_at
+        while_processing_error = file.processing_error
+
+    assert file.processing_started_at == None
+    assert file.processing_completed_at == None
+    assert file.processing_error == None
+
+    process_file(db.session, file, process)
+
+    assert isinstance(while_processing_started_at, datetime.datetime)
+    assert while_processing_completed_at == None
+    assert while_processing_error == None
+
+    assert isinstance(file.processing_started_at, datetime.datetime)
+    assert isinstance(file.processing_completed_at, datetime.datetime)
+    assert file.processing_error == None
+
+
+def test_error(db):
+    file = File(
+        id=str(uuid.uuid4()),
+        name="Test File",
+        contents="abcdefg",
+        uploaded_at=datetime.datetime.utcnow(),
+    )
+    db.session.add(file)
+    db.session.commit()
+
+    while_processing_started_at: Optional[datetime.datetime] = None
+    while_processing_completed_at: Optional[datetime.datetime] = None
+    while_processing_error: Optional[str] = None
+
+    def process():
+        nonlocal while_processing_started_at
+        nonlocal while_processing_completed_at
+        nonlocal while_processing_error
+
+        while_processing_started_at = file.processing_started_at
+        while_processing_completed_at = file.processing_completed_at
+        while_processing_error = file.processing_error
+
+        raise Exception("NOPE")
+
+    assert file.processing_started_at == None
+    assert file.processing_completed_at == None
+    assert file.processing_error == None
+
+    try:
+        process_file(db.session, file, process)
+    except Exception as error:
+        assert str(error) == "NOPE"
+
+    assert isinstance(while_processing_started_at, datetime.datetime)
+    assert while_processing_completed_at == None
+    assert while_processing_error == None
+
+    assert isinstance(file.processing_started_at, datetime.datetime)
+    assert isinstance(file.processing_completed_at, datetime.datetime)
+    assert file.processing_error == "NOPE"

--- a/util/jurisdiction_bulk_update.py
+++ b/util/jurisdiction_bulk_update.py
@@ -1,7 +1,36 @@
+import csv
+import io
 import uuid
-from arlo_server.models import Election, JurisdictionAdministration, User, Jurisdiction  # type: ignore
-from typing import Tuple, List
 from sqlalchemy import func
+from typing import Tuple, List
+
+from arlo_server.models import (
+    Election,
+    File,
+    JurisdictionAdministration,
+    User,
+    Jurisdiction,
+)
+from util.process_file import process_file
+
+
+JURISDICTION_NAME = "Jurisdiction"
+ADMIN_EMAIL = "Admin Email"
+
+
+def process_jurisdictions_file(session, election: Election, file: File) -> None:
+    assert election.jurisdictions_file_id == file.id
+
+    def process():
+        jurisdictions_csv = csv.DictReader(io.StringIO(file.contents))
+
+        bulk_update_jurisdictions(
+            session,
+            election,
+            [(row[JURISDICTION_NAME], row[ADMIN_EMAIL]) for row in jurisdictions_csv],
+        )
+
+    process_file(session, file, process)
 
 
 def bulk_update_jurisdictions(

--- a/util/process_file.py
+++ b/util/process_file.py
@@ -1,0 +1,36 @@
+import datetime
+from typing import Callable
+from sqlalchemy import update
+from sqlalchemy.orm.session import Session
+
+from arlo_server.models import File
+
+
+def process_file(session: Session, file: File, callback: Callable[[], None]) -> bool:
+    if file.processing_started_at:
+        return False
+
+    # Claim this file by updating the `processing_started_at` timestamp in such
+    # a way that it must not have been set before.
+    file.processing_started_at = datetime.datetime.utcnow()
+    result = session.execute(
+        update(File.__table__)
+        .where(File.id == file.id)
+        .where(File.processing_started_at == None)
+        .values(processing_started_at=file.processing_started_at)
+    )
+    if result.rowcount == 0:
+        return False
+
+    # If we got this far, `file` is ours to process.
+    session.add(file)
+    try:
+        callback()
+        file.processing_completed_at = datetime.datetime.utcnow()
+        session.commit()
+        return True
+    except Exception as error:
+        file.processing_completed_at = datetime.datetime.utcnow()
+        file.processing_error = str(error)
+        session.commit()
+        raise error


### PR DESCRIPTION
**Description**

In an effort to not block requests on things that could potentially take a long time, this puts the processing of jurisdiction files in the background.

**Testing**

Adds some new tests for the helper function `process_file` and updates tests to use the new backgrounding flow.

**Progress**

This doesn't require any more changes to make the feature work, unless I missed something. Some concerns I have:
- `bgcompute.py` doesn't seem to catch errors. I'm assuming Heroku will run the `worker` process in the `Procfile` again if it dies, but I don't know for sure.
- What happens if a file is being processed and a new file is uploaded while that is happening? In theory that could leave things in an inconsistent state.
- Did I get the `File` and `Election` relationship right?
- We should probably use ISO-8601 for all our JSON dates. This PR doesn't change any others that might exist, but we should do that.
- There's a little bit of duplication of the CSV logic, but it's fairly minimal. Wasn't sure what the right abstraction would be so I just left it.