### PR TITLE
test(pylint): enforce `dangerous-default-value` rule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -66,7 +66,8 @@ disable=all
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=singleton-comparison,
+enable=dangerous-default-value,
+       singleton-comparison,
        unused-import
 
 


### PR DESCRIPTION
**Description**

We had no violations of this rule, so this did not require any changes other than configuring pylint to look for it.

**Testing**

n/a

**Progress**

n/a
