### PR TITLE
Add created_at and updated_at timestamps to all db models

### DIFF
--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -1,10 +1,19 @@
 from sqlalchemy.orm import relationship, backref
+import sqlalchemy as sa
 from enum import Enum
-from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy, Model
 from flask_sqlalchemy.model import DefaultMeta
+from datetime import datetime as dt
 
 
-db = SQLAlchemy()
+class Base(Model):
+    created_at = sa.Column(sa.DateTime, default=dt.utcnow, nullable=False)
+    updated_at = sa.Column(
+        sa.DateTime, default=dt.utcnow, onupdate=dt.utcnow, nullable=False
+    )
+
+
+db = SQLAlchemy(model_class=Base)
 
 # Typing workaround from https://github.com/dropbox/sqlalchemy-stubs/issues/76#issuecomment-595839159
 BaseModel: DefaultMeta = db.Model


### PR DESCRIPTION
**Description**

Redefines the base model class to add `created_at` and `updated_at` timestamp fields to all models. Based on: https://flask-sqlalchemy.palletsprojects.com/en/2.x/customizing/#model-class.

**Testing**

Existing tests pass. Also manually checked the fields exist in the db.

**Progress**

Ready to review.