### PR TITLE
GET/POST rounds endpoints

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -18,3 +18,4 @@ import arlo_server.routes
 import arlo_server.contests
 import arlo_server.jurisdictions
 import arlo_server.sample_sizes
+import arlo_server.rounds

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -270,7 +270,7 @@ class SampledBallot(BaseModel):
     audit_board_id = db.Column(
         db.String(200),
         db.ForeignKey("audit_board.id", ondelete="cascade"),
-        nullable=False,
+        nullable=True,
     )
     vote = db.Column(db.String(200), nullable=True)
     comment = db.Column(db.Text, nullable=True)

--- a/arlo_server/rounds.py
+++ b/arlo_server/rounds.py
@@ -1,0 +1,156 @@
+from flask import jsonify, request
+from jsonschema import validate
+from werkzeug.exceptions import BadRequest, Conflict
+import uuid, datetime
+
+from arlo_server import app, db
+from arlo_server.models import (
+    Round,
+    RoundContest,
+    Election,
+    SampledBallot,
+    SampledBallotDraw,
+)
+from arlo_server.auth import with_election_access, UserType
+from arlo_server.sample_sizes import sample_size_options
+from util.isoformat import isoformat
+from audits import sampler
+
+
+CREATE_ROUND_REQUEST_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "roundNum": {"type": "integer", "minimum": 1,},
+        "sampleSize": {"type": "integer", "minimum": 1,},
+    },
+    "additionalProperties": False,
+    "required": ["roundNum"],
+}
+
+
+def serialize_round(r: Round) -> dict:
+    return {
+        "id": r.id,
+        "roundNum": r.round_num,
+        "startedAt": isoformat(r.started_at),
+        "endedAt": isoformat(r.ended_at),
+    }
+
+
+# Raises if invalid
+def validate_round(r: dict, election: Election):
+    validate(r, CREATE_ROUND_REQUEST_SCHEMA)
+
+    rounds = sorted(election.rounds, key=lambda r: r.round_num, reverse=True)
+    current_round = next(iter(rounds), None)
+    next_round_num = current_round.round_num + 1 if current_round else 1
+    if r["roundNum"] != next_round_num:
+        raise BadRequest(f"The next round should be round number {next_round_num}")
+
+    if current_round and not current_round.ended_at:
+        raise Conflict(f"The current round is not complete")
+
+    if r["roundNum"] == 1 and "sampleSize" not in r:
+        raise BadRequest(f"Sample size is required for round 1")
+
+
+def sample_ballots(election: Election, round: Round, sample_size: int):
+    # For now, we only support one targeted contest
+    targeted_contest = next(c for c in election.contests if c.is_targeted)
+
+    # Compute the total number of ballot samples in all rounds leading up to
+    # this one. Note that this corresponds to the number of SampledBallotDraws,
+    # not SampledBallots.
+    num_previously_sampled = (
+        SampledBallotDraw.query.join(Round).filter_by(election_id=election.id).count()
+    )
+
+    # Create the pool of ballots to sample (aka manifest) by combining the
+    # manifests from every jurisdiction in the contest's universe.
+    # Audits must be deterministic and repeatable for the same real world
+    # inputs. So the sampler expects the same input for the same real world
+    # data. Thus, we use the jurisdiction and batch names (deterministic real
+    # world ids) instead of the jurisdiction and batch ids (non-deterministic
+    # uuids that we generate for each audit).
+    manifest = {
+        (jurisdiction.name, batch.name): batch.num_ballots
+        for jurisdiction in targeted_contest.jurisdictions
+        for batch in jurisdiction.batches
+    }
+    batch_key_to_id = {
+        (jurisdiction.name, batch.name): batch.id
+        for jurisdiction in targeted_contest.jurisdictions
+        for batch in jurisdiction.batches
+    }
+
+    # Do the math! I.e. compute the actual sample
+    sample = sampler.draw_sample(
+        election.random_seed, manifest, sample_size, num_previously_sampled
+    )
+
+    # Record which ballots are sampled in the db.
+    # Note that a ballot may be sampled more than once (within a round or
+    # across multiple rounds). We create one SampledBallot for each real-world
+    # ballot that gets sampled, and record each time it gets sampled with a
+    # SampledBallotDraw. That way we can ensure that we don't need to actually
+    # look at a real-world ballot that we've already audited, even if it gets
+    # sampled again.
+    for (ticket_number, (batch_key, ballot_position), times_sampled) in sample:
+        batch_id = batch_key_to_id[batch_key]
+        if times_sampled == 1:
+            sampled_ballot = SampledBallot(
+                batch_id=batch_id, ballot_position=ballot_position,
+            )
+            db.session.add(sampled_ballot)
+
+        sampled_ballot_draw = SampledBallotDraw(
+            batch_id=batch_id,
+            ballot_position=ballot_position,
+            round_id=round.id,
+            ticket_number=ticket_number,
+        )
+        db.session.add(sampled_ballot_draw)
+
+    db.session.commit()
+
+
+@app.route("/election/<election_id>/round", methods=["GET"])
+@with_election_access(UserType.AUDIT_ADMIN)
+def list_rounds(election: Election):
+    rounds = sorted(election.rounds, key=lambda r: r.round_num)
+    return jsonify({"rounds": [serialize_round(r) for r in rounds]})
+
+
+@app.route("/election/<election_id>/round", methods=["POST"])
+@with_election_access(UserType.AUDIT_ADMIN)
+def create_round(election: Election):
+    json_round = request.get_json()
+    validate_round(json_round, election)
+
+    # For round 1, use the given sample size. In later rounds, use the 90%
+    # probability sample size.
+    sample_size = (
+        json_round["sampleSize"]
+        if json_round["roundNum"] == 1
+        else sample_size_options(election)[0.9]
+    )
+
+    round = Round(
+        id=str(uuid.uuid4()),
+        election_id=election.id,
+        round_num=json_round["roundNum"],
+        started_at=datetime.datetime.utcnow(),
+    )
+    db.session.add(round)
+
+    for contest in election.contests:
+        round_contest = RoundContest(
+            round_id=round.id, contest_id=contest.id, sample_size=sample_size
+        )
+        db.session.add(round_contest)
+
+    db.session.commit()
+
+    sample_ballots(election, round, sample_size)
+
+    return jsonify({"status": "ok"})

--- a/audits/sampler.py
+++ b/audits/sampler.py
@@ -10,8 +10,8 @@ import audits.macro as macro
 
 
 def draw_sample(
-    seed: str, manifest: Dict[str, int], sample_size: int, num_sampled=0
-) -> List[Tuple[str, Tuple[str, int], int]]:
+    seed: str, manifest: Dict[Any, int], sample_size: int, num_sampled=0
+) -> List[Tuple[str, Tuple[Any, int], int]]:
     """
     Draws uniform random sample with replacement of size <sample_size> from the
     provided ballot manifest.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,12 @@
 import pytest
 from flask.testing import FlaskClient
-import json, io
+import json, io, uuid
 from typing import List
 
 from arlo_server import app, db
-from arlo_server.models import Jurisdiction
-from helpers import post_json, create_election
+from arlo_server.models import Jurisdiction, USState
+from helpers import post_json, put_json, create_election
+from bgcompute import bgcompute_update_election_jurisdictions_file
 
 # The fixtures in this module are available in any test via dependency
 # injection.
@@ -48,5 +49,39 @@ def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
         },
     )
     assert json.loads(rv.data) == {"status": "ok"}
+    bgcompute_update_election_jurisdictions_file()
     jurisdictions = Jurisdiction.query.filter_by(election_id=election_id).all()
     yield [j.id for j in jurisdictions]
+
+
+@pytest.fixture
+def contest(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]) -> str:
+    contest = {
+        "id": str(uuid.uuid4()),
+        "name": "Contest 1",
+        "isTargeted": True,
+        "choices": [
+            {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 600,},
+            {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 400,},
+        ],
+        "totalBallotsCast": 1000,
+        "numWinners": 1,
+        "votesAllowed": 1,
+        "jurisdictionIds": jurisdiction_ids,
+    }
+    rv = put_json(client, f"/election/{election_id}/contest", [contest])
+    assert json.loads(rv.data) == {"status": "ok"}
+    yield contest
+
+
+@pytest.fixture
+def election_settings(client: FlaskClient, election_id: str) -> None:
+    settings = {
+        "electionName": "Test Election",
+        "online": True,
+        "randomSeed": "1234567890",
+        "riskLimit": 10,
+        "state": USState.California,
+    }
+    rv = put_json(client, f"/election/{election_id}/settings", settings)
+    assert json.loads(rv.data) == {"status": "ok"}

--- a/tests/test_rounds.py
+++ b/tests/test_rounds.py
@@ -1,0 +1,282 @@
+import pytest
+from flask.testing import FlaskClient
+from typing import List
+import json, io, datetime
+
+from arlo_server import db
+from arlo_server.models import (
+    SampledBallotDraw,
+    SampledBallot,
+    Round,
+    RoundContest,
+    RoundContestResult,
+    Batch,
+)
+from bgcompute import bgcompute_update_ballot_manifest_file
+from helpers import post_json, compare_json, assert_is_id, assert_is_date
+
+
+@pytest.fixture
+def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]):
+    rv = client.put(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/manifest",
+        data={
+            "manifest": (
+                io.BytesIO(
+                    b"Batch Name,Number of Ballots\n"
+                    b"1,23\n"
+                    b"2,101\n"
+                    b"3,122\n"
+                    b"4,400"
+                ),
+                "manifest.csv",
+            )
+        },
+    )
+    assert rv.status_code == 200
+    rv = client.put(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/manifest",
+        data={
+            "manifest": (
+                io.BytesIO(
+                    b"Batch Name,Number of Ballots\n"
+                    b"1,20\n"
+                    b"2,10\n"
+                    b"3,220\n"
+                    b"4,40"
+                ),
+                "manifest.csv",
+            )
+        },
+    )
+    assert rv.status_code == 200
+    bgcompute_update_ballot_manifest_file()
+
+
+def test_rounds_list_empty(client: FlaskClient, election_id: str):
+    rv = client.get(f"/election/{election_id}/round")
+    rounds = json.loads(rv.data)
+    assert rounds == {"rounds": []}
+
+
+def test_rounds_create_one(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest: dict,
+    manifests,
+):
+    sample_size = 119  # BRAVO sample size
+    rv = post_json(
+        client,
+        f"/election/{election_id}/round",
+        {"roundNum": 1, "sampleSize": sample_size,},
+    )
+    assert rv.status_code == 200
+    assert json.loads(rv.data) == {"status": "ok"}
+
+    rv = client.get(f"/election/{election_id}/round")
+    rounds = json.loads(rv.data)
+    compare_json(
+        rounds,
+        {
+            "rounds": [
+                {
+                    "id": assert_is_id,
+                    "roundNum": 1,
+                    "startedAt": assert_is_date,
+                    "endedAt": None,
+                }
+            ]
+        },
+    )
+
+    # Check that we also created RoundContest objects
+    round_contests = RoundContest.query.filter_by(
+        round_id=rounds["rounds"][0]["id"]
+    ).all()
+    assert len(round_contests) == 1
+    assert round_contests[0].contest_id == contest["id"]
+
+    # Check that the ballots got sampled
+    ballot_draws = SampledBallotDraw.query.filter_by(
+        round_id=rounds["rounds"][0]["id"]
+    ).all()
+    assert len(ballot_draws) == sample_size
+    # Because we sample with replacement, we might have less sampled ballots
+    # than ballot draws, so we'll just check that each draw has a corresponding
+    # ballot
+    for draw in ballot_draws:
+        assert SampledBallot.query.filter_by(
+            batch_id=draw.batch_id, ballot_position=draw.ballot_position
+        ).one_or_none()
+    # Check that we're sampling ballots from the two jurisdictions that uploaded manifests
+    sampled_jurisdictions = {draw.batch.jurisdiction_id for draw in ballot_draws}
+    assert sorted(sampled_jurisdictions) == sorted(jurisdiction_ids[:2])
+
+
+def test_rounds_create_two(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest: dict,
+    manifests,
+    election_settings,
+):
+    rv = post_json(
+        client, f"/election/{election_id}/round", {"roundNum": 1, "sampleSize": 119,},
+    )
+    assert rv.status_code == 200
+
+    # Fake that the first round got completed
+    round = Round.query.filter_by(election_id=election_id).one()
+    round.ended_at = datetime.datetime.utcnow()
+    db.session.add(
+        RoundContestResult(
+            round_id=round.id,
+            contest_id=contest["id"],
+            contest_choice_id=contest["choices"][0]["id"],
+            result=70,
+        )
+    )
+    db.session.add(
+        RoundContestResult(
+            round_id=round.id,
+            contest_id=contest["id"],
+            contest_choice_id=contest["choices"][1]["id"],
+            result=49,
+        )
+    )
+    db.session.commit()
+
+    rv = client.get(f"/election/{election_id}/round")
+    rounds = json.loads(rv.data)
+    compare_json(
+        rounds,
+        {
+            "rounds": [
+                {
+                    "id": assert_is_id,
+                    "roundNum": 1,
+                    "startedAt": assert_is_date,
+                    "endedAt": assert_is_date,
+                }
+            ]
+        },
+    )
+
+    rv = post_json(client, f"/election/{election_id}/round", {"roundNum": 2},)
+    assert rv.status_code == 200
+
+    rv = client.get(f"/election/{election_id}/round")
+    rounds = json.loads(rv.data)
+    compare_json(
+        rounds,
+        {
+            "rounds": [
+                {
+                    "id": assert_is_id,
+                    "roundNum": 1,
+                    "startedAt": assert_is_date,
+                    "endedAt": assert_is_date,
+                },
+                {
+                    "id": assert_is_id,
+                    "roundNum": 2,
+                    "startedAt": assert_is_date,
+                    "endedAt": None,
+                },
+            ]
+        },
+    )
+
+    ballot_draws = (
+        SampledBallotDraw.query.filter_by(round_id=rounds["rounds"][1]["id"])
+        .join(Batch)
+        .all()
+    )
+    # Check that we automatically select the 90% prob sample size
+    assert len(ballot_draws) == 205
+    # Check that we're sampling ballots from the two jurisdictions that uploaded manifests
+    sampled_jurisdictions = {draw.batch.jurisdiction_id for draw in ballot_draws}
+    assert sorted(sampled_jurisdictions) == sorted(jurisdiction_ids[:2])
+
+
+def test_rounds_create_before_previous_round_complete(
+    client: FlaskClient, election_id: str, contest: dict, manifests, election_settings
+):
+    rv = post_json(
+        client, f"/election/{election_id}/round", {"roundNum": 1, "sampleSize": 10,},
+    )
+    assert rv.status_code == 200
+
+    rv = post_json(client, f"/election/{election_id}/round", {"roundNum": 2},)
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {"message": "The current round is not complete", "errorType": "Conflict",}
+        ]
+    }
+
+
+def test_rounds_wrong_number_too_big(client: FlaskClient, election_id: str):
+    rv = post_json(
+        client, f"/election/{election_id}/round", {"roundNum": 2, "sampleSize": 10}
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "The next round should be round number 1",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+
+
+def test_rounds_wrong_number_too_small(
+    client: FlaskClient, election_id: str, contest: dict
+):
+    rv = post_json(
+        client, f"/election/{election_id}/round", {"roundNum": 1, "sampleSize": 10,},
+    )
+    assert rv.status_code == 200
+
+    rv = post_json(
+        client, f"/election/{election_id}/round", {"roundNum": 1, "sampleSize": 10,},
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "The next round should be round number 2",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+
+
+def test_rounds_missing_sample_size(client: FlaskClient, election_id: str):
+    rv = post_json(client, f"/election/{election_id}/round", {"roundNum": 1})
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "Sample size is required for round 1",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+
+
+def test_rounds_missing_round_num(client: FlaskClient, election_id: str):
+    rv = post_json(client, f"/election/{election_id}/round", {"sampleSize": 10})
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "'roundNum' is a required property",
+                "errorType": "Bad Request",
+            }
+        ]
+    }

--- a/tests/test_sample_sizes.py
+++ b/tests/test_sample_sizes.py
@@ -4,40 +4,6 @@ from typing import List
 import json, uuid
 
 from helpers import put_json
-from arlo_server.models import USState
-
-
-@pytest.fixture
-def contest(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]) -> str:
-    contest = {
-        "id": str(uuid.uuid4()),
-        "name": "Contest 1",
-        "isTargeted": True,
-        "choices": [
-            {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 600,},
-            {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 400,},
-        ],
-        "totalBallotsCast": 1000,
-        "numWinners": 1,
-        "votesAllowed": 1,
-        "jurisdictionIds": jurisdiction_ids,
-    }
-    rv = put_json(client, f"/election/{election_id}/contest", [contest])
-    assert json.loads(rv.data) == {"status": "ok"}
-    yield contest
-
-
-@pytest.fixture
-def election_settings(client: FlaskClient, election_id: str) -> None:
-    settings = {
-        "electionName": "Test Election",
-        "online": True,
-        "randomSeed": "1234567890",
-        "riskLimit": 10,
-        "state": USState.California,
-    }
-    rv = put_json(client, f"/election/{election_id}/settings", settings)
-    assert json.loads(rv.data) == {"status": "ok"}
 
 
 def test_sample_sizes_without_contests(client: FlaskClient, election_id: str):


### PR DESCRIPTION
**Description**

Task: #338 
Adds two new endpoints:
- GET /election/<election_id>/round - list the rounds in the audit so far
- POST /election/<election_id>/round - create a new round, which has a side effect of sampling the ballots

**Testing**

Added lots of new tests for validation as well as functionality.

**Progress**

Ready for review.