### PR TITLE
Wrap /election/<election_id>/contest response array in an object

### DIFF
--- a/arlo_server/contests.py
+++ b/arlo_server/contests.py
@@ -7,7 +7,7 @@ from arlo_server import app, db
 from arlo_server.routes import with_election_access, UserType
 from arlo_server.models import Contest, ContestChoice, Election, Jurisdiction
 
-contest_choice_schema = {
+CONTEST_CHOICE_SCHEMA = {
     "type": "object",
     "properties": {
         "id": {"type": "string"},
@@ -17,13 +17,13 @@ contest_choice_schema = {
     "required": ["id", "name", "numVotes"],
 }
 
-contest_schema = {
+CONTEST_SCHEMA = {
     "type": "object",
     "properties": {
         "id": {"type": "string"},
         "name": {"type": "string"},
         "isTargeted": {"type": "boolean"},
-        "choices": {"type": "array", "items": contest_choice_schema},
+        "choices": {"type": "array", "items": CONTEST_CHOICE_SCHEMA},
         "totalBallotsCast": {"type": "integer", "minimum": 0},
         "numWinners": {"type": "integer", "minimum": 1},
         "votesAllowed": {"type": "integer", "minimum": 1},
@@ -42,65 +42,62 @@ contest_schema = {
 }
 
 
-def serialize_contest_choice(db_contest_choice: ContestChoice) -> dict:
+def serialize_contest_choice(contest_choice: ContestChoice) -> dict:
     return {
-        "id": db_contest_choice.id,
-        "name": db_contest_choice.name,
-        "numVotes": db_contest_choice.num_votes,
+        "id": contest_choice.id,
+        "name": contest_choice.name,
+        "numVotes": contest_choice.num_votes,
     }
 
 
-def serialize_contest(db_contest: Contest) -> dict:
+def serialize_contest(contest: Contest) -> dict:
     return {
-        "id": db_contest.id,
-        "name": db_contest.name,
-        "isTargeted": db_contest.is_targeted,
-        "choices": [serialize_contest_choice(c) for c in db_contest.choices],
-        "totalBallotsCast": db_contest.total_ballots_cast,
-        "numWinners": db_contest.num_winners,
-        "votesAllowed": db_contest.votes_allowed,
-        "jurisdictionIds": [j.id for j in db_contest.jurisdictions],
+        "id": contest.id,
+        "name": contest.name,
+        "isTargeted": contest.is_targeted,
+        "choices": [serialize_contest_choice(c) for c in contest.choices],
+        "totalBallotsCast": contest.total_ballots_cast,
+        "numWinners": contest.num_winners,
+        "votesAllowed": contest.votes_allowed,
+        "jurisdictionIds": [j.id for j in contest.jurisdictions],
     }
 
 
-def deserialize_contest_choice(json_contest_choice: dict, contest_id: str) -> Contest:
+def deserialize_contest_choice(contest_choice: dict, contest_id: str) -> Contest:
     return ContestChoice(
-        id=json_contest_choice["id"],
+        id=contest_choice["id"],
         contest_id=contest_id,
-        name=json_contest_choice["name"],
-        num_votes=json_contest_choice["numVotes"],
+        name=contest_choice["name"],
+        num_votes=contest_choice["numVotes"],
     )
 
 
-def deserialize_contest(json_contest: dict, election_id: str) -> Contest:
+def deserialize_contest(contest: dict, election_id: str) -> Contest:
     jurisdictions = (
         db.session.query(Jurisdiction)
         .filter_by(election_id=election_id)
-        .filter(Jurisdiction.id.in_(json_contest["jurisdictionIds"]))
+        .filter(Jurisdiction.id.in_(contest["jurisdictionIds"]))
         .all()
     )
-    choices = [
-        deserialize_contest_choice(c, json_contest["id"])
-        for c in json_contest["choices"]
-    ]
+    choices = [deserialize_contest_choice(c, contest["id"]) for c in contest["choices"]]
     return Contest(
         election_id=election_id,
-        id=json_contest["id"],
-        name=json_contest["name"],
-        is_targeted=json_contest["isTargeted"],
+        id=contest["id"],
+        name=contest["name"],
+        is_targeted=contest["isTargeted"],
         choices=choices,
-        total_ballots_cast=json_contest["totalBallotsCast"],
-        num_winners=json_contest["numWinners"],
-        votes_allowed=json_contest["votesAllowed"],
+        total_ballots_cast=contest["totalBallotsCast"],
+        num_winners=contest["numWinners"],
+        votes_allowed=contest["votesAllowed"],
         jurisdictions=jurisdictions,
     )
 
 
 # Raises if invalid
-def validate_contests(json_contests: List[dict]) -> None:
-    validate(json_contests, {"type": "array", "items": contest_schema})
+def validate_contests(contests: List[dict]) -> None:
+    validate(contests, {"type": "array", "items": CONTEST_SCHEMA})
 
-    for contest in json_contests:
+    for contest in contests:
         total_votes = sum(c["numVotes"] for c in contest["choices"])
         total_allowed_votes = contest["totalBallotsCast"] * contest["votesAllowed"]
         if total_votes > total_allowed_votes:

--- a/arlo_server/contests.py
+++ b/arlo_server/contests.py
@@ -127,4 +127,5 @@ def create_or_update_all_contests(election: Election):
 @app.route("/election/<election_id>/contest", methods=["GET"])
 @with_election_access(UserType.AUDIT_ADMIN)
 def list_contests(election: Election):
-    return jsonify([serialize_contest(c) for c in election.contests])
+    json_contests = [serialize_contest(c) for c in election.contests]
+    return jsonify({"contests": json_contests})

--- a/tests/routes_tests/test_contests.py
+++ b/tests/routes_tests/test_contests.py
@@ -9,7 +9,7 @@ from helpers import put_json
 def test_contests_list_empty(client: FlaskClient, election_id: str):
     rv = client.get(f"/election/{election_id}/contest")
     contests = json.loads(rv.data)
-    assert contests == []
+    assert contests == {"contests": []}
 
 
 def test_contests_create_get_update_one(
@@ -33,7 +33,7 @@ def test_contests_create_get_update_one(
 
     rv = client.get(f"/election/{election_id}/contest")
     contests = json.loads(rv.data)
-    assert contests == [contest]
+    assert contests == {"contests": [contest]}
 
     contest["totalBallotsCast"] = contest["totalBallotsCast"] + 21
     contest["numWinners"] = 2
@@ -42,12 +42,11 @@ def test_contests_create_get_update_one(
     )
 
     rv = put_json(client, f"/election/{election_id}/contest", [contest])
-    print(json.loads(rv.data))
     assert json.loads(rv.data) == {"status": "ok"}
 
     rv = client.get(f"/election/{election_id}/contest")
     contests = json.loads(rv.data)
-    assert contests == [contest]
+    assert contests == {"contests": [contest]}
 
 
 def test_contests_create_get_update_multiple(
@@ -100,7 +99,7 @@ def test_contests_create_get_update_multiple(
 
     rv = client.get(f"/election/{election_id}/contest")
     json_contests = json.loads(rv.data)
-    assert contests == json_contests
+    assert json_contests == {"contests": contests}
 
     contests[0]["name"] = "Changed name"
     contests[1]["isTargeted"] = True
@@ -111,7 +110,7 @@ def test_contests_create_get_update_multiple(
 
     rv = client.get(f"/election/{election_id}/contest")
     json_contests = json.loads(rv.data)
-    assert contests == json_contests
+    assert json_contests == {"contests": contests}
 
 
 def test_contests_missing_field(


### PR DESCRIPTION
**Description**

Wraps the /election/<election_id>/contest response array in an object, as agreed upon as a best practice here: https://github.com/votingworks/arlo/pull/377#discussion_r396810023. Should be fine since it's not depended on yet.

Also did some minor code cleanup (in a separate commit).

**Testing**

Modified existing tests to cover.

**Progress**

Ready for review.