### PR TITLE
Changing to display audit names on audit list

### DIFF
--- a/arlo-client/src/components/CreateAudit.test.tsx
+++ b/arlo-client/src/components/CreateAudit.test.tsx
@@ -146,22 +146,22 @@ describe('CreateAudit', () => {
           elections: [
             {
               id: 'election-1',
-              name: '',
+              auditName: '',
               state: 'NY',
             },
             {
               id: 'election-2',
-              name: 'Election Two',
+              auditName: 'Election Two',
               state: 'FL',
             },
             {
               id: 'election-3',
-              name: 'Election Three',
+              auditName: 'Election Three',
               state: '',
             },
             {
               id: 'election-4',
-              name: 'Election Four',
+              auditName: 'Election Four',
               state: 'WA',
             },
           ],
@@ -194,7 +194,7 @@ describe('CreateAudit', () => {
           name: 'County One',
           election: {
             id: 'election-1',
-            name: 'Election One',
+            auditName: 'Election One',
             state: 'NY',
           },
         },
@@ -203,7 +203,7 @@ describe('CreateAudit', () => {
           name: 'County Two',
           election: {
             id: 'election-2',
-            name: '',
+            auditName: '',
             state: '',
           },
         },

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -152,7 +152,7 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
                   key={election.id}
                   className="bp3-button bp3-intent-primary"
                 >
-                  {election.name || 'Not named yet'}
+                  {election.auditName || 'Not named yet'}
                   {election.state && ` (${election.state})`}
                 </AuditLink>
               ))
@@ -164,7 +164,7 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
                 key={election.id}
                 className="bp3-button bp3-intent-primary"
               >
-                {election.name || 'Not named yet'}
+                {election.auditName || 'Not named yet'}
                 {election.state && ` (${election.state})`}
               </AuditLink>
             ))}

--- a/arlo-client/src/types.ts
+++ b/arlo-client/src/types.ts
@@ -142,8 +142,10 @@ export interface IAudit {
 
 export interface IElectionMeta {
   id: string
-  name: string
+  auditName: string
+  electionName: string
   state: string
+  isMultiJurisdiction: boolean
   electionDate: string
 }
 


### PR DESCRIPTION
**Description**

- The title in the buttons for the list on the Create Audit page of already-created audits associated with the authenticated user was still just `name` instead of either `auditName` or `electionName`, so I changed it to `auditName` as is proper.

**Testing**

- Updated the api mocks to reflect the change

**Progress**

- All good!
