### PR TITLE
refactor: extract auth functions into module

### DIFF
--- a/arlo_server/auth.py
+++ b/arlo_server/auth.py
@@ -1,0 +1,57 @@
+from enum import Enum
+from flask import session
+from typing import Optional, Tuple, Union
+from werkzeug.exceptions import Unauthorized, Forbidden
+
+from arlo_server.models import User
+
+
+class UserType(str, Enum):
+    AUDIT_ADMIN = "audit_admin"
+    JURISDICTION_ADMIN = "jurisdiction_admin"
+
+
+def set_loggedin_user(user_type: UserType, user_email: str):
+    session["_user"] = {"type": user_type, "email": user_email}
+
+
+def get_loggedin_user() -> Union[Tuple[UserType, str], Tuple[None, None]]:
+    user = session.get("_user", None)
+    return (user["type"], user["email"]) if user else (None, None)
+
+
+def get_loggedin_user_record():
+    user_type, user_email = get_loggedin_user()
+    return (
+        (user_type, User.query.filter_by(email=user_email).one())
+        if user_email
+        else (None, None)
+    )
+
+
+def clear_loggedin_user():
+    session["_user"] = None
+
+
+def require_audit_admin_for_organization(organization_id: Optional[str]):
+    if not organization_id:
+        return
+
+    user_type, user = get_loggedin_user_record()
+
+    if not user:
+        raise Unauthorized(
+            description=f"Anonymous users do not have access to organization {organization_id}"
+        )
+
+    if user_type != UserType.AUDIT_ADMIN:
+        raise Forbidden(
+            description=f"{user.email} is not logged in as an audit admin and so does not have access to organization {organization_id}"
+        )
+
+    for org in user.organizations:
+        if org.id == organization_id:
+            return
+    raise Forbidden(
+        description=f"{user.email} does not have access to organization {organization_id}"
+    )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,7 +3,8 @@ from email.utils import parsedate_to_datetime
 from typing import Any, Optional
 from flask.testing import FlaskClient
 
-from arlo_server.routes import create_organization, UserType
+from arlo_server.auth import UserType
+from arlo_server.routes import create_organization
 from arlo_server.models import db, AuditAdministration, User
 
 DEFAULT_USER_EMAIL = "admin@example.com"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,14 +2,12 @@ import pytest, json, uuid
 from unittest.mock import patch, Mock, MagicMock
 
 from arlo_server import app
+from arlo_server.auth import set_loggedin_user, clear_loggedin_user, UserType
 from arlo_server.routes import (
-    set_loggedin_user,
-    clear_loggedin_user,
     auth0_aa,
     auth0_ja,
     create_organization,
     create_election,
-    UserType,
 )
 from arlo_server.models import *
 from tests.helpers import create_org_and_admin

--- a/tests/test_jurisdictions.py
+++ b/tests/test_jurisdictions.py
@@ -5,7 +5,8 @@ from typing import List
 
 from helpers import post_json, compare_json, assert_is_date, create_org_and_admin
 from test_app import client
-from arlo_server.routes import create_election, UserType
+from arlo_server.auth import UserType
+from arlo_server.routes import create_election
 from arlo_server.models import Jurisdiction
 from bgcompute import bgcompute_update_election_jurisdictions_file
 

--- a/tests/test_new_election.py
+++ b/tests/test_new_election.py
@@ -4,7 +4,8 @@ from flask.testing import FlaskClient
 from typing import Any
 
 from arlo_server import app, db
-from arlo_server.routes import create_organization, UserType
+from arlo_server.auth import UserType
+from arlo_server.routes import create_organization
 from tests.helpers import create_org_and_admin, set_logged_in_user, post_json
 
 


### PR DESCRIPTION
**Description**

Pulls most auth-related functionality out of the mega-file `arlo_server.routes` to `arlo_server.auth`.

**Testing**

Covered by existing tests as there should be no changes in behavior.

**Progress**

I would like to start splitting routes out into their own files and this will help unblock that.
