### PR TITLE
Add Election.audit_name required field

### DIFF
--- a/arlo-client/src/types.ts
+++ b/arlo-client/src/types.ts
@@ -139,8 +139,7 @@ export interface IElectionMeta {
   id: string
   name: string
   state: string
-  // eslint-disable-next-line camelcase
-  election_date: string
+  electionDate: string
 }
 
 export interface IOrganizationMeta {

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -21,9 +21,13 @@ class Organization(BaseModel):
     elections = relationship("Election", backref="organization", passive_deletes=True)
 
 
+# Election is a slight misnomer - this model represents an audit.
 class Election(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
-    name = db.Column(db.String(200), nullable=True)
+    # audit_name must be unique within each Organization
+    audit_name = db.Column(db.String(200), nullable=False)
+    # election_name can be the same across audits
+    election_name = db.Column(db.String(200), nullable=True)
     state = db.Column(db.String(100), nullable=True)
     election_date = db.Column(db.Date, nullable=True)
     election_type = db.Column(db.String(200), nullable=True)
@@ -53,6 +57,8 @@ class Election(BaseModel):
         db.String(200), db.ForeignKey("file.id", ondelete="set null"), nullable=True
     )
     jurisdictions_file = relationship("File")
+
+    __table_args__ = (db.UniqueConstraint("organization_id", "audit_name"),)
 
 
 # these are typically counties

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+import pytest
+import json
+from flask.testing import FlaskClient
+
+from arlo_server import app, db
+from helpers import post_json
+
+# The fixtures in this module are available in any test via dependency
+# injection.
+
+
+@pytest.fixture
+def client() -> FlaskClient:
+    app.config["TESTING"] = True
+    client = app.test_client()
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+    yield client
+
+    db.session.commit()
+
+
+@pytest.fixture
+def election_id(client: FlaskClient, request) -> str:
+    rv = post_json(
+        client,
+        "/election/new",
+        {"auditName": f"Test Audit {request.function.__name__}"},
+    )
+    election_id = json.loads(rv.data)["electionId"]
+    yield election_id

--- a/tests/test_app_upload_jurisdictions_file.py
+++ b/tests/test_app_upload_jurisdictions_file.py
@@ -17,24 +17,7 @@ from arlo_server.models import (
 from bgcompute import bgcompute_update_election_jurisdictions_file
 
 
-@pytest.fixture
-def client() -> FlaskClient:
-    app.config["TESTING"] = True
-    client = app.test_client()
-
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-
-    yield client
-
-    db.session.commit()
-
-
-def test_missing_file(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_missing_file(client, election_id):
     rv = client.put(f"/election/{election_id}/jurisdictions/file")
     assert rv.status_code == 400
     assert json.loads(rv.data) == {
@@ -47,10 +30,7 @@ def test_missing_file(client):
     }
 
 
-def test_bad_csv_file(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_bad_csv_file(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={"jurisdictions": (io.BytesIO(b"not a CSV file"), "random.txt")},
@@ -72,10 +52,7 @@ def test_bad_csv_file(client):
     }
 
 
-def test_missing_one_csv_field(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_missing_one_csv_field(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={
@@ -97,10 +74,7 @@ def test_missing_one_csv_field(client):
     }
 
 
-def test_metadata(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_metadata(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={
@@ -148,10 +122,7 @@ def test_metadata(client):
     assert processing["error"] == None
 
 
-def test_replace_jurisdictions_file(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_replace_jurisdictions_file(client, election_id):
     # Create the initial file.
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
@@ -181,10 +152,7 @@ def test_replace_jurisdictions_file(client):
     assert File.query.count() == 1, "the old file should have been deleted"
 
 
-def test_no_jurisdiction(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_no_jurisdiction(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={
@@ -206,10 +174,7 @@ def test_no_jurisdiction(client):
     assert User.query.count() == 0
 
 
-def test_single_jurisdiction_single_admin(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_single_jurisdiction_single_admin(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={
@@ -234,10 +199,7 @@ def test_single_jurisdiction_single_admin(client):
     ]
 
 
-def test_single_jurisdiction_multiple_admins(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_single_jurisdiction_multiple_admins(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={
@@ -265,10 +227,7 @@ def test_single_jurisdiction_multiple_admins(client):
     ]
 
 
-def test_multiple_jurisdictions_single_admin(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-
+def test_multiple_jurisdictions_single_admin(client, election_id):
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={

--- a/tests/test_audit_basic_update.py
+++ b/tests/test_audit_basic_update.py
@@ -2,14 +2,9 @@ import json, uuid
 import pytest
 
 from helpers import post_json
-from test_app import client
 
 
-def test_audit_basic_update_create_contest(client):
-    rv = client.post("/election/new")
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_audit_basic_update_create_contest(client, election_id):
     contest_id = str(uuid.uuid4())
     candidate_id_1 = str(uuid.uuid4())
     candidate_id_2 = str(uuid.uuid4())
@@ -42,11 +37,7 @@ def test_audit_basic_update_create_contest(client):
     assert json.loads(rv.data)["status"] == "ok"
 
 
-def test_audit_basic_update_sets_default_for_contest_is_targeted(client):
-    rv = client.post("/election/new")
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_audit_basic_update_sets_default_for_contest_is_targeted(client, election_id):
     contest_id = str(uuid.uuid4())
     candidate_id_1 = str(uuid.uuid4())
     candidate_id_2 = str(uuid.uuid4())

--- a/tests/test_audit_status.py
+++ b/tests/test_audit_status.py
@@ -8,17 +8,10 @@ from helpers import (
     assert_is_date,
     assert_is_passphrase,
 )
-from test_app import (
-    client,
-    setup_whole_audit,
-)
+from test_app import setup_whole_audit
 
 
-def test_audit_status(client):
-    rv = client.post("/election/new")
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_audit_status(client, election_id):
     (
         url_prefix,
         contest_id,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,26 +1,16 @@
 import pytest, json, uuid
 from unittest.mock import patch, Mock, MagicMock
 
-from arlo_server import app
 from arlo_server.routes import (
     set_loggedin_user,
     clear_loggedin_user,
     auth0_aa,
     auth0_ja,
     create_organization,
-    create_election,
     UserType,
 )
 from arlo_server.models import *
 from tests.helpers import create_org_and_admin
-
-
-@pytest.fixture
-def client():
-    app.config["TESTING"] = True
-    client = app.test_client()
-
-    yield client
 
 
 def _setup_user(client, user_type, user_email):
@@ -30,15 +20,19 @@ def _setup_user(client, user_type, user_email):
 
 def test_auth_me(client):
     org_id, user_id = create_org_and_admin("Test Org", "admin@example.com")
-    election_id = create_election(organization_id=org_id)
+    election = Election(
+        id=str(uuid.uuid4()), audit_name="Test /auth/me", organization_id=org_id
+    )
     jurisdiction = Jurisdiction(
-        election_id=election_id, id=str(uuid.uuid4()), name="Test Jurisdiction"
+        election_id=election.id, id=str(uuid.uuid4()), name="Test Jurisdiction"
     )
     j_admin = JurisdictionAdministration(
         user_id=user_id, jurisdiction_id=jurisdiction.id
     )
+    election_id = election.id
     j_id = jurisdiction.id
 
+    db.session.add(election)
     db.session.add(jurisdiction)
     db.session.add(j_admin)
     db.session.commit()
@@ -56,9 +50,10 @@ def test_auth_me(client):
                 "elections": [
                     {
                         "id": election_id,
-                        "name": "",
+                        "auditName": "Test /auth/me",
+                        "electionName": None,
                         "state": None,
-                        "election_date": None,
+                        "electionDate": None,
                     }
                 ],
             }
@@ -69,9 +64,10 @@ def test_auth_me(client):
                 "name": "Test Jurisdiction",
                 "election": {
                     "id": election_id,
-                    "name": "",
+                    "auditName": "Test /auth/me",
+                    "electionName": None,
                     "state": None,
-                    "election_date": None,
+                    "electionDate": None,
                 },
             }
         ],
@@ -110,15 +106,18 @@ def test_jurisdictionadmin_start(client):
 
 def test_jurisdictionadmin_callback(client):
     org = create_organization("Test Organization")
-    election_id = create_election(organization_id=org.id)
+    election = Election(
+        id=str(uuid.uuid4()), audit_name="Test JA callback", organization_id=org.id
+    )
     jurisdiction = Jurisdiction(
-        election_id=election_id, id=str(uuid.uuid4()), name="Test Jurisdiction"
+        election_id=election.id, id=str(uuid.uuid4()), name="Test Jurisdiction"
     )
     u = User(
         id=str(uuid.uuid4()), email="bar@example.com", external_id="bar@example.com"
     )
     j_admin = JurisdictionAdministration(user_id=u.id, jurisdiction_id=jurisdiction.id)
 
+    db.session.add(election)
     db.session.add(jurisdiction)
     db.session.add(u)
     db.session.add(j_admin)

--- a/tests/test_ballot_list.py
+++ b/tests/test_ballot_list.py
@@ -3,7 +3,6 @@ import json
 import pytest
 
 from test_app import (
-    client,
     post_json,
     setup_whole_audit,
     setup_whole_multi_winner_audit,
@@ -11,11 +10,7 @@ from test_app import (
 import bgcompute
 
 
-def test_ballot_list_jurisdiction_two_rounds(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_ballot_list_jurisdiction_two_rounds(client, election_id):
     (
         url_prefix,
         contest_id,
@@ -79,11 +74,7 @@ def test_ballot_list_jurisdiction_two_rounds(client):
     assert len(ballot_list) == sample_size
 
 
-def test_ballot_list_audit_board_two_rounds(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_ballot_list_audit_board_two_rounds(client, election_id):
     (
         url_prefix,
         contest_id,
@@ -155,11 +146,7 @@ def test_ballot_list_audit_board_two_rounds(client):
     assert len(ballot_list) == sample_size
 
 
-def test_ballot_list_jurisdiction_ordering(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_ballot_list_jurisdiction_ordering(client, election_id):
     (
         url_prefix,
         contest_id,
@@ -197,11 +184,7 @@ def test_ballot_list_jurisdiction_ordering(client):
     assert unsorted_ballots == sorted_ballots
 
 
-def test_ballot_list_audit_board_ordering(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_ballot_list_audit_board_ordering(client, election_id):
     (
         url_prefix,
         contest_id,

--- a/tests/test_contests.py
+++ b/tests/test_contests.py
@@ -1,23 +1,15 @@
 import pytest
+from flask.testing import FlaskClient
 
 import json, uuid, io
 from typing import List
 
 from helpers import post_json, put_json
-from test_app import client
 from arlo_server.models import Jurisdiction
 
 
 @pytest.fixture()
-def election_id(client) -> str:
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-    yield election_id
-
-
-@pytest.fixture()
-def jurisdiction_ids(client, election_id: str) -> List[str]:
+def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
     rv = client.put(
         f"/election/{election_id}/jurisdictions/file",
         data={

--- a/tests/test_jurisdiction_bulk_update.py
+++ b/tests/test_jurisdiction_bulk_update.py
@@ -24,7 +24,7 @@ def db():
 
 def test_first_update(db):
     org = Organization(id=str(uuid.uuid4()), name="Test Org")
-    election = Election(id=str(uuid.uuid4()), organization=org)
+    election = Election(id=str(uuid.uuid4()), audit_name="Test Audit", organization=org)
     new_admins = bulk_update_jurisdictions(
         db.session, election, [("Jurisdiction #1", "bob.harris@ca.gov")]
     )
@@ -41,7 +41,7 @@ def test_first_update(db):
 
 def test_idempotent(db):
     org = Organization(id=str(uuid.uuid4()), name="Test Org")
-    election = Election(id=str(uuid.uuid4()), organization=org)
+    election = Election(id=str(uuid.uuid4()), audit_name="Test Audit", organization=org)
 
     # Do it once.
     bulk_update_jurisdictions(
@@ -63,7 +63,7 @@ def test_idempotent(db):
 
 def test_remove_outdated_jurisdictions(db):
     org = Organization(id=str(uuid.uuid4()), name="Test Org")
-    election = Election(id=str(uuid.uuid4()), organization=org)
+    election = Election(id=str(uuid.uuid4()), audit_name="Test Audit", organization=org)
 
     # Add jurisdictions.
     bulk_update_jurisdictions(

--- a/tests/test_new_election.py
+++ b/tests/test_new_election.py
@@ -1,4 +1,4 @@
-import json
+import json, uuid
 import pytest
 from flask.testing import FlaskClient
 from typing import Any
@@ -8,29 +8,17 @@ from arlo_server.routes import create_organization, UserType
 from tests.helpers import create_org_and_admin, set_logged_in_user, post_json
 
 
-@pytest.fixture
-def client() -> FlaskClient:
-    app.config["TESTING"] = True
-    client = app.test_client()
-
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-
-    yield client
-
-    db.session.commit()
-
-
 def test_without_org_with_anonymous_user(client: FlaskClient):
-    rv = client.post("/election/new")
-    assert json.loads(rv.data)["electionId"]
+    rv = post_json(client, "/election/new", {"auditName": "Test Audit"})
     assert rv.status_code == 200
+    assert json.loads(rv.data)["electionId"]
 
 
 def test_in_org_with_anonymous_user(client: FlaskClient):
     org = create_organization()
-    rv = post_json(client, "/election/new", {"organizationId": org.id})
+    rv = post_json(
+        client, "/election/new", {"auditName": "Test Audit", "organizationId": org.id}
+    )
     assert json.loads(rv.data) == {
         "errors": [
             {
@@ -48,7 +36,9 @@ def test_in_org_with_logged_in_admin(client: FlaskClient):
         client, user_type=UserType.AUDIT_ADMIN, user_email="admin@example.com"
     )
 
-    rv = post_json(client, "/election/new", {"organizationId": org_id})
+    rv = post_json(
+        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id}
+    )
     response = json.loads(rv.data)
     election_id = response.get("electionId", None)
     assert election_id, response
@@ -65,7 +55,9 @@ def test_in_org_with_logged_in_admin_without_access(client: FlaskClient):
         client, user_type=UserType.AUDIT_ADMIN, user_email="admin1@example.com"
     )
 
-    rv = post_json(client, "/election/new", {"organizationId": org2_id})
+    rv = post_json(
+        client, "/election/new", {"auditName": "Test Audit", "organizationId": org2_id}
+    )
     assert json.loads(rv.data) == {
         "errors": [
             {
@@ -83,7 +75,9 @@ def test_in_org_with_logged_in_jurisdiction_admin(client: FlaskClient):
         client, user_type=UserType.JURISDICTION_ADMIN, user_email="admin@example.com"
     )
 
-    rv = post_json(client, "/election/new", {"organizationId": org_id})
+    rv = post_json(
+        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id}
+    )
     assert json.loads(rv.data) == {
         "errors": [
             {
@@ -93,3 +87,95 @@ def test_in_org_with_logged_in_jurisdiction_admin(client: FlaskClient):
         ]
     }
     assert rv.status_code == 403
+
+
+def test_missing_audit_name(client: FlaskClient):
+    rv = post_json(client, "/election/new", {})
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "'auditName' is a required property",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+
+
+def test_without_org_duplicate_audit_name(client: FlaskClient):
+    rv = post_json(client, "/election/new", {"auditName": "Test Audit"})
+    assert rv.status_code == 200
+    assert json.loads(rv.data)["electionId"]
+
+    rv = post_json(client, "/election/new", {"auditName": "Test Audit"})
+    assert rv.status_code == 200
+    assert json.loads(rv.data)["electionId"]
+
+
+def test_in_org_duplicate_audit_name(client: FlaskClient):
+    org_id, _user_id = create_org_and_admin(user_email="admin@example.com")
+    set_logged_in_user(
+        client, user_type=UserType.AUDIT_ADMIN, user_email="admin@example.com"
+    )
+
+    rv = post_json(
+        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id}
+    )
+    assert rv.status_code == 200
+    assert json.loads(rv.data)["electionId"]
+
+    rv = post_json(
+        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id}
+    )
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": f"An audit with name 'Test Audit' already exists within your organization",
+                "errorType": "Conflict",
+            }
+        ]
+    }
+
+
+def test_two_orgs_same_name(client: FlaskClient):
+    org_id_1, _ = create_org_and_admin(user_email="admin1@example.com")
+    org_id_2, _ = create_org_and_admin(user_email="admin2@example.com")
+    set_logged_in_user(
+        client, user_type=UserType.AUDIT_ADMIN, user_email="admin1@example.com"
+    )
+
+    rv = post_json(
+        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id_1}
+    )
+    assert rv.status_code == 200
+    assert json.loads(rv.data)["electionId"]
+
+    set_logged_in_user(
+        client, user_type=UserType.AUDIT_ADMIN, user_email="admin2@example.com"
+    )
+
+    rv = post_json(
+        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id_2}
+    )
+    assert rv.status_code == 200
+    assert json.loads(rv.data)["electionId"]
+
+
+def test_election_reset(client, election_id):
+    rv = client.post(f"/election/{election_id}/audit/reset")
+    assert json.loads(rv.data) == {"status": "ok"}
+
+    rv = client.get(f"/election/{election_id}/audit/status")
+    status = json.loads(rv.data)
+
+    assert status["riskLimit"] == None
+    assert status["randomSeed"] == None
+    assert status["contests"] == []
+    assert status["jurisdictions"] == []
+    assert status["rounds"] == []
+
+
+def test_election_reset_not_found(client, election_id):
+    rv = client.post(f"/election/{str(uuid.uuid4())}/audit/reset")
+    assert rv.status_code == 404

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -3,7 +3,7 @@ import json, random
 import pytest
 
 from helpers import post_json
-from test_app import client, setup_whole_audit, run_whole_audit_flow
+from test_app import setup_whole_audit, run_whole_audit_flow
 import bgcompute
 
 
@@ -62,11 +62,7 @@ def run_audit_round(
     return len(ballot_list)
 
 
-def test_offline_audit_report(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_offline_audit_report(client, election_id):
     run_whole_audit_flow(
         client, election_id, "Primary 2019", 10, "12345678901234567890"
     )
@@ -104,11 +100,7 @@ def test_offline_audit_report(client):
     assert len(lines) == len(expected) + 3
 
 
-def test_one_round_audit_report(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_one_round_audit_report(client, election_id):
     (
         url_prefix,
         contest_id,
@@ -201,11 +193,7 @@ def test_one_round_audit_report(client):
     assert len(lines) == len(expected) + 3 + num_ballots - NUM_BALLOTS_SAMPLED_TWICE
 
 
-def test_two_round_audit_report(client):
-    rv = post_json(client, "/election/new", {})
-    election_id = json.loads(rv.data)["electionId"]
-    assert election_id
-
+def test_two_round_audit_report(client, election_id):
     (
         url_prefix,
         contest_id,


### PR DESCRIPTION
**Description**

Task: #345 
Unblocks: #349 

Adds `auditName` as a required field to `POST /election/new`. Also moves `Election.name` to `Election.election_name`.

Note: does not break `/audit/basic`, which still expects the `name` field (which corresponds to `election_name`.

**Testing**

Tests have to be updated everywhere because they all rely on `/election/new` to initialize the election. We pull this out into a universal fixture. Yay dependency injection!

Also adds one test to ensure `auditName` is required.

**Progress**

Ready for review. Sorry for the tedious test changes (just know they were even more tedious to make than they are to review!)