### PR TITLE
Add assert_ok test helper and typecheck tests

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -37,3 +37,6 @@ ignore_missing_imports = True
 
 [mypy-jsonschema.validators]
 ignore_missing_imports = True
+
+[mypy-pytest]
+ignore_missing_imports = True

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite("tests.helpers")

--- a/tests/routes_tests/test_audit_basic_update.py
+++ b/tests/routes_tests/test_audit_basic_update.py
@@ -1,6 +1,6 @@
 import json, uuid
 
-from helpers import post_json
+from tests.helpers import post_json
 
 
 def test_audit_basic_update_create_contest(client, election_id):

--- a/tests/routes_tests/test_audit_basic_update.py
+++ b/tests/routes_tests/test_audit_basic_update.py
@@ -1,6 +1,6 @@
 import json, uuid
 
-from tests.helpers import post_json
+from tests.helpers import assert_ok, post_json
 
 
 def test_audit_basic_update_create_contest(client, election_id):
@@ -33,7 +33,7 @@ def test_audit_basic_update_create_contest(client, election_id):
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
 
 def test_audit_basic_update_sets_default_for_contest_is_targeted(client, election_id):
@@ -65,7 +65,7 @@ def test_audit_basic_update_sets_default_for_contest_is_targeted(client, electio
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/audit/status")
     assert json.loads(rv.data)["contests"][0]["isTargeted"] is True

--- a/tests/routes_tests/test_audit_status.py
+++ b/tests/routes_tests/test_audit_status.py
@@ -2,14 +2,14 @@ import json
 import pytest
 from flask.testing import FlaskClient
 
-from helpers import (
+from tests.helpers import (
     compare_json,
     assert_is_id,
     assert_is_date,
     assert_is_passphrase,
     create_election,
 )
-from test_app import setup_whole_audit
+from tests.test_app import setup_whole_audit
 from util.process_file import ProcessingStatus
 
 

--- a/tests/routes_tests/test_ballot_list.py
+++ b/tests/routes_tests/test_ballot_list.py
@@ -3,8 +3,8 @@ from flask.testing import FlaskClient
 
 import pytest
 
-from helpers import post_json, create_election
-from test_app import setup_whole_audit
+from tests.helpers import post_json, create_election
+from tests.test_app import setup_whole_audit
 import bgcompute
 
 

--- a/tests/routes_tests/test_ballot_list.py
+++ b/tests/routes_tests/test_ballot_list.py
@@ -3,7 +3,7 @@ from flask.testing import FlaskClient
 
 import pytest
 
-from tests.helpers import post_json, create_election
+from tests.helpers import assert_ok, post_json, create_election
 from tests.test_app import setup_whole_audit
 import bgcompute
 
@@ -59,7 +59,7 @@ def test_ballot_list_jurisdiction_two_rounds(client, election_id):
             ]
         },
     )
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
     bgcompute.bgcompute()
 
     # Get the sample size and round id for the second round
@@ -127,7 +127,7 @@ def test_ballot_list_audit_board_two_rounds(client, election_id):
             ]
         },
     )
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
     bgcompute.bgcompute()
 
     # Get the sample size and round id for the second round

--- a/tests/routes_tests/test_contests.py
+++ b/tests/routes_tests/test_contests.py
@@ -3,7 +3,7 @@ from flask.testing import FlaskClient
 from typing import List
 import json, uuid
 
-from tests.helpers import post_json, put_json
+from tests.helpers import assert_ok, post_json, put_json
 from arlo_server.models import RoundContest
 from arlo_server.contests import JSONDict
 from arlo_server import db
@@ -64,7 +64,7 @@ def test_contests_list_empty(client, election_id):
 def test_contests_create_get_update_one(client, election_id, json_contests):
     contest = json_contests[0]
     rv = put_json(client, f"/election/{election_id}/contest", [contest])
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/contest")
     contests = json.loads(rv.data)
@@ -78,7 +78,7 @@ def test_contests_create_get_update_one(client, election_id, json_contests):
     )
 
     rv = put_json(client, f"/election/{election_id}/contest", [contest])
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/contest")
     contests = json.loads(rv.data)
@@ -93,7 +93,7 @@ def test_contests_create_get_update_multiple(
     jurisdiction_ids: List[str],
 ):
     rv = put_json(client, f"/election/{election_id}/contest", json_contests)
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/contest")
     contests = json.loads(rv.data)
@@ -107,7 +107,7 @@ def test_contests_create_get_update_multiple(
     json_contests[2]["jurisdictionIds"] = jurisdiction_ids[1:]
 
     rv = put_json(client, f"/election/{election_id}/contest", json_contests)
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/contest")
     contests = json.loads(rv.data)
@@ -125,7 +125,7 @@ def test_contests_round_status(
     manifests,  # pylint: disable=unused-argument
 ):
     rv = put_json(client, f"/election/{election_id}/contest", json_contests)
-    assert rv.status_code == 200
+    assert_ok(rv)
 
     SAMPLE_SIZE = 119  # Bravo sample size
     rv = post_json(
@@ -133,7 +133,7 @@ def test_contests_round_status(
         f"/election/{election_id}/round",
         {"roundNum": 1, "sampleSize": SAMPLE_SIZE},
     )
-    assert rv.status_code == 200
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/contest")
     contests = json.loads(rv.data)["contests"]

--- a/tests/routes_tests/test_contests.py
+++ b/tests/routes_tests/test_contests.py
@@ -3,7 +3,7 @@ from flask.testing import FlaskClient
 from typing import List
 import json, uuid
 
-from helpers import post_json, put_json
+from tests.helpers import post_json, put_json
 from arlo_server.models import RoundContest
 from arlo_server.contests import JSONDict
 from arlo_server import db

--- a/tests/routes_tests/test_election_settings.py
+++ b/tests/routes_tests/test_election_settings.py
@@ -3,7 +3,7 @@ from flask.testing import FlaskClient
 
 from arlo_server.models import Election, USState
 
-from tests.helpers import put_json, compare_json, asserts_startswith
+from tests.helpers import assert_ok, put_json, compare_json, asserts_startswith
 
 
 def test_get_empty(client: FlaskClient, election_id: str):
@@ -31,8 +31,7 @@ def test_update_election(client: FlaskClient, election_id: str):
     election["state"] = USState.Mississippi
 
     rv = put_json(client, f"/election/{election_id}/settings", election)
-    assert rv.status_code == 200, f"unexpected response: {rv.data}"
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     election_record = Election.query.filter_by(id=election_id).one()
     assert election_record.election_name == "An Updated Name"

--- a/tests/routes_tests/test_jurisdictions.py
+++ b/tests/routes_tests/test_jurisdictions.py
@@ -6,7 +6,7 @@ import json, io, uuid
 from datetime import datetime
 from typing import List
 
-from helpers import (
+from tests.helpers import (
     put_json,
     post_json,
     compare_json,
@@ -16,7 +16,6 @@ from helpers import (
 from arlo_server import db
 from arlo_server.models import (
     Jurisdiction,
-    Contest,
     AuditBoard,
     SampledBallot,
     SampledBallotDraw,
@@ -245,7 +244,7 @@ def test_jurisdictions_round_status(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
-    contest: Contest,  # pylint: disable=unused-argument
+    contest_id: str,  # pylint: disable=unused-argument
     election_settings,  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
@@ -360,7 +359,7 @@ def test_jurisdictions_round_status_offline(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
-    contest: Contest,  # pylint: disable=unused-argument
+    contest_id: str,  # pylint: disable=unused-argument
     election_settings,  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):

--- a/tests/routes_tests/test_jurisdictions.py
+++ b/tests/routes_tests/test_jurisdictions.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import List
 
 from tests.helpers import (
+    assert_ok,
     put_json,
     post_json,
     compare_json,
@@ -45,7 +46,7 @@ def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
             )
         },
     )
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
     bgcompute_update_election_jurisdictions_file()
     jurisdictions = (
         Jurisdiction.query.filter_by(election_id=election_id)
@@ -124,7 +125,7 @@ def test_jurisdictions_list_with_manifest(
             )
         },
     )
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
     assert bgcompute_update_ballot_manifest_file() == 1
 
     rv = client.get(f"/election/{election_id}/jurisdiction")
@@ -184,7 +185,7 @@ def test_duplicate_batch_name(client, election_id, jurisdiction_ids):
             )
         },
     )
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     with pytest.raises(SQLAlchemyError):
         bgcompute_update_ballot_manifest_file()
@@ -257,7 +258,7 @@ def test_jurisdictions_round_status(
         f"/election/{election_id}/round",
         {"roundNum": 1, "sampleSize": SAMPLE_SIZE},
     )
-    assert rv.status_code == 200
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)["jurisdictions"]
@@ -376,14 +377,14 @@ def test_jurisdictions_round_status_offline(
         "state": USState.California,
     }
     rv = put_json(client, f"/election/{election_id}/settings", settings)
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     rv = post_json(
         client,
         f"/election/{election_id}/round",
         {"roundNum": 1, "sampleSize": SAMPLE_SIZE},
     )
-    assert rv.status_code == 200
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)["jurisdictions"]

--- a/tests/routes_tests/test_new_election.py
+++ b/tests/routes_tests/test_new_election.py
@@ -3,7 +3,7 @@ from flask.testing import FlaskClient
 
 from arlo_server.auth import UserType
 from arlo_server.routes import create_organization
-from tests.helpers import create_org_and_admin, set_logged_in_user, post_json
+from tests.helpers import assert_ok, create_org_and_admin, set_logged_in_user, post_json
 
 
 def test_without_org_with_anonymous_user(client: FlaskClient):
@@ -222,7 +222,7 @@ def test_two_orgs_same_name(client: FlaskClient):
 
 def test_election_reset(client, election_id):
     rv = client.post(f"/election/{election_id}/audit/reset")
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)

--- a/tests/routes_tests/test_report.py
+++ b/tests/routes_tests/test_report.py
@@ -3,7 +3,7 @@ from flask.testing import FlaskClient
 
 import pytest
 
-from tests.helpers import post_json, create_election
+from tests.helpers import assert_ok, post_json, create_election
 from tests.test_app import setup_whole_audit, run_whole_audit_flow
 import bgcompute
 
@@ -42,7 +42,7 @@ def run_audit_round(
             f"/election/{election_id}/jurisdiction/{jurisdiction_id}/batch/{ballot['batch']['id']}/ballot/{ballot['position']}",
             {"vote": vote, "comment": f"Comment for ballot {i}" if i % 3 == 0 else "",},
         )
-        assert json.loads(rv.data)["status"] == "ok"
+        assert_ok(rv)
 
     # The results won't be exact since we used a (seeded) random choice above.
     # If we need exact results, we can always query the db or track results above.
@@ -63,7 +63,7 @@ def run_audit_round(
             ]
         },
     )
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     return len(ballot_list)
 

--- a/tests/routes_tests/test_report.py
+++ b/tests/routes_tests/test_report.py
@@ -3,8 +3,8 @@ from flask.testing import FlaskClient
 
 import pytest
 
-from helpers import post_json, create_election
-from test_app import setup_whole_audit, run_whole_audit_flow
+from tests.helpers import post_json, create_election
+from tests.test_app import setup_whole_audit, run_whole_audit_flow
 import bgcompute
 
 

--- a/tests/routes_tests/test_sample_sizes.py
+++ b/tests/routes_tests/test_sample_sizes.py
@@ -18,7 +18,7 @@ def test_sample_sizes_without_contests(client: FlaskClient, election_id: str):
 def test_sample_sizes_without_risk_limit(
     client: FlaskClient,
     election_id: str,
-    contest: str,  # pylint: disable=unused-argument
+    contest_id: str,  # pylint: disable=unused-argument
 ):
     rv = client.get(f"/election/{election_id}/sample-sizes")
     assert rv.status_code == 400
@@ -35,7 +35,7 @@ def test_sample_sizes_without_risk_limit(
 def test_sample_sizes_round_1(
     client: FlaskClient,
     election_id: str,
-    contest: str,  # pylint: disable=unused-argument
+    contest_id: str,  # pylint: disable=unused-argument
     election_settings: None,  # pylint: disable=unused-argument
 ):
     rv = client.get(f"/election/{election_id}/sample-sizes")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 import os, math, uuid
 import json, csv, io
 from flask.testing import FlaskClient
+from typing import Generator
 
 import pytest
 
@@ -12,7 +13,7 @@ small_manifest_file_path = os.path.join(os.path.dirname(__file__), "small-manife
 
 
 @pytest.fixture()
-def election_id(client: FlaskClient) -> str:
+def election_id(client: FlaskClient) -> Generator[str, None, None]:
     yield create_election(client, is_multi_jurisdiction=False)
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,7 +5,7 @@ from typing import Generator
 
 import pytest
 
-from tests.helpers import post_json, create_election
+from tests.helpers import assert_ok, post_json, create_election
 import bgcompute
 
 manifest_file_path = os.path.join(os.path.dirname(__file__), "manifest.csv")
@@ -82,7 +82,7 @@ def setup_audit_board(client, election_id, jurisdiction_id, audit_board_id):
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
 
 def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online=False):
@@ -128,10 +128,10 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.post(f"{url_prefix}/audit/freeze")
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     # before background compute, should be null sample size options
     rv = client.get("{}/audit/status".format(url_prefix))
@@ -178,7 +178,7 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get("{}/audit/status".format(url_prefix))
     status = json.loads(rv.data)
@@ -203,7 +203,7 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
         client, "{}/audit/sample-size".format(url_prefix), {"size": sample_size}
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     # upload the manifest
     data = {}
@@ -214,7 +214,7 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
         content_type="multipart/form-data",
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
     assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     rv = client.get("{}/audit/status".format(url_prefix))
@@ -230,7 +230,7 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
     rv = client.delete(
         "{}/jurisdiction/{}/manifest".format(url_prefix, jurisdiction_id)
     )
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get("{}/audit/status".format(url_prefix))
     status = json.loads(rv.data)
@@ -247,7 +247,7 @@ def setup_whole_audit(client, election_id, name, risk_limit, random_seed, online
         content_type="multipart/form-data",
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
     assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     setup_audit_board(client, election_id, jurisdiction_id, audit_board_id_1)
@@ -323,10 +323,10 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.post(f"{url_prefix}/audit/freeze")
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     # before background compute, should be null sample size options
     rv = client.get("{}/audit/status".format(url_prefix))
@@ -373,7 +373,7 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get("{}/audit/status".format(url_prefix))
     status = json.loads(rv.data)
@@ -396,7 +396,7 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
         client, "{}/audit/sample-size".format(url_prefix), {"size": sample_size}
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     # upload the manifest
     data = {}
@@ -407,7 +407,7 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
         content_type="multipart/form-data",
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
     assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     rv = client.get("{}/audit/status".format(url_prefix))
@@ -423,7 +423,7 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
     rv = client.delete(
         "{}/jurisdiction/{}/manifest".format(url_prefix, jurisdiction_id)
     )
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get("{}/audit/status".format(url_prefix))
     status = json.loads(rv.data)
@@ -440,7 +440,7 @@ def setup_whole_multi_winner_audit(client, election_id, name, risk_limit, random
         content_type="multipart/form-data",
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
     assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     # get the retrieval list for round 1
@@ -501,7 +501,7 @@ def run_whole_audit_flow(client, election_id, name, risk_limit, random_seed):
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get("{}/audit/status".format(url_prefix))
     status = json.loads(rv.data)
@@ -571,14 +571,14 @@ def test_small_election(client, election_id):
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     # not yet frozen
     rv = client.get(f"/election/{election_id}/audit/status")
     assert not json.loads(rv.data)["frozenAt"]
 
     rv = client.post(f"/election/{election_id}/audit/freeze")
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     # now frozen
     rv = client.get(f"/election/{election_id}/audit/status")
@@ -629,7 +629,7 @@ def test_small_election(client, election_id):
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
@@ -663,7 +663,7 @@ def test_small_election(client, election_id):
         content_type="multipart/form-data",
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
     assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     rv = client.get(f"/election/{election_id}/audit/status")
@@ -711,7 +711,7 @@ def test_small_election(client, election_id):
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
@@ -832,7 +832,7 @@ def test_multi_round_audit(client, election_id):
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get("{}/audit/status".format(url_prefix))
     status = json.loads(rv.data)
@@ -908,7 +908,7 @@ def test_multi_winner_election(client, election_id):
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
@@ -945,10 +945,10 @@ def test_multi_winner_election(client, election_id):
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.post(f"/election/{election_id}/audit/freeze")
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
     bgcompute.bgcompute()
 
     rv = client.get(f"/election/{election_id}/audit/status")
@@ -981,7 +981,7 @@ def test_multi_winner_election(client, election_id):
         content_type="multipart/form-data",
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
     assert bgcompute.bgcompute_update_ballot_manifest_file() == 1
 
     rv = client.get(f"/election/{election_id}/audit/status")
@@ -1027,7 +1027,7 @@ def test_multi_winner_election(client, election_id):
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/audit/status")
     status = json.loads(rv.data)
@@ -1081,7 +1081,7 @@ def test_multi_round_multi_winner_audit(client, election_id):
         },
     )
 
-    assert json.loads(rv.data)["status"] == "ok"
+    assert_ok(rv)
 
     rv = client.get("{}/audit/status".format(url_prefix))
     status = json.loads(rv.data)

--- a/tests/test_app_upload_jurisdictions_file.py
+++ b/tests/test_app_upload_jurisdictions_file.py
@@ -10,6 +10,7 @@ from arlo_server.models import (
     User,
 )
 from bgcompute import bgcompute_update_election_jurisdictions_file
+from tests.helpers import assert_ok
 
 
 def test_missing_file(client: FlaskClient, election_id: str):
@@ -79,8 +80,7 @@ def test_metadata(client, election_id):
             )
         },
     )
-    assert rv.status_code == 200
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     election = Election.query.filter_by(id=election_id).one()
     assert election.jurisdictions_file.contents == "Jurisdiction,Admin Email"
@@ -128,8 +128,7 @@ def test_replace_jurisdictions_file(client, election_id):
             )
         },
     )
-    assert rv.status_code == 200
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
     assert File.query.count() == 1, "the file should exist before a response is sent"
 
     # Replace it with another file.
@@ -142,8 +141,7 @@ def test_replace_jurisdictions_file(client, election_id):
             )
         },
     )
-    assert rv.status_code == 200
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
     assert File.query.count() == 1, "the old file should have been deleted"
 
 
@@ -157,8 +155,7 @@ def test_no_jurisdiction(client, election_id):
             )
         },
     )
-    assert rv.status_code == 200
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     # Process the file in the background.
     assert bgcompute_update_election_jurisdictions_file() == 1
@@ -179,8 +176,7 @@ def test_single_jurisdiction_single_admin(client, election_id):
             )
         },
     )
-    assert rv.status_code == 200
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     # Process the file in the background.
     assert bgcompute_update_election_jurisdictions_file() == 1
@@ -206,8 +202,7 @@ def test_single_jurisdiction_multiple_admins(client, election_id):
             )
         },
     )
-    assert rv.status_code == 200
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     # Process the file in the background.
     assert bgcompute_update_election_jurisdictions_file() == 1
@@ -234,8 +229,7 @@ def test_multiple_jurisdictions_single_admin(client, election_id):
             )
         },
     )
-    assert rv.status_code == 200
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     # Process the file in the background.
     assert bgcompute_update_election_jurisdictions_file() == 1

--- a/tests/test_rounds.py
+++ b/tests/test_rounds.py
@@ -12,6 +12,7 @@ from arlo_server.models import (
     Batch,
 )
 from tests.helpers import (
+    assert_ok,
     post_json,
     put_json,
     compare_json,
@@ -39,8 +40,7 @@ def test_rounds_create_one(
         f"/election/{election_id}/round",
         {"roundNum": 1, "sampleSize": sample_size,},
     )
-    assert rv.status_code == 200
-    assert json.loads(rv.data) == {"status": "ok"}
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/round")
     rounds = json.loads(rv.data)
@@ -111,12 +111,12 @@ def test_rounds_create_two(
         },
     ]
     rv = put_json(client, f"/election/{election_id}/contest", contests)
-    assert rv.status_code == 200
+    assert_ok(rv)
 
     rv = post_json(
         client, f"/election/{election_id}/round", {"roundNum": 1, "sampleSize": 119,},
     )
-    assert rv.status_code == 200
+    assert_ok(rv)
 
     # Fake that the first round got completed by setting Round.ended_at.
     # We also need to add RoundContestResults so that the next round sample
@@ -158,7 +158,7 @@ def test_rounds_create_two(
     )
 
     rv = post_json(client, f"/election/{election_id}/round", {"roundNum": 2},)
-    assert rv.status_code == 200
+    assert_ok(rv)
 
     rv = client.get(f"/election/{election_id}/round")
     rounds = json.loads(rv.data)
@@ -205,7 +205,7 @@ def test_rounds_create_before_previous_round_complete(
     rv = post_json(
         client, f"/election/{election_id}/round", {"roundNum": 1, "sampleSize": 10,},
     )
-    assert rv.status_code == 200
+    assert_ok(rv)
 
     rv = post_json(client, f"/election/{election_id}/round", {"roundNum": 2},)
     assert rv.status_code == 409
@@ -239,7 +239,7 @@ def test_rounds_wrong_number_too_small(
     rv = post_json(
         client, f"/election/{election_id}/round", {"roundNum": 1, "sampleSize": 10,},
     )
-    assert rv.status_code == 200
+    assert_ok(rv)
 
     rv = post_json(
         client, f"/election/{election_id}/round", {"roundNum": 1, "sampleSize": 10,},


### PR DESCRIPTION
**Description**

Adds an `assert_ok` test helper to check for successful API responses.
In order to get the assertion error messages to display well, we have to
do two things:
- Add `__tracebackhide__ = True` to the helper function, which treats it
as an inline assertion in the test error reporting
- Call `pytest.register_assert_rewrite("tests.helpers")`, which passes
through the assert error messages to the test error reporting

The latter change required making creating a `tests/__init__.py` file,
which had the bonus side-effect of causing `mypy` to actually run on the
tests for the first time (who knew?) So we also fix some type errors.

Last, we go and use `assert_ok` in all the appropriate places in existing tests (fairly straightforward find and replace).

**Testing**

Modifies existing tests.

**Progress**

Ready to review.