### PR TITLE
Audit setup stages ui management

### DIFF
--- a/arlo-client/src/components/Atoms/Sidebar.test.tsx
+++ b/arlo-client/src/components/Atoms/Sidebar.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import Sidebar, { ISidebarMenuItem } from './Sidebar'
+
+const mockMenuItems: ISidebarMenuItem[] = [
+  {
+    title: 'Item One',
+    activate: jest.fn(),
+    active: false,
+    state: 'live',
+  },
+  {
+    title: 'Item Two',
+    activate: jest.fn(),
+    active: false,
+    state: 'locked',
+  },
+  {
+    title: 'Item Three',
+    activate: jest.fn(),
+    active: false,
+    state: 'processing',
+  },
+  {
+    title: 'Item Four',
+    activate: jest.fn(),
+    active: true,
+    state: 'live',
+  },
+]
+
+describe('Sidebar', () => {
+  it('renders all options', () => {
+    const { container } = render(
+      <Sidebar menuItems={mockMenuItems} title="Test Sidebar" />
+    )
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/arlo-client/src/components/Atoms/Sidebar.tsx
+++ b/arlo-client/src/components/Atoms/Sidebar.tsx
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
 `
 
 export interface ISidebarMenuItem {
-  action: () => void
+  activate: () => void
   title: string
   active: boolean
   state: 'live' | 'processing' | 'locked'
@@ -33,7 +33,7 @@ const Sidebar = ({ menuItems, title }: IProps) => (
         <React.Fragment key={item.title}>
           {i > 0 && <Menu.Divider />}
           <Menu.Item
-            onClick={item.action}
+            onClick={item.activate}
             active={item.active}
             text={item.title}
             disabled={item.state !== 'live'}

--- a/arlo-client/src/components/Atoms/Sidebar.tsx
+++ b/arlo-client/src/components/Atoms/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Menu } from '@blueprintjs/core'
+import { Menu, Spinner } from '@blueprintjs/core'
 import H2Title from './H2Title'
 
 const Wrapper = styled.div`
@@ -17,6 +17,7 @@ export interface ISidebarMenuItem {
   action: () => void
   title: string
   active: boolean
+  state: 'live' | 'processing' | 'locked'
 }
 
 interface IProps {
@@ -35,6 +36,12 @@ const Sidebar = ({ menuItems, title }: IProps) => (
             onClick={item.action}
             active={item.active}
             text={item.title}
+            disabled={item.state !== 'live'}
+            labelElement={
+              item.state === 'processing' ? (
+                <Spinner size={Spinner.SIZE_SMALL} />
+              ) : null
+            }
           />
         </React.Fragment>
       ))}

--- a/arlo-client/src/components/Atoms/Sidebar.tsx
+++ b/arlo-client/src/components/Atoms/Sidebar.tsx
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
 `
 
 export interface ISidebarMenuItem {
-  activate: () => void
+  activate: (e?: unknown | null, force?: boolean) => void
   title: string
   active: boolean
   state: 'live' | 'processing' | 'locked'

--- a/arlo-client/src/components/Atoms/__snapshots__/Sidebar.test.tsx.snap
+++ b/arlo-client/src/components/Atoms/__snapshots__/Sidebar.test.tsx.snap
@@ -1,0 +1,112 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sidebar renders all options 1`] = `
+<div>
+  <div
+    class="sc-bwzfXH bUfEhr"
+  >
+    <h2
+      class="bp3-heading sc-bdVaJa ibVpPq"
+    >
+      Test Sidebar
+    </h2>
+    <ul
+      class="bp3-menu"
+    >
+      <li
+        class=""
+      >
+        <a
+          class="bp3-menu-item bp3-popover-dismiss"
+        >
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Item One
+          </div>
+        </a>
+      </li>
+      <li
+        class="bp3-menu-divider"
+      />
+      <li
+        class=""
+      >
+        <a
+          class="bp3-menu-item bp3-disabled"
+          tabindex="-1"
+        >
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Item Two
+          </div>
+        </a>
+      </li>
+      <li
+        class="bp3-menu-divider"
+      />
+      <li
+        class=""
+      >
+        <a
+          class="bp3-menu-item bp3-disabled"
+          tabindex="-1"
+        >
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Item Three
+          </div>
+          <span
+            class="bp3-menu-item-label"
+          >
+            <div
+              class="bp3-spinner"
+            >
+              <div
+                class="bp3-spinner-animation"
+              >
+                <svg
+                  height="20"
+                  stroke-width="16.00"
+                  viewBox="-3.00 -3.00 106.00 106.00"
+                  width="20"
+                >
+                  <path
+                    class="bp3-spinner-track"
+                    d="M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90"
+                  />
+                  <path
+                    class="bp3-spinner-head"
+                    d="M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90"
+                    pathLength="280"
+                    stroke-dasharray="280 280"
+                    stroke-dashoffset="210"
+                  />
+                </svg>
+              </div>
+            </div>
+          </span>
+        </a>
+      </li>
+      <li
+        class="bp3-menu-divider"
+      />
+      <li
+        class=""
+      >
+        <a
+          class="bp3-menu-item bp3-active bp3-intent-primary bp3-popover-dismiss"
+        >
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Item Four
+          </div>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/arlo-client/src/components/Audit/Setup/Contests/index.test.tsx
+++ b/arlo-client/src/components/Audit/Setup/Contests/index.test.tsx
@@ -92,6 +92,10 @@ function typeInto(input: Element, value: string): void {
   fireEvent.blur(input)
 }
 
+afterEach(() => {
+  ;(nextStage.activate as jest.Mock).mockClear()
+})
+
 describe('Audit Setup > Contests', () => {
   it('renders empty state correctly', () => {
     const { container } = render(

--- a/arlo-client/src/components/Audit/Setup/Contests/index.test.tsx
+++ b/arlo-client/src/components/Audit/Setup/Contests/index.test.tsx
@@ -4,6 +4,9 @@ import { regexpEscape } from '../../../testUtilities'
 import { statusStates } from '../../_mocks'
 import * as utilities from '../../../utilities'
 import Contests from './index'
+import relativeStages from '../_mocks'
+
+const { nextStage, prevStage } = relativeStages('Target Contests')
 
 const ContestsMocks = {
   inputs: [
@@ -95,8 +98,7 @@ describe('Audit Setup > Contests', () => {
       <Contests
         audit={statusStates[0]}
         isTargeted
-        nextStage={jest.fn()}
-        prevStage={jest.fn()}
+        {...relativeStages('Target Contests')}
       />
     )
     expect(container).toMatchSnapshot()
@@ -108,8 +110,7 @@ describe('Audit Setup > Contests', () => {
       <Contests
         audit={statusStates[0]}
         isTargeted
-        nextStage={jest.fn()}
-        prevStage={jest.fn()}
+        {...relativeStages('Target Contests')}
       />
     )
 
@@ -140,8 +141,7 @@ describe('Audit Setup > Contests', () => {
       <Contests
         audit={statusStates[0]}
         isTargeted
-        nextStage={jest.fn()}
-        prevStage={jest.fn()}
+        {...relativeStages('Target Contests')}
       />
     )
 
@@ -161,13 +161,12 @@ describe('Audit Setup > Contests', () => {
   })
 
   it('is able to submit the form successfully', async () => {
-    const nextStageMock = jest.fn()
     const { getByLabelText, getByText } = render(
       <Contests
         audit={statusStates[0]}
         isTargeted
-        nextStage={nextStageMock}
-        prevStage={jest.fn()}
+        nextStage={nextStage}
+        prevStage={prevStage}
       />
     )
 
@@ -181,18 +180,17 @@ describe('Audit Setup > Contests', () => {
 
     fireEvent.click(getByText('Submit & Next'), { bubbles: true })
     await wait(() => {
-      expect(nextStageMock).toHaveBeenCalledTimes(1)
+      expect(nextStage.activate).toHaveBeenCalledTimes(1)
     })
   })
 
   it('displays errors', async () => {
-    const nextStageMock = jest.fn()
     const { getByLabelText, getByTestId, getByText } = render(
       <Contests
         audit={statusStates[0]}
         isTargeted
-        nextStage={nextStageMock}
-        prevStage={jest.fn()}
+        nextStage={nextStage}
+        prevStage={prevStage}
       />
     )
 
@@ -219,7 +217,7 @@ describe('Audit Setup > Contests', () => {
 
     fireEvent.click(getByText('Submit & Next'), { bubbles: true })
     await wait(() => {
-      expect(nextStageMock).toHaveBeenCalledTimes(0)
+      expect(nextStage.activate).toHaveBeenCalledTimes(0)
     })
   })
 
@@ -228,8 +226,7 @@ describe('Audit Setup > Contests', () => {
       <Contests
         audit={statusStates[0]}
         isTargeted
-        nextStage={jest.fn()}
-        prevStage={jest.fn()}
+        {...relativeStages('Target Contests')}
       />
     )
 
@@ -273,8 +270,7 @@ describe('Audit Setup > Contests', () => {
       <Contests
         audit={statusStates[0]}
         isTargeted
-        nextStage={jest.fn()}
-        prevStage={jest.fn()}
+        {...relativeStages('Target Contests')}
       />
     )
 

--- a/arlo-client/src/components/Audit/Setup/Contests/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Contests/index.tsx
@@ -17,12 +17,13 @@ import FormButtonBar from '../../../Form/FormButtonBar'
 import FormButton from '../../../Form/FormButton'
 import { IContestValues, IValues, IChoiceValues } from './types'
 import schema from './schema'
+import { ISidebarMenuItem } from '../../../Atoms/Sidebar'
 
 interface IProps {
   audit: IAudit
   isTargeted: boolean
-  nextStage: () => void
-  prevStage: () => void
+  nextStage: ISidebarMenuItem
+  prevStage: ISidebarMenuItem
 }
 
 const contestValues: { contests: IContestValues[] } = {
@@ -65,7 +66,7 @@ const Contests: React.FC<IProps> = ({
         setIsLoading(true)
         // eslint-disable-next-line no-console
         console.log(v)
-        nextStage()
+        nextStage.activate()
       }}
     >
       {({ values, handleSubmit }: FormikProps<IValues>) => (
@@ -235,7 +236,7 @@ const Contests: React.FC<IProps> = ({
           {isLoading && <Spinner />}
           {!audit.contests.length && !isLoading && (
             <FormButtonBar>
-              <FormButton onClick={prevStage}>Back</FormButton>
+              <FormButton onClick={prevStage.activate}>Back</FormButton>
               <FormButton
                 type="submit"
                 intent="primary"

--- a/arlo-client/src/components/Audit/Setup/Participants/index.test.tsx
+++ b/arlo-client/src/components/Audit/Setup/Participants/index.test.tsx
@@ -87,14 +87,14 @@ describe('Audit Setup > Contests', () => {
       expect(apiMock).toBeCalledTimes(1)
       expect(apiMock).toHaveBeenNthCalledWith(
         1,
-        expect.stringMatching(/\/election\/[^/]+\/jurisdictions\/file/),
+        expect.stringMatching(/\/election\/[^/]+\/jurisdiction\/file/),
         { body: formData, method: 'PUT' }
       )
       expect(nextStage.activate).toHaveBeenCalledTimes(1)
     })
   })
 
-  it('handles api error on /election/:electionId/jurisdictions/file', async () => {
+  it('handles api error on /election/:electionId/jurisdiction/file', async () => {
     apiMock.mockRejectedValue({ message: 'error' })
 
     await fillAndSubmit()
@@ -106,7 +106,7 @@ describe('Audit Setup > Contests', () => {
     })
   })
 
-  it('handles server error on /election/:electionId/jurisdictions/file', async () => {
+  it('handles server error on /election/:electionId/jurisdiction/file', async () => {
     apiMock.mockResolvedValue(undefined)
     checkAndToastMock.mockReturnValue(true)
 

--- a/arlo-client/src/components/Audit/Setup/Participants/index.test.tsx
+++ b/arlo-client/src/components/Audit/Setup/Participants/index.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, wait } from '@testing-library/react'
 import { BrowserRouter as Router, useParams } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import { statusStates } from '../../_mocks'
+import relativeStages from '../_mocks'
 import Participants from './index'
 import jurisdictionFile from './_mocks'
 import * as utilities from '../../../utilities'
@@ -31,8 +32,9 @@ routeMock.mockReturnValue({
 const formData: FormData = new FormData()
 formData.append('jurisdictions', jurisdictionFile, jurisdictionFile.name)
 
+const { nextStage } = relativeStages('Participants')
+
 const fillAndSubmit = async () => {
-  const nextStageMock = jest.fn()
   const {
     getByText,
     getByLabelText,
@@ -41,7 +43,7 @@ const fillAndSubmit = async () => {
     getByTestId,
   } = render(
     <Router>
-      <Participants audit={statusStates[0]} nextStage={nextStageMock} />
+      <Participants audit={statusStates[0]} nextStage={nextStage} />
     </Router>
   )
 
@@ -59,7 +61,6 @@ const fillAndSubmit = async () => {
   await wait(() => expect(queryByLabelText('jurisdictions.csv')).toBeTruthy())
 
   fireEvent.click(getByText('Submit & Next'), { bubbles: true })
-  return nextStageMock
 }
 
 beforeEach(() => {
@@ -67,20 +68,21 @@ beforeEach(() => {
   toastSpy.mockClear()
   checkAndToastMock.mockClear()
   routeMock.mockClear()
+  ;(nextStage.activate as jest.Mock).mockClear()
 })
 
 describe('Audit Setup > Contests', () => {
   it('renders empty state correctly', () => {
     const { container } = render(
       <Router>
-        <Participants audit={statusStates[0]} nextStage={jest.fn()} />
+        <Participants audit={statusStates[0]} nextStage={nextStage} />
       </Router>
     )
     expect(container).toMatchSnapshot()
   })
 
   it('selects a state and submits it', async () => {
-    const nextStageMock = await fillAndSubmit()
+    await fillAndSubmit()
     await wait(() => {
       expect(apiMock).toBeCalledTimes(1)
       expect(apiMock).toHaveBeenNthCalledWith(
@@ -88,19 +90,19 @@ describe('Audit Setup > Contests', () => {
         expect.stringMatching(/\/election\/[^/]+\/jurisdictions\/file/),
         { body: formData, method: 'PUT' }
       )
-      expect(nextStageMock).toHaveBeenCalledTimes(1)
+      expect(nextStage.activate).toHaveBeenCalledTimes(1)
     })
   })
 
   it('handles api error on /election/:electionId/jurisdictions/file', async () => {
     apiMock.mockRejectedValue({ message: 'error' })
 
-    const nextStageMock = await fillAndSubmit()
+    await fillAndSubmit()
 
     await wait(() => {
       expect(apiMock).toBeCalledTimes(1)
       expect(toastSpy).toBeCalledTimes(1)
-      expect(nextStageMock).toHaveBeenCalledTimes(0)
+      expect(nextStage.activate).toHaveBeenCalledTimes(0)
     })
   })
 
@@ -108,13 +110,13 @@ describe('Audit Setup > Contests', () => {
     apiMock.mockResolvedValue(undefined)
     checkAndToastMock.mockReturnValue(true)
 
-    const nextStageMock = await fillAndSubmit()
+    await fillAndSubmit()
 
     await wait(() => {
       expect(apiMock).toBeCalledTimes(1)
       expect(toastSpy).toBeCalledTimes(0)
       expect(checkAndToastMock).toBeCalledTimes(1)
-      expect(nextStageMock).toHaveBeenCalledTimes(0)
+      expect(nextStage.activate).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/arlo-client/src/components/Audit/Setup/Participants/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Participants/index.tsx
@@ -42,7 +42,7 @@ const Participants: React.FC<IProps> = ({ audit, nextStage }: IProps) => {
         const formData: FormData = new FormData()
         formData.append('jurisdictions', values.csv, values.csv.name)
         const errorResponse: IErrorResponse = await api(
-          `/election/${electionId}/jurisdictions/file`,
+          `/election/${electionId}/jurisdiction/file`,
           {
             method: 'PUT',
             body: formData,

--- a/arlo-client/src/components/Audit/Setup/Participants/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Participants/index.tsx
@@ -15,6 +15,7 @@ import schema from './schema'
 import { ErrorLabel } from '../../../Form/_helpers'
 import FormSection, { FormSectionDescription } from '../../../Form/FormSection'
 import { api, checkAndToast } from '../../../utilities'
+import { ISidebarMenuItem } from '../../../Atoms/Sidebar'
 
 export const Select = styled(HTMLSelect)`
   margin-top: 5px;
@@ -27,7 +28,7 @@ const initialValues = {
 
 interface IProps {
   audit: IAudit
-  nextStage: () => void
+  nextStage: ISidebarMenuItem
 }
 
 const Participants: React.FC<IProps> = ({ audit, nextStage }: IProps) => {
@@ -49,7 +50,7 @@ const Participants: React.FC<IProps> = ({ audit, nextStage }: IProps) => {
         )
         if (checkAndToast(errorResponse)) return
       }
-      nextStage()
+      nextStage.activate()
     } catch (err) {
       toast.error(err.message)
     }
@@ -58,9 +59,7 @@ const Participants: React.FC<IProps> = ({ audit, nextStage }: IProps) => {
     <Formik
       initialValues={initialValues}
       validationSchema={schema}
-      onSubmit={v => {
-        submit(v)
-      }}
+      onSubmit={submit}
     >
       {({
         handleSubmit,

--- a/arlo-client/src/components/Audit/Setup/Review/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Review/index.tsx
@@ -6,7 +6,6 @@ import { ISidebarMenuItem } from '../../../Atoms/Sidebar'
 
 interface IProps {
   audit: IAudit
-  nextStage: ISidebarMenuItem
   prevStage: ISidebarMenuItem
 }
 

--- a/arlo-client/src/components/Audit/Setup/Review/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Review/index.tsx
@@ -2,11 +2,12 @@ import React from 'react'
 import { IAudit } from '../../../../types'
 import FormButtonBar from '../../../Form/FormButtonBar'
 import FormButton from '../../../Form/FormButton'
+import { ISidebarMenuItem } from '../../../Atoms/Sidebar'
 
 interface IProps {
   audit: IAudit
-  nextStage: () => void
-  prevStage: () => void
+  nextStage: ISidebarMenuItem
+  prevStage: ISidebarMenuItem
 }
 
 const Review: React.FC<IProps> = ({ prevStage }: IProps) => {
@@ -14,7 +15,7 @@ const Review: React.FC<IProps> = ({ prevStage }: IProps) => {
     <div>
       <p>Review</p>
       <FormButtonBar>
-        <FormButton onClick={prevStage}>Back</FormButton>
+        <FormButton onClick={prevStage.activate}>Back</FormButton>
       </FormButtonBar>
     </div>
   )

--- a/arlo-client/src/components/Audit/Setup/Settings/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Settings/index.tsx
@@ -2,11 +2,12 @@ import React from 'react'
 import { IAudit } from '../../../../types'
 import FormButtonBar from '../../../Form/FormButtonBar'
 import FormButton from '../../../Form/FormButton'
+import { ISidebarMenuItem } from '../../../Atoms/Sidebar'
 
 interface IProps {
   audit: IAudit
-  nextStage: () => void
-  prevStage: () => void
+  nextStage: ISidebarMenuItem
+  prevStage: ISidebarMenuItem
 }
 
 const Settings: React.FC<IProps> = ({ nextStage, prevStage }: IProps) => {
@@ -14,8 +15,8 @@ const Settings: React.FC<IProps> = ({ nextStage, prevStage }: IProps) => {
     <div>
       <p>Audit Settings</p>
       <FormButtonBar>
-        <FormButton onClick={prevStage}>Back</FormButton>
-        <FormButton onClick={nextStage}>Next</FormButton>
+        <FormButton onClick={prevStage.activate}>Back</FormButton>
+        <FormButton onClick={nextStage.activate}>Next</FormButton>
       </FormButtonBar>
     </div>
   )

--- a/arlo-client/src/components/Audit/Setup/_mocks.ts
+++ b/arlo-client/src/components/Audit/Setup/_mocks.ts
@@ -1,0 +1,23 @@
+import { ElementType } from '../../../types'
+import { setupStages } from './index'
+import { ISidebarMenuItem } from '../../Atoms/Sidebar'
+
+const relativeStages = (s: ElementType<typeof setupStages>) => {
+  const prevTitle = setupStages[setupStages.indexOf(s) - 1]
+  const prevStage: ISidebarMenuItem = {
+    title: prevTitle,
+    active: false,
+    activate: jest.fn(),
+    state: 'live',
+  }
+  const nextTitle = setupStages[setupStages.indexOf(s) + 1]
+  const nextStage: ISidebarMenuItem = {
+    title: nextTitle,
+    active: false,
+    activate: jest.fn(),
+    state: 'live',
+  }
+  return { prevStage, nextStage }
+}
+
+export default relativeStages

--- a/arlo-client/src/components/Audit/Setup/index.test.tsx
+++ b/arlo-client/src/components/Audit/Setup/index.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { BrowserRouter as Router, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { statusStates } from '../_mocks'
 import * as utilities from '../../utilities'
 import { asyncActRender } from '../../testUtilities'
 import Setup from './index'
+import relativeStages from './_mocks'
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
@@ -34,13 +35,11 @@ afterEach(() => {
 describe('Setup', () => {
   it('renders Participants stage', async () => {
     const { container } = await asyncActRender(
-      <Router>
-        <Setup
-          audit={statusStates[2]}
-          stage="Participants"
-          setStage={jest.fn()}
-        />
-      </Router>
+      <Setup
+        audit={statusStates[2]}
+        stage="Participants"
+        {...relativeStages('Participants')}
+      />
     )
     expect(container).toMatchSnapshot()
   })
@@ -50,7 +49,7 @@ describe('Setup', () => {
       <Setup
         audit={statusStates[2]}
         stage="Target Contests"
-        setStage={jest.fn()}
+        {...relativeStages('Target Contests')}
       />
     )
     expect(container).toMatchSnapshot()
@@ -61,7 +60,7 @@ describe('Setup', () => {
       <Setup
         audit={statusStates[2]}
         stage="Opportunistic Contests"
-        setStage={jest.fn()}
+        {...relativeStages('Opportunistic Contests')}
       />
     )
     expect(container).toMatchSnapshot()
@@ -72,7 +71,7 @@ describe('Setup', () => {
       <Setup
         audit={statusStates[2]}
         stage="Audit Settings"
-        setStage={jest.fn()}
+        {...relativeStages('Audit Settings')}
       />
     )
     expect(container).toMatchSnapshot()
@@ -83,7 +82,7 @@ describe('Setup', () => {
       <Setup
         audit={statusStates[2]}
         stage="Review & Launch"
-        setStage={jest.fn()}
+        {...relativeStages('Review & Launch')}
       />
     )
     expect(container).toMatchSnapshot()

--- a/arlo-client/src/components/Audit/Setup/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/index.tsx
@@ -18,22 +18,23 @@ export const setupStages = [
 interface IProps {
   stage: ElementType<typeof setupStages>
   audit: IAudit
-  prevStage: ISidebarMenuItem
-  nextStage: ISidebarMenuItem
+  prevStage: ISidebarMenuItem | undefined
+  nextStage: ISidebarMenuItem | undefined
 }
 
 const Setup: React.FC<IProps> = ({ stage, prevStage, audit, nextStage }) => {
   switch (stage) {
     case 'Participants':
-      return <Participants audit={audit} nextStage={nextStage} />
+      // prevStage === undefined, so don't send it
+      return <Participants audit={audit} nextStage={nextStage!} />
     case 'Target Contests':
       return (
         <Contests
           isTargeted
           key="targeted"
           audit={audit}
-          nextStage={nextStage}
-          prevStage={prevStage}
+          nextStage={nextStage!}
+          prevStage={prevStage!}
         />
       )
     case 'Opportunistic Contests':
@@ -42,18 +43,17 @@ const Setup: React.FC<IProps> = ({ stage, prevStage, audit, nextStage }) => {
           isTargeted={false}
           key="opportunistic"
           audit={audit}
-          nextStage={nextStage}
-          prevStage={prevStage}
+          nextStage={nextStage!}
+          prevStage={prevStage!}
         />
       )
     case 'Audit Settings':
       return (
-        <Settings audit={audit} nextStage={nextStage} prevStage={prevStage} />
+        <Settings audit={audit} nextStage={nextStage!} prevStage={prevStage!} />
       )
     case 'Review & Launch':
-      return (
-        <Review audit={audit} nextStage={nextStage} prevStage={prevStage} />
-      )
+      // nextStage === undefined, so don't send it
+      return <Review audit={audit} prevStage={prevStage!} />
     /* istanbul ignore next */
     default:
       return null

--- a/arlo-client/src/components/Audit/Setup/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/index.tsx
@@ -5,6 +5,7 @@ import Participants from './Participants'
 import Contests from './Contests'
 import Settings from './Settings'
 import Review from './Review'
+import { ISidebarMenuItem } from '../../Atoms/Sidebar'
 
 export const setupStages = [
   'Participants',
@@ -17,22 +18,11 @@ export const setupStages = [
 interface IProps {
   stage: ElementType<typeof setupStages>
   audit: IAudit
-  setStage: (stage: ElementType<typeof setupStages>) => void
+  prevStage: ISidebarMenuItem
+  nextStage: ISidebarMenuItem
 }
 
-const Setup: React.FC<IProps> = ({ stage, setStage, audit }) => {
-  const currentIndex = setupStages.indexOf(stage)
-  const nextStage = () => {
-    /* istanbul ignore else */
-    if (currentIndex < setupStages.length - 1)
-      setStage(setupStages[currentIndex + 1])
-  }
-  const prevStage = () => {
-    // modal warn that form data may be lost
-    /* istanbul ignore else */
-    if (currentIndex > 0) setStage(setupStages[currentIndex - 1])
-  }
-
+const Setup: React.FC<IProps> = ({ stage, prevStage, audit, nextStage }) => {
   switch (stage) {
     case 'Participants':
       return <Participants audit={audit} nextStage={nextStage} />

--- a/arlo-client/src/components/Audit/index.tsx
+++ b/arlo-client/src/components/Audit/index.tsx
@@ -74,7 +74,11 @@ const Audit: React.FC<{}> = () => {
     'Participants'
   )
 
-  const [menuItems] = useSetupMenuItems(stage, setStage)
+  const [menuItems, refresh] = useSetupMenuItems(stage, setStage)
+
+  useEffect(() => {
+    refresh()
+  }, [])
 
   const activeStage = menuItems.find(m => m.title === stage)
   const nextStage = menuItems[menuItems.indexOf(activeStage!) + 1]

--- a/arlo-client/src/components/Audit/index.tsx
+++ b/arlo-client/src/components/Audit/index.tsx
@@ -78,7 +78,7 @@ const Audit: React.FC<{}> = () => {
 
   useEffect(() => {
     refresh()
-  }, [])
+  }, [refresh])
 
   const activeStage = menuItems.find(m => m.title === stage)
   const nextStage = menuItems[menuItems.indexOf(activeStage!) + 1]

--- a/arlo-client/src/components/Audit/index.tsx
+++ b/arlo-client/src/components/Audit/index.tsx
@@ -7,7 +7,7 @@ import { api, checkAndToast } from '../utilities'
 import { IAudit, IErrorResponse, ElementType } from '../../types'
 import ResetButton from './ResetButton'
 import Wrapper from '../Atoms/Wrapper'
-import Sidebar from '../Atoms/Sidebar'
+import Sidebar, { ISidebarMenuItem } from '../Atoms/Sidebar'
 import { AuthDataContext } from '../UserContext'
 import Setup, { setupStages } from './Setup'
 import useSetupMenuItems from './useSetupMenuItems'
@@ -81,8 +81,10 @@ const Audit: React.FC<{}> = () => {
   }, [refresh])
 
   const activeStage = menuItems.find(m => m.title === stage)
-  const nextStage = menuItems[menuItems.indexOf(activeStage!) + 1]
-  const prevStage = menuItems[menuItems.indexOf(activeStage!) - 1]
+  const nextStage: ISidebarMenuItem | undefined =
+    menuItems[menuItems.indexOf(activeStage!) + 1]
+  const prevStage: ISidebarMenuItem | undefined =
+    menuItems[menuItems.indexOf(activeStage!) - 1]
 
   return (
     <Wrapper className={!isAuthenticated ? 'single-page' : ''}>

--- a/arlo-client/src/components/Audit/index.tsx
+++ b/arlo-client/src/components/Audit/index.tsx
@@ -79,26 +79,41 @@ const Audit: React.FC<{}> = () => {
     'Participants'
   )
 
-  const menuItems = useMemo(
+  const menuItems: ISidebarMenuItem[] = useMemo(
     () =>
-      setupStages.map(
-        (s: ElementType<typeof setupStages>): ISidebarMenuItem => {
-          return (() => {
-            switch (s) {
-              case 'Participants':
-              default:
-                return {
-                  title: s,
-                  active: s === stage,
-                  action: () => setStage(s),
-                  state: 'live', // dynamic functions to query the state of the data needed
-                } as ISidebarMenuItem
-            }
-          })()
+      setupStages.map((s: ElementType<typeof setupStages>) => {
+        const state = (() => {
+          switch (s) {
+            case 'Participants':
+              return 'live'
+            case 'Target Contests':
+              return 'processing'
+            case 'Opportunistic Contests':
+              return 'locked'
+            case 'Audit Settings':
+              return 'locked'
+            case 'Review & Launch':
+              return 'live'
+            /* istanbul ignoe next */
+            default:
+              return 'locked'
+          }
+        })()
+        return {
+          title: s,
+          active: s === stage,
+          activate: () => {
+            if (state === 'live') setStage(s)
+          },
+          state,
         }
-      ),
-    [stage]
+      }),
+    [stage, setupStages]
   )
+
+  const activeStage = menuItems.find(m => m.title === stage)
+  const nextStage = menuItems[menuItems.indexOf(activeStage!) + 1]
+  const prevStage = menuItems[menuItems.indexOf(activeStage!) - 1]
 
   return (
     <Wrapper className={!isAuthenticated ? 'single-page' : ''}>
@@ -114,7 +129,12 @@ const Audit: React.FC<{}> = () => {
           {meta!.type === 'audit_admin' && (
             <Sidebar title="Audit Setup" menuItems={menuItems} />
           )}
-          <Setup stage={stage} audit={audit} setStage={setStage} />
+          <Setup
+            stage={stage}
+            audit={audit}
+            nextStage={nextStage}
+            prevStage={prevStage}
+          />
         </>
       ) : (
         <>

--- a/arlo-client/src/components/Audit/index.tsx
+++ b/arlo-client/src/components/Audit/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useEffect,
-  useCallback,
-  useMemo,
-  useContext,
-} from 'react'
+import React, { useState, useEffect, useCallback, useContext } from 'react'
 import { useRouteMatch, RouteComponentProps } from 'react-router-dom'
 import EstimateSampleSize from './EstimateSampleSize'
 import SelectBallotsToAudit from './SelectBallotsToAudit'
@@ -13,9 +7,10 @@ import { api, checkAndToast } from '../utilities'
 import { IAudit, IErrorResponse, ElementType } from '../../types'
 import ResetButton from './ResetButton'
 import Wrapper from '../Atoms/Wrapper'
-import Sidebar, { ISidebarMenuItem } from '../Atoms/Sidebar'
+import Sidebar from '../Atoms/Sidebar'
 import { AuthDataContext } from '../UserContext'
 import Setup, { setupStages } from './Setup'
+import useSetupMenuItems from './useSetupMenuItems'
 
 const initialData: IAudit = {
   name: '',
@@ -79,42 +74,7 @@ const Audit: React.FC<{}> = () => {
     'Participants'
   )
 
-  const menuItems: ISidebarMenuItem[] = useMemo(
-    () =>
-      setupStages.map((s: ElementType<typeof setupStages>) => {
-        const state = (() => {
-          switch (s) {
-            case 'Participants':
-              return 'live'
-            case 'Target Contests':
-              return 'live'
-            case 'Opportunistic Contests':
-              return 'live'
-            case 'Audit Settings':
-              return 'live'
-            case 'Review & Launch':
-              return 'live'
-            /* istanbul ignore next */
-            default:
-              return 'locked'
-          }
-        })()
-        return {
-          title: s,
-          active: s === stage,
-          activate: (_, force = false) => {
-            if (state === 'live') {
-              if (!force) {
-                // launch confirm dialog
-              }
-              setStage(s)
-            }
-          },
-          state,
-        }
-      }),
-    [stage, setupStages]
-  )
+  const [menuItems] = useSetupMenuItems(stage, setStage)
 
   const activeStage = menuItems.find(m => m.title === stage)
   const nextStage = menuItems[menuItems.indexOf(activeStage!) + 1]

--- a/arlo-client/src/components/Audit/index.tsx
+++ b/arlo-client/src/components/Audit/index.tsx
@@ -82,11 +82,20 @@ const Audit: React.FC<{}> = () => {
   const menuItems = useMemo(
     () =>
       setupStages.map(
-        (s: ElementType<typeof setupStages>): ISidebarMenuItem => ({
-          title: s,
-          active: s === stage,
-          action: () => setStage(s),
-        })
+        (s: ElementType<typeof setupStages>): ISidebarMenuItem => {
+          return (() => {
+            switch (s) {
+              case 'Participants':
+              default:
+                return {
+                  title: s,
+                  active: s === stage,
+                  action: () => setStage(s),
+                  state: 'live', // dynamic functions to query the state of the data needed
+                } as ISidebarMenuItem
+            }
+          })()
+        }
       ),
     [stage]
   )

--- a/arlo-client/src/components/Audit/index.tsx
+++ b/arlo-client/src/components/Audit/index.tsx
@@ -87,14 +87,14 @@ const Audit: React.FC<{}> = () => {
             case 'Participants':
               return 'live'
             case 'Target Contests':
-              return 'processing'
+              return 'live'
             case 'Opportunistic Contests':
-              return 'locked'
+              return 'live'
             case 'Audit Settings':
-              return 'locked'
+              return 'live'
             case 'Review & Launch':
               return 'live'
-            /* istanbul ignoe next */
+            /* istanbul ignore next */
             default:
               return 'locked'
           }
@@ -102,8 +102,13 @@ const Audit: React.FC<{}> = () => {
         return {
           title: s,
           active: s === stage,
-          activate: () => {
-            if (state === 'live') setStage(s)
+          activate: (_, force = false) => {
+            if (state === 'live') {
+              if (!force) {
+                // launch confirm dialog
+              }
+              setStage(s)
+            }
           },
           state,
         }

--- a/arlo-client/src/components/Audit/useSetupMenuItems.tsx
+++ b/arlo-client/src/components/Audit/useSetupMenuItems.tsx
@@ -56,7 +56,9 @@ function useSetupMenuItems(
           title: s,
           active: s === stage,
           activate: (_, force = false) => {
+            /* istanbul ignore else */
             if (state === 'live') {
+              /* istanbul ignore next */
               if (!force) {
                 // launch confirm dialog
               }

--- a/arlo-client/src/components/Audit/useSetupMenuItems.tsx
+++ b/arlo-client/src/components/Audit/useSetupMenuItems.tsx
@@ -12,15 +12,15 @@ function useSetupMenuItems(
   )
   const [targetContests, setTargetContests] = useState<
     ISidebarMenuItem['state']
-  >('locked')
+  >('live')
   const [opportunisticContests, setOpportunisticContests] = useState<
     ISidebarMenuItem['state']
-  >('locked')
+  >('live')
   const [auditSettings, setAuditSettings] = useState<ISidebarMenuItem['state']>(
-    'locked'
+    'live'
   )
   const [reviewLaunch, setReviewLaunch] = useState<ISidebarMenuItem['state']>(
-    'locked'
+    'live'
   )
 
   const refresh = () => {

--- a/arlo-client/src/components/Audit/useSetupMenuItems.tsx
+++ b/arlo-client/src/components/Audit/useSetupMenuItems.tsx
@@ -68,7 +68,15 @@ function useSetupMenuItems(
           state,
         }
       }),
-    [stage, setupStages]
+    [
+      stage,
+      setStage,
+      participants,
+      targetContests,
+      opportunisticContests,
+      auditSettings,
+      reviewLaunch,
+    ]
   )
   return [menuItems, refresh]
 }

--- a/arlo-client/src/components/Audit/useSetupMenuItems.tsx
+++ b/arlo-client/src/components/Audit/useSetupMenuItems.tsx
@@ -1,0 +1,74 @@
+import { useState, useMemo } from 'react'
+import { setupStages } from './Setup'
+import { ElementType } from '../../types'
+import { ISidebarMenuItem } from '../Atoms/Sidebar'
+
+function useSetupMenuItems(
+  stage: ElementType<typeof setupStages>,
+  setStage: (s: ElementType<typeof setupStages>) => void
+): [ISidebarMenuItem[], () => void] {
+  const [participants, setParticipants] = useState<ISidebarMenuItem['state']>(
+    'live'
+  )
+  const [targetContests, setTargetContests] = useState<
+    ISidebarMenuItem['state']
+  >('locked')
+  const [opportunisticContests, setOpportunisticContests] = useState<
+    ISidebarMenuItem['state']
+  >('locked')
+  const [auditSettings, setAuditSettings] = useState<ISidebarMenuItem['state']>(
+    'locked'
+  )
+  const [reviewLaunch, setReviewLaunch] = useState<ISidebarMenuItem['state']>(
+    'locked'
+  )
+
+  const refresh = () => {
+    setParticipants('live')
+    setTargetContests('live')
+    setOpportunisticContests('live')
+    setAuditSettings('live')
+    setReviewLaunch('live')
+  }
+
+  const menuItems: ISidebarMenuItem[] = useMemo(
+    () =>
+      setupStages.map((s: ElementType<typeof setupStages>) => {
+        const state = (() => {
+          // move these to useStates, so they can be asynchronously updated
+          switch (s) {
+            case 'Participants':
+              return participants
+            case 'Target Contests':
+              return targetContests
+            case 'Opportunistic Contests':
+              return opportunisticContests
+            case 'Audit Settings':
+              return auditSettings
+            case 'Review & Launch':
+              return reviewLaunch
+            /* istanbul ignore next */
+            default:
+              return 'locked'
+          }
+        })()
+        return {
+          title: s,
+          active: s === stage,
+          activate: (_, force = false) => {
+            if (state === 'live') {
+              if (!force) {
+                // launch confirm dialog
+              }
+              setStage(s)
+            }
+          },
+          state,
+        }
+      }),
+    [stage, setupStages]
+  )
+  return [menuItems, refresh]
+}
+
+export default useSetupMenuItems


### PR DESCRIPTION
**Description**

- Lifting up and extracting out state management for the setup stages so we can add in logic for controlling navigation between them based on polling the data.
- Corrected `/jurisdictions/file` to `/jurisdiction/file` to comply with the recent endpoint fix

**Testing**

- Updating snapshots and test implementation

**Progress**

- I'm still working on doing the actual polling logic, but I wanted to get this one pushed up before it got too big and scope creep set in.