### PR TITLE
Add list rounds endpoint for jurisdiction admins

### DIFF
--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -66,7 +66,9 @@ class Election(BaseModel):
         order_by="Jurisdiction.name",
     )
     contests = relationship("Contest", backref="election", passive_deletes=True)
-    rounds = relationship("Round", backref="election", passive_deletes=True)
+    rounds = relationship(
+        "Round", backref="election", passive_deletes=True, order_by="Round.round_num"
+    )
 
     jurisdictions_file_id = db.Column(
         db.String(200), db.ForeignKey("file.id", ondelete="set null"), nullable=True


### PR DESCRIPTION
**Description**

Adds `GET /election/<election_id>/jurisdiction/<jurisdiction_id>/round` to list audit rounds when logged in as a jurisdiction admin.

This is pretty much the only piece of functionality that is identical for audit admins and jurisdiction admins, but instead of reusing the same endpoint, we make a new one. This has two benefits:
- All jurisdiction admin endpoints follow the same url scheme, which includes the jurisdiction id. So we can always check that the user is requesting info about district they are authorized for.
- Permissions are simpler to think about and implement. Every endpoint can only be accessed by one user type.


**Testing**

Updated the test cases to also try the same requests as a JA and expect the same results. It would be a bit nicer to have separate test cases, but since you need to do a lot of work to create the round before you can list it, the existing cases integrated creating/listing into the same test case. Factoring out the logic didn't seem worthwhile, since we don't plan to have other cases that need to test the same thing for different user types.

**Progress**

Ready for review.