### PR TITLE
refactor: introduce election access route decorator

### DIFF
--- a/arlo_server/election_settings.py
+++ b/arlo_server/election_settings.py
@@ -2,7 +2,7 @@ from flask import jsonify, request
 from jsonschema import validate
 
 from arlo_server import app, db
-from arlo_server.auth import require_audit_admin_for_organization
+from arlo_server.auth import with_election_access, UserType
 from arlo_server.models import Election, USState
 
 from util.jsonschema import nullable, Enum, Obj, Str, Bool, Int, IntRange
@@ -20,10 +20,8 @@ PUT_ELECTION_SETTINGS_REQUEST_SCHEMA = GET_ELECTION_SETTINGS_RESPONSE_SCHEMA
 
 
 @app.route("/election/<election_id>/settings", methods=["GET"])
-def get_election_settings(election_id: str):
-    election = Election.query.get_or_404(election_id)
-    require_audit_admin_for_organization(election.organization_id)
-
+@with_election_access(UserType.AUDIT_ADMIN)
+def get_election_settings(election: Election):
     response_data = {
         "electionName": election.election_name,
         "online": election.online,
@@ -38,10 +36,8 @@ def get_election_settings(election_id: str):
 
 
 @app.route("/election/<election_id>/settings", methods=["PUT"])
-def put_election_settings(election_id: str):
-    election = Election.query.get_or_404(election_id)
-    require_audit_admin_for_organization(election.organization_id)
-
+@with_election_access(UserType.AUDIT_ADMIN)
+def put_election_settings(election: Election):
     settings = request.get_json()
     validate(schema=PUT_ELECTION_SETTINGS_REQUEST_SCHEMA, instance=settings)
 

--- a/arlo_server/jurisdictions.py
+++ b/arlo_server/jurisdictions.py
@@ -3,10 +3,10 @@ from flask import jsonify
 from arlo_server import app, db
 from arlo_server.routes import (
     get_election,
-    require_audit_admin_for_organization,
     isoformat,
 )
-from arlo_server.models import Jurisdiction
+from arlo_server.models import Election, Jurisdiction
+from arlo_server.auth import with_election_access, UserType
 from util.process_file import serialize_file, serialize_file_processing
 
 
@@ -28,10 +28,8 @@ def serialize_jurisdiction(db_jurisdiction: Jurisdiction) -> dict:
 
 
 @app.route("/election/<election_id>/jurisdiction", methods=["GET"])
-def list_jurisdictions(election_id: str = None):
-    election = get_election(election_id)
-    require_audit_admin_for_organization(election.organization_id)
-
+@with_election_access(UserType.AUDIT_ADMIN)
+def list_jurisdictions(election: Election):
     jurisdictions = (
         Jurisdiction.query.filter_by(election_id=election.id)
         .order_by(Jurisdiction.name)

--- a/arlo_server/sample_sizes.py
+++ b/arlo_server/sample_sizes.py
@@ -6,15 +6,13 @@ from typing import Dict
 
 from arlo_server import app, db
 from arlo_server.models import Election, Contest
-from arlo_server.routes import require_audit_admin_for_organization
+from arlo_server.auth import with_election_access, UserType
 from audits import bravo, sampler_contest
 
 
 @app.route("/election/<election_id>/sample-sizes", methods=["GET"])
-def get_sample_sizes(election_id: str):
-    election = Election.query.get_or_404(election_id)
-    require_audit_admin_for_organization(election.organization_id)
-
+@with_election_access(UserType.AUDIT_ADMIN)
+def get_sample_sizes(election: Election):
     if not election.contests:
         raise BadRequest("Cannot compute sample sizes until contests are set")
     if not election.risk_limit:


### PR DESCRIPTION
**Description**

Closes #380
Refs #290

Decorating a route using `with_election_access` allows the route to be defined with an `election` parameter that will be be provided only if the election exists and the current user has access to it.

**Testing**

Existing tests should cover this okay, but to really test it I'd have to figure out how to test this more directly. I'm not sure what the right approach is there. Maybe create another Flask app per test that I then add test routes to?

**Progress**

This is a building block toward #290.