### PR TITLE
doc: update URL for election settings

### DIFF
--- a/docs/api-proposal/proposed-routes.md
+++ b/docs/api-proposal/proposed-routes.md
@@ -27,8 +27,8 @@ New routes are in **bold**.
 
 ![](audit-settings.png)
 
-- **GET /election/<election_id>** - get audit settings (risk limit, name, etc)
-- **PUT /election/<election_id>** - update audit settings
+- **GET /election/<election_id>/settings** - get audit settings (risk limit, name, etc)
+- **PUT /election/<election_id>/settings** - update audit settings
 
 ![](review-and-launch.png)
 


### PR DESCRIPTION
**Description**

I changed the URL to not conflict in #364, so this updates the docs.

**Testing**

Docs-only, no tests.

**Progress**

Should be good to go.
