### PR TITLE
fix: proess async jurisdictions file upload

### DIFF
--- a/tests/test_jurisdictions.py
+++ b/tests/test_jurisdictions.py
@@ -7,6 +7,7 @@ from helpers import post_json, compare_json, assert_is_date, create_org_and_admi
 from test_app import client
 from arlo_server.routes import create_election, UserType
 from arlo_server.models import Jurisdiction
+from bgcompute import bgcompute_update_election_jurisdictions_file
 
 
 @pytest.fixture()
@@ -43,6 +44,7 @@ def jurisdiction_ids(client, election_id: str) -> List[str]:
         },
     )
     assert json.loads(rv.data) == {"status": "ok"}
+    bgcompute_update_election_jurisdictions_file()
     jurisdictions = Jurisdiction.query.filter_by(election_id=election_id).all()
     yield [j.id for j in jurisdictions]
 


### PR DESCRIPTION
**Description**

Without this, `jurisdiction_ids` will always be an empty array. This was breaking `master`. This was a logical merge conflict between the test refactor and making the jurisdictions file upload async.

**Testing**

This PR is all about the testing. So much testing.

**Progress**

It's perfect now and always will be.
