### PR TITLE
fix: ensure `make resetdb` works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ resettestdb:
 	FLASK_ENV=test make resetdb
 
 resetdb:
-	${PIPENV} run python resetdb.py
+	FLASK_ENV=$${FLASK_ENV:-development} ${PIPENV} run python resetdb.py
 
 dev-environment: deps initdevdb install-development resetdb
 


### PR DESCRIPTION
**Description**

We now have to explicitly set `FLASK_ENV` to something other than `production` if we don't want it to be `production`. This makes `make resetdb` default to `development`, but allows overriding it since `make resettestdb` does exactly that.

**Testing**

n/a

**Progress**

This was broken by #399.
