### PR TITLE
Add GET /election/<election_id>/sample-sizes

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -17,3 +17,4 @@ import arlo_server.election_settings
 import arlo_server.routes
 import arlo_server.contests
 import arlo_server.jurisdictions
+import arlo_server.sample_sizes

--- a/arlo_server/sample_sizes.py
+++ b/arlo_server/sample_sizes.py
@@ -1,0 +1,55 @@
+from flask import jsonify, request
+from collections import defaultdict
+import math
+from werkzeug.exceptions import BadRequest
+from typing import Dict
+
+from arlo_server import app, db
+from arlo_server.models import Election, Contest
+from arlo_server.routes import require_audit_admin_for_organization
+from audits import bravo, sampler_contest
+
+
+@app.route("/election/<election_id>/sample-sizes", methods=["GET"])
+def get_sample_sizes(election_id: str):
+    election = Election.query.get_or_404(election_id)
+    require_audit_admin_for_organization(election.organization_id)
+
+    if not election.contests:
+        raise BadRequest("Cannot compute sample sizes until contests are set")
+    if not election.risk_limit:
+        raise BadRequest("Cannot compute sample sizes until risk limit is set")
+
+    # For now, we only support one targeted contest
+    contest = next(c for c in election.contests if c.is_targeted)
+
+    # Sum the audit results from previous rounds
+    results_by_choice: Dict[str, int] = defaultdict(int)
+    for result in contest.results:
+        results_by_choice[result.contest_choice_id] += result.result
+    results_so_far = {contest.id: results_by_choice}
+
+    # Do the math!
+    sample_sizes = bravo.get_sample_size(
+        election.risk_limit / 100,
+        sampler_contest.from_db_contest(contest),
+        results_so_far,
+    )
+
+    # Convert the results into a slightly more regular format
+    json_sizes = []
+    for prob, size in sample_sizes.items():
+        if prob == "asn":
+            json_sizes.append(
+                {
+                    "type": "ASN",
+                    "prob": round(size["prob"], 2),
+                    "size": int(math.ceil(size["size"])),
+                }
+            )
+        else:
+            json_sizes.append(
+                {"type": None, "prob": prob, "size": int(math.ceil(size)),}
+            )
+
+    return jsonify({"sampleSizes": json_sizes})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 import pytest
-import json
 from flask.testing import FlaskClient
+import json, io
+from typing import List
 
 from arlo_server import app, db
+from arlo_server.models import Jurisdiction
 from helpers import post_json, create_election
 
 # The fixtures in this module are available in any test via dependency
@@ -27,3 +29,24 @@ def client() -> FlaskClient:
 def election_id(client: FlaskClient) -> str:
     election_id = create_election(client)
     yield election_id
+
+
+@pytest.fixture
+def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
+    rv = client.put(
+        f"/election/{election_id}/jurisdiction/file",
+        data={
+            "jurisdictions": (
+                io.BytesIO(
+                    b"Jurisdiction,Admin Email\n"
+                    b"J1,a1@example.com\n"
+                    b"J2,a2@example.com\n"
+                    b"J3,a3@example.com"
+                ),
+                "jurisdictions.csv",
+            )
+        },
+    )
+    assert json.loads(rv.data) == {"status": "ok"}
+    jurisdictions = Jurisdiction.query.filter_by(election_id=election_id).all()
+    yield [j.id for j in jurisdictions]

--- a/tests/test_contests.py
+++ b/tests/test_contests.py
@@ -1,33 +1,10 @@
 import pytest
 from flask.testing import FlaskClient
 
-import json, uuid, io
-from typing import List
+import json, uuid
 
 from helpers import post_json, put_json
 from arlo_server.models import Jurisdiction
-
-
-@pytest.fixture()
-def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
-    rv = client.put(
-        f"/election/{election_id}/jurisdiction/file",
-        data={
-            "jurisdictions": (
-                io.BytesIO(
-                    b"Jurisdiction,Admin Email\n"
-                    b"J1,a1@example.com\n"
-                    b"J2,a2@example.com\n"
-                    b"J3,a3@example.com"
-                ),
-                "jurisdictions.csv",
-            )
-        },
-    )
-    assert json.loads(rv.data) == {"status": "ok"}
-    # TODO use the /elections/<election_id>/jurisdictions endpoint here once it's built
-    jurisdictions = Jurisdiction.query.filter_by(election_id=election_id).all()
-    yield [j.id for j in jurisdictions]
 
 
 def test_contests_list_empty(client, election_id):

--- a/tests/test_sample_sizes.py
+++ b/tests/test_sample_sizes.py
@@ -1,0 +1,83 @@
+import pytest
+from flask.testing import FlaskClient
+from typing import List
+import json, uuid
+
+from helpers import put_json
+from arlo_server.models import USState
+
+
+@pytest.fixture
+def contest(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]) -> str:
+    contest = {
+        "id": str(uuid.uuid4()),
+        "name": "Contest 1",
+        "isTargeted": True,
+        "choices": [
+            {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 600,},
+            {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 400,},
+        ],
+        "totalBallotsCast": 1000,
+        "numWinners": 1,
+        "votesAllowed": 1,
+        "jurisdictionIds": jurisdiction_ids,
+    }
+    rv = put_json(client, f"/election/{election_id}/contest", [contest])
+    assert json.loads(rv.data) == {"status": "ok"}
+    yield contest
+
+
+@pytest.fixture
+def election_settings(client: FlaskClient, election_id: str) -> None:
+    settings = {
+        "electionName": "Test Election",
+        "online": True,
+        "randomSeed": "1234567890",
+        "riskLimit": 10,
+        "state": USState.California,
+    }
+    rv = put_json(client, f"/election/{election_id}/settings", settings)
+    assert json.loads(rv.data) == {"status": "ok"}
+
+
+def test_sample_sizes_without_contests(client: FlaskClient, election_id: str):
+    rv = client.get(f"/election/{election_id}/sample-sizes")
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "Cannot compute sample sizes until contests are set",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+
+
+def test_sample_sizes_without_risk_limit(
+    client: FlaskClient, election_id: str, contest: str
+):
+    rv = client.get(f"/election/{election_id}/sample-sizes")
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "Cannot compute sample sizes until risk limit is set",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+
+
+def test_sample_sizes_round_1(
+    client: FlaskClient, election_id: str, contest: str, election_settings: None
+):
+    rv = client.get(f"/election/{election_id}/sample-sizes")
+    sample_sizes = json.loads(rv.data)
+    assert sample_sizes == {
+        "sampleSizes": [
+            {"prob": 0.52, "size": 119, "type": "ASN"},
+            {"prob": 0.7, "size": 184, "type": None},
+            {"prob": 0.8, "size": 244, "type": None},
+            {"prob": 0.9, "size": 351, "type": None},
+        ]
+    }


### PR DESCRIPTION


**Description**

This endpoint returns the estimated sample size options for the current round (the frontend will only use this for the first round for now, but we'll need the logic for later rounds as well, so it's implemented). This is based on the `compute_sample_sizes` function from the single-jurisdiction flow.

**Testing**

Added some basic tests for the new endpoint - two error cases where we don't have enough of the audit set up done to compute the sample sizes, one happy path.

**Progress**

Ready for review.
