### PR TITLE
pylint: enable syntax-error rule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -66,7 +66,8 @@ disable=all
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=dangerous-default-value,
+enable=syntax-error,
+       dangerous-default-value,
        possibly-unused-variable,
        singleton-comparison,
        undefined-variable,


### PR DESCRIPTION
**Description**

Enables the `syntax-error` rule for pylint. No syntax errors to fix.

**Testing**

N/A

**Progress**

Ready.