### PR TITLE
Adding contests api to AA setup 

### DIFF
--- a/arlo-client/src/components/Audit/Setup/Contests/__snapshots__/index.test.tsx.snap
+++ b/arlo-client/src/components/Audit/Setup/Contests/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,559 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Audit Setup > Contests handles api request error on initial load 1`] = `
+<div>
+  <form
+    data-testid="form-one"
+  >
+    <div
+      class="sc-bwzfXH hfheQC"
+    >
+      <h2
+        class="bp3-heading sc-bdVaJa ibVpPq"
+      >
+        Target Contests
+      </h2>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Contest  Info
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the name of the contest that will drive the audit.
+        </div>
+        <label
+          for="contests[0].name"
+        >
+          Contest
+           
+          
+           
+          Name
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].name"
+                name="contests[0].name"
+                style="padding-right: 10px;"
+                value=""
+              />
+            </div>
+          </div>
+        </label>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the number of winners for the contest.
+        </div>
+        <label
+          for="contests[0].numWinners"
+        >
+          Winners
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].numWinners"
+                name="contests[0].numWinners"
+                style="padding-right: 10px;"
+                value="1"
+              />
+            </div>
+          </div>
+        </label>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Number of selections the voter can make in the contest.
+        </div>
+        <label
+          for="contests[0].votesAllowed"
+        >
+          Votes Allowed
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].votesAllowed"
+                name="contests[0].votesAllowed"
+                style="padding-right: 10px;"
+                value="1"
+              />
+            </div>
+          </div>
+        </label>
+      </div>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Candidates/Choices & Vote Totals
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the name of each candidate choice that appears on the ballot for this contest.
+        </div>
+        <div
+          class="sc-fjdhpX ixwLIj"
+        >
+          <div
+            class="sc-cSHVUG jUKlPT"
+          >
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Name of Candidate/Choice 
+              1
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[0].name"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Votes for Candidate/Choice 
+              1
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[0].numVotes"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+          </div>
+          <div
+            class="sc-cSHVUG jUKlPT"
+          >
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Name of Candidate/Choice 
+              2
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[1].name"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Votes for Candidate/Choice 
+              2
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[1].numVotes"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+          </div>
+          <p
+            class="sc-kgoBCf jCkIWs"
+          >
+            Add a new candidate/choice
+          </p>
+        </div>
+      </div>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Total Ballots Cast
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+        </div>
+        <label
+          for="contests[0].totalBallotsCast"
+        >
+          Total Ballots for Contest
+           
+          
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].totalBallotsCast"
+                name="contests[0].totalBallotsCast"
+                style="padding-right: 10px;"
+                value=""
+              />
+            </div>
+          </div>
+        </label>
+      </div>
+    </div>
+    <div
+      class="sc-gqjmRU bEkPjh"
+    >
+      <button
+        class="bp3-button sc-gZMcBi eZVGYn"
+        type="button"
+      >
+        <span
+          class="bp3-button-text"
+        >
+          Back
+        </span>
+      </button>
+      <button
+        class="bp3-button bp3-intent-primary sc-gZMcBi eZVGYn"
+        type="submit"
+      >
+        <span
+          class="bp3-button-text"
+        >
+          Save & Next
+        </span>
+      </button>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`Audit Setup > Contests handles api request error on submission 1`] = `
+<div>
+  <form
+    data-testid="form-one"
+  >
+    <div
+      class="sc-bwzfXH hfheQC"
+    >
+      <h2
+        class="bp3-heading sc-bdVaJa ibVpPq"
+      >
+        Target Contests
+      </h2>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Contest  Info
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the name of the contest that will drive the audit.
+        </div>
+        <label
+          for="contests[0].name"
+        >
+          Contest
+           
+          
+           
+          Name
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].name"
+                name="contests[0].name"
+                style="padding-right: 10px;"
+                value="Contest Name"
+              />
+            </div>
+          </div>
+        </label>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the number of winners for the contest.
+        </div>
+        <label
+          for="contests[0].numWinners"
+        >
+          Winners
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].numWinners"
+                name="contests[0].numWinners"
+                style="padding-right: 10px;"
+                value="1"
+              />
+            </div>
+          </div>
+        </label>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Number of selections the voter can make in the contest.
+        </div>
+        <label
+          for="contests[0].votesAllowed"
+        >
+          Votes Allowed
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].votesAllowed"
+                name="contests[0].votesAllowed"
+                style="padding-right: 10px;"
+                value="1"
+              />
+            </div>
+          </div>
+        </label>
+      </div>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Candidates/Choices & Vote Totals
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the name of each candidate choice that appears on the ballot for this contest.
+        </div>
+        <div
+          class="sc-fjdhpX ixwLIj"
+        >
+          <div
+            class="sc-cSHVUG jUKlPT"
+          >
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Name of Candidate/Choice 
+              1
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[0].name"
+                    style="padding-right: 10px;"
+                    value="Choice One"
+                  />
+                </div>
+              </div>
+            </label>
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Votes for Candidate/Choice 
+              1
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[0].numVotes"
+                    style="padding-right: 10px;"
+                    value="10"
+                  />
+                </div>
+              </div>
+            </label>
+          </div>
+          <div
+            class="sc-cSHVUG jUKlPT"
+          >
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Name of Candidate/Choice 
+              2
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[1].name"
+                    style="padding-right: 10px;"
+                    value="Choice Two"
+                  />
+                </div>
+              </div>
+            </label>
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Votes for Candidate/Choice 
+              2
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[1].numVotes"
+                    style="padding-right: 10px;"
+                    value="20"
+                  />
+                </div>
+              </div>
+            </label>
+          </div>
+          <p
+            class="sc-kgoBCf jCkIWs"
+          >
+            Add a new candidate/choice
+          </p>
+        </div>
+      </div>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Total Ballots Cast
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+        </div>
+        <label
+          for="contests[0].totalBallotsCast"
+        >
+          Total Ballots for Contest
+           
+          
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].totalBallotsCast"
+                name="contests[0].totalBallotsCast"
+                style="padding-right: 10px;"
+                value="30"
+              />
+            </div>
+          </div>
+        </label>
+      </div>
+    </div>
+    <div
+      class="sc-gqjmRU bEkPjh"
+    >
+      <button
+        class="bp3-button sc-gZMcBi eZVGYn"
+        type="button"
+      >
+        <span
+          class="bp3-button-text"
+        >
+          Back
+        </span>
+      </button>
+      <button
+        class="bp3-button bp3-intent-primary sc-gZMcBi eZVGYn"
+        type="submit"
+      >
+        <span
+          class="bp3-button-text"
+        >
+          Save & Next
+        </span>
+      </button>
+    </div>
+  </form>
+</div>
+`;
+
 exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] = `
 <div>
   <form

--- a/arlo-client/src/components/Audit/Setup/Contests/__snapshots__/index.test.tsx.snap
+++ b/arlo-client/src/components/Audit/Setup/Contests/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,837 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Audit Setup > Contests renders empty state correctly 1`] = `
+exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] = `
+<div>
+  <form
+    data-testid="form-one"
+  >
+    <div
+      class="sc-bwzfXH hfheQC"
+    >
+      <h2
+        class="bp3-heading sc-bdVaJa ibVpPq"
+      >
+        Opportunistic Contests
+      </h2>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Contest  Info
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the name of the contest that will drive the audit.
+        </div>
+        <label
+          for="contests[0].name"
+        >
+          Contest
+           
+          
+           
+          Name
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].name"
+                name="contests[0].name"
+                style="padding-right: 10px;"
+                value=""
+              />
+            </div>
+          </div>
+        </label>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the number of winners for the contest.
+        </div>
+        <label
+          for="contests[0].numWinners"
+        >
+          Winners
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].numWinners"
+                name="contests[0].numWinners"
+                style="padding-right: 10px;"
+                value="1"
+              />
+            </div>
+          </div>
+        </label>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Number of selections the voter can make in the contest.
+        </div>
+        <label
+          for="contests[0].votesAllowed"
+        >
+          Votes Allowed
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].votesAllowed"
+                name="contests[0].votesAllowed"
+                style="padding-right: 10px;"
+                value="1"
+              />
+            </div>
+          </div>
+        </label>
+      </div>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Candidates/Choices & Vote Totals
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the name of each candidate choice that appears on the ballot for this contest.
+        </div>
+        <div
+          class="sc-fjdhpX ixwLIj"
+        >
+          <div
+            class="sc-cSHVUG jUKlPT"
+          >
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Name of Candidate/Choice 
+              1
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[0].name"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Votes for Candidate/Choice 
+              1
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[0].numVotes"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+          </div>
+          <div
+            class="sc-cSHVUG jUKlPT"
+          >
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Name of Candidate/Choice 
+              2
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[1].name"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Votes for Candidate/Choice 
+              2
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[1].numVotes"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+          </div>
+          <p
+            class="sc-kgoBCf jCkIWs"
+          >
+            Add a new candidate/choice
+          </p>
+        </div>
+      </div>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Total Ballots Cast
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+        </div>
+        <label
+          for="contests[0].totalBallotsCast"
+        >
+          Total Ballots for Contest
+           
+          
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].totalBallotsCast"
+                name="contests[0].totalBallotsCast"
+                style="padding-right: 10px;"
+                value=""
+              />
+            </div>
+          </div>
+        </label>
+      </div>
+    </div>
+    <div
+      class="sc-gqjmRU bEkPjh"
+    >
+      <button
+        class="bp3-button sc-gZMcBi eZVGYn"
+        type="button"
+      >
+        <span
+          class="bp3-button-text"
+        >
+          Back
+        </span>
+      </button>
+      <button
+        class="bp3-button bp3-intent-primary sc-gZMcBi eZVGYn"
+        type="submit"
+      >
+        <span
+          class="bp3-button-text"
+        >
+          Save & Next
+        </span>
+      </button>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
+<div>
+  <form
+    data-testid="form-one"
+  >
+    <div
+      class="sc-bwzfXH hfheQC"
+    >
+      <h2
+        class="bp3-heading sc-bdVaJa ibVpPq"
+      >
+        Target Contests
+      </h2>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Contest  Info
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the name of the contest that will drive the audit.
+        </div>
+        <label
+          for="contests[0].name"
+        >
+          Contest
+           
+          
+           
+          Name
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].name"
+                name="contests[0].name"
+                style="padding-right: 10px;"
+                value=""
+              />
+            </div>
+          </div>
+        </label>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the number of winners for the contest.
+        </div>
+        <label
+          for="contests[0].numWinners"
+        >
+          Winners
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].numWinners"
+                name="contests[0].numWinners"
+                style="padding-right: 10px;"
+                value="1"
+              />
+            </div>
+          </div>
+        </label>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Number of selections the voter can make in the contest.
+        </div>
+        <label
+          for="contests[0].votesAllowed"
+        >
+          Votes Allowed
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].votesAllowed"
+                name="contests[0].votesAllowed"
+                style="padding-right: 10px;"
+                value="1"
+              />
+            </div>
+          </div>
+        </label>
+      </div>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Candidates/Choices & Vote Totals
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the name of each candidate choice that appears on the ballot for this contest.
+        </div>
+        <div
+          class="sc-fjdhpX ixwLIj"
+        >
+          <div
+            class="sc-cSHVUG jUKlPT"
+          >
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Name of Candidate/Choice 
+              1
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[0].name"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Votes for Candidate/Choice 
+              1
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[0].numVotes"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+          </div>
+          <div
+            class="sc-cSHVUG jUKlPT"
+          >
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Name of Candidate/Choice 
+              2
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[1].name"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Votes for Candidate/Choice 
+              2
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[1].numVotes"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+          </div>
+          <p
+            class="sc-kgoBCf jCkIWs"
+          >
+            Add a new candidate/choice
+          </p>
+        </div>
+      </div>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Total Ballots Cast
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+        </div>
+        <label
+          for="contests[0].totalBallotsCast"
+        >
+          Total Ballots for Contest
+           
+          
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].totalBallotsCast"
+                name="contests[0].totalBallotsCast"
+                style="padding-right: 10px;"
+                value=""
+              />
+            </div>
+          </div>
+        </label>
+      </div>
+    </div>
+    <div
+      class="sc-gqjmRU bEkPjh"
+    >
+      <button
+        class="bp3-button sc-gZMcBi eZVGYn"
+        type="button"
+      >
+        <span
+          class="bp3-button-text"
+        >
+          Back
+        </span>
+      </button>
+      <button
+        class="bp3-button bp3-intent-primary sc-gZMcBi eZVGYn"
+        type="submit"
+      >
+        <span
+          class="bp3-button-text"
+        >
+          Save & Next
+        </span>
+      </button>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`] = `
+<div>
+  <form
+    data-testid="form-one"
+  >
+    <div
+      class="sc-bwzfXH hfheQC"
+    >
+      <h2
+        class="bp3-heading sc-bdVaJa ibVpPq"
+      >
+        Opportunistic Contests
+      </h2>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Contest  Info
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the name of the contest that will drive the audit.
+        </div>
+        <label
+          for="contests[0].name"
+        >
+          Contest
+           
+          
+           
+          Name
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].name"
+                name="contests[0].name"
+                style="padding-right: 10px;"
+                value=""
+              />
+            </div>
+          </div>
+        </label>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the number of winners for the contest.
+        </div>
+        <label
+          for="contests[0].numWinners"
+        >
+          Winners
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].numWinners"
+                name="contests[0].numWinners"
+                style="padding-right: 10px;"
+                value="1"
+              />
+            </div>
+          </div>
+        </label>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Number of selections the voter can make in the contest.
+        </div>
+        <label
+          for="contests[0].votesAllowed"
+        >
+          Votes Allowed
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].votesAllowed"
+                name="contests[0].votesAllowed"
+                style="padding-right: 10px;"
+                value="1"
+              />
+            </div>
+          </div>
+        </label>
+      </div>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Candidates/Choices & Vote Totals
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the name of each candidate choice that appears on the ballot for this contest.
+        </div>
+        <div
+          class="sc-fjdhpX ixwLIj"
+        >
+          <div
+            class="sc-cSHVUG jUKlPT"
+          >
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Name of Candidate/Choice 
+              1
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[0].name"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Votes for Candidate/Choice 
+              1
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[0].numVotes"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+          </div>
+          <div
+            class="sc-cSHVUG jUKlPT"
+          >
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Name of Candidate/Choice 
+              2
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[1].name"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+            <label
+              class="bp3-label sc-chPdSV ewyFtw"
+            >
+              Votes for Candidate/Choice 
+              2
+              <div
+                class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
+              >
+                <div
+                  class="bp3-input-group sc-bZQynM fFGKEg"
+                >
+                  <input
+                    class="bp3-input"
+                    name="contests[0].choices[1].numVotes"
+                    style="padding-right: 10px;"
+                    value=""
+                  />
+                </div>
+              </div>
+            </label>
+          </div>
+          <p
+            class="sc-kgoBCf jCkIWs"
+          >
+            Add a new candidate/choice
+          </p>
+        </div>
+      </div>
+      <div
+        class="sc-htpNat kLGmUl"
+      >
+        <h3
+          class="bp3-heading sc-ifAKCX fYInwY"
+        >
+          Total Ballots Cast
+        </h3>
+        <div
+          class="sc-bxivhb fbVQhV"
+        >
+          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+        </div>
+        <label
+          for="contests[0].totalBallotsCast"
+        >
+          Total Ballots for Contest
+           
+          
+          <div
+            class="sc-EHOje bXavad"
+          >
+            <div
+              class="bp3-input-group sc-bZQynM fFGKEg"
+            >
+              <input
+                class="bp3-input"
+                id="contests[0].totalBallotsCast"
+                name="contests[0].totalBallotsCast"
+                style="padding-right: 10px;"
+                value=""
+              />
+            </div>
+          </div>
+        </label>
+      </div>
+    </div>
+    <div
+      class="sc-gqjmRU bEkPjh"
+    >
+      <button
+        class="bp3-button sc-gZMcBi eZVGYn"
+        type="button"
+      >
+        <span
+          class="bp3-button-text"
+        >
+          Back
+        </span>
+      </button>
+      <button
+        class="bp3-button bp3-intent-primary sc-gZMcBi eZVGYn"
+        type="submit"
+      >
+        <span
+          class="bp3-button-text"
+        >
+          Save & Next
+        </span>
+      </button>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
 <div>
   <form
     data-testid="form-one"

--- a/arlo-client/src/components/Audit/Setup/Contests/_mocks.ts
+++ b/arlo-client/src/components/Audit/Setup/Contests/_mocks.ts
@@ -1,0 +1,189 @@
+import { IContests } from './types'
+
+export const contestMocks: {
+  [key in
+    | 'emptyTargeted'
+    | 'emptyOpportunistic'
+    | 'filledTargeted'
+    | 'filledOpportunistic']: IContests
+} = {
+  emptyTargeted: {
+    contests: [
+      {
+        id: '',
+        name: '',
+        isTargeted: true,
+        totalBallotsCast: '',
+        numWinners: '1',
+        votesAllowed: '1',
+        jurisdictionIds: [],
+        choices: [
+          {
+            id: '',
+            name: '',
+            numVotes: '',
+          },
+          {
+            id: '',
+            name: '',
+            numVotes: '',
+          },
+        ],
+      },
+    ],
+  },
+  emptyOpportunistic: {
+    contests: [
+      {
+        id: '',
+        name: '',
+        isTargeted: false,
+        totalBallotsCast: '',
+        numWinners: '1',
+        votesAllowed: '1',
+        jurisdictionIds: [],
+        choices: [
+          {
+            id: '',
+            name: '',
+            numVotes: '',
+          },
+          {
+            id: '',
+            name: '',
+            numVotes: '',
+          },
+        ],
+      },
+    ],
+  },
+  filledTargeted: {
+    contests: [
+      {
+        id: expect.stringMatching(/^[-0-9a-z]*$/),
+        name: 'Contest Name',
+        isTargeted: true,
+        totalBallotsCast: '30',
+        numWinners: '1',
+        votesAllowed: '1',
+        jurisdictionIds: [],
+        choices: [
+          {
+            id: expect.stringMatching(/^[-0-9a-z]*$/),
+            name: 'Choice One',
+            numVotes: '10',
+          },
+          {
+            id: expect.stringMatching(/^[-0-9a-z]*$/),
+            name: 'Choice Two',
+            numVotes: '20',
+          },
+        ],
+      },
+    ],
+  },
+  filledOpportunistic: {
+    contests: [
+      {
+        id: expect.stringMatching(/^[-0-9a-z]*$/),
+        name: 'Contest Name',
+        isTargeted: false,
+        totalBallotsCast: '30',
+        numWinners: '1',
+        votesAllowed: '1',
+        jurisdictionIds: [],
+        choices: [
+          {
+            id: expect.stringMatching(/^[-0-9a-z]*$/),
+            name: 'Choice Three',
+            numVotes: '10',
+          },
+          {
+            id: expect.stringMatching(/^[-0-9a-z]*$/),
+            name: 'Choice Four',
+            numVotes: '20',
+          },
+        ],
+      },
+    ],
+  },
+}
+
+export const contestsInputMocks = {
+  inputs: [
+    { key: 'Contest Name', value: 'Contest Name' },
+    { key: 'Name of Candidate/Choice 1', value: 'Choice One' },
+    { key: 'Name of Candidate/Choice 2', value: 'Choice Two' },
+    { key: 'Votes for Candidate/Choice 1', value: '10' },
+    { key: 'Votes for Candidate/Choice 2', value: '20' },
+    { key: 'Total Ballots for Contest', value: '30' },
+  ],
+  errorInputs: [
+    { key: 'Contest Name', value: '', error: 'Required' },
+    {
+      key: 'Total Ballots for Contest',
+      value: '',
+      error: 'Must be a number',
+    },
+    {
+      key: 'Total Ballots for Contest',
+      value: 'test',
+      error: 'Must be a number',
+    },
+    {
+      key: 'Total Ballots for Contest',
+      value: '-1',
+      error:
+        'Must be greater than or equal to the sum of votes for each candidate/choice',
+    },
+    {
+      key: 'Total Ballots for Contest',
+      value: '0.5',
+      error: 'Must be an integer',
+    },
+    { key: 'Name of Candidate/Choice 1', value: '', error: 'Required' },
+    { key: 'Name of Candidate/Choice 2', value: '', error: 'Required' },
+    {
+      key: 'Votes for Candidate/Choice 1',
+      value: '',
+      error: 'Must be a number',
+    },
+    {
+      key: 'Votes for Candidate/Choice 1',
+      value: 'test',
+      error: 'Must be a number',
+    },
+    {
+      key: 'Votes for Candidate/Choice 1',
+      value: '-1',
+      error: 'Must be a positive number',
+    },
+    {
+      key: 'Votes for Candidate/Choice 1',
+      value: '0.5',
+      error: 'Must be an integer',
+    },
+    {
+      key: 'Votes for Candidate/Choice 2',
+      value: '',
+      error: 'Must be a number',
+    },
+    {
+      key: 'Votes for Candidate/Choice 2',
+      value: 'test',
+      error: 'Must be a number',
+    },
+    {
+      key: 'Votes for Candidate/Choice 2',
+      value: '-1',
+      error: 'Must be a positive number',
+    },
+    {
+      key: 'Votes for Candidate/Choice 2',
+      value: '0.5',
+      error: 'Must be an integer',
+    },
+  ],
+}
+
+export default contestsInputMocks

--- a/arlo-client/src/components/Audit/Setup/Contests/_mocks.ts
+++ b/arlo-client/src/components/Audit/Setup/Contests/_mocks.ts
@@ -60,7 +60,7 @@ export const contestMocks: {
   filledTargeted: {
     contests: [
       {
-        id: expect.stringMatching(/^[-0-9a-z]*$/),
+        id: 'contest-id',
         name: 'Contest Name',
         isTargeted: true,
         totalBallotsCast: '30',
@@ -69,12 +69,12 @@ export const contestMocks: {
         jurisdictionIds: [],
         choices: [
           {
-            id: expect.stringMatching(/^[-0-9a-z]*$/),
+            id: 'choice-id',
             name: 'Choice One',
             numVotes: '10',
           },
           {
-            id: expect.stringMatching(/^[-0-9a-z]*$/),
+            id: 'choice-id',
             name: 'Choice Two',
             numVotes: '20',
           },
@@ -85,7 +85,7 @@ export const contestMocks: {
   filledOpportunistic: {
     contests: [
       {
-        id: expect.stringMatching(/^[-0-9a-z]*$/),
+        id: 'contest-id',
         name: 'Contest Name',
         isTargeted: false,
         totalBallotsCast: '30',
@@ -94,12 +94,12 @@ export const contestMocks: {
         jurisdictionIds: [],
         choices: [
           {
-            id: expect.stringMatching(/^[-0-9a-z]*$/),
+            id: 'choice-id',
             name: 'Choice Three',
             numVotes: '10',
           },
           {
-            id: expect.stringMatching(/^[-0-9a-z]*$/),
+            id: 'choice-id',
             name: 'Choice Four',
             numVotes: '20',
           },

--- a/arlo-client/src/components/Audit/Setup/Contests/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Contests/index.tsx
@@ -44,6 +44,7 @@ const Contests: React.FC<IProps> = ({
         totalBallotsCast: '',
         numWinners: '1',
         votesAllowed: '1',
+        jurisdictionIds: [],
         choices: [
           {
             id: '',
@@ -66,8 +67,8 @@ const Contests: React.FC<IProps> = ({
   }
   const submit = async (values: IContests) => {
     try {
-      const responseOne = await updateContests(values.contests)
-      if (!responseOne) return
+      const response = await updateContests(values.contests)
+      if (!response) return
       nextStage.activate()
     } catch (err) {
       toast.error(err.message)

--- a/arlo-client/src/components/Audit/Setup/Contests/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Contests/index.tsx
@@ -65,7 +65,6 @@ const Contests: React.FC<IProps> = ({
   const filteredContests = {
     contests: contests.filter(c => c.isTargeted === isTargeted),
   }
-  console.log(filteredContests)
   const submit = async (values: IContests) => {
     try {
       const response = await updateContests(values.contests)
@@ -81,6 +80,7 @@ const Contests: React.FC<IProps> = ({
         filteredContests.contests.length ? filteredContests : contestValues
       }
       validationSchema={schema}
+      enableReinitialize
       onSubmit={submit}
     >
       {({ values, handleSubmit }: FormikProps<IContests>) => (

--- a/arlo-client/src/components/Audit/Setup/Contests/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Contests/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import React from 'react'
 import { useParams } from 'react-router-dom'
-import { toast } from 'react-toastify'
 import { Formik, FormikProps, Form, Field, FieldArray } from 'formik'
 import { Spinner } from '@blueprintjs/core'
 import FormWrapper from '../../../Form/FormWrapper'
@@ -66,13 +65,9 @@ const Contests: React.FC<IProps> = ({
     contests: contests.filter(c => c.isTargeted === isTargeted),
   }
   const submit = async (values: IContests) => {
-    try {
-      const response = await updateContests(values.contests)
-      if (!response) return
-      nextStage.activate()
-    } catch (err) {
-      toast.error(err.message)
-    }
+    const response = await updateContests(values.contests)
+    if (!response) return
+    nextStage.activate()
   }
   return (
     <Formik

--- a/arlo-client/src/components/Audit/Setup/Contests/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Contests/index.tsx
@@ -65,6 +65,7 @@ const Contests: React.FC<IProps> = ({
   const filteredContests = {
     contests: contests.filter(c => c.isTargeted === isTargeted),
   }
+  console.log(filteredContests)
   const submit = async (values: IContests) => {
     try {
       const response = await updateContests(values.contests)

--- a/arlo-client/src/components/Audit/Setup/Contests/schema.ts
+++ b/arlo-client/src/components/Audit/Setup/Contests/schema.ts
@@ -1,6 +1,6 @@
 import * as Yup from 'yup'
 import number, { parse as parseNumber } from '../../../../utils/number-schema'
-import { IChoiceValues } from './types'
+import { ICandidate } from '../../../../types'
 
 const contestsSchema = Yup.object().shape({
   contests: Yup.array()
@@ -29,7 +29,7 @@ const contestsSchema = Yup.object().shape({
               const ballots = parseNumber(value)
               const { choices } = this.parent
               const totalVotes = choices.reduce(
-                (sum: number, choiceValue: IChoiceValues) =>
+                (sum: number, choiceValue: ICandidate) =>
                   sum + (parseNumber(choiceValue.numVotes) || 0),
                 0
               )

--- a/arlo-client/src/components/Audit/Setup/Contests/types.ts
+++ b/arlo-client/src/components/Audit/Setup/Contests/types.ts
@@ -1,18 +1,5 @@
-export interface IChoiceValues {
-  id?: string
-  name: string
-  numVotes: string | number
-}
+import { IContest } from '../../../../types'
 
-export interface IContestValues {
-  name: string
-  isTargeted: boolean
-  totalBallotsCast: string
-  numWinners: string
-  votesAllowed: string
-  choices: IChoiceValues[]
-}
-
-export interface IValues {
-  contests: IContestValues[]
+export interface IContests {
+  contests: IContest[]
 }

--- a/arlo-client/src/components/Audit/Setup/Contests/useContestsApi.ts
+++ b/arlo-client/src/components/Audit/Setup/Contests/useContestsApi.ts
@@ -20,14 +20,11 @@ interface IContestNumbered {
   jurisdictionIds: string[]
 }
 
-const numberifyContest = (
-  contest: IContest,
-  isTargeted: boolean
-): IContestNumbered => {
+const numberifyContest = (contest: IContest): IContestNumbered => {
   return {
     id: contest.id || uuidv4(), // preserve given id if present, generate new one if empty string
     name: contest.name,
-    isTargeted,
+    isTargeted: contest.isTargeted,
     totalBallotsCast: parseNumber(contest.totalBallotsCast),
     numWinners: parseNumber(contest.numWinners),
     votesAllowed: parseNumber(contest.votesAllowed),
@@ -113,7 +110,7 @@ const useContestsApi = (
         method: 'PUT',
         // stringify and numberify the contests (all number values are handled as strings clientside, but are required as numbers serverside)
         body: JSON.stringify(
-          mergedContests.contests.map(c => numberifyContest(c, isTargeted))
+          mergedContests.contests.map(c => numberifyContest(c))
         ),
         headers: {
           'Content-Type': 'application/json',

--- a/arlo-client/src/components/Audit/Setup/Contests/useContestsApi.ts
+++ b/arlo-client/src/components/Audit/Setup/Contests/useContestsApi.ts
@@ -5,7 +5,7 @@ import { IErrorResponse, IContest } from '../../../../types'
 import { IContests } from './types'
 import { parse as parseNumber } from '../../../../utils/number-schema'
 
-interface IContestNumbered {
+export interface IContestNumbered {
   id: string
   isTargeted: boolean
   name: string
@@ -20,7 +20,7 @@ interface IContestNumbered {
   jurisdictionIds: string[]
 }
 
-const numberifyContest = (contest: IContest): IContestNumbered => {
+export const numberifyContest = (contest: IContest): IContestNumbered => {
   return {
     id: contest.id || uuidv4(), // preserve given id if present, generate new one if empty string
     name: contest.name,

--- a/arlo-client/src/components/Audit/Setup/Contests/useContestsApi.ts
+++ b/arlo-client/src/components/Audit/Setup/Contests/useContestsApi.ts
@@ -1,0 +1,96 @@
+import { useEffect, useCallback, useState } from 'react'
+import uuidv4 from 'uuidv4'
+import { api, checkAndToast } from '../../../utilities'
+import { IErrorResponse, IContest } from '../../../../types'
+import { IContests } from './types'
+
+const useContestsApi = (
+  electionId: string,
+  isTargeted: boolean
+): [IContests, (arg0: IContest[]) => Promise<boolean>] => {
+  const defaultValues: IContests = {
+    contests: [
+      {
+        id: '',
+        name: '',
+        isTargeted,
+        totalBallotsCast: '',
+        numWinners: '1',
+        votesAllowed: '1',
+        choices: [
+          {
+            id: '',
+            name: '',
+            numVotes: '',
+          },
+          {
+            id: '',
+            name: '',
+            numVotes: '',
+          },
+        ],
+      },
+    ],
+  }
+  const [contests, setSettings] = useState(defaultValues)
+
+  const getContests = useCallback(async (): Promise<IContests> => {
+    const contestsOrError: IContests | IErrorResponse = await api(
+      `/election/${electionId}/contest`
+    )
+    if (checkAndToast(contestsOrError)) {
+      return defaultValues
+    }
+    return contestsOrError
+  }, [electionId, defaultValues])
+
+  const updateContests = async (newContests: IContest[]): Promise<boolean> => {
+    const oldContests = await getContests()
+    const updatedContests: IContest[] = oldContests.contests.reduce(
+      (a: IContest[], c) => {
+        const matchingContest = newContests.findIndex(v => v.id === c.id)
+        // replace old contest with new contest that has the same id, then remove it from newContests
+        if (matchingContest > -1) {
+          a.push(newContests[matchingContest])
+          newContests.splice(matchingContest, 1)
+        } else {
+          a.push(c)
+        }
+        return a
+      },
+      []
+    )
+    const mergedContests = {
+      contests: [
+        ...updatedContests,
+        // merge in all the new contests that weren't found by id, and generate unique ids for them
+        ...newContests.map(c => ({ ...c, id: uuidv4() })),
+      ],
+    }
+    const response: IErrorResponse = await api(
+      `/election/${electionId}/contest`,
+      {
+        method: 'PUT',
+        body: JSON.stringify(mergedContests),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    )
+    if (checkAndToast(response)) {
+      return false
+    }
+    setSettings(mergedContests)
+    return true
+  }
+
+  useEffect(() => {
+    ;(async () => {
+      const newContests = await getContests()
+      setSettings(newContests)
+    })()
+  }, [getContests])
+  return [contests, updateContests]
+}
+
+export default useContestsApi

--- a/arlo-client/src/components/Audit/Setup/Participants/index.tsx
+++ b/arlo-client/src/components/Audit/Setup/Participants/index.tsx
@@ -131,12 +131,7 @@ const Participants: React.FC<IProps> = ({ locked, nextStage }: IProps) => {
             <Spinner />
           ) : (
             <FormButtonBar>
-              <FormButton
-                type="submit"
-                intent="primary"
-                disabled={nextStage.state === 'locked'}
-                onClick={handleSubmit}
-              >
+              <FormButton type="submit" intent="primary" onClick={handleSubmit}>
                 Save &amp; Next
               </FormButton>
             </FormButtonBar>

--- a/arlo-client/src/components/Audit/Setup/__snapshots__/index.test.tsx.snap
+++ b/arlo-client/src/components/Audit/Setup/__snapshots__/index.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
                 id="election-name"
                 name="electionName"
                 style="padding-right: 10px;"
-                value=""
+                value="Election Name"
               />
             </div>
           </div>
@@ -207,7 +207,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
                 name="randomSeed"
                 style="padding-right: 10px;"
                 type="text"
-                value=""
+                value="12345"
               />
             </div>
           </div>
@@ -241,8 +241,6 @@ exports[`Setup renders Audit Settings stage 1`] = `
   </form>
 </div>
 `;
-
-exports[`Setup renders Audit Settings stage 2`] = `<div />`;
 
 exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
 <div>

--- a/arlo-client/src/components/Audit/Setup/__snapshots__/index.test.tsx.snap
+++ b/arlo-client/src/components/Audit/Setup/__snapshots__/index.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
                 id="election-name"
                 name="electionName"
                 style="padding-right: 10px;"
-                value="Election Name"
+                value=""
               />
             </div>
           </div>
@@ -207,7 +207,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
                 name="randomSeed"
                 style="padding-right: 10px;"
                 type="text"
-                value="12345"
+                value=""
               />
             </div>
           </div>
@@ -241,6 +241,8 @@ exports[`Setup renders Audit Settings stage 1`] = `
   </form>
 </div>
 `;
+
+exports[`Setup renders Audit Settings stage 2`] = `<div />`;
 
 exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
 <div>
@@ -2386,9 +2388,7 @@ exports[`Setup renders Participants stage with locked next stage 1`] = `
       class="sc-htpNat gtULUV"
     >
       <button
-        class="bp3-button bp3-disabled bp3-intent-primary sc-ifAKCX zdCNs"
-        disabled=""
-        tabindex="-1"
+        class="bp3-button bp3-intent-primary sc-ifAKCX zdCNs"
         type="submit"
       >
         <span

--- a/arlo-client/src/components/Audit/Setup/index.test.tsx
+++ b/arlo-client/src/components/Audit/Setup/index.test.tsx
@@ -5,6 +5,8 @@ import * as utilities from '../../utilities'
 import { asyncActRender } from '../../testUtilities'
 import Setup from './index'
 import relativeStages from './_mocks'
+import { contestMocks } from './Contests/_mocks'
+import useContestsApi from './Contests/useContestsApi'
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
@@ -15,6 +17,13 @@ const checkAndToastMock: jest.SpyInstance<
   Parameters<typeof utilities.checkAndToast>
 > = jest.spyOn(utilities, 'checkAndToast').mockReturnValue(false)
 apiMock.mockResolvedValue(auditSettings.all)
+
+const useContestsApiMock = useContestsApi as jest.Mock
+jest.mock('./Contests/useContestsApi')
+useContestsApiMock.mockImplementation(() => [
+  contestMocks.emptyTargeted,
+  jest.fn(),
+])
 
 checkAndToastMock.mockReturnValue(false)
 
@@ -95,6 +104,10 @@ describe('Setup', () => {
   })
 
   it('renders Opportunistic Contests stage', async () => {
+    useContestsApiMock.mockImplementation(() => [
+      contestMocks.emptyOpportunistic,
+      jest.fn(),
+    ])
     const { container } = await asyncActRender(
       <Setup
         stage="Opportunistic Contests"
@@ -105,6 +118,10 @@ describe('Setup', () => {
   })
 
   it('renders Opportunistic Contests stage with locked next stage', async () => {
+    useContestsApiMock.mockImplementation(() => [
+      contestMocks.emptyOpportunistic,
+      jest.fn(),
+    ])
     const { container } = await asyncActRender(
       <Setup
         stage="Opportunistic Contests"
@@ -115,6 +132,10 @@ describe('Setup', () => {
   })
 
   it('renders Opportunistic Contests stage with processing next stage', async () => {
+    useContestsApiMock.mockImplementation(() => [
+      contestMocks.emptyOpportunistic,
+      jest.fn(),
+    ])
     const { container } = await asyncActRender(
       <Setup
         stage="Opportunistic Contests"

--- a/arlo-client/src/components/Audit/_mocks.ts
+++ b/arlo-client/src/components/Audit/_mocks.ts
@@ -33,7 +33,19 @@ export const auditSettings: {
   },
 }
 
-export const statusStates: { [key: string]: IAudit } = {
+export const statusStates: {
+  [key in
+    | 'empty'
+    | 'contestFirstRound'
+    | 'sampleSizeOptions'
+    | 'jurisdictionsInitial'
+    | 'ballotManifestProcessed'
+    | 'ballotManifestProcessError'
+    | 'completeInFirstRound'
+    | 'firstRoundSampleSizeOptionsNull'
+    | 'firstRoundSampleSizeOptions'
+    | 'multiAuditBoardsAndRounds']: IAudit
+} = {
   empty: {
     name: '',
     riskLimit: '',

--- a/arlo-client/src/components/Audit/_mocks.ts
+++ b/arlo-client/src/components/Audit/_mocks.ts
@@ -43,6 +43,7 @@ export const statusStates: { [key: string]: IAudit } = {
     contests: [],
     jurisdictions: [],
     rounds: [],
+    isMultiJurisdiction: false,
   },
   contestFirstRound: {
     contests: [
@@ -93,6 +94,7 @@ export const statusStates: { [key: string]: IAudit } = {
     riskLimit: '1',
     frozenAt: null,
     online: true,
+    isMultiJurisdiction: false,
   },
   sampleSizeOptions: {
     contests: [
@@ -147,6 +149,7 @@ export const statusStates: { [key: string]: IAudit } = {
     riskLimit: '1',
     frozenAt: null,
     online: true,
+    isMultiJurisdiction: false,
   },
   jurisdictionsInitial: {
     contests: [
@@ -230,6 +233,7 @@ export const statusStates: { [key: string]: IAudit } = {
     riskLimit: '1',
     frozenAt: null,
     online: true,
+    isMultiJurisdiction: false,
   },
   ballotManifestProcessed: {
     contests: [
@@ -305,6 +309,7 @@ export const statusStates: { [key: string]: IAudit } = {
     riskLimit: '1',
     frozenAt: null,
     online: true,
+    isMultiJurisdiction: false,
   },
   ballotManifestProcessError: {
     contests: [
@@ -380,6 +385,7 @@ export const statusStates: { [key: string]: IAudit } = {
     riskLimit: '1',
     frozenAt: null,
     online: true,
+    isMultiJurisdiction: false,
   },
   completeInFirstRound: {
     contests: [
@@ -457,6 +463,7 @@ export const statusStates: { [key: string]: IAudit } = {
     riskLimit: '1',
     frozenAt: null,
     online: true,
+    isMultiJurisdiction: false,
   },
   firstRoundSampleSizeOptionsNull: {
     contests: [
@@ -527,6 +534,7 @@ export const statusStates: { [key: string]: IAudit } = {
     riskLimit: '1',
     frozenAt: null,
     online: true,
+    isMultiJurisdiction: false,
   },
   firstRoundSampleSizeOptions: {
     contests: [
@@ -620,6 +628,7 @@ export const statusStates: { [key: string]: IAudit } = {
     riskLimit: '1',
     frozenAt: null,
     online: true,
+    isMultiJurisdiction: false,
   },
   multiAuditBoardsAndRounds: {
     contests: [
@@ -737,6 +746,7 @@ export const statusStates: { [key: string]: IAudit } = {
     riskLimit: '1',
     frozenAt: null,
     online: true,
+    isMultiJurisdiction: false,
   },
 }
 

--- a/arlo-client/src/components/Audit/_mocks.ts
+++ b/arlo-client/src/components/Audit/_mocks.ts
@@ -65,6 +65,7 @@ export const statusStates: { [key: string]: IAudit } = {
         votesAllowed: '1',
         totalBallotsCast: '2123',
         isTargeted: true,
+        jurisdictionIds: [],
       },
     ],
     jurisdictions: [],
@@ -114,6 +115,7 @@ export const statusStates: { [key: string]: IAudit } = {
         votesAllowed: '1',
         totalBallotsCast: '2123',
         isTargeted: true,
+        jurisdictionIds: [],
       },
     ],
     jurisdictions: [],
@@ -167,6 +169,7 @@ export const statusStates: { [key: string]: IAudit } = {
         isTargeted: true,
         numWinners: '1',
         votesAllowed: '1',
+        jurisdictionIds: [],
       },
     ],
     jurisdictions: [
@@ -249,6 +252,7 @@ export const statusStates: { [key: string]: IAudit } = {
         votesAllowed: '1',
         totalBallotsCast: '2123',
         isTargeted: true,
+        jurisdictionIds: [],
       },
     ],
     jurisdictions: [
@@ -323,6 +327,7 @@ export const statusStates: { [key: string]: IAudit } = {
         votesAllowed: '1',
         totalBallotsCast: '2123',
         isTargeted: true,
+        jurisdictionIds: [],
       },
     ],
     jurisdictions: [
@@ -397,6 +402,7 @@ export const statusStates: { [key: string]: IAudit } = {
         votesAllowed: '1',
         totalBallotsCast: '2123',
         isTargeted: true,
+        jurisdictionIds: [],
       },
     ],
     jurisdictions: [
@@ -473,6 +479,7 @@ export const statusStates: { [key: string]: IAudit } = {
         isTargeted: true,
         numWinners: '1',
         votesAllowed: '1',
+        jurisdictionIds: [],
       },
     ],
     jurisdictions: [
@@ -542,6 +549,7 @@ export const statusStates: { [key: string]: IAudit } = {
         isTargeted: true,
         numWinners: '1',
         votesAllowed: '1',
+        jurisdictionIds: [],
       },
     ],
     jurisdictions: [
@@ -634,6 +642,7 @@ export const statusStates: { [key: string]: IAudit } = {
         isTargeted: true,
         numWinners: '1',
         votesAllowed: '1',
+        jurisdictionIds: [],
       },
     ],
     jurisdictions: [

--- a/arlo-client/src/components/Audit/index.tsx
+++ b/arlo-client/src/components/Audit/index.tsx
@@ -21,6 +21,7 @@ const initialData: IAudit = {
   contests: [],
   jurisdictions: [],
   rounds: [],
+  isMultiJurisdiction: false,
 }
 
 interface IParams {
@@ -65,6 +66,7 @@ const Audit: React.FC<{}> = () => {
   }, [updateAudit])
 
   const showSelectBallotsToAudit =
+    !audit.isMultiJurisdiction &&
     !!audit.contests.length &&
     audit.rounds[0].contests.every(c => !!c.sampleSizeOptions)
   const showCalculateRiskMeasurement =

--- a/arlo-client/src/components/Audit/useSetupMenuItems/getJurisdictionFileStatus.test.ts
+++ b/arlo-client/src/components/Audit/useSetupMenuItems/getJurisdictionFileStatus.test.ts
@@ -1,0 +1,21 @@
+import { toast } from 'react-toastify'
+import getJurisdictionFileStatus, {
+  FileProcessingStatus,
+} from './getJurisdictionFileStatus'
+import * as utilities from '../../utilities'
+
+const apiMock: jest.SpyInstance<
+  ReturnType<typeof utilities.api>,
+  Parameters<typeof utilities.api>
+> = jest.spyOn(utilities, 'api').mockRejectedValue(new Error('Network error'))
+const toastSpy = jest.spyOn(toast, 'error').mockImplementation()
+
+describe('getJurisdictionFileStatus', () => {
+  it('handles api request error', async () => {
+    const response = await getJurisdictionFileStatus('1')
+    expect(response).toBe(FileProcessingStatus.Errored)
+    expect(apiMock).toHaveBeenCalledTimes(1)
+    expect(toastSpy).toHaveBeenCalledTimes(1)
+    expect(toastSpy).toHaveBeenCalledWith('Network error')
+  })
+})

--- a/arlo-client/src/components/Audit/useSetupMenuItems/getRoundStatus.test.ts
+++ b/arlo-client/src/components/Audit/useSetupMenuItems/getRoundStatus.test.ts
@@ -1,0 +1,19 @@
+import { toast } from 'react-toastify'
+import getRoundStatus from './getRoundStatus'
+import * as utilities from '../../utilities'
+
+const apiMock: jest.SpyInstance<
+  ReturnType<typeof utilities.api>,
+  Parameters<typeof utilities.api>
+> = jest.spyOn(utilities, 'api').mockRejectedValue(new Error('Network error'))
+const toastSpy = jest.spyOn(toast, 'error').mockImplementation()
+
+describe('getRoundStatus', () => {
+  it('handles api request error', async () => {
+    const response = await getRoundStatus('1')
+    expect(response).toBeFalsy()
+    expect(apiMock).toHaveBeenCalledTimes(1)
+    expect(toastSpy).toHaveBeenCalledTimes(1)
+    expect(toastSpy).toHaveBeenCalledWith('Network error')
+  })
+})

--- a/arlo-client/src/components/Audit/useSetupMenuItems/getRoundStatus.ts
+++ b/arlo-client/src/components/Audit/useSetupMenuItems/getRoundStatus.ts
@@ -1,14 +1,20 @@
+import { toast } from 'react-toastify'
 import { api, checkAndToast } from '../../utilities'
 import { IRound, IErrorResponse } from '../../../types'
 
 const getRoundStatus = async (electionId: string): Promise<boolean> => {
-  const roundsOrError: { rounds: IRound[] } | IErrorResponse = await api(
-    `/election/${electionId}/round`
-  )
-  if (checkAndToast(roundsOrError) || !roundsOrError.rounds.length) {
+  try {
+    const roundsOrError: { rounds: IRound[] } | IErrorResponse = await api(
+      `/election/${electionId}/round`
+    )
+    if (checkAndToast(roundsOrError) || !roundsOrError.rounds.length) {
+      return false
+    }
+    return true
+  } catch (err) {
+    toast.error(err.message)
     return false
   }
-  return true
 }
 
 export default getRoundStatus

--- a/arlo-client/src/components/Audit/useSetupMenuItems/index.ts
+++ b/arlo-client/src/components/Audit/useSetupMenuItems/index.ts
@@ -56,10 +56,13 @@ function useSetupMenuItems(
           return true
         return false
       }
-      const complete = () => setContests('live')
+      const complete = () => {
+        setContests('live')
+        setStage('Target Contests')
+      }
       poll(condition, complete, (err: Error) => toast.error(err.message))
     }
-  }, [electionId, setContests])
+  }, [electionId, setContests, setStage])
 
   const lockAllIfRounds = useCallback(async () => {
     const roundsExist = await getRoundStatus(electionId)

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -148,7 +148,7 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
             meta!.organizations.map(o =>
               o.elections.map(election => (
                 <AuditLink
-                  to={`/election/${election.id}`}
+                  to={`/election/${election.id}/setup`}
                   key={election.id}
                   className="bp3-button bp3-intent-primary"
                 >
@@ -160,7 +160,7 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
           {meta!.jurisdictions.length > 0 &&
             meta!.jurisdictions.map(({ election }) => (
               <AuditLink
-                to={`/election/${election.id}`}
+                to={`/election/${election.id}/setup`}
                 key={election.id}
                 className="bp3-button bp3-intent-primary"
               >

--- a/arlo-client/src/components/DataEntry/Ballot.test.tsx
+++ b/arlo-client/src/components/DataEntry/Ballot.test.tsx
@@ -26,6 +26,7 @@ const contest = {
   votesAllowed: '1',
   totalBallotsCast: '2123',
   isTargeted: true,
+  jurisdictionIds: [],
 }
 
 describe('Ballot', () => {

--- a/arlo-client/src/components/__snapshots__/CreateAudit.test.tsx.snap
+++ b/arlo-client/src/components/__snapshots__/CreateAudit.test.tsx.snap
@@ -48,28 +48,28 @@ exports[`CreateAudit lists associated elections for authenticated AA user 1`] = 
     </button>
     <a
       class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
-      href="/election/election-1"
+      href="/election/election-1/setup"
     >
       Not named yet
        (NY)
     </a>
     <a
       class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
-      href="/election/election-2"
+      href="/election/election-2/setup"
     >
       Election Two
        (FL)
     </a>
     <a
       class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
-      href="/election/election-3"
+      href="/election/election-3/setup"
     >
       Election Three
       
     </a>
     <a
       class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
-      href="/election/election-4"
+      href="/election/election-4/setup"
     >
       Election Four
        (WA)
@@ -126,14 +126,14 @@ exports[`CreateAudit lists associated elections for authenticated JA user 1`] = 
     </button>
     <a
       class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
-      href="/election/election-1"
+      href="/election/election-1/setup"
     >
       Election One
        (NY)
     </a>
     <a
       class="bp3-button bp3-intent-primary sc-gqjmRU gbnvnx"
-      href="/election/election-2"
+      href="/election/election-2/setup"
     >
       Not named yet
       

--- a/arlo-client/src/setupProxy.js
+++ b/arlo-client/src/setupProxy.js
@@ -16,6 +16,7 @@ module.exports = function(app) {
   app.use(proxy('/election/new', { target }))
   app.use(proxy('/election/*/audit/**', { target }))
   app.use(proxy('/election/*/settings', { target }))
+  app.use(proxy('/election/*/contest', { target }))
   app.use(proxy('/election/*/jurisdiction/**', { target }))
   app.use(proxy('/election/*/jurisdictions/**', { target }))
   app.use(proxy('/election/*/admin/**', { target }))

--- a/arlo-client/src/setupProxy.js
+++ b/arlo-client/src/setupProxy.js
@@ -17,6 +17,7 @@ module.exports = function(app) {
   app.use(proxy('/election/*/audit/**', { target }))
   app.use(proxy('/election/*/settings', { target }))
   app.use(proxy('/election/*/contest', { target }))
+  app.use(proxy('/election/*/round', { target }))
   app.use(proxy('/election/*/jurisdiction/**', { target }))
   app.use(proxy('/election/*/jurisdictions/**', { target }))
   app.use(proxy('/election/*/admin/**', { target }))

--- a/arlo-client/src/types.ts
+++ b/arlo-client/src/types.ts
@@ -139,6 +139,7 @@ export interface IAudit {
   jurisdictions: IJurisdiction[]
   rounds: IRound[]
   frozenAt: string | null
+  isMultiJurisdiction: boolean
 }
 
 export interface IElectionMeta {

--- a/arlo-client/src/types.ts
+++ b/arlo-client/src/types.ts
@@ -42,6 +42,7 @@ export interface IContest {
   votesAllowed: string
   choices: ICandidate[]
   totalBallotsCast: string
+  jurisdictionIds: string[]
 }
 
 export interface IBallot {

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -327,6 +327,7 @@ def audit_status(election_id=None):
         frozenAt=isoformat(election.frozen_at),
         riskLimit=election.risk_limit,
         randomSeed=election.random_seed,
+        isMultiJurisdiction=election.is_multi_jurisdiction,
         contests=[
             {
                 "id": contest.id,

--- a/tests/routes_tests/test_audit_status.py
+++ b/tests/routes_tests/test_audit_status.py
@@ -60,6 +60,7 @@ def test_audit_status(client, election_id):
                 }
             ],
             "frozenAt": assert_is_date,
+            "isMultiJurisdiction": False,
             "jurisdictions": [
                 {
                     "auditBoards": [


### PR DESCRIPTION
**Description**

- Using the dedicated endpoints for GETting and PUTting contests to the backend from the AA setup screens for targeted and opportunistic contests using a custom hook.

**Testing**

- ~TODO~ Test all api interactions and states

**Progress**

- Ready for review!
- The component for selecting the jurisdictions will be in another PR to maintain manageable sizes
