### PR TITLE
test(pylint): enable `unused-argument` rule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -70,6 +70,7 @@ enable=dangerous-default-value,
        possibly-unused-variable,
        singleton-comparison,
        undefined-variable,
+       unused-argument,
        unused-import,
 
 

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -199,7 +199,7 @@ if ADMIN_PASSWORD:
     auth = HTTPBasicAuth()
 
     @auth.verify_password
-    def verify_password(username, password):
+    def verify_password(_username, password):
         # use a comparison method that prevents timing attacks:
         # https://securitypitfalls.wordpress.com/2018/08/03/constant-time-compare-in-python/
         return password is not None and hmac.compare_digest(password, ADMIN_PASSWORD)
@@ -713,6 +713,7 @@ def ballot_list(election_id, jurisdiction_id, round_id):
         .add_entity(Batch)
         .add_entity(AuditBoard)
         .filter(Round.id == round_id)
+        .filter(Round.election_id == election_id)
         .filter(Batch.jurisdiction_id == jurisdiction_id)
         .order_by(
             AuditBoard.name,
@@ -754,6 +755,7 @@ def ballot_list_by_audit_board(election_id, jurisdiction_id, audit_board_id, rou
         .add_entity(SampledBallot)
         .add_entity(Batch)
         .filter(Round.id == round_id)
+        .filter(Round.election_id == election_id)
         .filter(Batch.jurisdiction_id == jurisdiction_id)
         .filter(SampledBallot.audit_board_id == audit_board_id)
         .order_by(
@@ -1302,7 +1304,7 @@ def jurisdictionadmin_login_callback():
 @app.route("/")
 @app.route("/election/<election_id>")
 @app.route("/election/<election_id>/board/<board_id>")
-def serve(election_id=None, board_id=None):
+def serve(election_id=None, board_id=None):  # pylint: disable=unused-argument
     return app.send_static_file("index.html")
 
 

--- a/audit_math/macro.py
+++ b/audit_math/macro.py
@@ -143,7 +143,9 @@ def get_sample_sizes(
     risk_limit: float,
     contest: Contest,
     reported_results: Dict[str, Dict[str, Dict[str, int]]],
-    sample_results: Dict[str, Dict[str, Dict[str, int]]],
+    sample_results: Dict[
+        str, Dict[str, Dict[str, int]]
+    ],  # pylint: disable=unused-argument
 ) -> float:
     """
     Computes initial sample sizes parameterized by likelihood that the

--- a/audit_math/sampler.py
+++ b/audit_math/sampler.py
@@ -62,7 +62,6 @@ def draw_sample(
 def draw_ppeb_sample(
     seed: str,
     contest: Contest,
-    manifest: Dict[str, int],
     sample_size: int,
     num_sampled: int,
     batch_results: Dict[str, Dict[str, Dict[str, int]]],
@@ -76,12 +75,6 @@ def draw_ppeb_sample(
 
     Inputs:
         seed    - the random seed to use in sampling
-        manifest - mapping of batches to the ballots they contain:
-                    {
-                        batch1: num_balots,
-                        batch2: num_ballots,
-                        ...
-                    }
         sample_size - number of ballots to randomly draw
         num_sampled - number of ballots that have already been sampled
         batch_results - the result of the election, per batch:

--- a/tests/audit_math_tests/test_sampler.py
+++ b/tests/audit_math_tests/test_sampler.py
@@ -93,7 +93,7 @@ def test_draw_more_samples():
 def test_draw_macro_sample(macro_batches, macro_contest):
     # Test getting a sample
     sample = sampler.draw_ppeb_sample(
-        seed, macro_contest, {}, 10, 0, batch_results=macro_batches
+        seed, macro_contest, 10, 0, batch_results=macro_batches
     )
 
     for i, item in enumerate(sample):
@@ -107,7 +107,7 @@ def test_draw_more_macro_sample(macro_batches, macro_contest):
     # Test getting a sample
     samp_size = 5
     sample = sampler.draw_ppeb_sample(
-        seed, macro_contest, {}, samp_size, 0, batch_results=macro_batches,
+        seed, macro_contest, samp_size, 0, batch_results=macro_batches,
     )
     assert samp_size == len(sample), "Received sample of size {}, expected {}".format(
         samp_size, len(sample)
@@ -121,7 +121,7 @@ def test_draw_more_macro_sample(macro_batches, macro_contest):
 
     samp_size = 5
     sample = sampler.draw_ppeb_sample(
-        seed, macro_contest, {}, samp_size, num_sampled=5, batch_results=macro_batches
+        seed, macro_contest, samp_size, num_sampled=5, batch_results=macro_batches
     )
     assert samp_size == len(sample), "Received sample of size {}, expected {}".format(
         samp_size, len(sample)

--- a/tests/routes_tests/test_new_election.py
+++ b/tests/routes_tests/test_new_election.py
@@ -234,6 +234,6 @@ def test_election_reset(client, election_id):
     assert status["rounds"] == []
 
 
-def test_election_reset_not_found(client, election_id):
+def test_election_reset_not_found(client):
     rv = client.post(f"/election/{str(uuid.uuid4())}/audit/reset")
     assert rv.status_code == 404

--- a/tests/routes_tests/test_sample_sizes.py
+++ b/tests/routes_tests/test_sample_sizes.py
@@ -16,7 +16,9 @@ def test_sample_sizes_without_contests(client: FlaskClient, election_id: str):
 
 
 def test_sample_sizes_without_risk_limit(
-    client: FlaskClient, election_id: str, contest: str
+    client: FlaskClient,
+    election_id: str,
+    contest: str,  # pylint: disable=unused-argument
 ):
     rv = client.get(f"/election/{election_id}/sample-sizes")
     assert rv.status_code == 400
@@ -31,7 +33,10 @@ def test_sample_sizes_without_risk_limit(
 
 
 def test_sample_sizes_round_1(
-    client: FlaskClient, election_id: str, contest: str, election_settings: None
+    client: FlaskClient,
+    election_id: str,
+    contest: str,  # pylint: disable=unused-argument
+    election_settings: None,  # pylint: disable=unused-argument
 ):
     rv = client.get(f"/election/{election_id}/sample-sizes")
     sample_sizes = json.loads(rv.data)

--- a/tests/test_rounds.py
+++ b/tests/test_rounds.py
@@ -64,7 +64,7 @@ def test_rounds_create_one(
     election_id: str,
     jurisdiction_ids: List[str],
     contest: dict,
-    manifests,
+    manifests,  # pylint: disable=unused-argument
 ):
     sample_size = 119  # BRAVO sample size
     rv = post_json(
@@ -120,8 +120,8 @@ def test_rounds_create_two(
     election_id: str,
     jurisdiction_ids: List[str],
     contest: dict,
-    manifests,
-    election_settings,
+    manifests,  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
 ):
     rv = post_json(
         client, f"/election/{election_id}/round", {"roundNum": 1, "sampleSize": 119,},
@@ -203,7 +203,11 @@ def test_rounds_create_two(
 
 
 def test_rounds_create_before_previous_round_complete(
-    client: FlaskClient, election_id: str, contest: dict, manifests, election_settings
+    client: FlaskClient,
+    election_id: str,
+    contest: dict,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
 ):
     rv = post_json(
         client, f"/election/{election_id}/round", {"roundNum": 1, "sampleSize": 10,},
@@ -235,7 +239,9 @@ def test_rounds_wrong_number_too_big(client: FlaskClient, election_id: str):
 
 
 def test_rounds_wrong_number_too_small(
-    client: FlaskClient, election_id: str, contest: dict
+    client: FlaskClient,
+    election_id: str,
+    contest: dict,  # pylint: disable=unused-argument
 ):
     rv = post_json(
         client, f"/election/{election_id}/round", {"roundNum": 1, "sampleSize": 10,},


### PR DESCRIPTION
**Description**

This fixes the violations in a variety of ways:
- underscore-prefix arguments we want to keep and can change the name
- disable specific instances where we can't fix yet
- remove unused arguments when possible

**Testing**

n/a

**Progress**

n/a
