### PR TITLE
Add currentRoundStatus to list contests endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-client:
 
 # To run a specific test: TEST=<test name> make test-server
 test-server:
-	FLASK_ENV=test python3.7 -m pipenv run python -m pytest -k '${TEST}' --ignore=arlo-client
+	FLASK_ENV=test python3.7 -m pipenv run python -m pytest -k '${TEST}' --ignore=arlo-client -vv --disable-warnings -x
 
 # Only tests audit_math
 test-math:


### PR DESCRIPTION
**Description**

This adds a field `currentRoundStatus` to each contest in the output of
/election/<election_id>/contest. `currentRoundStatus` is null until the
audit starts. Once the audit starts, it is an object with two fields:

- `isRiskLimitMet` - whether the calculated risk measurement for that
contest meets the audit risk limit (or null if we're not done auditing
ballots for that contest yet)

- `numSampledBallots` - how many ballot samples were drawn for this contest

**Testing**

Updating existing tests for the null case. Added a new test to test the status once the round has started.

**Progress**

Ready for review.