### PR TITLE
test: improve error messages for `compare_json`

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,7 @@
 import uuid, json, re
+import pytest
 from email.utils import parsedate_to_datetime
-from typing import Any, Optional
+from typing import Any, List, Optional, Union
 from flask.testing import FlaskClient
 
 from arlo_server.auth import UserType
@@ -88,22 +89,97 @@ def asserts_startswith(prefix: str):
     return assert_startswith
 
 
-# Checks that a json blob (represented as a Python dict) is equal-ish to an expected
-# dict. The expected dict can contain assertion functions in place of any non-deterministic values.
 def compare_json(actual_json, expected_json):
-    if isinstance(expected_json, dict):
-        assert isinstance(actual_json, dict)
-        for k, v in expected_json.items():
-            compare_json(actual_json[k], v)
-        assert actual_json.keys() == expected_json.keys()
-    elif isinstance(expected_json, list):
-        assert isinstance(actual_json, list)
-        for i, v in enumerate(expected_json):
-            compare_json(actual_json[i], v)
-        assert len(actual_json) == len(expected_json)
-    elif callable(expected_json):
-        expected_json(actual_json)
-    else:
-        assert (
-            actual_json == expected_json
-        ), f"Actual: {actual_json}\nExpected: {expected_json}"
+    """
+    Checks that a json blob (represented as a Python dict) is equal-ish to an
+    expected dict. The expected dict can contain assertion functions in place of
+    any non-deterministic values.
+    """
+
+    def serialize_keypath(keypath: List[Union[str, int]]) -> str:
+        return f"root{''.join([f'[{serialize_key(key)}]' for key in keypath])}"
+
+    def serialize_key(key: Union[str, int]) -> str:
+        return f'"{key}"' if isinstance(key, str) else f"{key}"
+
+    def inner_compare_json(
+        actual_json, expected_json, current_keypath: List[Union[str, int]]
+    ):
+        if isinstance(expected_json, dict):
+            assert isinstance(
+                actual_json, dict
+            ), f"expected dict, got {type(actual_json).__name__} at {serialize_keypath(current_keypath)}"
+            for k, v in expected_json.items():
+                inner_compare_json(actual_json[k], v, current_keypath + [k])
+            assert (
+                actual_json.keys() == expected_json.keys()
+            ), f"dict keys do not match at {serialize_keypath(current_keypath)}"
+        elif isinstance(expected_json, list):
+            assert isinstance(
+                actual_json, list
+            ), f"expected list, got {type(actual_json).__name__} at {serialize_keypath(current_keypath)}"
+            for i, v in enumerate(expected_json):
+                inner_compare_json(actual_json[i], v, current_keypath + [i])
+            assert len(actual_json) == len(
+                expected_json
+            ), f"list lengths do not match at {serialize_keypath(current_keypath)}"
+        elif callable(expected_json):
+            try:
+                expected_json(actual_json)
+            except Exception as error:
+                raise AssertionError(
+                    f"custom comparison failed at {serialize_keypath(current_keypath)}"
+                ) from error
+        else:
+            assert (
+                actual_json == expected_json
+            ), f"Actual: {actual_json}\nExpected: {expected_json}\nKeypath: {serialize_keypath(current_keypath)}"
+
+    inner_compare_json(actual_json, expected_json, [])
+
+
+def test_compare_json():
+    def asserts_gt(n: int):
+        def assert_gt(value: int):
+            assert isinstance(value, int)
+            assert value > n
+
+        return assert_gt
+
+    compare_json([], [])
+    compare_json({}, {})
+    compare_json("a", "a")
+    compare_json(1, 1)
+    compare_json([1, {}], [1, {}])
+    compare_json(1, asserts_gt(0))
+
+    with pytest.raises(AssertionError, match=r"Actual: 1\nExpected: 2\nKeypath: root"):
+        compare_json(1, 2)
+
+    with pytest.raises(
+        AssertionError, match=r'Actual: 1\nExpected: 2\nKeypath: root\["a"\]'
+    ):
+        compare_json({"a": 1}, {"a": 2})
+
+    with pytest.raises(AssertionError, match=r"dict keys do not match at root"):
+        compare_json({"a": 1}, {})
+
+    with pytest.raises(AssertionError, match=r"expected dict, got list at root"):
+        compare_json([], {})
+
+    with pytest.raises(AssertionError, match=r"expected list, got dict at root"):
+        compare_json({}, [])
+
+    with pytest.raises(AssertionError, match=r"list lengths do not match at root"):
+        compare_json([1], [])
+
+    with pytest.raises(
+        AssertionError, match=r"Actual: 2\nExpected: 3\nKeypath: root\[1\]"
+    ):
+        compare_json([1, 2], [1, 3])
+
+    with pytest.raises(AssertionError, match=r"custom comparison failed at root"):
+        compare_json(1, asserts_gt(1))
+
+    with pytest.raises(AssertionError, match=r"custom comparison failed at root\[2\]"):
+        compare_json([1, 2, 3], [asserts_gt(0), asserts_gt(1), asserts_gt(3)])


### PR DESCRIPTION
**Description**

Changes `compare_json` to keep track of the key path that lead to the values being compared and ensures that the path is included in the error message. The original assertion message is still included, but we now include a key path like so: `root["rounds"][0]["startedAt"]`.

**Testing**

`compare_json` doesn't have any tests of its own behavior, but is used in lots of tests.

**Progress**

I made this change while working on #344 since I was changing some deeply-nested fields and wasn't sure exactly which value `compare_json` was complaining about.
