### PR TITLE
Makefile improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,11 @@ jobs:
       - run:
           name: type check
           command: |
-            make typecheck
+            make typecheck-server
       - run:
           name: check formatting
           command: |
-            make format-python
+            make format-server
             git diff-index --quiet HEAD -- || (echo "Found unexpected changes!" && git diff && exit 1)
       - run:
           name: backend tests

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PIPENV=python3.7 -m pipenv
 
 deps:
 	sudo apt install python3.7 python3-pip nodejs libpython3.7-dev libpq-dev
@@ -11,13 +12,13 @@ initdevdb:
 	sudo -u postgres psql -c "create database arlo with owner arlo;"
 
 install:
-	python3.7 -m pipenv install
+	${PIPENV} install
 	yarn install
 	yarn --cwd arlo-client install
 	yarn --cwd arlo-client build
 
 install-development:
-	python3.7 -m pipenv install --dev
+	${PIPENV} install --dev
 	yarn install
 	yarn --cwd arlo-client install
 
@@ -25,37 +26,38 @@ resettestdb:
 	FLASK_ENV=test make resetdb
 
 resetdb:
-	python3.7 -m pipenv run python resetdb.py
+	${PIPENV} run python resetdb.py
 
 dev-environment: deps initdevdb install-development resetdb
 
-typecheck:
-	python3.7 -m pipenv run mypy .
+typecheck-server:
+	${PIPENV} run mypy .
 
-format-python:
-	python3.7 -m pipenv run black .
+format-server:
+	${PIPENV} run black .
 
 lint-server:
-	find . -name '*.py' | xargs python3.7 -m pipenv run pylint
+	find . -name '*.py' | xargs ${PIPENV} run pylint
 
 test-client:
 	yarn --cwd arlo-client lint
 	yarn --cwd arlo-client test
 
-# To run a specific test: TEST=<test name> make test-server
+# To run tests matching a search string: TEST=<search string> make test-server
+# To run specific test files: FILE=<file path> make test-server
+# To pass in additional flags to pytest: FLAGS=<extra flags> make test-server
 test-server:
-	FLASK_ENV=test python3.7 -m pipenv run python -m pytest -k '${TEST}' --ignore=arlo-client -vv
+	FLASK_ENV=test ${PIPENV} run python -m pytest ${FILE} \
+		-k '${TEST}' --ignore=arlo-client -vv ${FLAGS}
 
-# Only tests audit_math
 test-math:
-	FLASK_ENV=test python3.7 -m pipenv run python -m pytest tests/audit_math_tests -k '${TEST}' 
+	FILE=tests/audit_math_tests make test-server
 
-
-# Only tests utils
 test-utils:
-	FLASK_ENV=test python3.7 -m pipenv run python -m pytest tests/util_tests -k '${TEST}' 
+	FILE=tests/util_tests make test-server
 
-
-# Only tests routes
 test-routes:
-	FLASK_ENV=test python3.7 -m pipenv run python -m pytest tests/routes_tests -k '${TEST}' 
+	FILE=tests/routes_tests make test-server
+
+python-shell:
+	${PIPENV} run python

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn --cwd arlo-client tsc && lint-staged && yarn --cwd arlo-client lint-staged"
+      "pre-commit": "yarn --cwd arlo-client tsc && lint-staged && yarn --cwd arlo-client lint-staged && make typecheck-server"
     }
   },
   "lint-staged": {
@@ -15,7 +15,8 @@
       "prettier --write"
     ],
     "*.py": [
-      "python3.7 -m pipenv run black"
+      "python3.7 -m pipenv run black",
+      "python3.7 -m pipenv run pylint"
     ],
     "package.json": [
       "sort-package-json"


### PR DESCRIPTION

**Description**

Makefile improvements:
- Pull out the command to run pipenv into a variable
- Add `FILE` and `FLAGS` variables to make test-server
- Use those variables to implement the modularized server test commands
- Name server targets consistently (always use "server", not "python")
- Add a command `make python-shell` to run a python shell

Also adds Python lint and typecheck to the pre-commit hooks

**Testing**

Ran a smattering of the commands

**Progress**

Ready for review