### PR TITLE
Add @with_jurisdiction_access route decorator

### DIFF
--- a/arlo_server/contests.py
+++ b/arlo_server/contests.py
@@ -4,7 +4,7 @@ from werkzeug.exceptions import BadRequest
 from sqlalchemy import func
 
 from arlo_server import app, db
-from arlo_server.auth import with_election_access, UserType
+from arlo_server.auth import with_election_access
 from arlo_server.models import (
     Contest,
     ContestChoice,
@@ -158,7 +158,7 @@ def round_status_by_contest(
 
 
 @app.route("/election/<election_id>/contest", methods=["PUT"])
-@with_election_access(UserType.AUDIT_ADMIN)
+@with_election_access
 def create_or_update_all_contests(election: Election):
     json_contests = request.get_json()
     validate_contests(json_contests)
@@ -175,7 +175,7 @@ def create_or_update_all_contests(election: Election):
 
 
 @app.route("/election/<election_id>/contest", methods=["GET"])
-@with_election_access(UserType.AUDIT_ADMIN)
+@with_election_access
 def list_contests(election: Election):
     current_round = get_current_round(election)
     round_status = round_status_by_contest(current_round, election.contests)

--- a/arlo_server/election_settings.py
+++ b/arlo_server/election_settings.py
@@ -1,7 +1,7 @@
 from flask import jsonify, request
 
 from arlo_server import app, db
-from arlo_server.auth import with_election_access, UserType
+from arlo_server.auth import with_election_access
 from arlo_server.models import Election, USState
 
 from util.jsonschema import validate
@@ -35,7 +35,7 @@ PUT_ELECTION_SETTINGS_REQUEST_SCHEMA = GET_ELECTION_SETTINGS_RESPONSE_SCHEMA
 
 
 @app.route("/election/<election_id>/settings", methods=["GET"])
-@with_election_access(UserType.AUDIT_ADMIN)
+@with_election_access
 def get_election_settings(election: Election):
     response_data = {
         "electionName": election.election_name,
@@ -51,7 +51,7 @@ def get_election_settings(election: Election):
 
 
 @app.route("/election/<election_id>/settings", methods=["PUT"])
-@with_election_access(UserType.AUDIT_ADMIN)
+@with_election_access
 def put_election_settings(election: Election):
     settings = request.get_json()
     validate(schema=PUT_ELECTION_SETTINGS_REQUEST_SCHEMA, instance=settings)

--- a/arlo_server/jurisdictions.py
+++ b/arlo_server/jurisdictions.py
@@ -13,7 +13,7 @@ from arlo_server.models import (
     Round,
     AuditBoard,
 )
-from arlo_server.auth import with_election_access, UserType
+from arlo_server.auth import with_election_access
 from arlo_server.rounds import get_current_round
 from util.process_file import serialize_file, serialize_file_processing
 from util.jsonschema import JSONDict
@@ -124,7 +124,7 @@ def round_status_by_jurisdiction(
 
 
 @app.route("/election/<election_id>/jurisdiction", methods=["GET"])
-@with_election_access(UserType.AUDIT_ADMIN)
+@with_election_access
 def list_jurisdictions(election: Election):
     current_round = get_current_round(election)
     round_status = round_status_by_jurisdiction(

--- a/arlo_server/rounds.py
+++ b/arlo_server/rounds.py
@@ -12,7 +12,7 @@ from arlo_server.models import (
     SampledBallot,
     SampledBallotDraw,
 )
-from arlo_server.auth import with_election_access, UserType
+from arlo_server.auth import with_election_access
 from arlo_server.sample_sizes import sample_size_options
 from util.isoformat import isoformat
 from audit_math import sampler
@@ -120,14 +120,14 @@ def sample_ballots(election: Election, round: Round, sample_size: int):
 
 
 @app.route("/election/<election_id>/round", methods=["GET"])
-@with_election_access(UserType.AUDIT_ADMIN)
+@with_election_access
 def list_rounds(election: Election):
     rounds = sorted(election.rounds, key=lambda r: r.round_num)
     return jsonify({"rounds": [serialize_round(r) for r in rounds]})
 
 
 @app.route("/election/<election_id>/round", methods=["POST"])
-@with_election_access(UserType.AUDIT_ADMIN)
+@with_election_access
 def create_round(election: Election):
     json_round = request.get_json()
     validate_round(json_round, election)

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -250,7 +250,7 @@ def election_new():
 
 
 @app.route("/election/<election_id>/jurisdiction/file", methods=["GET"])
-@with_election_access(UserType.AUDIT_ADMIN)
+@with_election_access
 def get_jurisdictions_file(election: Election):
     jurisdictions_file = election.jurisdictions_file
 
@@ -264,7 +264,7 @@ def get_jurisdictions_file(election: Election):
 
 
 @app.route("/election/<election_id>/jurisdiction/file", methods=["PUT"])
-@with_election_access(UserType.AUDIT_ADMIN)
+@with_election_access
 def update_jurisdictions_file(election: Election):
     if "jurisdictions" not in request.files:
         return (

--- a/arlo_server/sample_sizes.py
+++ b/arlo_server/sample_sizes.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 from arlo_server import app
 from arlo_server.models import Election
-from arlo_server.auth import with_election_access, UserType
+from arlo_server.auth import with_election_access
 from audit_math import bravo, sampler_contest
 
 
@@ -34,7 +34,7 @@ def sample_size_options(election: Election) -> dict:
 
 
 @app.route("/election/<election_id>/sample-sizes", methods=["GET"])
-@with_election_access(UserType.AUDIT_ADMIN)
+@with_election_access
 def get_sample_sizes(election: Election):
     sample_sizes = sample_size_options(election)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,8 @@ def client() -> FlaskClient:
 
 
 @pytest.fixture
-def election_id() -> str:
-    yield create_election()
+def election_id(client: FlaskClient) -> str:
+    yield create_election(client)
 
 
 @pytest.fixture

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,7 +10,6 @@ from arlo_server.models import (
     db,
     AuditAdministration,
     User,
-    Election,
     Jurisdiction,
     JurisdictionAdministration,
 )
@@ -80,19 +79,21 @@ def create_jurisdiction_and_admin(
 
 
 def create_election(
+    client: FlaskClient,
     audit_name: str = "Test Audit",
     organization_id: str = None,
     is_multi_jurisdiction: bool = True,
 ):
-    election = Election(
-        id=str(uuid.uuid4()),
-        audit_name=audit_name,
-        organization_id=organization_id,
-        is_multi_jurisdiction=is_multi_jurisdiction,
+    rv = post_json(
+        client,
+        "/election/new",
+        {
+            "auditName": audit_name,
+            "organizationId": organization_id,
+            "isMultiJurisdiction": is_multi_jurisdiction,
+        },
     )
-    db.session.add(election)
-    db.session.commit()
-    return election.id
+    return json.loads(rv.data)["electionId"]
 
 
 def assert_is_id(x):

--- a/tests/routes_tests/test_audit_status.py
+++ b/tests/routes_tests/test_audit_status.py
@@ -1,6 +1,5 @@
 import json
 import pytest
-from flask.testing import FlaskClient
 
 from helpers import (
     compare_json,
@@ -14,9 +13,8 @@ from util.process_file import ProcessingStatus
 
 
 @pytest.fixture()
-def election_id(client: FlaskClient) -> str:
-    election_id = create_election(client, is_multi_jurisdiction=False)
-    yield election_id
+def election_id() -> str:
+    yield create_election(is_multi_jurisdiction=False)
 
 
 def test_audit_status(client, election_id):

--- a/tests/routes_tests/test_audit_status.py
+++ b/tests/routes_tests/test_audit_status.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from flask.testing import FlaskClient
 
 from helpers import (
     compare_json,
@@ -13,8 +14,8 @@ from util.process_file import ProcessingStatus
 
 
 @pytest.fixture()
-def election_id() -> str:
-    yield create_election(is_multi_jurisdiction=False)
+def election_id(client: FlaskClient) -> str:
+    yield create_election(client, is_multi_jurisdiction=False)
 
 
 def test_audit_status(client, election_id):

--- a/tests/routes_tests/test_auth.py
+++ b/tests/routes_tests/test_auth.py
@@ -28,8 +28,9 @@ def org_id():
 
 
 @pytest.fixture
-def election_id(org_id: str):
-    return create_election(organization_id=org_id)
+def election_id(client: FlaskClient, org_id: str):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
+    return create_election(client, organization_id=org_id)
 
 
 @pytest.fixture
@@ -241,7 +242,8 @@ def test_with_jurisdiction_access_wrong_org(
     client: FlaskClient, election_id: str, jurisdiction_id: str
 ):
     org_id_2, _ = create_org_and_admin("Org 2", "aa2@example.com")
-    election_id_2 = create_election(organization_id=org_id_2)
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, "aa2@example.com")
+    election_id_2 = create_election(client, organization_id=org_id_2)
     create_jurisdiction_and_admin(election_id_2, user_email="ja2@example.com")
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, "ja2@example.com")
     rv = client.get(f"/election/{election_id}/jurisdiction/{jurisdiction_id}/test_auth")
@@ -259,7 +261,10 @@ def test_with_jurisdiction_access_wrong_org(
 def test_with_jurisdiction_access_wrong_election(
     client: FlaskClient, org_id: str, election_id: str, jurisdiction_id: str
 ):
-    election_id_2 = create_election(audit_name="Audit 2", organization_id=org_id)
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
+    election_id_2 = create_election(
+        client, audit_name="Audit 2", organization_id=org_id
+    )
     create_jurisdiction_and_admin(election_id_2, user_email="ja2@example.com")
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, "ja2@example.com")
     rv = client.get(f"/election/{election_id}/jurisdiction/{jurisdiction_id}/test_auth")

--- a/tests/routes_tests/test_auth.py
+++ b/tests/routes_tests/test_auth.py
@@ -1,45 +1,54 @@
+import pytest
 from flask.testing import FlaskClient
-import json, uuid
+import json
 from unittest.mock import Mock, MagicMock
 
 from arlo_server.auth import UserType
 from arlo_server.routes import (
     auth0_aa,
     auth0_ja,
-    create_organization,
 )
-from arlo_server.models import *
-from tests.helpers import create_org_and_admin, set_logged_in_user
+from tests.helpers import (
+    set_logged_in_user,
+    clear_logged_in_user,
+    create_org_and_admin,
+    create_jurisdiction_and_admin,
+    create_election,
+)
 
 
-def test_auth_me(client: FlaskClient):
-    org_id, user_id = create_org_and_admin("Test Org", "admin@example.com")
-    election = Election(
-        id=str(uuid.uuid4()),
-        audit_name="Test /auth/me",
-        organization_id=org_id,
-        is_multi_jurisdiction=True,
+AA_EMAIL = "aa@example.com"
+JA_EMAIL = "ja@example.com"
+
+
+@pytest.fixture
+def org_id():
+    org_id, aa_id = create_org_and_admin("Test Org", AA_EMAIL)
+    return org_id
+
+
+@pytest.fixture
+def election_id(org_id: str):
+    return create_election(organization_id=org_id)
+
+
+@pytest.fixture
+def jurisdiction_id(election_id: str):
+    jurisdiction_id, ja_id = create_jurisdiction_and_admin(
+        election_id, user_email=JA_EMAIL
     )
-    jurisdiction = Jurisdiction(
-        election_id=election.id, id=str(uuid.uuid4()), name="Test Jurisdiction"
-    )
-    j_admin = JurisdictionAdministration(
-        user_id=user_id, jurisdiction_id=jurisdiction.id
-    )
-    election_id = election.id
-    j_id = jurisdiction.id
+    return jurisdiction_id
 
-    db.session.add(election)
-    db.session.add(jurisdiction)
-    db.session.add(j_admin)
-    db.session.commit()
 
-    set_logged_in_user(client, UserType.AUDIT_ADMIN, "admin@example.com")
+def test_auth_me_audit_admin(
+    client: FlaskClient, org_id: str, election_id: str,
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
 
     rv = client.get("/auth/me")
     assert json.loads(rv.data) == {
         "type": UserType.AUDIT_ADMIN,
-        "email": "admin@example.com",
+        "email": AA_EMAIL,
         "organizations": [
             {
                 "name": "Test Org",
@@ -47,7 +56,7 @@ def test_auth_me(client: FlaskClient):
                 "elections": [
                     {
                         "id": election_id,
-                        "auditName": "Test /auth/me",
+                        "auditName": "Test Audit",
                         "electionName": None,
                         "state": None,
                         "electionDate": None,
@@ -56,13 +65,27 @@ def test_auth_me(client: FlaskClient):
                 ],
             }
         ],
+        "jurisdictions": [],
+    }
+
+
+def test_auth_me_jurisdiction_admin(
+    client: FlaskClient, election_id: str, jurisdiction_id: str
+):
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, JA_EMAIL)
+
+    rv = client.get("/auth/me")
+    assert json.loads(rv.data) == {
+        "type": UserType.JURISDICTION_ADMIN,
+        "email": JA_EMAIL,
+        "organizations": [],
         "jurisdictions": [
             {
-                "id": j_id,
+                "id": jurisdiction_id,
                 "name": "Test Jurisdiction",
                 "election": {
                     "id": election_id,
-                    "auditName": "Test /auth/me",
+                    "auditName": "Test Audit",
                     "electionName": None,
                     "state": None,
                     "electionDate": None,
@@ -78,13 +101,13 @@ def test_auditadmin_start(client: FlaskClient):
     assert rv.status_code == 302
 
 
-def test_auditadmin_callback(client: FlaskClient):
-    create_org_and_admin("Test Organization", "foo@example.com")
-
+def test_auditadmin_callback(
+    client: FlaskClient, org_id: str,  # pylint: disable=unused-argument
+):
     auth0_aa.authorize_access_token = MagicMock(return_value=None)
 
     mock_response = Mock()
-    mock_response.json = MagicMock(return_value={"email": "foo@example.com"})
+    mock_response.json = MagicMock(return_value={"email": AA_EMAIL})
     auth0_aa.get = Mock(return_value=mock_response)
 
     rv = client.get("/auth/auditadmin/callback?code=foobar")
@@ -92,7 +115,7 @@ def test_auditadmin_callback(client: FlaskClient):
 
     with client.session_transaction() as session:
         assert session["_user"]["type"] == UserType.AUDIT_ADMIN
-        assert session["_user"]["email"] == "foo@example.com"
+        assert session["_user"]["email"] == AA_EMAIL
 
     assert auth0_aa.authorize_access_token.called
     assert auth0_aa.get.called
@@ -103,32 +126,13 @@ def test_jurisdictionadmin_start(client: FlaskClient):
     assert rv.status_code == 302
 
 
-def test_jurisdictionadmin_callback(client: FlaskClient):
-    org = create_organization("Test Organization")
-    election = Election(
-        id=str(uuid.uuid4()),
-        audit_name="Test JA callback",
-        organization_id=org.id,
-        is_multi_jurisdiction=True,
-    )
-    jurisdiction = Jurisdiction(
-        election_id=election.id, id=str(uuid.uuid4()), name="Test Jurisdiction"
-    )
-    u = User(
-        id=str(uuid.uuid4()), email="bar@example.com", external_id="bar@example.com"
-    )
-    j_admin = JurisdictionAdministration(user_id=u.id, jurisdiction_id=jurisdiction.id)
-
-    db.session.add(election)
-    db.session.add(jurisdiction)
-    db.session.add(u)
-    db.session.add(j_admin)
-    db.session.commit()
-
+def test_jurisdictionadmin_callback(
+    client: FlaskClient, jurisdiction_id: str  # pylint: disable=unused-argument
+):
     auth0_ja.authorize_access_token = MagicMock(return_value=None)
 
     mock_response = Mock()
-    mock_response.json = MagicMock(return_value={"email": "bar@example.com"})
+    mock_response.json = MagicMock(return_value={"email": JA_EMAIL})
     auth0_ja.get = Mock(return_value=mock_response)
 
     rv = client.get("/auth/jurisdictionadmin/callback?code=foobar")
@@ -136,14 +140,14 @@ def test_jurisdictionadmin_callback(client: FlaskClient):
 
     with client.session_transaction() as session:
         assert session["_user"]["type"] == UserType.JURISDICTION_ADMIN
-        assert session["_user"]["email"] == "bar@example.com"
+        assert session["_user"]["email"] == JA_EMAIL
 
     assert auth0_ja.authorize_access_token.called
     assert auth0_ja.get.called
 
 
 def test_logout(client: FlaskClient):
-    set_logged_in_user(client, UserType.AUDIT_ADMIN, "admin@example.com")
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
 
     rv = client.get("/auth/logout")
 
@@ -151,3 +155,195 @@ def test_logout(client: FlaskClient):
         assert session["_user"] is None
 
     assert rv.status_code == 302
+
+
+# Tests for route decorators. We have added special routes to test the
+# decorators that are set up in conftest.py.
+
+
+def test_with_election_access_audit_admin(client: FlaskClient, election_id: str):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
+    rv = client.get(f"/election/{election_id}/test_auth")
+    assert rv.status_code == 200
+    assert json.loads(rv.data) == election_id
+
+
+def test_with_election_access_wrong_org(
+    client: FlaskClient, org_id: str, election_id: str
+):
+    create_org_and_admin("Org 2", "aa2@example.com")
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, "aa2@example.com")
+    rv = client.get(f"/election/{election_id}/test_auth")
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"aa2@example.com does not have access to organization {org_id}",
+            }
+        ]
+    }
+
+
+def test_with_election_access_not_found(
+    client: FlaskClient, election_id: str  # pylint: disable=unused-argument
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, "aa2@example.com")
+    rv = client.get(f"/election/not-a-real-id/test_auth")
+    assert rv.status_code == 404
+
+
+def test_with_election_access_jurisdiction_admin(
+    client: FlaskClient,
+    org_id: str,
+    election_id: str,
+    jurisdiction_id: str,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, JA_EMAIL)
+    rv = client.get(f"/election/{election_id}/test_auth")
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"{JA_EMAIL} is not logged in as an audit admin and so does not have access to organization {org_id}",
+            }
+        ]
+    }
+
+
+def test_with_election_access_anonymous_user(
+    client: FlaskClient, org_id: str, election_id: str
+):
+    clear_logged_in_user(client)
+    rv = client.get(f"/election/{election_id}/test_auth")
+    assert rv.status_code == 401
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Unauthorized",
+                "message": f"Anonymous users do not have access to organization {org_id}",
+            }
+        ]
+    }
+
+
+def test_with_jurisdiction_access_jurisdiction_admin(
+    client: FlaskClient, election_id: str, jurisdiction_id: str
+):
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, JA_EMAIL)
+    rv = client.get(f"/election/{election_id}/jurisdiction/{jurisdiction_id}/test_auth")
+    assert rv.status_code == 200
+    assert json.loads(rv.data) == [election_id, jurisdiction_id]
+
+
+def test_with_jurisdiction_access_wrong_org(
+    client: FlaskClient, election_id: str, jurisdiction_id: str
+):
+    org_id_2, _ = create_org_and_admin("Org 2", "aa2@example.com")
+    election_id_2 = create_election(organization_id=org_id_2)
+    create_jurisdiction_and_admin(election_id_2, user_email="ja2@example.com")
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, "ja2@example.com")
+    rv = client.get(f"/election/{election_id}/jurisdiction/{jurisdiction_id}/test_auth")
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"ja2@example.com does not have access to jurisdiction {jurisdiction_id}",
+            }
+        ]
+    }
+
+
+def test_with_jurisdiction_access_wrong_election(
+    client: FlaskClient, org_id: str, election_id: str, jurisdiction_id: str
+):
+    election_id_2 = create_election(audit_name="Audit 2", organization_id=org_id)
+    create_jurisdiction_and_admin(election_id_2, user_email="ja2@example.com")
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, "ja2@example.com")
+    rv = client.get(f"/election/{election_id}/jurisdiction/{jurisdiction_id}/test_auth")
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"ja2@example.com does not have access to jurisdiction {jurisdiction_id}",
+            }
+        ]
+    }
+
+
+def test_with_jurisdiction_access_wrong_jurisdiction(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_id: str,  # pylint: disable=unused-argument
+):
+    jurisdiction_id_2, _ = create_jurisdiction_and_admin(
+        election_id, jurisdiction_name="Jurisdiction 2", user_email="ja2@example.com"
+    )
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, JA_EMAIL)
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id_2}/test_auth"
+    )
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"{JA_EMAIL} does not have access to jurisdiction {jurisdiction_id_2}",
+            }
+        ]
+    }
+
+
+def test_with_jurisdiction_access_election_not_found(
+    client: FlaskClient,
+    election_id: str,  # pylint: disable=unused-argument
+    jurisdiction_id: str,
+):
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, JA_EMAIL)
+    rv = client.get(f"/election/not-a-real-id/jurisdiction/{jurisdiction_id}/test_auth")
+    assert rv.status_code == 404
+
+
+def test_with_jurisdiction_access_jurisdiction_not_found(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_id: str,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, JA_EMAIL)
+    rv = client.get(f"/election/{election_id}/jurisdiction/not-a-real-id/test_auth")
+    assert rv.status_code == 404
+
+
+def test_with_jurisdiction_access_audit_admin(
+    client: FlaskClient, election_id: str, jurisdiction_id: str
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
+    rv = client.get(f"/election/{election_id}/jurisdiction/{jurisdiction_id}/test_auth")
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"{AA_EMAIL} is not logged in as a jurisdiction admin and so does not have access to jurisdiction {jurisdiction_id}",
+            }
+        ]
+    }
+
+
+def test_with_jurisdiction_access_anonymous_user(
+    client: FlaskClient, election_id: str, jurisdiction_id: str
+):
+    clear_logged_in_user(client)
+    rv = client.get(f"/election/{election_id}/jurisdiction/{jurisdiction_id}/test_auth")
+    assert rv.status_code == 401
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Unauthorized",
+                "message": f"Anonymous users do not have access to jurisdiction {jurisdiction_id}",
+            }
+        ]
+    }

--- a/tests/routes_tests/test_ballot_list.py
+++ b/tests/routes_tests/test_ballot_list.py
@@ -1,4 +1,5 @@
 import json
+from flask.testing import FlaskClient
 
 import pytest
 
@@ -8,8 +9,8 @@ import bgcompute
 
 
 @pytest.fixture()
-def election_id() -> str:
-    yield create_election(is_multi_jurisdiction=False)
+def election_id(client: FlaskClient) -> str:
+    yield create_election(client, is_multi_jurisdiction=False)
 
 
 def test_ballot_list_jurisdiction_two_rounds(client, election_id):

--- a/tests/routes_tests/test_ballot_list.py
+++ b/tests/routes_tests/test_ballot_list.py
@@ -1,5 +1,4 @@
 import json
-from flask.testing import FlaskClient
 
 import pytest
 
@@ -9,9 +8,8 @@ import bgcompute
 
 
 @pytest.fixture()
-def election_id(client: FlaskClient) -> str:
-    election_id = create_election(client, is_multi_jurisdiction=False)
-    yield election_id
+def election_id() -> str:
+    yield create_election(is_multi_jurisdiction=False)
 
 
 def test_ballot_list_jurisdiction_two_rounds(client, election_id):

--- a/tests/routes_tests/test_report.py
+++ b/tests/routes_tests/test_report.py
@@ -1,5 +1,4 @@
 import json, random
-from flask.testing import FlaskClient
 
 import pytest
 
@@ -9,9 +8,8 @@ import bgcompute
 
 
 @pytest.fixture()
-def election_id(client: FlaskClient) -> str:
-    election_id = create_election(client, is_multi_jurisdiction=False)
-    yield election_id
+def election_id() -> str:
+    yield create_election(is_multi_jurisdiction=False)
 
 
 def run_audit_round(

--- a/tests/routes_tests/test_report.py
+++ b/tests/routes_tests/test_report.py
@@ -1,4 +1,5 @@
 import json, random
+from flask.testing import FlaskClient
 
 import pytest
 
@@ -8,8 +9,8 @@ import bgcompute
 
 
 @pytest.fixture()
-def election_id() -> str:
-    yield create_election(is_multi_jurisdiction=False)
+def election_id(client: FlaskClient) -> str:
+    yield create_election(client, is_multi_jurisdiction=False)
 
 
 def run_audit_round(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,8 +12,8 @@ small_manifest_file_path = os.path.join(os.path.dirname(__file__), "small-manife
 
 
 @pytest.fixture()
-def election_id() -> str:
-    yield create_election(is_multi_jurisdiction=False)
+def election_id(client: FlaskClient) -> str:
+    yield create_election(client, is_multi_jurisdiction=False)
 
 
 def test_index(client):
@@ -41,8 +41,12 @@ def test_session(client):
 
 
 def test_whole_audit_flow(client: FlaskClient):
-    election_id_1 = create_election(audit_name="Audit 1", is_multi_jurisdiction=False)
-    election_id_2 = create_election(audit_name="Audit 2", is_multi_jurisdiction=False)
+    election_id_1 = create_election(
+        client, audit_name="Audit 1", is_multi_jurisdiction=False
+    )
+    election_id_2 = create_election(
+        client, audit_name="Audit 2", is_multi_jurisdiction=False
+    )
 
     print("running whole audit flow " + election_id_1)
     run_whole_audit_flow(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,9 +12,8 @@ small_manifest_file_path = os.path.join(os.path.dirname(__file__), "small-manife
 
 
 @pytest.fixture()
-def election_id(client: FlaskClient) -> str:
-    election_id = create_election(client, is_multi_jurisdiction=False)
-    yield election_id
+def election_id() -> str:
+    yield create_election(is_multi_jurisdiction=False)
 
 
 def test_index(client):
@@ -42,12 +41,8 @@ def test_session(client):
 
 
 def test_whole_audit_flow(client: FlaskClient):
-    election_id_1 = create_election(
-        client, audit_name="Audit 1", is_multi_jurisdiction=False
-    )
-    election_id_2 = create_election(
-        client, audit_name="Audit 2", is_multi_jurisdiction=False
-    )
+    election_id_1 = create_election(audit_name="Audit 1", is_multi_jurisdiction=False)
+    election_id_2 = create_election(audit_name="Audit 2", is_multi_jurisdiction=False)
 
     print("running whole audit flow " + election_id_1)
     run_whole_audit_flow(


### PR DESCRIPTION
**Description**

Adds a route decorator `@with_jurisdiction_access`. This decorator requires jurisdiction admin (JA) authorization, checks that it matches the given election/jurisdiction ids, and loads the election and jurisdiction objects.

Also modifies `@with_election_access` to not take a user type and only accept audit admin (AA) authorization.

To simplify permissions for the time being, AAs and JAs will not share any routes. JA routes will always have a `jurisdiction_id` in the path so we can easily check that they are trying to access the jurisdiction for which they are authorized.

**Testing**

Lots of new tests here, trying to cover every case of incorrect authorization - could use a good review to make sure I'm not missing something.

Here's a summary:
 - test_with_election_access_audit_admin
 - test_with_election_access_wrong_org
 - test_with_election_access_not_found
 - test_with_election_access_jurisdiction_admin
 - test_with_election_access_anonymous_user
 - test_with_jurisdiction_access_jurisdiction_admin
 - test_with_jurisdiction_access_wrong_org
 - test_with_jurisdiction_access_election_not_found
 - test_with_jurisdiction_access_jurisdiction_not_found
 - test_with_jurisdiction_access_audit_admin
 - test_with_jurisdiction_access_anonymous_user

**Progress**

Ready for review.