### PR TITLE
refactoring Audit/_mocks

### DIFF
--- a/arlo-client/src/components/Audit/CalculateRiskMeasurement.test.tsx
+++ b/arlo-client/src/components/Audit/CalculateRiskMeasurement.test.tsx
@@ -7,11 +7,11 @@ import { statusStates, dummyBallots, incompleteDummyBallots } from './_mocks'
 import * as utilities from '../utilities'
 import { asyncActRender } from '../testUtilities'
 
-statusStates[3].online = false
-statusStates[4].online = false
-statusStates[5].online = false
-statusStates[6].online = false
-statusStates[7].online = false
+statusStates.jurisdictionsInitial.online = false
+statusStates.ballotManifestProcessed.online = false
+statusStates.completeInFirstRound.online = false
+statusStates.firstRoundSampleSizeOptionsNull.online = false
+statusStates.firstRoundSampleSizeOptions.online = false
 
 jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation()
 
@@ -32,7 +32,7 @@ const sharedSetIsLoadingMock = jest.fn()
 const sharedUpdateAuditMock = jest.fn()
 const sharedGetStatusMock = jest
   .fn()
-  .mockImplementation(async () => statusStates[5])
+  .mockImplementation(async () => statusStates.completeInFirstRound)
 const sharedToastSpy = jest.spyOn(toast, 'error').mockImplementation()
 
 let jspdfInstance: jsPDF
@@ -61,7 +61,7 @@ describe('CalculateRiskMeasurement', () => {
   it('renders first round correctly', () => {
     const container = render(
       <CalculateRiskMeasurement
-        audit={statusStates[4]}
+        audit={statusStates.ballotManifestProcessed}
         isLoading={false}
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -75,7 +75,7 @@ describe('CalculateRiskMeasurement', () => {
   it('renders completion in first round correctly', () => {
     const container = render(
       <CalculateRiskMeasurement
-        audit={statusStates[5]}
+        audit={statusStates.completeInFirstRound}
         isLoading={false}
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -89,7 +89,7 @@ describe('CalculateRiskMeasurement', () => {
   it('renders first round with loading correctly', () => {
     const container = render(
       <CalculateRiskMeasurement
-        audit={statusStates[4]}
+        audit={statusStates.ballotManifestProcessed}
         isLoading
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -103,7 +103,7 @@ describe('CalculateRiskMeasurement', () => {
   it('renders completion in first round with loading correctly', () => {
     const container = render(
       <CalculateRiskMeasurement
-        audit={statusStates[5]}
+        audit={statusStates.completeInFirstRound}
         isLoading
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -121,7 +121,7 @@ describe('CalculateRiskMeasurement', () => {
     }))
     const { container, getByLabelText, queryAllByText, getByText } = render(
       <CalculateRiskMeasurement
-        audit={statusStates[4]}
+        audit={statusStates.ballotManifestProcessed}
         isLoading={false}
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -211,11 +211,13 @@ describe('CalculateRiskMeasurement', () => {
 
     const getStatusMock = jest
       .fn()
-      .mockImplementation(async () => statusStates[6])
+      .mockImplementation(
+        async () => statusStates.firstRoundSampleSizeOptionsNull
+      )
 
     const { getByText } = render(
       <CalculateRiskMeasurement
-        audit={statusStates[4]}
+        audit={statusStates.ballotManifestProcessed}
         isLoading={false}
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -250,11 +252,13 @@ describe('CalculateRiskMeasurement', () => {
 
     const getStatusMock = jest
       .fn()
-      .mockImplementation(async () => statusStates[6])
+      .mockImplementation(
+        async () => statusStates.firstRoundSampleSizeOptionsNull
+      )
 
     const { getByText } = render(
       <CalculateRiskMeasurement
-        audit={statusStates[4]}
+        audit={statusStates.ballotManifestProcessed}
         isLoading={false}
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -294,7 +298,7 @@ describe('CalculateRiskMeasurement', () => {
     apiMock.mockImplementationOnce(async () => dummyBallots)
     const { getByText } = render(
       <CalculateRiskMeasurement
-        audit={statusStates[3]}
+        audit={statusStates.jurisdictionsInitial}
         isLoading={false}
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -322,7 +326,7 @@ describe('CalculateRiskMeasurement', () => {
     apiMock.mockImplementationOnce(async () => dummyBallots)
     const { getByText } = render(
       <CalculateRiskMeasurement
-        audit={statusStates[3]}
+        audit={statusStates.jurisdictionsInitial}
         isLoading={false}
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -350,7 +354,7 @@ describe('CalculateRiskMeasurement', () => {
     window.open = jest.fn()
     const { getByText } = render(
       <CalculateRiskMeasurement
-        audit={statusStates[4]}
+        audit={statusStates.ballotManifestProcessed}
         isLoading={false}
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -374,7 +378,7 @@ describe('CalculateRiskMeasurement', () => {
     window.open = jest.fn()
     const { getByText } = render(
       <CalculateRiskMeasurement
-        audit={statusStates[5]}
+        audit={statusStates.completeInFirstRound}
         isLoading={false}
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -398,7 +402,7 @@ describe('CalculateRiskMeasurement', () => {
     const toastSpy = jest.spyOn(toast, 'error').mockImplementation()
     const { getByLabelText, getByText } = render(
       <CalculateRiskMeasurement
-        audit={statusStates[4]}
+        audit={statusStates.ballotManifestProcessed}
         isLoading={false}
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -433,11 +437,11 @@ describe('CalculateRiskMeasurement', () => {
   })
 
   it('downloads data entry flow sheets', async () => {
-    statusStates[7].online = true
+    statusStates.firstRoundSampleSizeOptions.online = true
     apiMock.mockImplementationOnce(async () => dummyBallots)
     const { getByText } = render(
       <CalculateRiskMeasurement
-        audit={statusStates[7]}
+        audit={statusStates.firstRoundSampleSizeOptions}
         isLoading={false}
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -467,11 +471,11 @@ describe('CalculateRiskMeasurement', () => {
   })
 
   it('renders online mode progress bar', async () => {
-    statusStates[4].online = true
+    statusStates.ballotManifestProcessed.online = true
     apiMock.mockImplementationOnce(async () => incompleteDummyBallots)
     const { container } = await asyncActRender(
       <CalculateRiskMeasurement
-        audit={statusStates[4]}
+        audit={statusStates.ballotManifestProcessed}
         isLoading
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}
@@ -483,11 +487,11 @@ describe('CalculateRiskMeasurement', () => {
   })
 
   it('renders online mode progress bar in multiple rounds', async () => {
-    statusStates[8].online = true
+    statusStates.multiAuditBoardsAndRounds.online = true
     apiMock.mockImplementationOnce(async () => incompleteDummyBallots)
     const { container } = await asyncActRender(
       <CalculateRiskMeasurement
-        audit={statusStates[8]}
+        audit={statusStates.multiAuditBoardsAndRounds}
         isLoading
         setIsLoading={sharedSetIsLoadingMock}
         updateAudit={sharedUpdateAuditMock}

--- a/arlo-client/src/components/Audit/EstimateSampleSize.test.tsx
+++ b/arlo-client/src/components/Audit/EstimateSampleSize.test.tsx
@@ -215,7 +215,7 @@ describe('EstimateSampleSize', () => {
   it('renders empty state correctly', () => {
     const { container, rerender } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -227,7 +227,7 @@ describe('EstimateSampleSize', () => {
 
     rerender(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -241,7 +241,7 @@ describe('EstimateSampleSize', () => {
   it('renders after contests creation correctly', () => {
     const { container, rerender } = render(
       <EstimateSampleSize
-        audit={statusStates[1]}
+        audit={statusStates.contestFirstRound}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -253,7 +253,7 @@ describe('EstimateSampleSize', () => {
 
     rerender(
       <EstimateSampleSize
-        audit={statusStates[1]}
+        audit={statusStates.contestFirstRound}
         isLoading
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -267,7 +267,7 @@ describe('EstimateSampleSize', () => {
   it('renders after sample size is estimated correctly', () => {
     const { container, rerender } = render(
       <EstimateSampleSize
-        audit={statusStates[3]}
+        audit={statusStates.jurisdictionsInitial}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -279,7 +279,7 @@ describe('EstimateSampleSize', () => {
 
     rerender(
       <EstimateSampleSize
-        audit={statusStates[3]}
+        audit={statusStates.jurisdictionsInitial}
         isLoading
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -293,7 +293,7 @@ describe('EstimateSampleSize', () => {
   it('renders after manifest is uploaded correctly', () => {
     const { container, rerender } = render(
       <EstimateSampleSize
-        audit={statusStates[4]}
+        audit={statusStates.ballotManifestProcessed}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -305,7 +305,7 @@ describe('EstimateSampleSize', () => {
 
     rerender(
       <EstimateSampleSize
-        audit={statusStates[4]}
+        audit={statusStates.ballotManifestProcessed}
         isLoading
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -319,7 +319,7 @@ describe('EstimateSampleSize', () => {
   it('renders during rounds stage correctly', () => {
     const { container, rerender } = render(
       <EstimateSampleSize
-        audit={statusStates[5]}
+        audit={statusStates.completeInFirstRound}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -331,7 +331,7 @@ describe('EstimateSampleSize', () => {
 
     rerender(
       <EstimateSampleSize
-        audit={statusStates[5]}
+        audit={statusStates.completeInFirstRound}
         isLoading
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -345,7 +345,7 @@ describe('EstimateSampleSize', () => {
   it('changes audits to be offline and online', () => {
     const { getByLabelText } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -381,7 +381,7 @@ describe('EstimateSampleSize', () => {
     // skip until feature is complete in backend
     const { getByText, getAllByText, queryByText } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -415,7 +415,7 @@ describe('EstimateSampleSize', () => {
   it('adds and removes choices', async () => {
     const { getByText, getAllByText, queryAllByText } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -448,13 +448,13 @@ describe('EstimateSampleSize', () => {
     const setIsLoadingMock = jest.fn()
     const getStatusMock = jest
       .fn()
-      .mockImplementationOnce(async () => statusStates[0])
-      .mockImplementationOnce(async () => statusStates[1])
-      .mockImplementationOnce(async () => statusStates[2])
+      .mockImplementationOnce(async () => statusStates.empty)
+      .mockImplementationOnce(async () => statusStates.contestFirstRound)
+      .mockImplementationOnce(async () => statusStates.sampleSizeOptions)
 
     const { getByLabelText, getByText } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={setIsLoadingMock}
         updateAudit={updateAuditMock}
@@ -508,11 +508,11 @@ describe('EstimateSampleSize', () => {
     const setIsLoadingMock = jest.fn()
     const getStatusMock = jest
       .fn()
-      .mockImplementation(async () => statusStates[0])
+      .mockImplementation(async () => statusStates.empty)
 
     const { getByLabelText, getByText } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={setIsLoadingMock}
         updateAudit={updateAuditMock}
@@ -549,7 +549,7 @@ describe('EstimateSampleSize', () => {
     apiMock.mockReset()
     const { getByLabelText, getByTestId, getByText } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -588,7 +588,7 @@ describe('EstimateSampleSize', () => {
   it('displays an error when the total votes are greater than the allowed votes and more than one vote is allowed per contest', async () => {
     const { getByLabelText, getByTestId } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -635,7 +635,7 @@ describe('EstimateSampleSize', () => {
   it('displays no error when the total votes are greater than the ballot count, but less than the total allowed votes for a contest', async () => {
     const { getByLabelText, queryByTestId } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -686,7 +686,7 @@ describe('EstimateSampleSize', () => {
     const updateAuditMock = jest.fn()
     const { getByLabelText, getByText } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={updateAuditMock}
@@ -719,7 +719,7 @@ describe('EstimateSampleSize', () => {
     const updateAuditMock = jest.fn()
     const { getByLabelText, getByText } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={updateAuditMock}
@@ -752,7 +752,7 @@ describe('EstimateSampleSize', () => {
     const updateAuditMock = jest.fn()
     const { getByLabelText, getByText } = render(
       <EstimateSampleSize
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={updateAuditMock}

--- a/arlo-client/src/components/Audit/SelectBallotsToAudit.test.tsx
+++ b/arlo-client/src/components/Audit/SelectBallotsToAudit.test.tsx
@@ -21,15 +21,15 @@ const toastSpy = jest.spyOn(toast, 'error').mockImplementation()
 async function inputAndSubmitForm() {
   const getStatusMock = jest
     .fn()
-    .mockImplementationOnce(async () => statusStates[4]) // the POST to /election/{electionId}/audit/status after jurisdictions
-    .mockImplementation(async () => statusStates[5]) // the POST to /election/{electionId}/audit/status after manifest
+    .mockImplementationOnce(async () => statusStates.ballotManifestProcessed) // the POST to /election/{electionId}/audit/status after jurisdictions
+    .mockImplementation(async () => statusStates.completeInFirstRound) // the POST to /election/{electionId}/audit/status after manifest
   const updateAuditMock = jest
     .fn()
-    .mockImplementationOnce(async () => statusStates[5]) // the POST to /election/{electionId}/audit/status after manifest
+    .mockImplementationOnce(async () => statusStates.completeInFirstRound) // the POST to /election/{electionId}/audit/status after manifest
 
   const { getByLabelText, getByText } = render(
     <SelectBallotsToAudit
-      audit={statusStates[2]}
+      audit={statusStates.sampleSizeOptions}
       isLoading={false}
       setIsLoading={jest.fn()}
       updateAudit={updateAuditMock}
@@ -76,7 +76,7 @@ describe('SelectBallotsToAudit', () => {
   it('renders correctly', () => {
     const { container, rerender } = render(
       <SelectBallotsToAudit
-        audit={statusStates[1]}
+        audit={statusStates.contestFirstRound}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -88,7 +88,7 @@ describe('SelectBallotsToAudit', () => {
 
     rerender(
       <SelectBallotsToAudit
-        audit={statusStates[1]}
+        audit={statusStates.contestFirstRound}
         isLoading
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -102,7 +102,7 @@ describe('SelectBallotsToAudit', () => {
   it('has radio for selecting sampleSize', () => {
     const { getByText, getByLabelText } = render(
       <SelectBallotsToAudit
-        audit={statusStates[2]}
+        audit={statusStates.sampleSizeOptions}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -134,11 +134,11 @@ describe('SelectBallotsToAudit', () => {
   it('conditionally shows custom text input and submits', async () => {
     const getStatusMock = jest
       .fn()
-      .mockImplementationOnce(async () => statusStates[3]) // the POST to /election/{electionId}/audit/status after jurisdictions
-      .mockImplementation(async () => statusStates[4]) // the POST to /election/{electionId}/audit/status after manifest
+      .mockImplementationOnce(async () => statusStates.jurisdictionsInitial) // the POST to /election/{electionId}/audit/status after jurisdictions
+      .mockImplementation(async () => statusStates.ballotManifestProcessed) // the POST to /election/{electionId}/audit/status after manifest
     const updateAuditMock = jest
       .fn()
-      .mockImplementationOnce(async () => statusStates[4]) // the POST to /election/{electionId}/audit/status after manifest
+      .mockImplementationOnce(async () => statusStates.ballotManifestProcessed) // the POST to /election/{electionId}/audit/status after manifest
     apiMock.mockImplementation(async () => {})
 
     const {
@@ -149,7 +149,7 @@ describe('SelectBallotsToAudit', () => {
       queryAllByText,
     } = render(
       <SelectBallotsToAudit
-        audit={statusStates[2]}
+        audit={statusStates.sampleSizeOptions}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={updateAuditMock}
@@ -226,15 +226,15 @@ describe('SelectBallotsToAudit', () => {
   it('bails if the manifest failed to start processing', async () => {
     const getStatusMock = jest
       .fn()
-      .mockImplementation(async () => statusStates[3]) // the POST to /election/{electionId}/audit/status after jurisdictions
+      .mockImplementation(async () => statusStates.jurisdictionsInitial) // the POST to /election/{electionId}/audit/status after jurisdictions
     const updateAuditMock = jest
       .fn()
-      .mockImplementationOnce(async () => statusStates[4]) // the POST to /election/{electionId}/audit/status after manifest
+      .mockImplementationOnce(async () => statusStates.ballotManifestProcessed) // the POST to /election/{electionId}/audit/status after manifest
     apiMock.mockImplementation(async () => {})
 
     const { getByText, getByLabelText } = render(
       <SelectBallotsToAudit
-        audit={statusStates[2]}
+        audit={statusStates.sampleSizeOptions}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={updateAuditMock}
@@ -261,15 +261,15 @@ describe('SelectBallotsToAudit', () => {
   it('does not bail if the manifest processing errors', async () => {
     const getStatusMock = jest
       .fn()
-      .mockImplementation(async () => statusStates[9]) // the POST to /election/{electionId}/audit/status after jurisdictions
+      .mockImplementation(async () => statusStates.ballotManifestProcessError) // the POST to /election/{electionId}/audit/status after jurisdictions
     const updateAuditMock = jest
       .fn()
-      .mockImplementationOnce(async () => statusStates[4]) // the POST to /election/{electionId}/audit/status after manifest
+      .mockImplementationOnce(async () => statusStates.ballotManifestProcessed) // the POST to /election/{electionId}/audit/status after manifest
     apiMock.mockImplementation(async () => {})
 
     const { getByText, getByLabelText } = render(
       <SelectBallotsToAudit
-        audit={statusStates[2]}
+        audit={statusStates.sampleSizeOptions}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={updateAuditMock}
@@ -307,15 +307,15 @@ describe('SelectBallotsToAudit', () => {
 
     const getStatusMock = jest
       .fn()
-      .mockImplementation(async () => statusStates[3]) // the POST to /election/{electionId}/audit/status after jurisdictions
+      .mockImplementation(async () => statusStates.jurisdictionsInitial) // the POST to /election/{electionId}/audit/status after jurisdictions
     const updateAuditMock = jest
       .fn()
-      .mockImplementationOnce(async () => statusStates[4]) // the POST to /election/{electionId}/audit/status after manifest
+      .mockImplementationOnce(async () => statusStates.ballotManifestProcessed) // the POST to /election/{electionId}/audit/status after manifest
     apiMock.mockImplementation(async () => {})
 
     const { getByText, getByLabelText } = render(
       <SelectBallotsToAudit
-        audit={statusStates[2]}
+        audit={statusStates.sampleSizeOptions}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={updateAuditMock}
@@ -344,7 +344,7 @@ describe('SelectBallotsToAudit', () => {
     const { getByLabelText } = render(
       <Router>
         <SelectBallotsToAudit
-          audit={statusStates[5]}
+          audit={statusStates.completeInFirstRound}
           isLoading={false}
           setIsLoading={jest.fn()}
           updateAudit={jest.fn()}
@@ -364,7 +364,7 @@ describe('SelectBallotsToAudit', () => {
   it('changes number of audits', () => {
     const { getByLabelText, container } = render(
       <SelectBallotsToAudit
-        audit={statusStates[1]}
+        audit={statusStates.contestFirstRound}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -551,13 +551,13 @@ describe('SelectBallotsToAudit', () => {
   })
 
   it('uses the highest prob value from duplicate sampleSizes', () => {
-    statusStates[1].rounds[0].contests[0].sampleSizeOptions = [
+    statusStates.contestFirstRound.rounds[0].contests[0].sampleSizeOptions = [
       { size: 30, prob: 0.8, type: null },
       { size: 30, prob: 0.9, type: null },
     ]
     const { queryAllByText } = render(
       <SelectBallotsToAudit
-        audit={statusStates[1]}
+        audit={statusStates.contestFirstRound}
         isLoading={false}
         setIsLoading={jest.fn()}
         updateAudit={jest.fn()}
@@ -574,7 +574,7 @@ describe('SelectBallotsToAudit', () => {
   })
 
   it('does not display duplicate sampleSize options', () => {
-    const statusState = { ...statusStates[1] }
+    const statusState = { ...statusStates.contestFirstRound }
     statusState.rounds[0].contests[0].sampleSizeOptions = [
       { size: 30, prob: null, type: null },
       { size: 30, prob: null, type: null },

--- a/arlo-client/src/components/Audit/Setup/Contests/index.test.tsx
+++ b/arlo-client/src/components/Audit/Setup/Contests/index.test.tsx
@@ -100,7 +100,7 @@ describe('Audit Setup > Contests', () => {
   it('renders empty state correctly', () => {
     const { container } = render(
       <Contests
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isTargeted
         {...relativeStages('Target Contests')}
       />
@@ -112,7 +112,7 @@ describe('Audit Setup > Contests', () => {
     // skip until feature is complete in backend
     const { getByText, getAllByText, queryByText } = render(
       <Contests
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isTargeted
         {...relativeStages('Target Contests')}
       />
@@ -143,7 +143,7 @@ describe('Audit Setup > Contests', () => {
   it('adds and removes choices', async () => {
     const { getByText, getAllByText, queryAllByText } = render(
       <Contests
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isTargeted
         {...relativeStages('Target Contests')}
       />
@@ -167,7 +167,7 @@ describe('Audit Setup > Contests', () => {
   it('is able to submit the form successfully', async () => {
     const { getByLabelText, getByText } = render(
       <Contests
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isTargeted
         nextStage={nextStage}
         prevStage={prevStage}
@@ -191,7 +191,7 @@ describe('Audit Setup > Contests', () => {
   it('displays errors', async () => {
     const { getByLabelText, getByTestId, getByText } = render(
       <Contests
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isTargeted
         nextStage={nextStage}
         prevStage={prevStage}
@@ -228,7 +228,7 @@ describe('Audit Setup > Contests', () => {
   it('displays an error when the total votes are greater than the allowed votes and more than one vote is allowed per contest', async () => {
     const { getByLabelText, getByTestId } = render(
       <Contests
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isTargeted
         {...relativeStages('Target Contests')}
       />
@@ -272,7 +272,7 @@ describe('Audit Setup > Contests', () => {
   it('displays no error when the total votes are greater than the ballot count, but less than the total allowed votes for a contest', async () => {
     const { getByLabelText, queryByTestId } = render(
       <Contests
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         isTargeted
         {...relativeStages('Target Contests')}
       />

--- a/arlo-client/src/components/Audit/Setup/Participants/index.test.tsx
+++ b/arlo-client/src/components/Audit/Setup/Participants/index.test.tsx
@@ -59,7 +59,7 @@ const fillAndSubmit = async () => {
     getByTestId,
   } = await asyncActRender(
     <Router>
-      <Participants audit={statusStates[0]} nextStage={nextStage} />
+      <Participants audit={statusStates.empty} nextStage={nextStage} />
     </Router>
   )
 
@@ -92,7 +92,7 @@ describe('Audit Setup > Participants', () => {
   it('renders empty state correctly', async () => {
     const { container } = await asyncActRender(
       <Router>
-        <Participants audit={statusStates[0]} nextStage={nextStage} />
+        <Participants audit={statusStates.empty} nextStage={nextStage} />
       </Router>
     )
     expect(container).toMatchSnapshot()

--- a/arlo-client/src/components/Audit/Setup/Settings/index.test.tsx
+++ b/arlo-client/src/components/Audit/Setup/Settings/index.test.tsx
@@ -36,7 +36,7 @@ const fillAndSubmit = async () => {
   const { getByText, getByLabelText, getByTestId } = await asyncActRender(
     <Router>
       <Settings
-        audit={statusStates[0]}
+        audit={statusStates.empty}
         nextStage={nextStage}
         prevStage={prevStage}
       />

--- a/arlo-client/src/components/Audit/Setup/index.test.tsx
+++ b/arlo-client/src/components/Audit/Setup/index.test.tsx
@@ -37,7 +37,7 @@ describe('Setup', () => {
   it('renders Participants stage', async () => {
     const { container } = await asyncActRender(
       <Setup
-        audit={statusStates[2]}
+        audit={statusStates.sampleSizeOptions}
         stage="Participants"
         {...relativeStages('Participants')}
       />
@@ -48,7 +48,7 @@ describe('Setup', () => {
   it('renders Target Contests stage', async () => {
     const { container } = await asyncActRender(
       <Setup
-        audit={statusStates[2]}
+        audit={statusStates.sampleSizeOptions}
         stage="Target Contests"
         {...relativeStages('Target Contests')}
       />
@@ -59,7 +59,7 @@ describe('Setup', () => {
   it('renders Opportunistic Contests stage', async () => {
     const { container } = await asyncActRender(
       <Setup
-        audit={statusStates[2]}
+        audit={statusStates.sampleSizeOptions}
         stage="Opportunistic Contests"
         {...relativeStages('Opportunistic Contests')}
       />
@@ -70,7 +70,7 @@ describe('Setup', () => {
   it('renders Audit Settings stage', async () => {
     const { container } = await asyncActRender(
       <Setup
-        audit={statusStates[2]}
+        audit={statusStates.sampleSizeOptions}
         stage="Audit Settings"
         {...relativeStages('Audit Settings')}
       />
@@ -81,7 +81,7 @@ describe('Setup', () => {
   it('renders Review & Launch stage', async () => {
     const { container } = await asyncActRender(
       <Setup
-        audit={statusStates[2]}
+        audit={statusStates.sampleSizeOptions}
         stage="Review & Launch"
         {...relativeStages('Review & Launch')}
       />

--- a/arlo-client/src/components/Audit/_mocks.ts
+++ b/arlo-client/src/components/Audit/_mocks.ts
@@ -33,8 +33,8 @@ export const auditSettings: {
   },
 }
 
-export const statusStates: IAudit[] = [
-  {
+export const statusStates: { [key: string]: IAudit } = {
+  empty: {
     name: '',
     riskLimit: '',
     frozenAt: null,
@@ -44,7 +44,7 @@ export const statusStates: IAudit[] = [
     jurisdictions: [],
     rounds: [],
   },
-  {
+  contestFirstRound: {
     contests: [
       {
         choices: [
@@ -93,7 +93,7 @@ export const statusStates: IAudit[] = [
     frozenAt: null,
     online: true,
   },
-  {
+  sampleSizeOptions: {
     contests: [
       {
         choices: [
@@ -146,7 +146,7 @@ export const statusStates: IAudit[] = [
     frozenAt: null,
     online: true,
   },
-  {
+  jurisdictionsInitial: {
     contests: [
       {
         choices: [
@@ -228,7 +228,7 @@ export const statusStates: IAudit[] = [
     frozenAt: null,
     online: true,
   },
-  {
+  ballotManifestProcessed: {
     contests: [
       {
         choices: [
@@ -302,7 +302,81 @@ export const statusStates: IAudit[] = [
     frozenAt: null,
     online: true,
   },
-  {
+  ballotManifestProcessError: {
+    contests: [
+      {
+        choices: [
+          {
+            id: 'choice-1',
+            name: 'choice one',
+            numVotes: 792,
+          },
+          {
+            id: 'choice-2',
+            name: 'choice two',
+            numVotes: 1325,
+          },
+        ],
+        id: 'contest-1',
+        name: 'contest name',
+        numWinners: '1',
+        votesAllowed: '1',
+        totalBallotsCast: '2123',
+        isTargeted: true,
+      },
+    ],
+    jurisdictions: [
+      {
+        auditBoards: [
+          {
+            id: 'audit-board-1',
+            name: 'Audit Board #1',
+            members: [],
+            ballots: [],
+          },
+        ],
+        ballotManifest: {
+          filename: 'Ballot Manifest May 2019 Election - WYNADOTTE.csv',
+          numBallots: 2117,
+          numBatches: 10,
+          uploadedAt: '2019-07-18T16:34:07.000Z',
+          processing: { status: 'ERRORED' },
+        },
+        contests: ['contest-1'],
+        id: 'jurisdiction-1',
+        name: 'Jurisdiction 1',
+      },
+    ],
+    rounds: [
+      {
+        contests: [
+          {
+            endMeasurements: {
+              isComplete: null,
+              pvalue: null,
+            },
+            id: 'contest-1',
+            results: {},
+            sampleSize: 379,
+            sampleSizeOptions: [
+              { size: 269, type: 'ASN', prob: null },
+              { size: 379, prob: 0.8, type: null },
+              { size: 78, prob: null, type: null },
+            ],
+          },
+        ],
+        endedAt: null,
+        startedAt: '2019-07-18T16:34:07.000Z',
+        id: 'round-1',
+      },
+    ],
+    name: 'contest name',
+    randomSeed: '12345678901234567890abcdefghijklmnopqrstuvwxyz😊',
+    riskLimit: '1',
+    frozenAt: null,
+    online: true,
+  },
+  completeInFirstRound: {
     contests: [
       {
         choices: [
@@ -378,7 +452,7 @@ export const statusStates: IAudit[] = [
     frozenAt: null,
     online: true,
   },
-  {
+  firstRoundSampleSizeOptionsNull: {
     contests: [
       {
         choices: [
@@ -447,7 +521,7 @@ export const statusStates: IAudit[] = [
     frozenAt: null,
     online: true,
   },
-  {
+  firstRoundSampleSizeOptions: {
     contests: [
       {
         choices: [
@@ -539,7 +613,7 @@ export const statusStates: IAudit[] = [
     frozenAt: null,
     online: true,
   },
-  {
+  multiAuditBoardsAndRounds: {
     contests: [
       {
         choices: [
@@ -655,81 +729,7 @@ export const statusStates: IAudit[] = [
     frozenAt: null,
     online: true,
   },
-  {
-    contests: [
-      {
-        choices: [
-          {
-            id: 'choice-1',
-            name: 'choice one',
-            numVotes: 792,
-          },
-          {
-            id: 'choice-2',
-            name: 'choice two',
-            numVotes: 1325,
-          },
-        ],
-        id: 'contest-1',
-        name: 'contest name',
-        numWinners: '1',
-        votesAllowed: '1',
-        totalBallotsCast: '2123',
-        isTargeted: true,
-      },
-    ],
-    jurisdictions: [
-      {
-        auditBoards: [
-          {
-            id: 'audit-board-1',
-            name: 'Audit Board #1',
-            members: [],
-            ballots: [],
-          },
-        ],
-        ballotManifest: {
-          filename: 'Ballot Manifest May 2019 Election - WYNADOTTE.csv',
-          numBallots: 2117,
-          numBatches: 10,
-          uploadedAt: '2019-07-18T16:34:07.000Z',
-          processing: { status: 'ERRORED' },
-        },
-        contests: ['contest-1'],
-        id: 'jurisdiction-1',
-        name: 'Jurisdiction 1',
-      },
-    ],
-    rounds: [
-      {
-        contests: [
-          {
-            endMeasurements: {
-              isComplete: null,
-              pvalue: null,
-            },
-            id: 'contest-1',
-            results: {},
-            sampleSize: 379,
-            sampleSizeOptions: [
-              { size: 269, type: 'ASN', prob: null },
-              { size: 379, prob: 0.8, type: null },
-              { size: 78, prob: null, type: null },
-            ],
-          },
-        ],
-        endedAt: null,
-        startedAt: '2019-07-18T16:34:07.000Z',
-        id: 'round-1',
-      },
-    ],
-    name: 'contest name',
-    randomSeed: '12345678901234567890abcdefghijklmnopqrstuvwxyz😊',
-    riskLimit: '1',
-    frozenAt: null,
-    online: true,
-  },
-]
+}
 
 export const ballotManifest = new File(
   ['ballot manifest'],

--- a/arlo-client/src/components/Audit/index.test.tsx
+++ b/arlo-client/src/components/Audit/index.test.tsx
@@ -59,7 +59,7 @@ afterEach(() => {
 
 describe('RiskLimitingAuditForm', () => {
   it('fetches initial state from api', async () => {
-    apiMock.mockImplementation(async () => statusStates[0])
+    apiMock.mockImplementation(async () => statusStates.empty)
     const { container } = await asyncActRender(
       <Router>
         <Audit />
@@ -72,7 +72,7 @@ describe('RiskLimitingAuditForm', () => {
       expect(apiMock.mock.calls[0][0]).toMatch(
         /\/election\/[^/]+\/audit\/status/
       )
-      expect(apiMock.mock.results[0].value).resolves.toBe(statusStates[0])
+      expect(apiMock.mock.results[0].value).resolves.toBe(statusStates.empty)
     })
   })
 
@@ -96,7 +96,7 @@ describe('RiskLimitingAuditForm', () => {
   })
 
   it('does not render SelectBallotsToAudit when /audit/status is processing samplesizes', async () => {
-    apiMock.mockImplementation(async () => statusStates[1])
+    apiMock.mockImplementation(async () => statusStates.contestFirstRound)
     const { container, queryByTestId } = await asyncActRender(
       <Router>
         <Audit />
@@ -110,12 +110,14 @@ describe('RiskLimitingAuditForm', () => {
       expect(apiMock.mock.calls[0][0]).toMatch(
         /\/election\/[^/]+\/audit\/status/
       )
-      expect(apiMock.mock.results[0].value).resolves.toBe(statusStates[1])
+      expect(apiMock.mock.results[0].value).resolves.toBe(
+        statusStates.contestFirstRound
+      )
     })
   })
 
   it('renders SelectBallotsToAudit when /audit/status returns contest data', async () => {
-    apiMock.mockImplementation(async () => statusStates[2])
+    apiMock.mockImplementation(async () => statusStates.sampleSizeOptions)
     const { container, getByTestId } = await asyncActRender(
       <Router>
         <Audit />
@@ -133,12 +135,14 @@ describe('RiskLimitingAuditForm', () => {
       expect(apiMock.mock.calls[0][0]).toMatch(
         /\/election\/[^/]+\/audit\/status/
       )
-      expect(apiMock.mock.results[0].value).resolves.toBe(statusStates[2])
+      expect(apiMock.mock.results[0].value).resolves.toBe(
+        statusStates.sampleSizeOptions
+      )
     })
   })
 
   it('does not render CalculateRiskMeasurement when audit.jurisdictions has length but audit.rounds does not', async () => {
-    apiMock.mockImplementation(async () => statusStates[3])
+    apiMock.mockImplementation(async () => statusStates.jurisdictionsInitial)
     const { container, getByTestId, queryByTestId } = await asyncActRender(
       <Router>
         <Audit />
@@ -157,13 +161,15 @@ describe('RiskLimitingAuditForm', () => {
       expect(apiMock.mock.calls[0][0]).toMatch(
         /\/election\/[^/]+\/audit\/status/
       )
-      expect(apiMock.mock.results[0].value).resolves.toBe(statusStates[3])
+      expect(apiMock.mock.results[0].value).resolves.toBe(
+        statusStates.jurisdictionsInitial
+      )
     })
   })
 
   it('renders CalculateRiskMeasurement when /audit/status returns round data', async () => {
     apiMock
-      .mockImplementationOnce(async () => statusStates[4])
+      .mockImplementationOnce(async () => statusStates.ballotManifestProcessed)
       .mockImplementationOnce(async () => dummyBallots)
     const { container, getByTestId } = await asyncActRender(
       <Router>
@@ -182,13 +188,15 @@ describe('RiskLimitingAuditForm', () => {
       expect(apiMock.mock.calls[0][0]).toMatch(
         /\/election\/[^/]+\/audit\/status/
       )
-      expect(apiMock.mock.results[0].value).resolves.toBe(statusStates[4])
+      expect(apiMock.mock.results[0].value).resolves.toBe(
+        statusStates.ballotManifestProcessed
+      )
     })
   })
 
   it('renders sidebar when authenticated on /setup', async () => {
     apiMock
-      .mockImplementationOnce(async () => statusStates[2])
+      .mockImplementationOnce(async () => statusStates.sampleSizeOptions)
       .mockImplementationOnce(async () => ({
         type: 'audit_admin',
         name: 'Joe',
@@ -230,7 +238,7 @@ describe('RiskLimitingAuditForm', () => {
       },
     })
     apiMock
-      .mockImplementationOnce(async () => statusStates[2])
+      .mockImplementationOnce(async () => statusStates.sampleSizeOptions)
       .mockImplementationOnce(async () => ({
         type: 'audit_admin',
         name: 'Joe',
@@ -265,7 +273,7 @@ describe('RiskLimitingAuditForm', () => {
 
   it('sidebar changes stages', async () => {
     apiMock
-      .mockImplementationOnce(async () => statusStates[2])
+      .mockImplementationOnce(async () => statusStates.sampleSizeOptions)
       .mockImplementationOnce(async () => ({
         type: 'audit_admin',
         name: 'Joe',
@@ -305,7 +313,7 @@ describe('RiskLimitingAuditForm', () => {
 
   it('next and back buttons change stages', async () => {
     apiMock
-      .mockImplementationOnce(async () => statusStates[2])
+      .mockImplementationOnce(async () => statusStates.sampleSizeOptions)
       .mockImplementationOnce(async () => ({
         type: 'audit_admin',
         name: 'Joe',

--- a/arlo-client/src/components/DataEntry/MemberForm.test.tsx
+++ b/arlo-client/src/components/DataEntry/MemberForm.test.tsx
@@ -16,7 +16,7 @@ const checkAndToastMock: jest.SpyInstance<
 
 checkAndToastMock.mockReturnValue(false)
 
-const dummy = statusStates[3]
+const dummy = statusStates.jurisdictionsInitial
 dummy.jurisdictions[0].auditBoards = [dummyBoard[0]]
 
 apiMock

--- a/arlo-client/src/components/DataEntry/index.test.tsx
+++ b/arlo-client/src/components/DataEntry/index.test.tsx
@@ -8,7 +8,7 @@ import { statusStates } from '../Audit/_mocks'
 import * as utilities from '../utilities'
 import { IAudit, IBallot } from '../../types'
 
-const memberDummy = statusStates[3]
+const memberDummy = statusStates.jurisdictionsInitial
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,

--- a/arlo-client/src/components/DataEntry/index_members.test.tsx
+++ b/arlo-client/src/components/DataEntry/index_members.test.tsx
@@ -8,7 +8,7 @@ import { statusStates } from '../Audit/_mocks'
 import * as utilities from '../utilities'
 import { IAudit, IBallot } from '../../types'
 
-const memberlessDummy = statusStates[3]
+const memberlessDummy = statusStates.jurisdictionsInitial
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,


### PR DESCRIPTION
**Description**

- I initially had the sequence of states of return values from the `/status` endpoint as a reference, and then repurposed it as mock data. The problem was that while initially it was fine to have it as an array, it quickly became bloated, unwieldy, and incredibly difficult to maintain and update. So I went back through and converted it to an object with named keys that (hopefully) make more sense.

**Testing**

- Passes existing tests.

**Progress**

- Should be good, though feedback on if the names I used are semantic enough would be nice.
