### PR TITLE
Authorization for audit boards

### DIFF
--- a/arlo_server/auth.py
+++ b/arlo_server/auth.py
@@ -4,30 +4,32 @@ from flask import session
 from typing import Callable, Optional, Tuple, Union
 from werkzeug.exceptions import Unauthorized, Forbidden
 
-from arlo_server.models import Election, User, Jurisdiction
+from arlo_server.models import Election, User, Jurisdiction, Round, AuditBoard
 
 
 class UserType(str, Enum):
+    # Audit admins are represented with a User record associated with one or
+    # more Organizations and use User.email as their login key.
     AUDIT_ADMIN = "audit_admin"
+    # Jurisdiction admins are represented with a User record associated with
+    # one or more Jurisdictions and use User.email as their login key.
     JURISDICTION_ADMIN = "jurisdiction_admin"
+    # Audit boards are represented by the AuditBoard record and use
+    # AuditBoard.id as their login key. In the real world, a member of an audit
+    # board will log in on behalf of the audit board by navigating to
+    # /audit-board/<passphrase>, initiating the session. We consider the whole
+    # audit board to be one "logged in user," as opposed to trying to know
+    # which specific audit board member logged in.
+    AUDIT_BOARD = "audit_board"
 
 
-def set_loggedin_user(user_type: UserType, user_email: str):
-    session["_user"] = {"type": user_type, "email": user_email}
+def set_loggedin_user(user_type: UserType, user_key: str):
+    session["_user"] = {"type": user_type, "key": user_key}
 
 
 def get_loggedin_user() -> Union[Tuple[UserType, str], Tuple[None, None]]:
     user = session.get("_user", None)
-    return (user["type"], user["email"]) if user else (None, None)
-
-
-def get_loggedin_user_record():
-    user_type, user_email = get_loggedin_user()
-    return (
-        (user_type, User.query.filter_by(email=user_email).one())
-        if user_email
-        else (None, None)
-    )
+    return (user["type"], user["key"]) if user else (None, None)
 
 
 def clear_loggedin_user():
@@ -38,18 +40,19 @@ def require_audit_admin_for_organization(organization_id: Optional[str]):
     if not organization_id:
         return
 
-    user_type, user = get_loggedin_user_record()
+    user_type, user_key = get_loggedin_user()
 
-    if not user:
+    if not user_type:
         raise Unauthorized(
             description=f"Anonymous users do not have access to organization {organization_id}"
         )
 
     if user_type != UserType.AUDIT_ADMIN:
         raise Forbidden(
-            description=f"{user.email} is not logged in as an audit admin and so does not have access to organization {organization_id}"
+            description=f"User is not logged in as an audit admin and so does not have access to organization {organization_id}"
         )
 
+    user = User.query.filter_by(email=user_key).one()
     for org in user.organizations:
         if org.id == organization_id:
             return
@@ -58,21 +61,20 @@ def require_audit_admin_for_organization(organization_id: Optional[str]):
     )
 
 
-def require_jurisdiction_admin_for_jurisdiction(
-    jurisdiction_id: str, election: Election
-):
-    user_type, user = get_loggedin_user_record()
+def require_jurisdiction_admin_for_jurisdiction(jurisdiction_id: str, election_id: str):
+    user_type, user_key = get_loggedin_user()
 
-    if not user:
+    if not user_type:
         raise Unauthorized(
             description=f"Anonymous users do not have access to jurisdiction {jurisdiction_id}"
         )
 
     if user_type != UserType.JURISDICTION_ADMIN:
         raise Forbidden(
-            description=f"{user.email} is not logged in as a jurisdiction admin and so does not have access to jurisdiction {jurisdiction_id}"
+            description=f"User is not logged in as a jurisdiction admin and so does not have access to jurisdiction {jurisdiction_id}"
         )
 
+    user = User.query.filter_by(email=user_key).one()
     jurisdiction = next(
         (j for j in user.jurisdictions if j.id == jurisdiction_id), None
     )
@@ -80,9 +82,43 @@ def require_jurisdiction_admin_for_jurisdiction(
         raise Forbidden(
             description=f"{user.email} does not have access to jurisdiction {jurisdiction_id}"
         )
-    if jurisdiction.election_id != election.id:
+    if jurisdiction.election_id != election_id:
         raise Forbidden(
-            description=f"Jurisdiction {jurisdiction.id} is not associated with election {election.id}"
+            description=f"Jurisdiction {jurisdiction.id} is not associated with election {election_id}"
+        )
+
+
+def require_audit_board_logged_in(
+    audit_board: AuditBoard, election_id: str, jurisdiction: Jurisdiction, round_id: str
+):
+    user_type, user_key = get_loggedin_user()
+
+    if not user_key:
+        raise Unauthorized(
+            description=f"Anonymous users do not have access to audit board {audit_board.id}"
+        )
+
+    if user_type != UserType.AUDIT_BOARD:
+        raise Forbidden(
+            description=f"User is not logged in as an audit board and so does not have access to audit board {audit_board.id}"
+        )
+
+    if audit_board.id != user_key:
+        raise Forbidden(
+            description=f"User does not have access to audit board {audit_board.id}"
+        )
+
+    if audit_board.jurisdiction.election_id != election_id:
+        raise Forbidden(
+            description=f"Audit board {audit_board.id} is not associated with election {election_id}"
+        )
+    if audit_board.jurisdiction_id != jurisdiction.id:
+        raise Forbidden(
+            description=f"Audit board {audit_board.id} is not associated with jurisdiction {jurisdiction.id}"
+        )
+    if audit_board.round_id != round_id:
+        raise Forbidden(
+            description=f"Audit board {audit_board.id} is not associated with round {round_id}"
         )
 
 
@@ -128,18 +164,58 @@ def with_jurisdiction_access(route: Callable):
 
     @functools.wraps(route)
     def wrapper(*args, **kwargs):
-        if "election_id" not in kwargs:
-            raise Exception(f"expected 'election_id' in kwargs but got: {kwargs}")
-        if "jurisdiction_id" not in kwargs:
-            raise Exception(f"expected 'jurisdiction_id' in kwargs but got: {kwargs}")
+        for key in ["election_id", "jurisdiction_id"]:
+            if key not in kwargs:
+                raise Exception(f"expected '{key}' in kwargs but got: {kwargs}")
 
         election = Election.query.get_or_404(kwargs.pop("election_id"))
         jurisdiction = Jurisdiction.query.get_or_404(kwargs.pop("jurisdiction_id"))
 
-        require_jurisdiction_admin_for_jurisdiction(jurisdiction.id, election)
+        require_jurisdiction_admin_for_jurisdiction(jurisdiction.id, election.id)
 
         kwargs["election"] = election
         kwargs["jurisdiction"] = jurisdiction
+
+        return route(*args, **kwargs)
+
+    return wrapper
+
+
+def with_audit_board_access(route: Callable):
+    """
+    Flask route decorator that restricts access to a route to Audit Board
+    members that are part of the audit board for the election, jurisdiction,
+    round, and audit board ids in the route's path. It also loads the
+    election, jurisdiction, round, and audit board objects.
+
+    To use this, you must have:
+    - a path component named `election_id`
+    - a route parameter named `election`
+    - a path component named `jurisdiction_id`
+    - a route parameter named `jurisdiction`
+    - a path component named `round_id`
+    - a route parameter named `round`
+    - a path component named `audit_board_id`
+    - a route parameter named `audit_board`
+    """
+
+    @functools.wraps(route)
+    def wrapper(*args, **kwargs):
+        for key in ["election_id", "jurisdiction_id", "round_id", "audit_board_id"]:
+            if key not in kwargs:
+                raise Exception(f"expected '{key}' in kwargs but got: {kwargs}")
+
+        election = Election.query.get_or_404(kwargs.pop("election_id"))
+        jurisdiction = Jurisdiction.query.get_or_404(kwargs.pop("jurisdiction_id"))
+        round = Round.query.get_or_404(kwargs.pop("round_id"))
+        audit_board = AuditBoard.query.get_or_404(kwargs.pop("audit_board_id"))
+
+        require_audit_board_logged_in(audit_board, election.id, jurisdiction, round.id)
+
+        kwargs["election"] = election
+        kwargs["jurisdiction"] = jurisdiction
+        kwargs["round"] = round
+        kwargs["audit_board"] = audit_board
 
         return route(*args, **kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,14 @@ from arlo_server.models import (
     Round,
     RoundContestResult,
     Contest,
+    AuditBoard,
 )
-from arlo_server.auth import with_election_access, with_jurisdiction_access, UserType
+from arlo_server.auth import (
+    UserType,
+    with_election_access,
+    with_jurisdiction_access,
+    with_audit_board_access,
+)
 from tests.helpers import (
     assert_ok,
     put_json,
@@ -287,3 +293,19 @@ def auth_decorator_test_routes():
         assert election
         assert jurisdiction
         return jsonify([election.id, jurisdiction.id])
+
+    @app.route(
+        "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board/<audit_board_id>/test_auth"
+    )
+    @with_audit_board_access
+    def fake_audit_board_route(
+        election: Election,
+        jurisdiction: Jurisdiction,
+        round: Round,
+        audit_board: AuditBoard,
+    ):
+        assert election
+        assert jurisdiction
+        assert round
+        assert audit_board
+        return jsonify([election.id, jurisdiction.id, round.id, audit_board.id])

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -41,10 +41,10 @@ def assert_ok(rv: Response):
 
 
 def set_logged_in_user(
-    client: FlaskClient, user_type: UserType, user_email=DEFAULT_AA_EMAIL
+    client: FlaskClient, user_type: UserType, user_key=DEFAULT_AA_EMAIL
 ):
     with client.session_transaction() as session:  # type: ignore
-        session["_user"] = {"type": user_type, "email": user_email}
+        session["_user"] = {"type": user_type, "key": user_key}
 
 
 def clear_logged_in_user(client: FlaskClient):
@@ -101,7 +101,7 @@ def create_election(
     audit_name: str = "Test Audit",
     organization_id: str = None,
     is_multi_jurisdiction: bool = True,
-):
+) -> str:
     rv = post_json(
         client,
         "/election/new",
@@ -111,7 +111,7 @@ def create_election(
             "isMultiJurisdiction": is_multi_jurisdiction,
         },
     )
-    return json.loads(rv.data)["electionId"]
+    return str(json.loads(rv.data)["electionId"])
 
 
 def assert_is_id(x):

--- a/tests/routes_tests/test_auth.py
+++ b/tests/routes_tests/test_auth.py
@@ -1,10 +1,12 @@
 import pytest
 from flask.testing import FlaskClient
-import json, re
+import json, re, uuid
 from unittest.mock import Mock, MagicMock
 from urllib.parse import urlparse, parse_qs
+from typing import List
 
 from arlo_server.auth import UserType
+from arlo_server.models import db, AuditBoard, Round
 from arlo_server.routes import (
     auth0_aa,
     auth0_ja,
@@ -23,23 +25,149 @@ JA_EMAIL = "ja@example.com"
 
 
 @pytest.fixture
-def org_id():
+def org_id() -> str:
     org_id, aa_id = create_org_and_admin("Test Org", AA_EMAIL)
     return org_id
 
 
 @pytest.fixture
-def election_id(client: FlaskClient, org_id: str):
+def election_id(client: FlaskClient, org_id: str) -> str:
     set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
     return create_election(client, organization_id=org_id)
 
 
 @pytest.fixture
-def jurisdiction_id(election_id: str):
+def jurisdiction_id(election_id: str) -> str:
     jurisdiction_id, ja_id = create_jurisdiction_and_admin(
         election_id, user_email=JA_EMAIL
     )
     return jurisdiction_id
+
+
+def create_round(election_id: str, round_num=1) -> str:
+    round = Round(id=str(uuid.uuid4()), election_id=election_id, round_num=round_num)
+    db.session.add(round)
+    db.session.commit()
+    return str(round.id)
+
+
+@pytest.fixture
+def round_id(election_id: str) -> str:
+    return create_round(election_id)
+
+
+def create_audit_board(jurisdiction_id: str, round_id: str) -> str:
+    id = str(uuid.uuid4())
+    audit_board = AuditBoard(
+        id=id,
+        jurisdiction_id=jurisdiction_id,
+        round_id=round_id,
+        passphrase=f"passphrase-{id}",
+    )
+    db.session.add(audit_board)
+    db.session.commit()
+    return str(audit_board.id)
+
+
+@pytest.fixture
+def audit_board_id(jurisdiction_id: str, round_id: str) -> str:
+    return create_audit_board(jurisdiction_id, round_id)
+
+
+# Tests for log in/log out flows
+
+
+def check_redirect_contains_redirect_uri(response, expected_url):
+    assert response.status_code == 302
+    location = urlparse(response.location)
+    query_vars = parse_qs(location.query)
+    assert query_vars["redirect_uri"]
+    redirect_uri = query_vars["redirect_uri"][0]
+
+    # common problem is a trailing slash on origin
+    # which makes a double slash like 'http://localhost//authorize'
+    # which won't work. So testing to make sure there is no '//'
+    # other than '://'
+    assert re.search("[^:]\/\/", redirect_uri) is None
+    assert expected_url in redirect_uri
+
+
+def test_auditadmin_start(client: FlaskClient):
+    rv = client.get("/auth/auditadmin/start")
+    check_redirect_contains_redirect_uri(rv, "/auth/auditadmin/callback")
+
+
+def test_auditadmin_callback(
+    client: FlaskClient, org_id: str,  # pylint: disable=unused-argument
+):
+    auth0_aa.authorize_access_token = MagicMock(return_value=None)
+
+    mock_response = Mock()
+    mock_response.json = MagicMock(return_value={"email": AA_EMAIL})
+    auth0_aa.get = Mock(return_value=mock_response)
+
+    rv = client.get("/auth/auditadmin/callback?code=foobar")
+    assert rv.status_code == 302
+
+    with client.session_transaction() as session:  # type: ignore
+        assert session["_user"]["type"] == UserType.AUDIT_ADMIN
+        assert session["_user"]["key"] == AA_EMAIL
+
+    assert auth0_aa.authorize_access_token.called
+    assert auth0_aa.get.called
+
+
+def test_jurisdictionadmin_start(client: FlaskClient):
+    rv = client.get("/auth/jurisdictionadmin/start")
+    check_redirect_contains_redirect_uri(rv, "/auth/jurisdictionadmin/callback")
+
+
+def test_jurisdictionadmin_callback(
+    client: FlaskClient, jurisdiction_id: str  # pylint: disable=unused-argument
+):
+    auth0_ja.authorize_access_token = MagicMock(return_value=None)
+
+    mock_response = Mock()
+    mock_response.json = MagicMock(return_value={"email": JA_EMAIL})
+    auth0_ja.get = Mock(return_value=mock_response)
+
+    rv = client.get("/auth/jurisdictionadmin/callback?code=foobar")
+    assert rv.status_code == 302
+
+    with client.session_transaction() as session:  # type: ignore
+        assert session["_user"]["type"] == UserType.JURISDICTION_ADMIN
+        assert session["_user"]["key"] == JA_EMAIL
+
+    assert auth0_ja.authorize_access_token.called
+    assert auth0_ja.get.called
+
+
+def test_audit_board_log_in(
+    client: FlaskClient, election_id: str, audit_board_round_1_ids: List[str],
+):
+    audit_board = AuditBoard.query.get(audit_board_round_1_ids[0])
+    rv = client.get(f"/auditboard/{audit_board.passphrase}")
+    assert rv.status_code == 302
+    location = urlparse(rv.location)
+    assert location.path == f"/election/{election_id}/board/{audit_board.id}"
+
+    with client.session_transaction() as session:  # type: ignore
+        assert session["_user"]["type"] == UserType.AUDIT_BOARD
+        assert session["_user"]["key"] == audit_board.id
+
+
+def test_logout(client: FlaskClient):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
+
+    rv = client.get("/auth/logout")
+
+    with client.session_transaction() as session:  # type: ignore
+        assert session["_user"] is None
+
+    assert rv.status_code == 302
+
+
+# Tests for /auth/me
 
 
 def test_auth_me_audit_admin(
@@ -98,80 +226,13 @@ def test_auth_me_jurisdiction_admin(
     }
 
 
-def check_redirect_contains_redirect_uri(response, expected_url):
-    assert response.status_code == 302
-    location = urlparse(response.location)
-    query_vars = parse_qs(location.query)
-    assert query_vars["redirect_uri"]
-    redirect_uri = query_vars["redirect_uri"][0]
-
-    # common problem is a trailing slash on origin
-    # which makes a double slash like 'http://localhost//authorize'
-    # which won't work. So testing to make sure there is no '//'
-    # other than '://'
-    assert re.search("[^:]\/\/", redirect_uri) is None
-    assert expected_url in redirect_uri
-
-
-def test_auditadmin_start(client: FlaskClient):
-    rv = client.get("/auth/auditadmin/start")
-    check_redirect_contains_redirect_uri(rv, "/auth/auditadmin/callback")
-
-
-def test_auditadmin_callback(
-    client: FlaskClient, org_id: str,  # pylint: disable=unused-argument
+def test_auth_me_audit_board(
+    client: FlaskClient, audit_board_round_1_ids: List[str],
 ):
-    auth0_aa.authorize_access_token = MagicMock(return_value=None)
-
-    mock_response = Mock()
-    mock_response.json = MagicMock(return_value={"email": AA_EMAIL})
-    auth0_aa.get = Mock(return_value=mock_response)
-
-    rv = client.get("/auth/auditadmin/callback?code=foobar")
-    assert rv.status_code == 302
-
-    with client.session_transaction() as session:  # type: ignore
-        assert session["_user"]["type"] == UserType.AUDIT_ADMIN
-        assert session["_user"]["email"] == AA_EMAIL
-
-    assert auth0_aa.authorize_access_token.called
-    assert auth0_aa.get.called
-
-
-def test_jurisdictionadmin_start(client: FlaskClient):
-    rv = client.get("/auth/jurisdictionadmin/start")
-    check_redirect_contains_redirect_uri(rv, "/auth/jurisdictionadmin/callback")
-
-
-def test_jurisdictionadmin_callback(
-    client: FlaskClient, jurisdiction_id: str  # pylint: disable=unused-argument
-):
-    auth0_ja.authorize_access_token = MagicMock(return_value=None)
-
-    mock_response = Mock()
-    mock_response.json = MagicMock(return_value={"email": JA_EMAIL})
-    auth0_ja.get = Mock(return_value=mock_response)
-
-    rv = client.get("/auth/jurisdictionadmin/callback?code=foobar")
-    assert rv.status_code == 302
-
-    with client.session_transaction() as session:  # type: ignore
-        assert session["_user"]["type"] == UserType.JURISDICTION_ADMIN
-        assert session["_user"]["email"] == JA_EMAIL
-
-    assert auth0_ja.authorize_access_token.called
-    assert auth0_ja.get.called
-
-
-def test_logout(client: FlaskClient):
-    set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
-
-    rv = client.get("/auth/logout")
-
-    with client.session_transaction() as session:  # type: ignore
-        assert session["_user"] is None
-
-    assert rv.status_code == 302
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_round_1_ids[0])
+    rv = client.get("/auth/me")
+    assert rv.status_code == 200
+    assert json.loads(rv.data) == {}
 
 
 # Tests for route decorators. We have added special routes to test the
@@ -223,7 +284,24 @@ def test_with_election_access_jurisdiction_admin(
         "errors": [
             {
                 "errorType": "Forbidden",
-                "message": f"{JA_EMAIL} is not logged in as an audit admin and so does not have access to organization {org_id}",
+                "message": f"User is not logged in as an audit admin and so does not have access to organization {org_id}",
+            }
+        ]
+    }
+
+
+def test_with_election_access_audit_board_user(
+    client: FlaskClient, org_id: str, election_id: str, audit_board_id: str,
+):
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+
+    rv = client.get(f"/election/{election_id}/test_auth")
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"User is not logged in as an audit admin and so does not have access to organization {org_id}",
             }
         ]
     }
@@ -348,7 +426,23 @@ def test_with_jurisdiction_access_audit_admin(
         "errors": [
             {
                 "errorType": "Forbidden",
-                "message": f"{AA_EMAIL} is not logged in as a jurisdiction admin and so does not have access to jurisdiction {jurisdiction_id}",
+                "message": f"User is not logged in as a jurisdiction admin and so does not have access to jurisdiction {jurisdiction_id}",
+            }
+        ]
+    }
+
+
+def test_with_jurisdiction_access_audit_board_user(
+    client: FlaskClient, election_id: str, jurisdiction_id: str, audit_board_id: str,
+):
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+    rv = client.get(f"/election/{election_id}/jurisdiction/{jurisdiction_id}/test_auth")
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"User is not logged in as a jurisdiction admin and so does not have access to jurisdiction {jurisdiction_id}",
             }
         ]
     }
@@ -368,3 +462,261 @@ def test_with_jurisdiction_access_anonymous_user(
             }
         ]
     }
+
+
+def test_with_audit_board_access_audit_board_user(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_id: str,
+    round_id: str,
+    audit_board_id: str,
+):
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/audit-board/{audit_board_id}/test_auth"
+    )
+    assert rv.status_code == 200
+    assert json.loads(rv.data) == [
+        election_id,
+        jurisdiction_id,
+        round_id,
+        audit_board_id,
+    ]
+
+
+def test_with_audit_board_access_audit_admin(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_id: str,
+    round_id: str,
+    audit_board_id: str,
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/audit-board/{audit_board_id}/test_auth"
+    )
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"User is not logged in as an audit board and so does not have access to audit board {audit_board_id}",
+            }
+        ]
+    }
+
+
+def test_with_audit_board_access_jurisdiction_admin(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_id: str,
+    round_id: str,
+    audit_board_id: str,
+):
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, JA_EMAIL)
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/audit-board/{audit_board_id}/test_auth"
+    )
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"User is not logged in as an audit board and so does not have access to audit board {audit_board_id}",
+            }
+        ]
+    }
+
+
+def test_with_audit_board_access_anonymous_user(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_id: str,
+    round_id: str,
+    audit_board_id: str,
+):
+    clear_logged_in_user(client)
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/audit-board/{audit_board_id}/test_auth"
+    )
+    assert rv.status_code == 401
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Unauthorized",
+                "message": f"Anonymous users do not have access to audit board {audit_board_id}",
+            }
+        ]
+    }
+
+
+def test_with_audit_board_access_wrong_org(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_id: str,
+    round_id: str,
+    audit_board_id: str,
+):
+    org_id_2, _ = create_org_and_admin("Org 2", "aa2@example.com")
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, "aa2@example.com")
+    election_id_2 = create_election(client, organization_id=org_id_2)
+    jurisdiction_id_2, _ = create_jurisdiction_and_admin(
+        election_id_2, user_email="ja2@example.com"
+    )
+    round_id_2 = create_round(election_id_2)
+    audit_board_id_2 = create_audit_board(jurisdiction_id_2, round_id_2)
+
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id_2)
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/audit-board/{audit_board_id}/test_auth"
+    )
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"User does not have access to audit board {audit_board_id}",
+            }
+        ]
+    }
+
+
+def test_with_audit_board_access_wrong_election(
+    client: FlaskClient, audit_board_id: str,
+):
+    org_id_2, _ = create_org_and_admin("Org 2", "aa2@example.com")
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, "aa2@example.com")
+    election_id_2 = create_election(client, organization_id=org_id_2)
+    jurisdiction_id_2, _ = create_jurisdiction_and_admin(
+        election_id_2, user_email="ja2@example.com"
+    )
+    round_id_2 = create_round(election_id_2)
+
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+
+    rv = client.get(
+        f"/election/{election_id_2}/jurisdiction/{jurisdiction_id_2}/round/{round_id_2}/audit-board/{audit_board_id}/test_auth"
+    )
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"Audit board {audit_board_id} is not associated with election {election_id_2}",
+            }
+        ]
+    }
+
+
+def test_with_audit_board_access_wrong_jurisdiction(
+    client: FlaskClient, election_id: str, round_id: str, audit_board_id: str,
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
+    jurisdiction_id_2, _ = create_jurisdiction_and_admin(
+        election_id, jurisdiction_name="J2", user_email="ja2@example.com"
+    )
+
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id_2}/round/{round_id}/audit-board/{audit_board_id}/test_auth"
+    )
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"Audit board {audit_board_id} is not associated with jurisdiction {jurisdiction_id_2}",
+            }
+        ]
+    }
+
+
+def test_with_audit_board_access_wrong_round(
+    client: FlaskClient, election_id: str, jurisdiction_id: str, audit_board_id: str,
+):
+    round_id_2 = create_round(election_id, round_num=2)
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id_2}/audit-board/{audit_board_id}/test_auth"
+    )
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"Audit board {audit_board_id} is not associated with round {round_id_2}",
+            }
+        ]
+    }
+
+
+def test_with_audit_board_access_wrong_audit_board(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_id: str,
+    round_id: str,
+    audit_board_id: str,
+):
+    audit_board_id_2 = create_audit_board(jurisdiction_id, round_id)
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/audit-board/{audit_board_id_2}/test_auth"
+    )
+    assert rv.status_code == 403
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Forbidden",
+                "message": f"User does not have access to audit board {audit_board_id_2}",
+            }
+        ]
+    }
+
+
+def test_with_audit_board_access_election_not_found(
+    client: FlaskClient, jurisdiction_id: str, round_id: str, audit_board_id: str,
+):
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+    rv = client.get(
+        f"/election/not-a-real-id/jurisdiction/{jurisdiction_id}/round/{round_id}/audit-board/{audit_board_id}/test_auth"
+    )
+    assert rv.status_code == 404
+
+
+def test_with_audit_board_access_jurisdiction_not_found(
+    client: FlaskClient, election_id: str, round_id: str, audit_board_id: str,
+):
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/not-a-real-id/round/{round_id}/audit-board/{audit_board_id}/test_auth"
+    )
+    assert rv.status_code == 404
+
+
+def test_with_audit_board_access_round_not_found(
+    client: FlaskClient, election_id: str, jurisdiction_id: str, audit_board_id: str,
+):
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/not-a-real-id/audit-board/{audit_board_id}/test_auth"
+    )
+    assert rv.status_code == 404
+
+
+def test_with_audit_board_access_audit_board_not_found(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_id: str,
+    round_id: str,
+    audit_board_id: str,
+):
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/audit-board/not-a-real-id/test_auth"
+    )
+    assert rv.status_code == 404

--- a/tests/routes_tests/test_new_election.py
+++ b/tests/routes_tests/test_new_election.py
@@ -40,9 +40,7 @@ def test_in_org_with_anonymous_user(client: FlaskClient):
 
 def test_in_org_with_logged_in_admin(client: FlaskClient):
     org_id, _user_id = create_org_and_admin(user_email="admin@example.com")
-    set_logged_in_user(
-        client, user_type=UserType.AUDIT_ADMIN, user_email="admin@example.com"
-    )
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, "admin@example.com")
 
     rv = post_json(
         client,
@@ -65,9 +63,7 @@ def test_in_org_with_logged_in_admin(client: FlaskClient):
 def test_in_org_with_logged_in_admin_without_access(client: FlaskClient):
     _org1_id, _user1_id = create_org_and_admin(user_email="admin1@example.com")
     org2_id, _user2_id = create_org_and_admin(user_email="admin2@example.com")
-    set_logged_in_user(
-        client, user_type=UserType.AUDIT_ADMIN, user_email="admin1@example.com"
-    )
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, "admin1@example.com")
 
     rv = post_json(
         client,
@@ -91,9 +87,7 @@ def test_in_org_with_logged_in_admin_without_access(client: FlaskClient):
 
 def test_in_org_with_logged_in_jurisdiction_admin(client: FlaskClient):
     org_id, _user_id = create_org_and_admin(user_email="admin@example.com")
-    set_logged_in_user(
-        client, user_type=UserType.JURISDICTION_ADMIN, user_email="admin@example.com"
-    )
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, "admin@example.com")
 
     rv = post_json(
         client,
@@ -107,7 +101,7 @@ def test_in_org_with_logged_in_jurisdiction_admin(client: FlaskClient):
     assert json.loads(rv.data) == {
         "errors": [
             {
-                "message": f"admin@example.com is not logged in as an audit admin and so does not have access to organization {org_id}",
+                "message": f"User is not logged in as an audit admin and so does not have access to organization {org_id}",
                 "errorType": "Forbidden",
             }
         ]
@@ -148,9 +142,7 @@ def test_without_org_duplicate_audit_name(client: FlaskClient):
 
 def test_in_org_duplicate_audit_name(client: FlaskClient):
     org_id, _user_id = create_org_and_admin(user_email="admin@example.com")
-    set_logged_in_user(
-        client, user_type=UserType.AUDIT_ADMIN, user_email="admin@example.com"
-    )
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, "admin@example.com")
 
     rv = post_json(
         client,
@@ -187,9 +179,7 @@ def test_in_org_duplicate_audit_name(client: FlaskClient):
 def test_two_orgs_same_name(client: FlaskClient):
     org_id_1, _ = create_org_and_admin(user_email="admin1@example.com")
     org_id_2, _ = create_org_and_admin(user_email="admin2@example.com")
-    set_logged_in_user(
-        client, user_type=UserType.AUDIT_ADMIN, user_email="admin1@example.com"
-    )
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, "admin1@example.com")
 
     rv = post_json(
         client,
@@ -203,9 +193,7 @@ def test_two_orgs_same_name(client: FlaskClient):
     assert rv.status_code == 200
     assert json.loads(rv.data)["electionId"]
 
-    set_logged_in_user(
-        client, user_type=UserType.AUDIT_ADMIN, user_email="admin2@example.com"
-    )
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, "admin2@example.com")
 
     rv = post_json(
         client,


### PR DESCRIPTION
**Description**

Adds a user type for audit boards. This user type is a bit different for a couple of reasons:
- It doesn't correspond to one real world person, it corresponds to the entire audit board.
- It's not represented by a User record in the database, but rather by the AuditBoard record
- The audit board logs in by hitting `GET /auditboard/<passphrase>`, instead of using auth0 with email/password.

This PR:
- Adds the new user type
- Implements the login flow for audit boards
- Adds a `with_audit_board_access` decorator for routes that
should be restricted to audit board users
- Updates the session data format and auth helper functions to accommodate the differences outlined above

**Testing**

Adds a bunch of new test cases:
- test_audit_board_log_in
- test_auth_me_audit_board
- test_with_election_access_audit_board_user
- test_with_jurisdiction_access_audit_board_user
- test_with_audit_board_access_audit_board_user
- test_with_audit_board_access_audit_admin
- test_with_audit_board_access_jurisdiction_admin
- test_with_audit_board_access_anonymous_user
- test_with_audit_board_access_wrong_org
- test_with_audit_board_access_wrong_election
- test_with_audit_board_access_wrong_jurisdiction
- test_with_audit_board_access_wrong_round
- test_with_audit_board_access_wrong_audit_board
- test_with_audit_board_access_election_not_found
- test_with_audit_board_access_jurisdiction_not_found
- test_with_audit_board_access_round_not_found
- test_with_audit_board_access_audit_board_not_found

**Progress**

Ready for review