### PR TITLE
Add list audit boards endpoint for jurisdiction admins

### DIFF
--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -253,7 +253,10 @@ class AuditBoard(BaseModel):
     signed_off_at = db.Column(db.DateTime(timezone=False), nullable=True)
 
     sampled_ballots = relationship(
-        "SampledBallot", backref="audit_board", passive_deletes=True
+        "SampledBallot",
+        backref="audit_board",
+        passive_deletes=True,
+        order_by="SampledBallot.batch_id, SampledBallot.ballot_position",
     )
 
     __table_args__ = (db.UniqueConstraint("jurisdiction_id", "round_id", "name"),)

--- a/tests/routes_tests/test_audit_boards.py
+++ b/tests/routes_tests/test_audit_boards.py
@@ -9,6 +9,9 @@ from tests.helpers import (
     assert_ok,
     create_jurisdiction_admin,
     set_logged_in_user,
+    compare_json,
+    assert_is_id,
+    assert_is_date,
 )
 from arlo_server.models import (
     db,
@@ -23,6 +26,7 @@ from arlo_server.auth import UserType
 
 JA_EMAIL = "ja@example.com"
 SAMPLE_SIZE = 119  # Bravo sample size
+J1_SAMPLES = 81
 
 
 def assert_ballots_got_assigned_correctly(
@@ -129,6 +133,20 @@ def as_jurisdiction_admin(client: FlaskClient, jurisdiction_ids: List[str]):
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, JA_EMAIL)
 
 
+def test_audit_boards_list_empty(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    round_id: str,
+    as_jurisdiction_admin,  # pylint: disable=unused-argument
+):
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/audit-board",
+    )
+    audit_boards = json.loads(rv.data)
+    assert audit_boards == {"auditBoards": []}
+
+
 def test_audit_boards_create_one(
     client: FlaskClient,
     election_id: str,
@@ -147,6 +165,99 @@ def test_audit_boards_create_one(
         round_id,
         expected_num_audit_boards=1,
         expected_num_ballots=75,
+    )
+
+
+def test_audit_boards_list_one(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    round_id: str,
+    as_jurisdiction_admin,  # pylint: disable=unused-argument
+):
+    rv = post_json(
+        client,
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/audit-board",
+        [{"name": "Audit Board #1"}],
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/audit-board",
+    )
+    audit_boards = json.loads(rv.data)
+    compare_json(
+        audit_boards,
+        {
+            "auditBoards": [
+                {
+                    "id": assert_is_id,
+                    "name": "Audit Board #1",
+                    "signedOffAt": None,
+                    "currentRoundStatus": {
+                        "numSampledBallots": J1_SAMPLES,
+                        "numAuditedBallots": 0,
+                    },
+                }
+            ]
+        },
+    )
+
+    # Fake auditing some ballots
+    audit_board = AuditBoard.query.get(audit_boards["auditBoards"][0]["id"])
+    num_audited_samples = 0
+    for ballot in audit_board.sampled_ballots[:10]:
+        ballot.vote = "YES"
+        num_audited_samples += len(ballot.draws)
+    db.session.commit()
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/audit-board",
+    )
+    audit_boards = json.loads(rv.data)
+    compare_json(
+        audit_boards,
+        {
+            "auditBoards": [
+                {
+                    "id": assert_is_id,
+                    "name": "Audit Board #1",
+                    "signedOffAt": None,
+                    "currentRoundStatus": {
+                        "numSampledBallots": J1_SAMPLES,
+                        "numAuditedBallots": num_audited_samples,
+                    },
+                }
+            ]
+        },
+    )
+
+    # Finish auditing ballots and sign off
+    audit_board = db.session.merge(audit_board)
+    for ballot in audit_board.sampled_ballots[10:]:
+        ballot.vote = "NO"
+    audit_board.signed_off_at = datetime.utcnow()
+    db.session.commit()
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/audit-board",
+    )
+    audit_boards = json.loads(rv.data)
+    compare_json(
+        audit_boards,
+        {
+            "auditBoards": [
+                {
+                    "id": assert_is_id,
+                    "name": "Audit Board #1",
+                    "signedOffAt": assert_is_date,
+                    "currentRoundStatus": {
+                        "numSampledBallots": J1_SAMPLES,
+                        "numAuditedBallots": J1_SAMPLES,
+                    },
+                }
+            ]
+        },
     )
 
 
@@ -171,7 +282,104 @@ def test_audit_boards_create_two(
     )
 
 
-def test_audit_boards_round_2(
+def test_audit_boards_list_two(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    round_id: str,
+    as_jurisdiction_admin,  # pylint: disable=unused-argument
+):
+    AB1_SAMPLES = 54
+
+    rv = post_json(
+        client,
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/audit-board",
+        [{"name": "Audit Board #1"}, {"name": "Audit Board #2"}],
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/audit-board",
+    )
+    audit_boards = json.loads(rv.data)
+    compare_json(
+        audit_boards,
+        {
+            "auditBoards": [
+                {
+                    "id": assert_is_id,
+                    "name": "Audit Board #1",
+                    "signedOffAt": None,
+                    "currentRoundStatus": {
+                        "numSampledBallots": AB1_SAMPLES,
+                        "numAuditedBallots": 0,
+                    },
+                },
+                {
+                    "id": assert_is_id,
+                    "name": "Audit Board #2",
+                    "signedOffAt": None,
+                    "currentRoundStatus": {
+                        "numSampledBallots": J1_SAMPLES - AB1_SAMPLES,
+                        "numAuditedBallots": 0,
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fake auditing some ballots
+    audit_board_1 = AuditBoard.query.get(audit_boards["auditBoards"][0]["id"])
+    num_audited_samples_1 = 0
+    for ballot in audit_board_1.sampled_ballots[:10]:
+        ballot.vote = "YES"
+        num_audited_samples_1 += len(ballot.draws)
+    audit_board_2 = AuditBoard.query.get(audit_boards["auditBoards"][1]["id"])
+    num_audited_samples_2 = 0
+    for ballot in audit_board_2.sampled_ballots[:20]:
+        ballot.vote = "YES"
+        num_audited_samples_2 += len(ballot.draws)
+    db.session.commit()
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/audit-board",
+    )
+    audit_boards = json.loads(rv.data)["auditBoards"]
+
+    assert audit_boards[0]["currentRoundStatus"] == {
+        "numSampledBallots": AB1_SAMPLES,
+        "numAuditedBallots": num_audited_samples_1,
+    }
+    assert audit_boards[1]["currentRoundStatus"] == {
+        "numSampledBallots": J1_SAMPLES - AB1_SAMPLES,
+        "numAuditedBallots": num_audited_samples_2,
+    }
+
+    # Finish auditing ballots and sign off
+    audit_board_1 = db.session.merge(audit_board_1)
+    for ballot in audit_board_1.sampled_ballots[10:]:
+        ballot.vote = "NO"
+    audit_board_1.signed_off_at = datetime.utcnow()
+    db.session.commit()
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/audit-board",
+    )
+    audit_boards = json.loads(rv.data)["auditBoards"]
+
+    assert_is_date(audit_boards[0]["signedOffAt"])
+    assert audit_boards[0]["currentRoundStatus"] == {
+        "numSampledBallots": AB1_SAMPLES,
+        "numAuditedBallots": AB1_SAMPLES,
+    }
+    assert audit_boards[1]["signedOffAt"] is None
+    assert audit_boards[1]["currentRoundStatus"] == {
+        "numSampledBallots": J1_SAMPLES - AB1_SAMPLES,
+        "numAuditedBallots": num_audited_samples_2,
+    }
+
+
+def test_audit_boards_create_round_2(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],
@@ -195,6 +403,77 @@ def test_audit_boards_round_2(
         expected_num_audit_boards=3,
         expected_num_ballots=134,
     )
+
+
+def test_audit_boards_list_round_2(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    round_id: str,
+    round_2_id: str,
+    as_jurisdiction_admin,  # pylint: disable=unused-argument
+):
+    J1_SAMPLES_ROUND_2 = 148  # 90% prob sample size
+    AB1_SAMPLES_ROUND_2 = 92
+    AB2_SAMPLES_ROUND_2 = 29
+
+    rv = post_json(
+        client,
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/audit-board",
+        [
+            {"name": "Audit Board #1"},
+            {"name": "Audit Board #2"},
+            {"name": "Audit Board #3"},
+        ],
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/audit-board",
+    )
+    audit_boards = json.loads(rv.data)
+    compare_json(
+        audit_boards,
+        {
+            "auditBoards": [
+                {
+                    "id": assert_is_id,
+                    "name": "Audit Board #1",
+                    "signedOffAt": None,
+                    "currentRoundStatus": {
+                        "numSampledBallots": AB1_SAMPLES_ROUND_2,
+                        "numAuditedBallots": 0,
+                    },
+                },
+                {
+                    "id": assert_is_id,
+                    "name": "Audit Board #2",
+                    "signedOffAt": None,
+                    "currentRoundStatus": {
+                        "numSampledBallots": AB2_SAMPLES_ROUND_2,
+                        "numAuditedBallots": 0,
+                    },
+                },
+                {
+                    "id": assert_is_id,
+                    "name": "Audit Board #3",
+                    "signedOffAt": None,
+                    "currentRoundStatus": {
+                        "numSampledBallots": J1_SAMPLES_ROUND_2
+                        - AB1_SAMPLES_ROUND_2
+                        - AB2_SAMPLES_ROUND_2,
+                        "numAuditedBallots": 0,
+                    },
+                },
+            ]
+        },
+    )
+
+    # Can still access round 1 audit boards
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/audit-board",
+    )
+    assert rv.status_code == 200
 
 
 def test_audit_boards_missing_field(


### PR DESCRIPTION
**Description**

Adds `GET
/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board`, which a jurisdiction admin can use to get the list of audit boards they created for the round, as well as the status (ballots sampled, ballots audited) for each audit board.

**Testing**

Adds new test cases for no audit boards, one audit board, two audit boards, and audit boards in round 2 of the audit. In each test case, tries out various stages (before the audit boards start, once they've audited some ballots, once they've finished auditing ballots and signed off).

**Progress**

Ready to review.