### PR TITLE
Hiding reset button when user is authenticated

### DIFF
--- a/arlo-client/src/components/Audit/ResetButton.test.tsx
+++ b/arlo-client/src/components/Audit/ResetButton.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, wait } from '@testing-library/react'
 import { toast } from 'react-toastify'
 import ResetButton from './ResetButton'
 import * as utilities from '../utilities'
+import AuthDataProvider from '../UserContext'
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
@@ -13,7 +14,7 @@ const checkAndToastMock: jest.SpyInstance<
   Parameters<typeof utilities.checkAndToast>
 > = jest.spyOn(utilities, 'checkAndToast').mockReturnValue(false)
 
-apiMock.mockImplementationOnce(async () => '{}')
+apiMock.mockImplementationOnce(async () => ({}))
 checkAndToastMock.mockReturnValue(false)
 const toastSpy = jest.spyOn(toast, 'error').mockImplementation()
 
@@ -29,6 +30,30 @@ describe('ResetButton', () => {
     const { container } = render(
       <ResetButton electionId="1" updateAudit={updateAuditMock} />
     )
+    expect(container).toMatchSnapshot()
+  })
+
+  it('does not render when authenticated', () => {
+    apiMock.mockImplementation(async () => ({
+      type: 'audit_admin',
+      name: 'Joe',
+      email: 'test@email.org',
+      jurisdictions: [],
+      organizations: [
+        {
+          id: 'org-id',
+          name: 'State',
+          elections: [],
+        },
+      ],
+    }))
+    const updateAuditMock = jest.fn()
+    const { container, queryAllByText } = render(
+      <AuthDataProvider>
+        <ResetButton electionId="1" updateAudit={updateAuditMock} />
+      </AuthDataProvider>
+    )
+    expect(queryAllByText('Clear & Restart').length).toBe(0)
     expect(container).toMatchSnapshot()
   })
 

--- a/arlo-client/src/components/Audit/ResetButton.tsx
+++ b/arlo-client/src/components/Audit/ResetButton.tsx
@@ -4,6 +4,7 @@ import { Button } from '@blueprintjs/core'
 import { toast } from 'react-toastify'
 import { api, checkAndToast } from '../utilities'
 import { IErrorResponse } from '../../types'
+import { useAuthDataContext } from '../UserContext'
 
 interface IProps {
   updateAudit: () => void
@@ -16,6 +17,7 @@ const ResetButton: React.FC<IProps> = ({
   disabled,
   updateAudit,
 }: IProps) => {
+  const { isAuthenticated } = useAuthDataContext()
   const resetButtonWrapper = document.getElementById('reset-button-wrapper')
   const reset = async () => {
     try {
@@ -31,7 +33,7 @@ const ResetButton: React.FC<IProps> = ({
       toast.error(err.message)
     }
   }
-  if (resetButtonWrapper) {
+  if (resetButtonWrapper && !isAuthenticated) {
     return ReactDOM.createPortal(
       <Button onClick={reset} icon="refresh" disabled={disabled}>
         Clear &amp; Restart

--- a/arlo-client/src/components/Audit/__snapshots__/ResetButton.test.tsx.snap
+++ b/arlo-client/src/components/Audit/__snapshots__/ResetButton.test.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ResetButton does not render when authenticated 1`] = `<div />`;
+
 exports[`ResetButton renders 1`] = `<div />`;
 
 exports[`ResetButton renders disabled 1`] = `<div />`;


### PR DESCRIPTION
**Description**

- Made the reset button not show if the user is authenticated, since it's only useful on the single page flow, and hazardous on the multi jurisdiction flow.

**Testing**

- Testing that it vanishes when it isn't wanted

**Progress**

- Should be good to go!