### PR TITLE
test(pylint): enforce `unused-import` rule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -66,7 +66,8 @@ disable=all
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=singleton-comparison
+enable=singleton-comparison,
+       unused-import
 
 
 [REPORTS]

--- a/arlo_server/contests.py
+++ b/arlo_server/contests.py
@@ -4,7 +4,7 @@ from jsonschema import validate
 from werkzeug.exceptions import BadRequest
 
 from arlo_server import app, db
-from arlo_server.routes import get_election, with_election_access, UserType
+from arlo_server.routes import with_election_access, UserType
 from arlo_server.models import Contest, ContestChoice, Election, Jurisdiction
 
 contest_choice_schema = {

--- a/arlo_server/election_settings.py
+++ b/arlo_server/election_settings.py
@@ -5,7 +5,7 @@ from arlo_server import app, db
 from arlo_server.auth import with_election_access, UserType
 from arlo_server.models import Election, USState
 
-from util.jsonschema import nullable, Enum, Obj, Str, Bool, Int, IntRange
+from util.jsonschema import nullable, Enum, Obj, Str, Bool, IntRange
 
 GET_ELECTION_SETTINGS_RESPONSE_SCHEMA = Obj(
     electionName=nullable(Str),

--- a/arlo_server/jurisdictions.py
+++ b/arlo_server/jurisdictions.py
@@ -1,10 +1,6 @@
 from flask import jsonify
 
-from arlo_server import app, db
-from arlo_server.routes import (
-    get_election,
-    isoformat,
-)
+from arlo_server import app
 from arlo_server.models import Election, Jurisdiction
 from arlo_server.auth import with_election_access, UserType
 from util.process_file import serialize_file, serialize_file_processing

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -1,5 +1,4 @@
 from sqlalchemy.orm import relationship, backref
-from typing import Union, List
 from enum import Enum
 from flask_sqlalchemy import SQLAlchemy
 from flask_sqlalchemy.model import DefaultMeta

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -1,13 +1,11 @@
-import os, datetime, csv, io, math, json, uuid, locale, re, hmac, urllib.parse, itertools
-from enum import Enum, auto
-from typing import Optional, Tuple, Union
+import os, datetime, csv, io, json, uuid, re, hmac, urllib.parse, itertools
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
-from flask import Flask, jsonify, request, Response, redirect, session
+from flask import jsonify, request, Response, redirect, session
 from flask_httpauth import HTTPBasicAuth
 
-from audit_math import sampler, bravo, sampler_contest
+from audit_math import bravo, sampler_contest
 from werkzeug.exceptions import (
     InternalServerError,
     Unauthorized,
@@ -17,7 +15,7 @@ from werkzeug.exceptions import (
 )
 from xkcdpass import xkcd_password as xp
 
-from sqlalchemy import event, func
+from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.exc import IntegrityError
 
@@ -48,10 +46,8 @@ from config import (
 )
 
 from util.ballot_manifest import sample_ballots
-from util.binpacking import Bucket, BalancedBucketList
 from util.isoformat import isoformat
-from util.jurisdiction_bulk_update import bulk_update_jurisdictions
-from util.process_file import process_file, serialize_file, serialize_file_processing
+from util.process_file import serialize_file, serialize_file_processing
 
 AUDIT_BOARD_MEMBER_COUNT = 2
 WORDS = xp.generate_wordlist(wordfile=xp.locate_wordfile())

--- a/arlo_server/sample_sizes.py
+++ b/arlo_server/sample_sizes.py
@@ -1,11 +1,10 @@
-from flask import jsonify, request
+from flask import jsonify
 from collections import defaultdict
-import math
 from werkzeug.exceptions import BadRequest
 from typing import Dict
 
-from arlo_server import app, db
-from arlo_server.models import Election, Contest
+from arlo_server import app
+from arlo_server.models import Election
 from arlo_server.auth import with_election_access, UserType
 from audit_math import bravo, sampler_contest
 

--- a/audit_math/bravo.py
+++ b/audit_math/bravo.py
@@ -7,7 +7,7 @@ targeted is being audited completely independently.
 """
 import math
 from scipy import stats
-from typing import Dict, Tuple, Any, Union, Optional
+from typing import Dict, Tuple, Union, Optional
 
 from .sampler_contest import Contest
 

--- a/audit_math/macro.py
+++ b/audit_math/macro.py
@@ -10,7 +10,7 @@ MACRO was developed by Philip Stark
 import math
 from .sampler_contest import Contest
 
-from typing import Any, Dict, List, Tuple
+from typing import Dict, Tuple
 
 
 def compute_error(

--- a/audit_math/sampler.py
+++ b/audit_math/sampler.py
@@ -1,10 +1,6 @@
 # Handles generating sample sizes and taking samples
-import math
-import numpy as np
-from scipy import stats
 from typing import cast, Any, Dict, List, Tuple
 import consistent_sampler
-import operator
 
 import audit_math.macro as macro
 from .sampler_contest import Contest

--- a/audit_math/sampler_contest.py
+++ b/audit_math/sampler_contest.py
@@ -2,7 +2,7 @@
 A Module containing the Contest class, which encapsulates useful info for RLA
 computations.
 """
-from typing import Dict, Optional, Tuple, List, cast
+from typing import Dict, Tuple, List, cast
 import operator
 
 

--- a/bgcompute.py
+++ b/bgcompute.py
@@ -1,15 +1,10 @@
-# type: ignore
-import time, json
+import time
 
-from flask import Flask
-from sqlalchemy.orm import joinedload
-
-from arlo_server import app, db
+from arlo_server import db
 from arlo_server.models import Election, File, Jurisdiction, RoundContest
 from arlo_server.routes import compute_sample_sizes
 from util.ballot_manifest import process_ballot_manifest_file
 from util.jurisdiction_bulk_update import process_jurisdictions_file
-from util.process_file import process_file
 
 
 def bgcompute():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from typing import List
 
 from arlo_server import app, db
 from arlo_server.models import Jurisdiction, USState
-from helpers import post_json, put_json, create_election
+from helpers import put_json, create_election
 from bgcompute import bgcompute_update_election_jurisdictions_file
 
 # The fixtures in this module are available in any test via dependency

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,11 +1,9 @@
 import os, math, uuid
-import tempfile
 import json, csv, io
 from flask.testing import FlaskClient
 
 import pytest
 
-from arlo_server import app, db
 from tests.helpers import post_json, create_election
 import bgcompute
 

--- a/tests/test_app_upload_jurisdictions_file.py
+++ b/tests/test_app_upload_jurisdictions_file.py
@@ -1,12 +1,7 @@
-import os, math, uuid
-import tempfile
-import json, csv, io
+import json, io
 
 from flask.testing import FlaskClient
-from tests.helpers import post_json
-import pytest
 
-from arlo_server import app, db
 from arlo_server.models import (
     Election,
     File,
@@ -17,7 +12,7 @@ from arlo_server.models import (
 from bgcompute import bgcompute_update_election_jurisdictions_file
 
 
-def test_missing_file(client, election_id):
+def test_missing_file(client: FlaskClient, election_id: str):
     rv = client.put(f"/election/{election_id}/jurisdiction/file")
     assert rv.status_code == 400
     assert json.loads(rv.data) == {
@@ -30,7 +25,7 @@ def test_missing_file(client, election_id):
     }
 
 
-def test_bad_csv_file(client, election_id):
+def test_bad_csv_file(client: FlaskClient, election_id: str):
     rv = client.put(
         f"/election/{election_id}/jurisdiction/file",
         data={"jurisdictions": (io.BytesIO(b"not a CSV file"), "random.txt")},

--- a/tests/test_audit_basic_update.py
+++ b/tests/test_audit_basic_update.py
@@ -1,5 +1,4 @@
 import json, uuid
-import pytest
 
 from helpers import post_json
 

--- a/tests/test_audit_status.py
+++ b/tests/test_audit_status.py
@@ -3,7 +3,6 @@ import pytest
 from flask.testing import FlaskClient
 
 from helpers import (
-    post_json,
     compare_json,
     assert_is_id,
     assert_is_date,

--- a/tests/test_ballot_list.py
+++ b/tests/test_ballot_list.py
@@ -4,7 +4,7 @@ from flask.testing import FlaskClient
 import pytest
 
 from helpers import post_json, create_election
-from test_app import setup_whole_audit, setup_whole_multi_winner_audit
+from test_app import setup_whole_audit
 import bgcompute
 
 

--- a/tests/test_bravo.py
+++ b/tests/test_bravo.py
@@ -1,8 +1,7 @@
 import pytest
 import math
-import numpy as np
 
-from audit_math import bravo, sampler
+from audit_math import bravo
 from audit_math.sampler_contest import Contest
 
 seed = "12345678901234567890abcdefghijklmnopqrstuvwxyz😊"

--- a/tests/test_contests.py
+++ b/tests/test_contests.py
@@ -1,19 +1,20 @@
-import pytest
 from flask.testing import FlaskClient
+from typing import List
 
 import json, uuid
 
-from helpers import post_json, put_json
-from arlo_server.models import Jurisdiction
+from helpers import put_json
 
 
-def test_contests_list_empty(client, election_id):
+def test_contests_list_empty(client: FlaskClient, election_id: str):
     rv = client.get(f"/election/{election_id}/contest")
     contests = json.loads(rv.data)
     assert contests == []
 
 
-def test_contests_create_get_update_one(client, election_id, jurisdiction_ids):
+def test_contests_create_get_update_one(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
     contest = {
         "id": str(uuid.uuid4()),
         "name": "Contest 1",
@@ -49,7 +50,9 @@ def test_contests_create_get_update_one(client, election_id, jurisdiction_ids):
     assert contests == [contest]
 
 
-def test_contests_create_get_update_multiple(client, election_id, jurisdiction_ids):
+def test_contests_create_get_update_multiple(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
     contests = [
         {
             "id": str(uuid.uuid4()),
@@ -111,7 +114,9 @@ def test_contests_create_get_update_multiple(client, election_id, jurisdiction_i
     assert contests == json_contests
 
 
-def test_contests_missing_field(client, election_id, jurisdiction_ids):
+def test_contests_missing_field(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
     contest = {
         "id": str(uuid.uuid4()),
         "name": "Contest 1",
@@ -159,7 +164,7 @@ def test_contests_missing_field(client, election_id, jurisdiction_ids):
         }
 
 
-def test_contest_too_many_votes(client, election_id):
+def test_contest_too_many_votes(client: FlaskClient, election_id: str):
     contest = {
         "id": str(uuid.uuid4()),
         "name": "Contest 1",

--- a/tests/test_election_settings.py
+++ b/tests/test_election_settings.py
@@ -1,5 +1,4 @@
 import json
-import pytest
 from flask.testing import FlaskClient
 
 from arlo_server.models import Election, USState

--- a/tests/test_jurisdictions.py
+++ b/tests/test_jurisdictions.py
@@ -1,11 +1,10 @@
 import pytest
 from flask.testing import FlaskClient
 
-import json, io, uuid
+import json, io
 from typing import List
 
-from helpers import post_json, compare_json, assert_is_date, create_org_and_admin
-from arlo_server.auth import UserType
+from helpers import compare_json, assert_is_date
 from arlo_server.models import Jurisdiction
 from bgcompute import (
     bgcompute_update_election_jurisdictions_file,

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -1,8 +1,6 @@
 import pytest
-import math
-import numpy as np
 
-from audit_math import sampler, macro
+from audit_math import macro
 from audit_math.sampler_contest import Contest
 
 seed = "12345678901234567890abcdefghijklmnopqrstuvwxyz😊"

--- a/tests/test_new_election.py
+++ b/tests/test_new_election.py
@@ -1,9 +1,6 @@
 import json, uuid
-import pytest
 from flask.testing import FlaskClient
-from typing import Any
 
-from arlo_server import app, db
 from arlo_server.auth import UserType
 from arlo_server.routes import create_organization
 from tests.helpers import create_org_and_admin, set_logged_in_user, post_json

--- a/tests/test_sample_sizes.py
+++ b/tests/test_sample_sizes.py
@@ -1,9 +1,5 @@
-import pytest
 from flask.testing import FlaskClient
-from typing import List
-import json, uuid
-
-from helpers import put_json
+import json
 
 
 def test_sample_sizes_without_contests(client: FlaskClient, election_id: str):

--- a/util/ballot_manifest.py
+++ b/util/ballot_manifest.py
@@ -4,9 +4,8 @@ import locale
 import uuid
 from sqlalchemy.orm.session import Session
 from typing import Dict, List, Tuple
-from werkzeug.exceptions import BadRequest
 
-from audit_math import sampler, sampler_contest
+from audit_math import sampler
 from arlo_server.models import (
     Batch,
     Election,

--- a/util/binpacking.py
+++ b/util/binpacking.py
@@ -1,4 +1,3 @@
-import csv
 import operator
 import numpy
 from typing import Dict, Optional, Tuple, List, cast

--- a/util/isoformat.py
+++ b/util/isoformat.py
@@ -3,9 +3,6 @@ from typing import Optional, Union
 
 
 def isoformat(
-    datetime: Optional[Union[datetime.datetime, datetime.date]]
+    value: Optional[Union[datetime.datetime, datetime.date]]
 ) -> Optional[str]:
-    if datetime is not None:
-        return datetime.isoformat()
-    else:
-        return None
+    return value.isoformat() if value is not None else None

--- a/util/jurisdiction_bulk_update.py
+++ b/util/jurisdiction_bulk_update.py
@@ -1,7 +1,6 @@
 import csv
 import io
 import uuid
-from sqlalchemy import func
 from typing import Tuple, List
 
 from arlo_server.models import (


### PR DESCRIPTION
**Description**

In most cases I simply removed the unused imports, but in a couple cases I used the imported symbols as type annotations.

**Testing**

n/a

**Progress**

n/a
