### PR TITLE
feat: process ballot manifest uploads in the background

### DIFF
--- a/API.md
+++ b/API.md
@@ -55,9 +55,20 @@ poll until those values are filled.
         }
       ],
       "ballotManifest": {
-        "filename": "Adams_County_Manifest.csv",
+        "file": {
+          "name": "Adams_County_Manifest.csv",
+          "uploadedAt": "2019-06-17 11:45:00"
+        },
+        "processing": {
+          "status": "PROCESSED",
+          "startedAt": "2019-06-17 11:45:00",
+          "completedAt": "2019-06-17 11:45:03",
+          "error": null
+        },
         "numBallots": 123456,
         "numBatches": 560,
+        // Deprecated fields.
+        "filename": "Adams_County_Manifest.csv",
         "uploadedAt": "2019-06-17 11:45:00"
       }
     }
@@ -177,7 +188,7 @@ poll until those values are filled.
 }
 ```
 
-- `POST /election/{electionId}/jurisdiction/<jurisdiction_id>/manifest` -- the ballot manifest
+- `PUT /election/{electionId}/jurisdiction/<jurisdiction_id>/manifest` -- the ballot manifest
 
 straight file upload `multipart/form-data`
 

--- a/arlo-client/docs/api_sequence.md
+++ b/arlo-client/docs/api_sequence.md
@@ -317,15 +317,15 @@ status endpoint again.
 }
 ```
 
-Now that the front end has the `jurisdiction_id` available, it can POST the
+Now that the front end has the `jurisdiction_id` available, it can PUT the
 ballot manifest:
 
-- `POST /election/{electionId}/jurisdiction/<jurisdiction_id>/manifest`
+- `PUT /election/{electionId}/jurisdiction/<jurisdiction_id>/manifest`
 
 - `src/components/Audit/SelectBallotsToAudit.tsx` > `SelectBallotsToAudit` >
   `handlePost()` > `api()` Straight file upload `multipart/form-data`
 
-And then GET the updated status:
+And then GET the updated status.:
 
 - `GET /election/{electionId}/audit/status`
 

--- a/arlo-client/src/components/Audit/SelectBallotsToAudit.tsx
+++ b/arlo-client/src/components/Audit/SelectBallotsToAudit.tsx
@@ -171,7 +171,7 @@ const SelectBallotsToAudit: React.FC<IProps> = ({
         const errorResponse: IErrorResponse = await api(
           `/election/${electionId}/jurisdiction/${jurisdictionID}/manifest`,
           {
-            method: 'POST',
+            method: 'PUT',
             body: formData,
           }
         )

--- a/arlo_server/jurisdictions.py
+++ b/arlo_server/jurisdictions.py
@@ -7,6 +7,7 @@ from arlo_server.routes import (
     isoformat,
 )
 from arlo_server.models import Jurisdiction
+from util.process_file import serialize_file, serialize_file_processing
 
 
 def serialize_jurisdiction(db_jurisdiction: Jurisdiction) -> dict:
@@ -14,14 +15,14 @@ def serialize_jurisdiction(db_jurisdiction: Jurisdiction) -> dict:
         "id": db_jurisdiction.id,
         "name": db_jurisdiction.name,
         "ballotManifest": {
-            "filename": db_jurisdiction.manifest_file.name
+            "file": serialize_file(db_jurisdiction.manifest_file)
+            if db_jurisdiction.manifest_file
+            else None,
+            "processing": serialize_file_processing(db_jurisdiction.manifest_file)
             if db_jurisdiction.manifest_file
             else None,
             "numBallots": db_jurisdiction.manifest_num_ballots,
             "numBatches": db_jurisdiction.manifest_num_batches,
-            "uploadedAt": isoformat(db_jurisdiction.manifest_file.uploaded_at)
-            if db_jurisdiction.manifest_file
-            else None,
         },
     }
 

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -80,9 +80,6 @@ class Jurisdiction(BaseModel):
     )
     manifest_file = relationship("File")
 
-    # any error in the upload? null == none
-    manifest_errors = db.Column(db.Text, nullable=True)
-
     batches = relationship("Batch", backref="jurisdiction", passive_deletes=True)
     audit_boards = relationship(
         "AuditBoard", backref="jurisdiction", passive_deletes=True

--- a/audits/sampler.py
+++ b/audits/sampler.py
@@ -2,13 +2,16 @@
 import math
 import numpy as np
 from scipy import stats
+from typing import cast, Any, Dict, List, Tuple
 import consistent_sampler
 import operator
 
 import audits.macro as macro
 
 
-def draw_sample(seed, manifest, sample_size, num_sampled=0):
+def draw_sample(
+    seed: str, manifest: Dict[str, int], sample_size: int, num_sampled=0
+) -> List[Tuple[str, Tuple[str, int], int]]:
     """
     Draws uniform random sample with replacement of size <sample_size> from the
     provided ballot manifest.
@@ -42,15 +45,21 @@ def draw_sample(seed, manifest, sample_size, num_sampled=0):
         for i in range(manifest[batch]):
             ballots.append((batch, i))
 
-    return list(
-        consistent_sampler.sampler(
-            ballots,
-            seed=seed,
-            take=sample_size + num_sampled,
-            with_replacement=True,
-            output="tuple",
-        )
-    )[num_sampled:]
+    return cast(
+        # The signature of `consistent_sampler.sampler` can't be represented by
+        # mypy yet, so it is typed as a less specific version of what it really
+        # is. This casts it back to the more specific version.
+        List[Tuple[str, Tuple[str, int], int]],
+        list(
+            consistent_sampler.sampler(
+                ballots,
+                seed=seed,
+                take=sample_size + num_sampled,
+                with_replacement=True,
+                output="tuple",
+            )
+        )[num_sampled:],
+    )
 
 
 def draw_ppeb_sample(
@@ -81,9 +90,6 @@ def draw_ppeb_sample(
                     ...
                 ]
     """
-
-    # Here we do PPEB.
-    margins = contest.margins
 
     assert batch_results, "Must have batch-level results to use MACRO"
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -210,22 +210,23 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
     # upload the manifest
     data = {}
     data["manifest"] = (open(manifest_file_path, "rb"), "manifest.csv")
-    rv = client.post(
+    rv = client.put(
         "{}/jurisdiction/{}/manifest".format(url_prefix, jurisdiction_id),
         data=data,
         content_type="multipart/form-data",
     )
 
     assert json.loads(rv.data)["status"] == "ok"
+    assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     rv = client.get("{}/audit/status".format(url_prefix))
     status = json.loads(rv.data)
     manifest = status["jurisdictions"][0]["ballotManifest"]
 
-    assert manifest["filename"] == "manifest.csv"
     assert manifest["numBallots"] == 86147
     assert manifest["numBatches"] == 484
-    assert manifest["uploadedAt"]
+    assert manifest["file"]["name"] == "manifest.csv"
+    assert manifest["file"]["uploadedAt"]
 
     # delete the manifest and make sure that works
     rv = client.delete(
@@ -237,19 +238,19 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
     status = json.loads(rv.data)
     manifest = status["jurisdictions"][0]["ballotManifest"]
 
-    assert manifest["filename"] is None
-    assert manifest["uploadedAt"] is None
+    assert manifest["file"] is None
 
     # upload the manifest again
     data = {}
     data["manifest"] = (open(manifest_file_path, "rb"), "manifest.csv")
-    rv = client.post(
+    rv = client.put(
         "{}/jurisdiction/{}/manifest".format(url_prefix, jurisdiction_id),
         data=data,
         content_type="multipart/form-data",
     )
 
     assert json.loads(rv.data)["status"] == "ok"
+    assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     setup_audit_board(client, election_id, jurisdiction_id, audit_board_id_1)
 
@@ -402,22 +403,23 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
     # upload the manifest
     data = {}
     data["manifest"] = (open(manifest_file_path, "rb"), "manifest.csv")
-    rv = client.post(
+    rv = client.put(
         "{}/jurisdiction/{}/manifest".format(url_prefix, jurisdiction_id),
         data=data,
         content_type="multipart/form-data",
     )
 
     assert json.loads(rv.data)["status"] == "ok"
+    assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     rv = client.get("{}/audit/status".format(url_prefix))
     status = json.loads(rv.data)
     manifest = status["jurisdictions"][0]["ballotManifest"]
 
-    assert manifest["filename"] == "manifest.csv"
     assert manifest["numBallots"] == 86147
     assert manifest["numBatches"] == 484
-    assert manifest["uploadedAt"]
+    assert manifest["file"]["name"] == "manifest.csv"
+    assert manifest["file"]["uploadedAt"]
 
     # delete the manifest and make sure that works
     rv = client.delete(
@@ -429,19 +431,19 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
     status = json.loads(rv.data)
     manifest = status["jurisdictions"][0]["ballotManifest"]
 
-    assert manifest["filename"] is None
-    assert manifest["uploadedAt"] is None
+    assert manifest["file"] is None
 
     # upload the manifest again
     data = {}
     data["manifest"] = (open(manifest_file_path, "rb"), "manifest.csv")
-    rv = client.post(
+    rv = client.put(
         "{}/jurisdiction/{}/manifest".format(url_prefix, jurisdiction_id),
         data=data,
         content_type="multipart/form-data",
     )
 
     assert json.loads(rv.data)["status"] == "ok"
+    assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     # get the retrieval list for round 1
     rv = client.get(
@@ -657,22 +659,23 @@ def test_small_election(client, election_id):
     # upload the manifest
     data = {}
     data["manifest"] = (open(small_manifest_file_path, "rb"), "small-manifest.csv")
-    rv = client.post(
+    rv = client.put(
         f"/election/{election_id}/jurisdiction/{jurisdiction_id}/manifest",
         data=data,
         content_type="multipart/form-data",
     )
 
     assert json.loads(rv.data)["status"] == "ok"
+    assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
     manifest = status["jurisdictions"][0]["ballotManifest"]
 
-    assert manifest["filename"] == "small-manifest.csv"
     assert manifest["numBallots"] == 2117
     assert manifest["numBatches"] == 10
-    assert manifest["uploadedAt"]
+    assert manifest["file"]["name"] == "small-manifest.csv"
+    assert manifest["file"]["uploadedAt"]
 
     # get the retrieval list for round 1
     rv = client.get(
@@ -974,22 +977,23 @@ def test_multi_winner_election(client, election_id):
     # upload the manifest
     data = {}
     data["manifest"] = (open(small_manifest_file_path, "rb"), "small-manifest.csv")
-    rv = client.post(
+    rv = client.put(
         f"/election/{election_id}/jurisdiction/{jurisdiction_id}/manifest",
         data=data,
         content_type="multipart/form-data",
     )
 
     assert json.loads(rv.data)["status"] == "ok"
+    assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
     manifest = status["jurisdictions"][0]["ballotManifest"]
 
-    assert manifest["filename"] == "small-manifest.csv"
     assert manifest["numBallots"] == 2117
     assert manifest["numBatches"] == 10
-    assert manifest["uploadedAt"]
+    assert manifest["file"]["name"] == "small-manifest.csv"
+    assert manifest["file"]["uploadedAt"]
 
     # get the retrieval list for round 1
     rv = client.get(

--- a/tests/test_audit_status.py
+++ b/tests/test_audit_status.py
@@ -11,6 +11,7 @@ from helpers import (
     create_election,
 )
 from test_app import setup_whole_audit
+from util.process_file import ProcessingStatus
 
 
 @pytest.fixture()
@@ -80,9 +81,16 @@ def test_audit_status(client, election_id):
                         },
                     ],
                     "ballotManifest": {
-                        "filename": "manifest.csv",
+                        "file": {"name": "manifest.csv", "uploadedAt": assert_is_date},
+                        "processing": {
+                            "status": ProcessingStatus.PROCESSED,
+                            "startedAt": assert_is_date,
+                            "completedAt": assert_is_date,
+                            "error": None,
+                        },
                         "numBallots": 86147,
                         "numBatches": 484,
+                        "filename": "manifest.csv",
                         "uploadedAt": assert_is_date,
                     },
                     "batches": lambda x: x,  # pass

--- a/tests/test_jurisdictions.py
+++ b/tests/test_jurisdictions.py
@@ -7,7 +7,10 @@ from typing import List
 from helpers import post_json, compare_json, assert_is_date, create_org_and_admin
 from arlo_server.auth import UserType
 from arlo_server.models import Jurisdiction
-from bgcompute import bgcompute_update_election_jurisdictions_file
+from bgcompute import (
+    bgcompute_update_election_jurisdictions_file,
+    bgcompute_update_ballot_manifest_file,
+)
 
 
 @pytest.fixture()
@@ -49,37 +52,37 @@ def test_jurisdictions_list_no_manifest(client, election_id, jurisdiction_ids):
             "id": jurisdiction_ids[2],
             "name": "J1",
             "ballotManifest": {
-                "filename": None,
+                "file": None,
+                "processing": None,
                 "numBallots": None,
                 "numBatches": None,
-                "uploadedAt": None,
             },
         },
         {
             "id": jurisdiction_ids[0],
             "name": "J2",
             "ballotManifest": {
-                "filename": None,
+                "file": None,
+                "processing": None,
                 "numBallots": None,
                 "numBatches": None,
-                "uploadedAt": None,
             },
         },
         {
             "id": jurisdiction_ids[1],
             "name": "J3",
             "ballotManifest": {
-                "filename": None,
+                "file": None,
+                "processing": None,
                 "numBallots": None,
                 "numBatches": None,
-                "uploadedAt": None,
             },
         },
     ]
 
 
 def test_jurisdictions_list_with_manifest(client, election_id, jurisdiction_ids):
-    rv = client.post(
+    rv = client.put(
         f"/election/{election_id}/jurisdiction/{jurisdiction_ids[2]}/manifest",
         data={
             "manifest": (
@@ -95,6 +98,7 @@ def test_jurisdictions_list_with_manifest(client, election_id, jurisdiction_ids)
         },
     )
     assert json.loads(rv.data) == {"status": "ok"}
+    assert bgcompute_update_ballot_manifest_file() == 1
 
     rv = client.get(f"/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)
@@ -103,30 +107,35 @@ def test_jurisdictions_list_with_manifest(client, election_id, jurisdiction_ids)
             "id": jurisdiction_ids[2],
             "name": "J1",
             "ballotManifest": {
-                "filename": "manifest.csv",
+                "file": {"name": "manifest.csv", "uploadedAt": assert_is_date},
+                "processing": {
+                    "status": "PROCESSED",
+                    "startedAt": assert_is_date,
+                    "completedAt": assert_is_date,
+                    "error": None,
+                },
                 "numBallots": 23 + 101 + 122 + 400,
                 "numBatches": 4,
-                "uploadedAt": assert_is_date,
             },
         },
         {
             "id": jurisdiction_ids[0],
             "name": "J2",
             "ballotManifest": {
-                "filename": None,
+                "file": None,
+                "processing": None,
                 "numBallots": None,
                 "numBatches": None,
-                "uploadedAt": None,
             },
         },
         {
             "id": jurisdiction_ids[1],
             "name": "J3",
             "ballotManifest": {
-                "filename": None,
+                "file": None,
+                "processing": None,
                 "numBallots": None,
                 "numBatches": None,
-                "uploadedAt": None,
             },
         },
     ]

--- a/util/ballot_manifest.py
+++ b/util/ballot_manifest.py
@@ -1,0 +1,172 @@
+import csv
+import io
+import locale
+import uuid
+from sqlalchemy.orm.session import Session
+from typing import Dict, List, Tuple
+from werkzeug.exceptions import BadRequest
+
+from audits import sampler, sampler_contest
+from arlo_server.models import (
+    Batch,
+    Election,
+    File,
+    Jurisdiction,
+    Round,
+    SampledBallot,
+    SampledBallotDraw,
+)
+from util.binpacking import BalancedBucketList, Bucket
+from util.process_file import process_file
+
+BATCH_NAME = "Batch Name"
+NUMBER_OF_BALLOTS = "Number of Ballots"
+STORAGE_LOCATION = "Storage Location"
+TABULATOR = "Tabulator"
+
+
+def process_ballot_manifest_file(
+    session: Session, jurisdiction: Jurisdiction, file: File
+):
+    assert jurisdiction.manifest_file_id == file.id
+
+    def process():
+        manifest_csv = csv.DictReader(io.StringIO(file.contents))
+
+        missing_fields = [
+            field
+            for field in [BATCH_NAME, NUMBER_OF_BALLOTS]
+            if field not in manifest_csv.fieldnames
+        ]
+
+        if missing_fields:
+            raise Exception(f"Missing required CSV fields: {', '.join(missing_fields)}")
+
+        num_batches = 0
+        num_ballots = 0
+        for row in manifest_csv:
+            num_ballots_in_batch_csv = row[NUMBER_OF_BALLOTS]
+
+            try:
+                num_ballots_in_batch = locale.atoi(num_ballots_in_batch_csv)
+            except ValueError as error:
+                raise Exception(
+                    f"Invalid value for '{NUMBER_OF_BALLOTS}' on line {manifest_csv.line_num}: {num_ballots_in_batch}"
+                ) from error
+
+            batch = Batch(
+                id=str(uuid.uuid4()),
+                name=row[BATCH_NAME],
+                jurisdiction_id=jurisdiction.id,
+                num_ballots=num_ballots_in_batch,
+                storage_location=row.get(STORAGE_LOCATION, None),
+                tabulator=row.get(TABULATOR, None),
+            )
+            session.add(batch)
+            num_batches += 1
+            num_ballots += batch.num_ballots
+
+        jurisdiction.manifest_num_ballots = num_ballots
+        jurisdiction.manifest_num_batches = num_batches
+
+    process_file(session, file, process)
+
+    election = jurisdiction.election
+
+    # If we're in the single-jurisdiction flow, posting the ballot manifest
+    # starts the first round, so we need to sample the ballots.
+    # In the multi-jurisdiction flow, this happens after all jurisdictions
+    # upload manifests, and is triggered by a different endpoint.
+    if not election.is_multi_jurisdiction:
+        sample_ballots(session, election, election.rounds[0])
+
+
+def sample_ballots(session: Session, election: Election, round: Round):
+    # assume only one contest
+    round_contest = round.round_contests[0]
+    jurisdiction = election.jurisdictions[0]
+
+    num_sampled = (
+        session.query(SampledBallotDraw)
+        .join(SampledBallotDraw.batch)
+        .filter_by(jurisdiction_id=jurisdiction.id)
+        .count()
+    )
+    if not num_sampled:
+        num_sampled = 0
+
+    chosen_sample_size = round_contest.sample_size
+
+    # the sampler needs to have the same inputs given the same manifest
+    # so we use the batch name, rather than the batch id
+    # (because the batch ID is an internally generated uuid
+    #  that changes from one run to the next.)
+    manifest = {}
+    batch_id_from_name = {}
+    for batch in jurisdiction.batches:
+        manifest[batch.name] = batch.num_ballots
+        batch_id_from_name[batch.name] = batch.id
+
+    sample = sampler.draw_sample(
+        election.random_seed, manifest, chosen_sample_size, num_sampled=num_sampled,
+    )
+
+    audit_boards = jurisdiction.audit_boards
+
+    batch_sizes: Dict[str, int] = {}
+    batches_to_ballots: Dict[str, List[Tuple[int, str, int]]] = {}
+    # Build batch - batch_size map
+    for (ticket_number, (batch_name, ballot_position), sample_number) in sample:
+        if batch_name in batch_sizes:
+            if (
+                sample_number == 1
+            ):  # if we've already seen it, it doesn't affect batch size
+                batch_sizes[batch_name] += 1
+            batches_to_ballots[batch_name].append(
+                (ballot_position, ticket_number, sample_number)
+            )
+        else:
+            batch_sizes[batch_name] = 1
+            batches_to_ballots[batch_name] = [
+                (ballot_position, ticket_number, sample_number)
+            ]
+
+    # Create the buckets and initially assign batches
+    buckets = [Bucket(audit_board.name) for audit_board in audit_boards]
+    for i, batch in enumerate(batch_sizes):
+        buckets[i % len(audit_boards)].add_batch(batch, batch_sizes[batch])
+
+    # Now assign batchest fairly
+    bl = BalancedBucketList(buckets)
+
+    # read audit board and batch info out
+    for audit_board_num, bucket in enumerate(bl.buckets):
+        audit_board = audit_boards[audit_board_num]
+        for batch_name in bucket.batches:
+
+            for (ballot_position, ticket_number, sample_number) in batches_to_ballots[
+                batch_name
+            ]:
+                # sampler is 0-indexed, we're 1-indexing here
+                ballot_position += 1
+
+                batch_id = batch_id_from_name[batch_name]
+
+                if sample_number == 1:
+                    sampled_ballot = SampledBallot(
+                        batch_id=batch_id,
+                        ballot_position=ballot_position,
+                        audit_board_id=audit_board.id,
+                    )
+                    session.add(sampled_ballot)
+
+                sampled_ballot_draw = SampledBallotDraw(
+                    batch_id=batch_id,
+                    ballot_position=ballot_position,
+                    round_id=round.id,
+                    ticket_number=ticket_number,
+                )
+
+                session.add(sampled_ballot_draw)
+
+    session.commit()

--- a/util/isoformat.py
+++ b/util/isoformat.py
@@ -1,0 +1,11 @@
+import datetime
+from typing import Optional, Union
+
+
+def isoformat(
+    datetime: Optional[Union[datetime.datetime, datetime.date]]
+) -> Optional[str]:
+    if datetime is not None:
+        return datetime.isoformat()
+    else:
+        return None

--- a/util/process_file.py
+++ b/util/process_file.py
@@ -1,9 +1,10 @@
 import datetime
-from typing import Callable
+from typing import Any, Callable, Dict
 from sqlalchemy import update
 from sqlalchemy.orm.session import Session
 
-from arlo_server.models import File
+from arlo_server.models import File, ProcessingStatus
+from util.isoformat import isoformat
 
 
 def process_file(session: Session, file: File, callback: Callable[[], None]) -> bool:
@@ -34,3 +35,33 @@ def process_file(session: Session, file: File, callback: Callable[[], None]) -> 
         file.processing_error = str(error)
         session.commit()
         raise error
+
+
+def serialize_file(file: File, contents=False) -> Dict[str, Any]:
+    result = {
+        "name": file.name,
+        "uploadedAt": isoformat(file.uploaded_at),
+    }
+
+    if contents:
+        result["contents"] = file.contents
+
+    return result
+
+
+def serialize_file_processing(file: File) -> Dict[str, Any]:
+    if file.processing_error:
+        status = ProcessingStatus.ERRORED
+    elif file.processing_completed_at:
+        status = ProcessingStatus.PROCESSED
+    elif file.processing_started_at:
+        status = ProcessingStatus.PROCESSING
+    else:
+        status = ProcessingStatus.READY_TO_PROCESS
+
+    return {
+        "status": status,
+        "startedAt": isoformat(file.processing_started_at),
+        "completedAt": isoformat(file.processing_completed_at),
+        "error": file.processing_error,
+    }


### PR DESCRIPTION
**Description**

This tries to maintain as much backward-compatibility as possible, but one breaking change is that the endpoint changed from POST to PUT. I updated the API docs and the frontend code to use PUT.

**Testing**

Adjusts current tests, but doesn't really add any new ones.

**Progress**

The front-end still needs to be updated to check the `ballotManifest.processing.status` value.