### PR TITLE
fix: require uniqueness of jurisdiction & batch names

### DIFF
--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -90,6 +90,8 @@ class Jurisdiction(BaseModel):
         passive_deletes=True,
     )
 
+    __table_args__ = (db.UniqueConstraint("election_id", "name"),)
+
 
 class User(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
@@ -161,6 +163,8 @@ class Batch(BaseModel):
     ballot_draws = relationship(
         "SampledBallotDraw", backref="batch", passive_deletes=True
     )
+
+    __table_args__ = (db.UniqueConstraint("jurisdiction_id", "name"),)
 
 
 class Contest(BaseModel):

--- a/tests/routes_tests/test_jurisdictions.py
+++ b/tests/routes_tests/test_jurisdictions.py
@@ -1,10 +1,12 @@
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 from flask.testing import FlaskClient
 
 import json, io
 from typing import List
 
-from helpers import compare_json, assert_is_date
+from helpers import compare_json, assert_is_date, asserts_startswith
+from arlo_server import db
 from arlo_server.models import Jurisdiction
 from bgcompute import (
     bgcompute_update_election_jurisdictions_file,
@@ -32,7 +34,11 @@ def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
     )
     assert json.loads(rv.data) == {"status": "ok"}
     bgcompute_update_election_jurisdictions_file()
-    jurisdictions = Jurisdiction.query.filter_by(election_id=election_id).all()
+    jurisdictions = (
+        Jurisdiction.query.filter_by(election_id=election_id)
+        .order_by(Jurisdiction.name)
+        .all()
+    )
     assert len(jurisdictions) == 3
     yield [j.id for j in jurisdictions]
 
@@ -48,7 +54,7 @@ def test_jurisdictions_list_no_manifest(client, election_id, jurisdiction_ids):
     jurisdictions = json.loads(rv.data)
     assert jurisdictions == [
         {
-            "id": jurisdiction_ids[2],
+            "id": jurisdiction_ids[0],
             "name": "J1",
             "ballotManifest": {
                 "file": None,
@@ -58,7 +64,7 @@ def test_jurisdictions_list_no_manifest(client, election_id, jurisdiction_ids):
             },
         },
         {
-            "id": jurisdiction_ids[0],
+            "id": jurisdiction_ids[1],
             "name": "J2",
             "ballotManifest": {
                 "file": None,
@@ -68,7 +74,7 @@ def test_jurisdictions_list_no_manifest(client, election_id, jurisdiction_ids):
             },
         },
         {
-            "id": jurisdiction_ids[1],
+            "id": jurisdiction_ids[2],
             "name": "J3",
             "ballotManifest": {
                 "file": None,
@@ -82,7 +88,7 @@ def test_jurisdictions_list_no_manifest(client, election_id, jurisdiction_ids):
 
 def test_jurisdictions_list_with_manifest(client, election_id, jurisdiction_ids):
     rv = client.put(
-        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[2]}/manifest",
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/manifest",
         data={
             "manifest": (
                 io.BytesIO(
@@ -103,7 +109,7 @@ def test_jurisdictions_list_with_manifest(client, election_id, jurisdiction_ids)
     jurisdictions = json.loads(rv.data)
     expected = [
         {
-            "id": jurisdiction_ids[2],
+            "id": jurisdiction_ids[0],
             "name": "J1",
             "ballotManifest": {
                 "file": {"name": "manifest.csv", "uploadedAt": assert_is_date},
@@ -118,7 +124,7 @@ def test_jurisdictions_list_with_manifest(client, election_id, jurisdiction_ids)
             },
         },
         {
-            "id": jurisdiction_ids[0],
+            "id": jurisdiction_ids[1],
             "name": "J2",
             "ballotManifest": {
                 "file": None,
@@ -128,7 +134,68 @@ def test_jurisdictions_list_with_manifest(client, election_id, jurisdiction_ids)
             },
         },
         {
+            "id": jurisdiction_ids[2],
+            "name": "J3",
+            "ballotManifest": {
+                "file": None,
+                "processing": None,
+                "numBallots": None,
+                "numBatches": None,
+            },
+        },
+    ]
+    compare_json(jurisdictions, expected)
+
+
+def test_duplicate_batch_name(client, election_id, jurisdiction_ids):
+    rv = client.put(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/manifest",
+        data={
+            "manifest": (
+                io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n" b"1,101\n"),
+                "manifest.csv",
+            )
+        },
+    )
+    assert json.loads(rv.data) == {"status": "ok"}
+
+    with pytest.raises(SQLAlchemyError):
+        bgcompute_update_ballot_manifest_file()
+
+    db.session.rollback()
+
+    rv = client.get(f"/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)
+    expected = [
+        {
+            "id": jurisdiction_ids[0],
+            "name": "J1",
+            "ballotManifest": {
+                "file": {"name": "manifest.csv", "uploadedAt": assert_is_date},
+                "processing": {
+                    "status": "ERRORED",
+                    "startedAt": assert_is_date,
+                    "completedAt": assert_is_date,
+                    "error": asserts_startswith(
+                        '(psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "batch_jurisdiction_id_name_key"'
+                    ),
+                },
+                "numBallots": None,
+                "numBatches": None,
+            },
+        },
+        {
             "id": jurisdiction_ids[1],
+            "name": "J2",
+            "ballotManifest": {
+                "file": None,
+                "processing": None,
+                "numBallots": None,
+                "numBatches": None,
+            },
+        },
+        {
+            "id": jurisdiction_ids[2],
             "name": "J3",
             "ballotManifest": {
                 "file": None,

--- a/tests/util_tests/test_jurisdiction_bulk_update.py
+++ b/tests/util_tests/test_jurisdiction_bulk_update.py
@@ -19,7 +19,7 @@ def db():
 
     yield arlo_server.db
 
-    arlo_server.db.session.commit()
+    arlo_server.db.session.rollback()
 
 
 def test_first_update(db):


### PR DESCRIPTION
**Description**

`Jurisdiction` names must now be unique per `Election`, and `Batch` names must now be unique per `Jurisdiction`. Since these are handled via database constraints, we'll get an exception whenever we try to commit a session that would violate those constraints. It turns out that capturing and handling such an error correctly in `process_file` required some changes. We now roll back the session on error, then update the file processing metadata.

Closes #389

**Testing**

Adds a new test for `process_file` to ensure database constraint errors are recorded properly.

**Progress**

This puts the raw error database message into `processing_error`, which is probably not suitable for display to an end user. We should consider catching the error at a higher level than `process_file` and updating it.
