### PR TITLE
Remove Round.started_at and use Round.created_at

### DIFF
--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -253,7 +253,6 @@ class Round(BaseModel):
         db.String(200), db.ForeignKey("election.id", ondelete="cascade"), nullable=False
     )
     round_num = db.Column(db.Integer, nullable=False)
-    started_at = db.Column(db.DateTime, nullable=False)
     ended_at = db.Column(db.DateTime, nullable=True)
 
     __table_args__ = (db.UniqueConstraint("election_id", "round_num"),)

--- a/arlo_server/rounds.py
+++ b/arlo_server/rounds.py
@@ -33,7 +33,7 @@ def serialize_round(r: Round) -> dict:
     return {
         "id": r.id,
         "roundNum": r.round_num,
-        "startedAt": isoformat(r.started_at),
+        "startedAt": isoformat(r.created_at),
         "endedAt": isoformat(r.ended_at),
     }
 
@@ -141,10 +141,7 @@ def create_round(election: Election):
     )
 
     round = Round(
-        id=str(uuid.uuid4()),
-        election_id=election.id,
-        round_num=json_round["roundNum"],
-        started_at=datetime.datetime.utcnow(),
+        id=str(uuid.uuid4()), election_id=election.id, round_num=json_round["roundNum"],
     )
     db.session.add(round)
 

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -126,10 +126,7 @@ def setup_next_round(election):
 
     print("adding round {:d} for election {:s}".format(len(rounds) + 1, election.id))
     round = Round(
-        id=str(uuid.uuid4()),
-        election_id=election.id,
-        round_num=len(rounds) + 1,
-        started_at=datetime.datetime.utcnow(),
+        id=str(uuid.uuid4()), election_id=election.id, round_num=len(rounds) + 1,
     )
 
     db.session.add(round)
@@ -397,7 +394,7 @@ def audit_status(election_id=None):
         rounds=[
             {
                 "id": round.id,
-                "startedAt": isoformat(round.started_at),
+                "startedAt": isoformat(round.created_at),
                 "endedAt": isoformat(round.ended_at),
                 "contests": [
                     {
@@ -1041,7 +1038,7 @@ def audit_report(election_id):
         )
 
         report_writer.writerow(
-            ["Round {:d} Start".format(round.round_num), round.started_at]
+            ["Round {:d} Start".format(round.round_num), round.created_at]
         )
         report_writer.writerow(
             ["Round {:d} End".format(round.round_num), round.ended_at]


### PR DESCRIPTION
**Description**

After #404, the fields should have the same value, so no reason to have both around and confuse people. No change to any APIs.

**Testing**

Existing tests pass.

**Progress**

Ready for review.