### PR TITLE
Stabilize E2E tests

### DIFF
--- a/arlo-client/wdio.conf.js
+++ b/arlo-client/wdio.conf.js
@@ -45,7 +45,7 @@ exports.config = {
   // and 30 processes will get spawned. The property handles how many capabilities
   // from the same test should run tests.
   //
-  maxInstances: 10,
+  maxInstances: 1,
   //
   // If you have trouble getting all important capabilities together, check out the
   // Sauce Labs platform configurator - a great tool to configure your capabilities:
@@ -56,7 +56,7 @@ exports.config = {
       // maxInstances can get overwritten per capability. So if you have an in-house Selenium
       // grid with only 5 firefox instances available you can make sure that not more than
       // 5 instances get started at a time.
-      maxInstances: 5,
+      maxInstances: 1,
       //
       browserName: 'chrome',
       // If outputDir is provided WebdriverIO can capture driver session logs

--- a/arlo-client/wdio.conf.js
+++ b/arlo-client/wdio.conf.js
@@ -99,7 +99,7 @@ exports.config = {
   baseUrl: 'http://localhost:3000',
   //
   // Default timeout for all waitFor* commands.
-  waitforTimeout: 10000,
+  waitforTimeout: 20000,
   //
   // Default timeout in milliseconds for request
   // if Selenium Grid doesn't send response


### PR DESCRIPTION
**Description**

- Theorizing that running the tests in parallel with each other might be causing them to interfere with each other and/or burden the bgcompute script, limiting the `maxInstances` to 1.
- Increasing the timeout length from 10000 to 20000 to give more time for background processes to complete before bailing on the tests.

**Notes**

- My observation is that the test failures have nothing to do with the tests themselves. The parts that fail are invariably passed successfully in other portions of the same test run, and when re-run the failures take place in completely disparate parts of the suite. However, they all tend to be related to waiting on the background processes. Therefore, helping the tests cope with them more patiently should reduce the flakiness. :crossed_fingers: 
