### PR TITLE
fix: require audit admin role to reset elections

### DIFF
--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -1311,8 +1311,11 @@ def pretty_affiliation(affiliation):
 
 @app.route("/election/<election_id>/audit/reset", methods=["POST"])
 def audit_reset(election_id):
+    election = Election.query.filter_by(id=election_id).one()
+    require_audit_admin_for_organization(election.organization_id)
+
     # deleting the election cascades to all the data structures
-    Election.query.filter_by(id=election_id).delete()
+    db.session.delete(election)
     db.session.commit()
 
     create_election(election_id)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,6 +29,11 @@ def set_logged_in_user(
         session["_user"] = {"type": user_type, "email": user_email}
 
 
+def clear_logged_in_user(client: FlaskClient):
+    with client.session_transaction() as session:
+        session.pop("_user")
+
+
 def create_user(email=DEFAULT_USER_EMAIL):
     user = User(id=str(uuid.uuid4()), email=email, external_id=email)
     db.session.add(user)


### PR DESCRIPTION
**Description**

Refs #290 
Piggybacks on ~#359~ #362

**Testing**

Adds a test case ensuring that only audit admins for an organization can reset elections in that organization. Also adds a test helper to clear the logged-in user.

**Progress**

I know authorization isn't the highest priority thing right now, but this is a particularly destructive action so I wanted it to be restricted sooner rather than later.
