### PR TITLE
Remove unused params from sampler.draw_sample

### DIFF
--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -185,15 +185,8 @@ def sample_ballots(election, round):
         manifest[batch.name] = batch.num_ballots
         batch_id_from_name[batch.name] = batch.id
 
-    contests = [
-        sampler_contest.from_db_contest(contest) for contest in election.contests
-    ]
     sample = sampler.draw_sample(
-        election.random_seed,
-        contests,
-        manifest,
-        chosen_sample_size,
-        num_sampled=num_sampled,
+        election.random_seed, manifest, chosen_sample_size, num_sampled=num_sampled,
     )
 
     audit_boards = jurisdiction.audit_boards

--- a/audits/sampler.py
+++ b/audits/sampler.py
@@ -8,14 +8,13 @@ import operator
 import audits.macro as macro
 
 
-def draw_sample(
-    seed, contest, manifest, sample_size, num_sampled=0, batch_results=None
-):
+def draw_sample(seed, manifest, sample_size, num_sampled=0):
     """
     Draws uniform random sample with replacement of size <sample_size> from the
     provided ballot manifest.
 
     Inputs:
+        seed - random seed
         sample_size - number of ballots to randomly draw
         num_sampled - number of ballots that have already been sampled
         manifest - mapping of batches to the ballots they contain:

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -48,7 +48,7 @@ def test_draw_sample():
         "pct 4": 25,
     }
 
-    sample = sampler.draw_sample(seed, bravo_contests, manifest, 20)
+    sample = sampler.draw_sample(seed, manifest, 20)
 
     for i, item in enumerate(sample):
         expected = expected_sample[i]
@@ -67,7 +67,7 @@ def test_draw_more_samples():
     }
 
     samp_size = 10
-    sample = sampler.draw_sample(seed, bravo_contests, manifest, 10)
+    sample = sampler.draw_sample(seed, manifest, 10)
     assert samp_size == len(sample), "Received sample of size {}, expected {}".format(
         samp_size, len(sample)
     )
@@ -79,7 +79,7 @@ def test_draw_more_samples():
         )
 
     samp_size = 10
-    sample = sampler.draw_sample(seed, bravo_contests, manifest, 10, num_sampled=10)
+    sample = sampler.draw_sample(seed, manifest, 10, num_sampled=10)
     assert samp_size == len(sample), "Received sample of size {}, expected {}".format(
         samp_size, len(sample)
     )
@@ -132,49 +132,6 @@ def test_draw_more_macro_sample(macro_batches, macro_contest):
             item, expected
         )
 
-
-bravo_contests = {
-    "test1": {"cand1": 600, "cand2": 400, "ballots": 1000, "numWinners": 1},
-    "test2": {
-        "cand1": 600,
-        "cand2": 200,
-        "cand3": 100,
-        "ballots": 900,
-        "numWinners": 1,
-    },
-    "test3": {"cand1": 100, "ballots": 100, "numWinners": 1},
-    "test4": {"cand1": 100, "ballots": 100, "numWinners": 1},
-    "test5": {"cand1": 500, "cand2": 500, "ballots": 1000, "numWinners": 1},
-    "test6": {
-        "cand1": 300,
-        "cand2": 200,
-        "cand3": 200,
-        "ballots": 1000,
-        "numWinners": 1,
-    },
-    "test7": {
-        "cand1": 300,
-        "cand2": 200,
-        "cand3": 100,
-        "ballots": 700,
-        "numWinners": 2,
-    },
-    "test8": {
-        "cand1": 300,
-        "cand2": 300,
-        "cand3": 100,
-        "ballots": 700,
-        "numWinners": 2,
-    },
-    "test9": {"cand1": 300, "cand2": 200, "ballots": 700, "numWinners": 2},
-    "test10": {
-        "cand1": 600,
-        "cand2": 300,
-        "cand3": 100,
-        "ballots": 1000,
-        "numWinners": 2,
-    },
-}
 
 expected_sample = [
     ("0.000617786", ("pct 2", 3), 1),


### PR DESCRIPTION
**Description**

The `contest` and `batch_results` parameters are not needed in `draw_sample`, so this PR removes them.

**Testing**

Updated existing tests.

**Progress**

Ready for review.