### PR TITLE
Add Election.is_multi_jurisdiction flag

### DIFF
--- a/arlo-client/src/components/CreateAudit.test.tsx
+++ b/arlo-client/src/components/CreateAudit.test.tsx
@@ -59,7 +59,10 @@ describe('CreateAudit', () => {
       expect(apiMock).toBeCalledTimes(1)
       expect(apiMock).toHaveBeenNthCalledWith(1, '/election/new', {
         method: 'POST',
-        body: JSON.stringify({ auditName: 'Audit Name' }),
+        body: JSON.stringify({
+          auditName: 'Audit Name',
+          isMultiJurisdiction: false,
+        }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -119,6 +122,7 @@ describe('CreateAudit', () => {
         body: JSON.stringify({
           organizationId: 'org-id',
           auditName: 'Audit Name',
+          isMultiJurisdiction: true,
         }),
         headers: {
           'Content-Type': 'application/json',

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -50,8 +50,12 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
     try {
       setLoading(true)
       const data = isAuthenticated
-        ? { organizationId: meta!.organizations[0].id, auditName }
-        : { auditName }
+        ? {
+            organizationId: meta!.organizations[0].id,
+            auditName,
+            isMultiJurisdiction: true,
+          }
+        : { auditName, isMultiJurisdiction: false }
       const response: { electionId: string } | IErrorResponse = await api(
         '/election/new',
         {

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -38,6 +38,10 @@ class Election(BaseModel):
     # an election is "online" if every ballot is entered online, vs. offline in a tally sheet.
     online = db.Column(db.Boolean, nullable=False, default=False)
 
+    # False for our old single-jurisdiction flow,
+    # True for our new multi-jurisdiction flow
+    is_multi_jurisdiction = db.Column(db.Boolean, nullable=False)
+
     # Who does this election belong to?
     organization_id = db.Column(
         db.String(200),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import json
 from flask.testing import FlaskClient
 
 from arlo_server import app, db
-from helpers import post_json
+from helpers import post_json, create_election
 
 # The fixtures in this module are available in any test via dependency
 # injection.
@@ -24,11 +24,6 @@ def client() -> FlaskClient:
 
 
 @pytest.fixture
-def election_id(client: FlaskClient, request) -> str:
-    rv = post_json(
-        client,
-        "/election/new",
-        {"auditName": f"Test Audit {request.function.__name__}"},
-    )
-    election_id = json.loads(rv.data)["electionId"]
+def election_id(client: FlaskClient) -> str:
+    election_id = create_election(client)
     yield election_id

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -47,6 +47,24 @@ def create_org_and_admin(org_name="Test Org", user_email=DEFAULT_USER_EMAIL):
     return org.id, u.id
 
 
+def create_election(
+    client: FlaskClient,
+    audit_name: str = "Test Audit",
+    organization_id: str = None,
+    is_multi_jurisdiction: bool = True,
+):
+    rv = post_json(
+        client,
+        "/election/new",
+        {
+            "auditName": audit_name,
+            "organizationId": organization_id,
+            "isMultiJurisdiction": is_multi_jurisdiction,
+        },
+    )
+    return json.loads(rv.data)["electionId"]
+
+
 def assert_is_id(x):
     assert isinstance(x, str)
     uuid.UUID(x, version=4)  # Will raise exception on non-UUID strings

--- a/tests/test_audit_status.py
+++ b/tests/test_audit_status.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from flask.testing import FlaskClient
 
 from helpers import (
     post_json,
@@ -7,8 +8,15 @@ from helpers import (
     assert_is_id,
     assert_is_date,
     assert_is_passphrase,
+    create_election,
 )
 from test_app import setup_whole_audit
+
+
+@pytest.fixture()
+def election_id(client: FlaskClient) -> str:
+    election_id = create_election(client, is_multi_jurisdiction=False)
+    yield election_id
 
 
 def test_audit_status(client, election_id):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,7 +19,10 @@ def _setup_user(client, user_type, user_email):
 def test_auth_me(client):
     org_id, user_id = create_org_and_admin("Test Org", "admin@example.com")
     election = Election(
-        id=str(uuid.uuid4()), audit_name="Test /auth/me", organization_id=org_id
+        id=str(uuid.uuid4()),
+        audit_name="Test /auth/me",
+        organization_id=org_id,
+        is_multi_jurisdiction=True,
     )
     jurisdiction = Jurisdiction(
         election_id=election.id, id=str(uuid.uuid4()), name="Test Jurisdiction"
@@ -52,6 +55,7 @@ def test_auth_me(client):
                         "electionName": None,
                         "state": None,
                         "electionDate": None,
+                        "isMultiJurisdiction": True,
                     }
                 ],
             }
@@ -66,6 +70,7 @@ def test_auth_me(client):
                     "electionName": None,
                     "state": None,
                     "electionDate": None,
+                    "isMultiJurisdiction": True,
                 },
             }
         ],
@@ -105,7 +110,10 @@ def test_jurisdictionadmin_start(client):
 def test_jurisdictionadmin_callback(client):
     org = create_organization("Test Organization")
     election = Election(
-        id=str(uuid.uuid4()), audit_name="Test JA callback", organization_id=org.id
+        id=str(uuid.uuid4()),
+        audit_name="Test JA callback",
+        organization_id=org.id,
+        is_multi_jurisdiction=True,
     )
     jurisdiction = Jurisdiction(
         election_id=election.id, id=str(uuid.uuid4()), name="Test Jurisdiction"

--- a/tests/test_ballot_list.py
+++ b/tests/test_ballot_list.py
@@ -1,13 +1,17 @@
 import json
+from flask.testing import FlaskClient
 
 import pytest
 
-from test_app import (
-    post_json,
-    setup_whole_audit,
-    setup_whole_multi_winner_audit,
-)
+from helpers import post_json, create_election
+from test_app import setup_whole_audit, setup_whole_multi_winner_audit
 import bgcompute
+
+
+@pytest.fixture()
+def election_id(client: FlaskClient) -> str:
+    election_id = create_election(client, is_multi_jurisdiction=False)
+    yield election_id
 
 
 def test_ballot_list_jurisdiction_two_rounds(client, election_id):

--- a/tests/test_jurisdiction_bulk_update.py
+++ b/tests/test_jurisdiction_bulk_update.py
@@ -24,7 +24,12 @@ def db():
 
 def test_first_update(db):
     org = Organization(id=str(uuid.uuid4()), name="Test Org")
-    election = Election(id=str(uuid.uuid4()), audit_name="Test Audit", organization=org)
+    election = Election(
+        id=str(uuid.uuid4()),
+        audit_name="Test Audit",
+        organization=org,
+        is_multi_jurisdiction=True,
+    )
     new_admins = bulk_update_jurisdictions(
         db.session, election, [("Jurisdiction #1", "bob.harris@ca.gov")]
     )
@@ -41,7 +46,12 @@ def test_first_update(db):
 
 def test_idempotent(db):
     org = Organization(id=str(uuid.uuid4()), name="Test Org")
-    election = Election(id=str(uuid.uuid4()), audit_name="Test Audit", organization=org)
+    election = Election(
+        id=str(uuid.uuid4()),
+        audit_name="Test Audit",
+        organization=org,
+        is_multi_jurisdiction=True,
+    )
 
     # Do it once.
     bulk_update_jurisdictions(
@@ -63,7 +73,12 @@ def test_idempotent(db):
 
 def test_remove_outdated_jurisdictions(db):
     org = Organization(id=str(uuid.uuid4()), name="Test Org")
-    election = Election(id=str(uuid.uuid4()), audit_name="Test Audit", organization=org)
+    election = Election(
+        id=str(uuid.uuid4()),
+        audit_name="Test Audit",
+        organization=org,
+        is_multi_jurisdiction=True,
+    )
 
     # Add jurisdictions.
     bulk_update_jurisdictions(

--- a/tests/test_jurisdictions.py
+++ b/tests/test_jurisdictions.py
@@ -11,24 +11,6 @@ from bgcompute import bgcompute_update_election_jurisdictions_file
 
 
 @pytest.fixture()
-def audit_admin_email(client: FlaskClient) -> str:
-    user_email = "admin@example.com"
-    with client.session_transaction() as session:
-        session["_user"] = {"type": UserType.AUDIT_ADMIN, "email": user_email}
-    return user_email
-
-
-@pytest.fixture()
-def election_id(client: FlaskClient, audit_admin_email: str) -> str:
-    org_id, _ = create_org_and_admin("Test Org", audit_admin_email)
-    rv = post_json(
-        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id}
-    )
-    election_id = json.loads(rv.data)["electionId"]
-    yield election_id
-
-
-@pytest.fixture()
 def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
     # We expect the list endpoint to order the jurisdictions by name, so we
     # upload them out of order.
@@ -49,6 +31,7 @@ def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
     assert json.loads(rv.data) == {"status": "ok"}
     bgcompute_update_election_jurisdictions_file()
     jurisdictions = Jurisdiction.query.filter_by(election_id=election_id).all()
+    assert len(jurisdictions) == 3
     yield [j.id for j in jurisdictions]
 
 

--- a/tests/test_new_election.py
+++ b/tests/test_new_election.py
@@ -10,7 +10,11 @@ from tests.helpers import create_org_and_admin, set_logged_in_user, post_json
 
 
 def test_without_org_with_anonymous_user(client: FlaskClient):
-    rv = post_json(client, "/election/new", {"auditName": "Test Audit"})
+    rv = post_json(
+        client,
+        "/election/new",
+        {"auditName": "Test Audit", "isMultiJurisdiction": False},
+    )
     assert rv.status_code == 200
     assert json.loads(rv.data)["electionId"]
 
@@ -18,7 +22,13 @@ def test_without_org_with_anonymous_user(client: FlaskClient):
 def test_in_org_with_anonymous_user(client: FlaskClient):
     org = create_organization()
     rv = post_json(
-        client, "/election/new", {"auditName": "Test Audit", "organizationId": org.id}
+        client,
+        "/election/new",
+        {
+            "auditName": "Test Audit",
+            "organizationId": org.id,
+            "isMultiJurisdiction": True,
+        },
     )
     assert json.loads(rv.data) == {
         "errors": [
@@ -38,7 +48,13 @@ def test_in_org_with_logged_in_admin(client: FlaskClient):
     )
 
     rv = post_json(
-        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id}
+        client,
+        "/election/new",
+        {
+            "auditName": "Test Audit",
+            "organizationId": org_id,
+            "isMultiJurisdiction": True,
+        },
     )
     response = json.loads(rv.data)
     election_id = response.get("electionId", None)
@@ -57,7 +73,13 @@ def test_in_org_with_logged_in_admin_without_access(client: FlaskClient):
     )
 
     rv = post_json(
-        client, "/election/new", {"auditName": "Test Audit", "organizationId": org2_id}
+        client,
+        "/election/new",
+        {
+            "auditName": "Test Audit",
+            "organizationId": org2_id,
+            "isMultiJurisdiction": True,
+        },
     )
     assert json.loads(rv.data) == {
         "errors": [
@@ -77,7 +99,13 @@ def test_in_org_with_logged_in_jurisdiction_admin(client: FlaskClient):
     )
 
     rv = post_json(
-        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id}
+        client,
+        "/election/new",
+        {
+            "auditName": "Test Audit",
+            "organizationId": org_id,
+            "isMultiJurisdiction": True,
+        },
     )
     assert json.loads(rv.data) == {
         "errors": [
@@ -104,11 +132,19 @@ def test_missing_audit_name(client: FlaskClient):
 
 
 def test_without_org_duplicate_audit_name(client: FlaskClient):
-    rv = post_json(client, "/election/new", {"auditName": "Test Audit"})
+    rv = post_json(
+        client,
+        "/election/new",
+        {"auditName": "Test Audit", "isMultiJurisdiction": False},
+    )
     assert rv.status_code == 200
     assert json.loads(rv.data)["electionId"]
 
-    rv = post_json(client, "/election/new", {"auditName": "Test Audit"})
+    rv = post_json(
+        client,
+        "/election/new",
+        {"auditName": "Test Audit", "isMultiJurisdiction": False},
+    )
     assert rv.status_code == 200
     assert json.loads(rv.data)["electionId"]
 
@@ -120,13 +156,25 @@ def test_in_org_duplicate_audit_name(client: FlaskClient):
     )
 
     rv = post_json(
-        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id}
+        client,
+        "/election/new",
+        {
+            "auditName": "Test Audit",
+            "organizationId": org_id,
+            "isMultiJurisdiction": True,
+        },
     )
     assert rv.status_code == 200
     assert json.loads(rv.data)["electionId"]
 
     rv = post_json(
-        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id}
+        client,
+        "/election/new",
+        {
+            "auditName": "Test Audit",
+            "organizationId": org_id,
+            "isMultiJurisdiction": True,
+        },
     )
     assert rv.status_code == 409
     assert json.loads(rv.data) == {
@@ -147,7 +195,13 @@ def test_two_orgs_same_name(client: FlaskClient):
     )
 
     rv = post_json(
-        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id_1}
+        client,
+        "/election/new",
+        {
+            "auditName": "Test Audit",
+            "organizationId": org_id_1,
+            "isMultiJurisdiction": True,
+        },
     )
     assert rv.status_code == 200
     assert json.loads(rv.data)["electionId"]
@@ -157,7 +211,13 @@ def test_two_orgs_same_name(client: FlaskClient):
     )
 
     rv = post_json(
-        client, "/election/new", {"auditName": "Test Audit", "organizationId": org_id_2}
+        client,
+        "/election/new",
+        {
+            "auditName": "Test Audit",
+            "organizationId": org_id_2,
+            "isMultiJurisdiction": True,
+        },
     )
     assert rv.status_code == 200
     assert json.loads(rv.data)["electionId"]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,10 +1,17 @@
 import json, random
+from flask.testing import FlaskClient
 
 import pytest
 
-from helpers import post_json
+from helpers import post_json, create_election
 from test_app import setup_whole_audit, run_whole_audit_flow
 import bgcompute
+
+
+@pytest.fixture()
+def election_id(client: FlaskClient) -> str:
+    election_id = create_election(client, is_multi_jurisdiction=False)
+    yield election_id
 
 
 def run_audit_round(


### PR DESCRIPTION
**Description**

Task: #358 
Instead of using the existence of Election.organization_id to tell us whether we're in the old single-jurisdiction flow or the new multi-jurisdiction flow, add a flag that tells us.

**Testing**

Updated existing tests to expect this flag. Specifically, `test_jurisdictions` tests the ballot manifest upload endpoint, which now relies on this flag.

**Progress**

Ready for review. @MorganLove I tried my hand at updating the frontend code to send this flag (and the frontend tests), since I figured it would be a small change. Let me know how you feel about it.
