### PR TITLE
fix(csp): allow unsafe inline scripts for now

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -25,6 +25,11 @@ T = Talisman(
     force_https_permanent=True,
     session_cookie_http_only=True,
     feature_policy="camera 'none'; microphone 'none'; geolocation 'none'",
+    # TODO: Configure webpack to use a nonce: https://webpack.js.org/guides/csp/.
+    content_security_policy={
+        "default-src": "'self'",
+        "script-src": "'self' 'unsafe-inline'",
+    },
 )
 app.secret_key = SESSION_SECRET
 


### PR DESCRIPTION
**Description**

Webpack injects some JavaScript into the HTML when running `react-scripts build`, and the default CSP provided by Talisman is too strict. This changes the CSP to allow unsafe inline scripts, though the longer-term fix is to generate a nonce and provide it to both Webpack and Talisman.

**Testing**

n/a

**Progress**

This was broken by #399.