### PR TITLE
Add currentRoundStatus to list jurisdictions endpoint

### DIFF
--- a/arlo_server/contests.py
+++ b/arlo_server/contests.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Optional
 from flask import request, jsonify
 from werkzeug.exceptions import BadRequest
 from sqlalchemy import func
@@ -16,10 +16,8 @@ from arlo_server.models import (
     Batch,
 )
 from arlo_server.rounds import get_current_round
-from util.jsonschema import validate
+from util.jsonschema import validate, JSONDict
 
-# An approximation of a JSON object type, since we can't do recursive types
-JSONDict = Dict[str, Any]
 
 CONTEST_CHOICE_SCHEMA = {
     "type": "object",

--- a/arlo_server/contests.py
+++ b/arlo_server/contests.py
@@ -67,7 +67,6 @@ def serialize_contest_choice(contest_choice: ContestChoice) -> JSONDict:
 
 
 def serialize_contest(contest: Contest, round_status: Optional[JSONDict]) -> JSONDict:
-    jurisdictions = sorted(contest.jurisdictions, key=lambda j: j.name)
     return {
         "id": contest.id,
         "name": contest.name,
@@ -76,7 +75,7 @@ def serialize_contest(contest: Contest, round_status: Optional[JSONDict]) -> JSO
         "totalBallotsCast": contest.total_ballots_cast,
         "numWinners": contest.num_winners,
         "votesAllowed": contest.votes_allowed,
-        "jurisdictionIds": [j.id for j in jurisdictions],
+        "jurisdictionIds": [j.id for j in contest.jurisdictions],
         "currentRoundStatus": round_status,
     }
 

--- a/arlo_server/jurisdictions.py
+++ b/arlo_server/jurisdictions.py
@@ -126,14 +126,12 @@ def round_status_by_jurisdiction(
 @app.route("/election/<election_id>/jurisdiction", methods=["GET"])
 @with_election_access(UserType.AUDIT_ADMIN)
 def list_jurisdictions(election: Election):
-    jurisdictions = sorted(election.jurisdictions, key=lambda j: j.name)
-
     current_round = get_current_round(election)
     round_status = round_status_by_jurisdiction(
-        current_round, jurisdictions, election.online
+        current_round, election.jurisdictions, election.online
     )
 
     json_jurisdictions = [
-        serialize_jurisdiction(j, round_status[j.id]) for j in jurisdictions
+        serialize_jurisdiction(j, round_status[j.id]) for j in election.jurisdictions
     ]
     return jsonify({"jurisdictions": json_jurisdictions})

--- a/arlo_server/jurisdictions.py
+++ b/arlo_server/jurisdictions.py
@@ -1,35 +1,139 @@
 from flask import jsonify
+from typing import List, Dict, Optional
+from enum import Enum
+from sqlalchemy import func
 
 from arlo_server import app
-from arlo_server.models import Election, Jurisdiction
+from arlo_server.models import (
+    Election,
+    Jurisdiction,
+    SampledBallotDraw,
+    SampledBallot,
+    Batch,
+    Round,
+    AuditBoard,
+)
 from arlo_server.auth import with_election_access, UserType
+from arlo_server.rounds import get_current_round
 from util.process_file import serialize_file, serialize_file_processing
+from util.jsonschema import JSONDict
 
 
-def serialize_jurisdiction(db_jurisdiction: Jurisdiction) -> dict:
+def serialize_jurisdiction(
+    jurisdiction: Jurisdiction, round_status: Optional[JSONDict]
+) -> JSONDict:
     return {
-        "id": db_jurisdiction.id,
-        "name": db_jurisdiction.name,
+        "id": jurisdiction.id,
+        "name": jurisdiction.name,
         "ballotManifest": {
-            "file": serialize_file(db_jurisdiction.manifest_file)
-            if db_jurisdiction.manifest_file
+            "file": serialize_file(jurisdiction.manifest_file)
+            if jurisdiction.manifest_file
             else None,
-            "processing": serialize_file_processing(db_jurisdiction.manifest_file)
-            if db_jurisdiction.manifest_file
+            "processing": serialize_file_processing(jurisdiction.manifest_file)
+            if jurisdiction.manifest_file
             else None,
-            "numBallots": db_jurisdiction.manifest_num_ballots,
-            "numBatches": db_jurisdiction.manifest_num_batches,
+            "numBallots": jurisdiction.manifest_num_ballots,
+            "numBatches": jurisdiction.manifest_num_batches,
         },
+        "currentRoundStatus": round_status,
+    }
+
+
+class JurisdictionStatus(str, Enum):
+    NOT_STARTED = "NOT_STARTED"
+    IN_PROGRESS = "IN_PROGRESS"
+    COMPLETE = "COMPLETE"
+
+
+def round_status_by_jurisdiction(
+    round: Optional[Round], jurisdictions: List[Jurisdiction], online: bool
+) -> Dict[str, Optional[JSONDict]]:
+    if not round:
+        return {j.id: None for j in jurisdictions}
+
+    audit_boards_set_up = dict(
+        AuditBoard.query.filter_by(round_id=round.id)
+        .group_by(AuditBoard.jurisdiction_id)
+        .values(AuditBoard.jurisdiction_id, func.count())
+    )
+    audit_boards_signed_off = dict(
+        AuditBoard.query.filter_by(round_id=round.id)
+        .filter(AuditBoard.signed_off_at.isnot(None))
+        .group_by(AuditBoard.jurisdiction_id)
+        .values(AuditBoard.jurisdiction_id, func.count())
+    )
+
+    sampled_ballot_count_by_jurisdiction = dict(
+        SampledBallotDraw.query.filter_by(round_id=round.id)
+        .join(Batch)
+        .group_by(Batch.jurisdiction_id)
+        .values(Batch.jurisdiction_id, func.count())
+    )
+    audited_ballot_count_by_jurisdiction = dict(
+        SampledBallotDraw.query.filter_by(round_id=round.id)
+        .join(SampledBallot)
+        .filter(SampledBallot.vote.isnot(None))
+        .join(Batch)
+        .group_by(Batch.jurisdiction_id)
+        .values(Batch.jurisdiction_id, func.count())
+    )
+
+    def num_ballots_sampled(jurisdiction_id: str) -> int:
+        return sampled_ballot_count_by_jurisdiction.get(jurisdiction_id, 0)
+
+    # NOT_STARTED = the jurisdiction hasn’t set up any audit boards
+    # IN_PROGRESS = the audit boards are set up
+    # COMPLETE = all of the audit boards have signed off on their ballots
+    def status(jurisdiction_id: str) -> JurisdictionStatus:
+        num_set_up = audit_boards_set_up.get(jurisdiction_id, 0)
+        num_signed_off = audit_boards_signed_off.get(jurisdiction_id, 0)
+        num_sampled = num_ballots_sampled(jurisdiction_id)
+
+        # Special case: jurisdictions that don't get any ballots assigned are
+        # COMPLETE from the get-go
+        if num_sampled == 0:
+            return JurisdictionStatus.COMPLETE
+        elif num_set_up == 0:
+            return JurisdictionStatus.NOT_STARTED
+        elif num_signed_off != num_set_up:
+            return JurisdictionStatus.IN_PROGRESS
+        else:
+            return JurisdictionStatus.COMPLETE
+
+    def num_ballots_audited(jurisdiction_id: str) -> int:
+        if online:
+            return audited_ballot_count_by_jurisdiction.get(jurisdiction_id, 0)
+        else:
+            # For offline audits, we can't track incremental progress on
+            # auditing ballots, so we just report 0 ballots until the round is
+            # complete, then report all the sampled ballots.
+            return (
+                0
+                if status(jurisdiction_id) != JurisdictionStatus.COMPLETE
+                else num_ballots_sampled(jurisdiction_id)
+            )
+
+    return {
+        j.id: {
+            "status": status(j.id),
+            "numBallotsSampled": num_ballots_sampled(j.id),
+            "numBallotsAudited": num_ballots_audited(j.id),
+        }
+        for j in jurisdictions
     }
 
 
 @app.route("/election/<election_id>/jurisdiction", methods=["GET"])
 @with_election_access(UserType.AUDIT_ADMIN)
 def list_jurisdictions(election: Election):
-    jurisdictions = (
-        Jurisdiction.query.filter_by(election_id=election.id)
-        .order_by(Jurisdiction.name)
-        .all()
+    jurisdictions = sorted(election.jurisdictions, key=lambda j: j.name)
+
+    current_round = get_current_round(election)
+    round_status = round_status_by_jurisdiction(
+        current_round, jurisdictions, election.online
     )
 
-    return jsonify([serialize_jurisdiction(j) for j in jurisdictions])
+    json_jurisdictions = [
+        serialize_jurisdiction(j, round_status[j.id]) for j in jurisdictions
+    ]
+    return jsonify({"jurisdictions": json_jurisdictions})

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -241,6 +241,7 @@ class AuditBoard(BaseModel):
     member_2 = db.Column(db.String(200), nullable=True)
     member_2_affiliation = db.Column(db.String(200), nullable=True)
     passphrase = db.Column(db.String(1000), unique=True, nullable=True)
+    signed_off_at = db.Column(db.DateTime(timezone=False), nullable=True)
 
     sampled_ballots = relationship(
         "SampledBallot", backref="audit_board", passive_deletes=True

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -60,7 +60,10 @@ class Election(BaseModel):
     frozen_at = db.Column(db.DateTime(timezone=False), nullable=True)
 
     jurisdictions = relationship(
-        "Jurisdiction", backref="election", passive_deletes=True
+        "Jurisdiction",
+        backref="election",
+        passive_deletes=True,
+        order_by="Jurisdiction.name",
     )
     contests = relationship("Contest", backref="election", passive_deletes=True)
     rounds = relationship("Round", backref="election", passive_deletes=True)

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -96,10 +96,7 @@ class Jurisdiction(BaseModel):
         "AuditBoard", backref="jurisdiction", passive_deletes=True
     )
     contests = relationship(
-        "Contest",
-        secondary="contest_jurisdiction",
-        backref="jurisdictions",
-        passive_deletes=True,
+        "Contest", secondary="contest_jurisdiction", passive_deletes=True,
     )
 
     __table_args__ = (db.UniqueConstraint("election_id", "name"),)
@@ -194,6 +191,12 @@ class Contest(BaseModel):
     choices = relationship("ContestChoice", backref="contest", passive_deletes=True)
     results = relationship(
         "RoundContestResult", backref="contest", passive_deletes=True
+    )
+    jurisdictions = relationship(
+        "Jurisdiction",
+        secondary="contest_jurisdiction",
+        order_by="Jurisdiction.name",
+        passive_deletes=True,
     )
 
 

--- a/tests/routes_tests/test_jurisdictions.py
+++ b/tests/routes_tests/test_jurisdictions.py
@@ -2,12 +2,26 @@ import pytest
 from sqlalchemy.exc import SQLAlchemyError
 from flask.testing import FlaskClient
 
-import json, io
+import json, io, uuid
+from datetime import datetime
 from typing import List
 
-from helpers import compare_json, assert_is_date, asserts_startswith
+from helpers import (
+    put_json,
+    post_json,
+    compare_json,
+    assert_is_date,
+    asserts_startswith,
+)
 from arlo_server import db
-from arlo_server.models import Jurisdiction
+from arlo_server.models import (
+    Jurisdiction,
+    Contest,
+    AuditBoard,
+    SampledBallot,
+    SampledBallotDraw,
+    USState,
+)
 from bgcompute import (
     bgcompute_update_election_jurisdictions_file,
     bgcompute_update_ballot_manifest_file,
@@ -43,50 +57,59 @@ def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
     yield [j.id for j in jurisdictions]
 
 
-def test_jurisdictions_list_empty(client, election_id):
+def test_jurisdictions_list_empty(client: FlaskClient, election_id: str):
     rv = client.get(f"/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)
-    assert jurisdictions == []
+    assert jurisdictions == {"jurisdictions": []}
 
 
-def test_jurisdictions_list_no_manifest(client, election_id, jurisdiction_ids):
+def test_jurisdictions_list_no_manifest(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
     rv = client.get(f"/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)
-    assert jurisdictions == [
-        {
-            "id": jurisdiction_ids[0],
-            "name": "J1",
-            "ballotManifest": {
-                "file": None,
-                "processing": None,
-                "numBallots": None,
-                "numBatches": None,
+    assert jurisdictions == {
+        "jurisdictions": [
+            {
+                "id": jurisdiction_ids[0],
+                "name": "J1",
+                "ballotManifest": {
+                    "file": None,
+                    "processing": None,
+                    "numBallots": None,
+                    "numBatches": None,
+                },
+                "currentRoundStatus": None,
             },
-        },
-        {
-            "id": jurisdiction_ids[1],
-            "name": "J2",
-            "ballotManifest": {
-                "file": None,
-                "processing": None,
-                "numBallots": None,
-                "numBatches": None,
+            {
+                "id": jurisdiction_ids[1],
+                "name": "J2",
+                "ballotManifest": {
+                    "file": None,
+                    "processing": None,
+                    "numBallots": None,
+                    "numBatches": None,
+                },
+                "currentRoundStatus": None,
             },
-        },
-        {
-            "id": jurisdiction_ids[2],
-            "name": "J3",
-            "ballotManifest": {
-                "file": None,
-                "processing": None,
-                "numBallots": None,
-                "numBatches": None,
+            {
+                "id": jurisdiction_ids[2],
+                "name": "J3",
+                "ballotManifest": {
+                    "file": None,
+                    "processing": None,
+                    "numBallots": None,
+                    "numBatches": None,
+                },
+                "currentRoundStatus": None,
             },
-        },
-    ]
+        ]
+    }
 
 
-def test_jurisdictions_list_with_manifest(client, election_id, jurisdiction_ids):
+def test_jurisdictions_list_with_manifest(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
     rv = client.put(
         f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/manifest",
         data={
@@ -107,43 +130,48 @@ def test_jurisdictions_list_with_manifest(client, election_id, jurisdiction_ids)
 
     rv = client.get(f"/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)
-    expected = [
-        {
-            "id": jurisdiction_ids[0],
-            "name": "J1",
-            "ballotManifest": {
-                "file": {"name": "manifest.csv", "uploadedAt": assert_is_date},
-                "processing": {
-                    "status": "PROCESSED",
-                    "startedAt": assert_is_date,
-                    "completedAt": assert_is_date,
-                    "error": None,
+    expected = {
+        "jurisdictions": [
+            {
+                "id": jurisdiction_ids[0],
+                "name": "J1",
+                "ballotManifest": {
+                    "file": {"name": "manifest.csv", "uploadedAt": assert_is_date},
+                    "processing": {
+                        "status": "PROCESSED",
+                        "startedAt": assert_is_date,
+                        "completedAt": assert_is_date,
+                        "error": None,
+                    },
+                    "numBallots": 23 + 101 + 122 + 400,
+                    "numBatches": 4,
                 },
-                "numBallots": 23 + 101 + 122 + 400,
-                "numBatches": 4,
+                "currentRoundStatus": None,
             },
-        },
-        {
-            "id": jurisdiction_ids[1],
-            "name": "J2",
-            "ballotManifest": {
-                "file": None,
-                "processing": None,
-                "numBallots": None,
-                "numBatches": None,
+            {
+                "id": jurisdiction_ids[1],
+                "name": "J2",
+                "ballotManifest": {
+                    "file": None,
+                    "processing": None,
+                    "numBallots": None,
+                    "numBatches": None,
+                },
+                "currentRoundStatus": None,
             },
-        },
-        {
-            "id": jurisdiction_ids[2],
-            "name": "J3",
-            "ballotManifest": {
-                "file": None,
-                "processing": None,
-                "numBallots": None,
-                "numBatches": None,
+            {
+                "id": jurisdiction_ids[2],
+                "name": "J3",
+                "ballotManifest": {
+                    "file": None,
+                    "processing": None,
+                    "numBallots": None,
+                    "numBatches": None,
+                },
+                "currentRoundStatus": None,
             },
-        },
-    ]
+        ]
+    }
     compare_json(jurisdictions, expected)
 
 
@@ -166,43 +194,244 @@ def test_duplicate_batch_name(client, election_id, jurisdiction_ids):
 
     rv = client.get(f"/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)
-    expected = [
-        {
-            "id": jurisdiction_ids[0],
-            "name": "J1",
-            "ballotManifest": {
-                "file": {"name": "manifest.csv", "uploadedAt": assert_is_date},
-                "processing": {
-                    "status": "ERRORED",
-                    "startedAt": assert_is_date,
-                    "completedAt": assert_is_date,
-                    "error": asserts_startswith(
-                        '(psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "batch_jurisdiction_id_name_key"'
-                    ),
+    expected = {
+        "jurisdictions": [
+            {
+                "id": jurisdiction_ids[0],
+                "name": "J1",
+                "ballotManifest": {
+                    "file": {"name": "manifest.csv", "uploadedAt": assert_is_date},
+                    "processing": {
+                        "status": "ERRORED",
+                        "startedAt": assert_is_date,
+                        "completedAt": assert_is_date,
+                        "error": asserts_startswith(
+                            '(psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "batch_jurisdiction_id_name_key"'
+                        ),
+                    },
+                    "numBallots": None,
+                    "numBatches": None,
                 },
-                "numBallots": None,
-                "numBatches": None,
+                "currentRoundStatus": None,
             },
-        },
-        {
-            "id": jurisdiction_ids[1],
-            "name": "J2",
-            "ballotManifest": {
-                "file": None,
-                "processing": None,
-                "numBallots": None,
-                "numBatches": None,
+            {
+                "id": jurisdiction_ids[1],
+                "name": "J2",
+                "ballotManifest": {
+                    "file": None,
+                    "processing": None,
+                    "numBallots": None,
+                    "numBatches": None,
+                },
+                "currentRoundStatus": None,
             },
-        },
-        {
-            "id": jurisdiction_ids[2],
-            "name": "J3",
-            "ballotManifest": {
-                "file": None,
-                "processing": None,
-                "numBallots": None,
-                "numBatches": None,
+            {
+                "id": jurisdiction_ids[2],
+                "name": "J3",
+                "ballotManifest": {
+                    "file": None,
+                    "processing": None,
+                    "numBallots": None,
+                    "numBatches": None,
+                },
+                "currentRoundStatus": None,
             },
-        },
-    ]
+        ]
+    }
     compare_json(jurisdictions, expected)
+
+
+def test_jurisdictions_round_status(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+    contest: Contest,  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+):
+    SAMPLE_SIZE = 119  # Bravo sample size
+    J1_SAMPLES = 81  # Expected result of sampler for jurisdiction 1
+    AB1_SAMPLES = 23  # Arbitrary num of ballots to assign to audit board 1
+
+    rv = post_json(
+        client,
+        f"/election/{election_id}/round",
+        {"roundNum": 1, "sampleSize": SAMPLE_SIZE},
+    )
+    assert rv.status_code == 200
+
+    rv = client.get(f"/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+
+    assert jurisdictions[0]["currentRoundStatus"] == {
+        "status": "NOT_STARTED",
+        "numBallotsSampled": J1_SAMPLES,
+        "numBallotsAudited": 0,
+    }
+    assert jurisdictions[1]["currentRoundStatus"] == {
+        "status": "NOT_STARTED",
+        "numBallotsSampled": SAMPLE_SIZE - J1_SAMPLES,
+        "numBallotsAudited": 0,
+    }
+    assert jurisdictions[2]["currentRoundStatus"] == {
+        "status": "COMPLETE",
+        "numBallotsSampled": 0,
+        "numBallotsAudited": 0,
+    }
+
+    # Simulate creating some audit boards
+    rv = client.get(f"/election/{election_id}/round")
+    round = json.loads(rv.data)["rounds"][0]
+
+    ballots = (
+        SampledBallot.query.join(SampledBallotDraw)
+        .filter_by(round_id=round["id"])
+        .all()
+    )
+    audit_board_1 = AuditBoard(
+        id=str(uuid.uuid4()),
+        jurisdiction_id=jurisdiction_ids[0],
+        round_id=round["id"],
+        sampled_ballots=ballots[: AB1_SAMPLES + 1],
+    )
+    audit_board_2 = AuditBoard(
+        id=str(uuid.uuid4()),
+        jurisdiction_id=jurisdiction_ids[0],
+        round_id=round["id"],
+        sampled_ballots=ballots[AB1_SAMPLES + 1 :],
+    )
+    db.session.add(audit_board_1)
+    db.session.add(audit_board_2)
+    db.session.commit()
+
+    rv = client.get(f"/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+
+    assert jurisdictions[0]["currentRoundStatus"] == {
+        "status": "IN_PROGRESS",
+        "numBallotsSampled": J1_SAMPLES,
+        "numBallotsAudited": 0,
+    }
+    assert jurisdictions[1]["currentRoundStatus"] == {
+        "status": "NOT_STARTED",
+        "numBallotsSampled": SAMPLE_SIZE - J1_SAMPLES,
+        "numBallotsAudited": 0,
+    }
+    assert jurisdictions[2]["currentRoundStatus"] == {
+        "status": "COMPLETE",
+        "numBallotsSampled": 0,
+        "numBallotsAudited": 0,
+    }
+
+    # Simulate one audit board auditing all its ballots and signing off
+    audit_board_1 = db.session.merge(audit_board_1)  # Reload into the session
+    for ballot in audit_board_1.sampled_ballots:
+        ballot.vote = "YES"
+    audit_board_1.signed_off_at = datetime.utcnow()
+    db.session.commit()
+
+    rv = client.get(f"/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+
+    assert jurisdictions[0]["currentRoundStatus"] == {
+        "status": "IN_PROGRESS",
+        "numBallotsSampled": J1_SAMPLES,
+        "numBallotsAudited": AB1_SAMPLES,
+    }
+
+    # Simulate the other audit board auditing all its ballots and signing off
+    audit_board_2 = db.session.merge(audit_board_2)  # Reload into the session
+    for ballot in audit_board_2.sampled_ballots:
+        ballot.vote = "NO"
+    audit_board_2.signed_off_at = datetime.utcnow()
+    db.session.commit()
+
+    rv = client.get(f"/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+
+    assert jurisdictions[0]["currentRoundStatus"] == {
+        "status": "COMPLETE",
+        "numBallotsSampled": J1_SAMPLES,
+        "numBallotsAudited": J1_SAMPLES,
+    }
+
+
+def test_jurisdictions_round_status_offline(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+    contest: Contest,  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+):
+    SAMPLE_SIZE = 119  # Bravo sample size
+    J1_SAMPLES = 81  # Expected result of sampler for jurisdiction 1
+    AB1_SAMPLES = 23  # Arbitrary num of ballots to assign to audit board 1
+
+    # Change the settings to offline
+    settings = {
+        "electionName": "Test Election",
+        "online": False,
+        "randomSeed": "1234567890",
+        "riskLimit": 10,
+        "state": USState.California,
+    }
+    rv = put_json(client, f"/election/{election_id}/settings", settings)
+    assert json.loads(rv.data) == {"status": "ok"}
+
+    rv = post_json(
+        client,
+        f"/election/{election_id}/round",
+        {"roundNum": 1, "sampleSize": SAMPLE_SIZE},
+    )
+    assert rv.status_code == 200
+
+    rv = client.get(f"/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+
+    assert jurisdictions[0]["currentRoundStatus"] == {
+        "status": "NOT_STARTED",
+        "numBallotsSampled": J1_SAMPLES,
+        "numBallotsAudited": 0,
+    }
+
+    # Simulate creating an audit board
+    rv = client.get(f"/election/{election_id}/round")
+    round = json.loads(rv.data)["rounds"][0]
+
+    ballots = (
+        SampledBallot.query.join(SampledBallotDraw)
+        .filter_by(round_id=round["id"])
+        .all()
+    )
+    audit_board_1 = AuditBoard(
+        id=str(uuid.uuid4()),
+        jurisdiction_id=jurisdiction_ids[0],
+        round_id=round["id"],
+        sampled_ballots=ballots[: AB1_SAMPLES + 1],
+    )
+    db.session.add(audit_board_1)
+    db.session.commit()
+
+    rv = client.get(f"/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+
+    assert jurisdictions[0]["currentRoundStatus"] == {
+        "status": "IN_PROGRESS",
+        "numBallotsSampled": J1_SAMPLES,
+        "numBallotsAudited": 0,
+    }
+
+    # Simulate the audit board signing off
+    audit_board_1 = db.session.merge(audit_board_1)  # Reload into the session
+    audit_board_1.signed_off_at = datetime.utcnow()
+    db.session.commit()
+
+    rv = client.get(f"/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+
+    assert jurisdictions[0]["currentRoundStatus"] == {
+        "status": "COMPLETE",
+        "numBallotsSampled": J1_SAMPLES,
+        "numBallotsAudited": J1_SAMPLES,
+    }

--- a/util/jsonschema.py
+++ b/util/jsonschema.py
@@ -2,7 +2,10 @@ import jsonschema
 import jsonschema.validators
 from typing import Any, Dict, List, Union
 
-JSONSchema = Dict[str, Any]
+# An approximation of a JSON object type, since mypy doesn't support
+# recursive types.
+JSONDict = Dict[str, Any]
+JSONSchema = JSONDict
 
 
 def validate(instance: Any, schema: JSONSchema):


### PR DESCRIPTION
**Description**

Task: #338 
This adds a field `currentRoundStatus` to each jurisdiction in the output of /election/<election_id>/jurisdiction. `currentRoundStatus` is null until the audit starts. Once the audit starts, it is an object with three fields:

- `status`:
    - `NOT_STARTED` = the jurisdiction hasn’t set up any audit boards
    - `IN_PROGRESS` = the audit boards are set up
    - `COMPLETE` = all of the audit boards have signed off on their ballots

- `numBallotsSampled` - how many ballot samples were drawn for this jurisdiction
- `numBallotsAudited` - how many of the drawn ballot samples have been audited so far

Also adds a new field `signed_off_at` to the `AuditBoard` data model, signifying when the audit board members have finalized their audit results.

While I was at it, I wrapped the jurisdictions array returned by this endpoint in an object, similar to #388.

**Testing**

Updating existing tests (all testing before audit start). Added a new test case walking through the various statuses.

**Progress**

Ready for review.