### PR TITLE
refactor: extract ballot manifest file fields

### DIFF
--- a/arlo_server/jurisdictions.py
+++ b/arlo_server/jurisdictions.py
@@ -14,10 +14,14 @@ def serialize_jurisdiction(db_jurisdiction: Jurisdiction) -> dict:
         "id": db_jurisdiction.id,
         "name": db_jurisdiction.name,
         "ballotManifest": {
-            "filename": db_jurisdiction.manifest_filename,
+            "filename": db_jurisdiction.manifest_file.name
+            if db_jurisdiction.manifest_file
+            else None,
             "numBallots": db_jurisdiction.manifest_num_ballots,
             "numBatches": db_jurisdiction.manifest_num_batches,
-            "uploadedAt": isoformat(db_jurisdiction.manifest_uploaded_at),
+            "uploadedAt": isoformat(db_jurisdiction.manifest_file.uploaded_at)
+            if db_jurisdiction.manifest_file
+            else None,
         },
     }
 

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -72,17 +72,16 @@ class Jurisdiction(BaseModel):
         db.String(200), db.ForeignKey("election.id", ondelete="cascade"), nullable=False
     )
     name = db.Column(db.String(200), nullable=False)
-    manifest = db.Column(db.Text, nullable=True)
-    manifest_filename = db.Column(db.String(250), nullable=True)
-    manifest_uploaded_at = db.Column(db.DateTime(timezone=False), nullable=True)
     manifest_num_ballots = db.Column(db.Integer)
     manifest_num_batches = db.Column(db.Integer)
 
+    manifest_file_id = db.Column(
+        db.String(200), db.ForeignKey("file.id", ondelete="set null"), nullable=True
+    )
+    manifest_file = relationship("File")
+
     # any error in the upload? null == none
     manifest_errors = db.Column(db.Text, nullable=True)
-
-    # a JSON array of field names that are included in the CSV
-    manifest_fields = db.Column(db.Text, nullable=True)
 
     batches = relationship("Batch", backref="jurisdiction", passive_deletes=True)
     audit_boards = relationship(


### PR DESCRIPTION
**Description**

This will make it easier to process the ballot manifest file in the background (#344), re-using existing background file processing code.

**Testing**

Covered by existing tests as this should not change behavior.

**Progress**

This is progress toward #344.
