### PR TITLE
Add audit board sign-off endpoint

### DIFF
--- a/tests/routes_tests/test_audit_boards.py
+++ b/tests/routes_tests/test_audit_boards.py
@@ -1,6 +1,6 @@
-import json
+import json, random
 from flask.testing import FlaskClient
-from typing import List
+from typing import List, Tuple
 from datetime import datetime
 from collections import defaultdict
 
@@ -10,13 +10,19 @@ from tests.helpers import (
     compare_json,
     assert_is_id,
     assert_is_date,
+    create_jurisdiction_admin,
+    set_logged_in_user,
 )
 from arlo_server.models import (
     db,
     AuditBoard,
     SampledBallot,
     Batch,
+    Round,
+    RoundContest,
+    Contest,
 )
+from arlo_server.auth import UserType
 
 J1_SAMPLES = 81
 
@@ -509,3 +515,210 @@ def test_audit_boards_bad_round_id(
         [{"name": "Audit Board #1"}],
     )
     assert rv.status_code == 404
+
+
+def set_up_audit_board(
+    client: FlaskClient, election_id: str, jurisdiction_id: str, audit_board_id: str
+) -> Tuple[str, str]:
+    SILLY_NAMES = [
+        "Joe Schmo",
+        "Jane Plain",
+        "Derk Clerk",
+        "Bubbikin Republican",
+        "Clem O'Hat Democrat",
+    ]
+    member_1 = random.choice(SILLY_NAMES)
+    member_2 = random.choice(SILLY_NAMES)
+
+    # Order of the names shouldn't matter for sign-off, so we shuffle
+    # the names each time we set up the audit board members
+    member_names = [
+        {"name": member_1, "affiliation": "DEM"},
+        {"name": member_2, "affiliation": "REP"},
+    ]
+    random.shuffle(member_names)
+
+    # Set up the audit board
+    rv = post_json(
+        client,
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/audit-board/{audit_board_id}",
+        {"members": member_names},
+    )
+    assert_ok(rv)
+
+    # Fake auditing all the ballots
+    ballots = SampledBallot.query.filter_by(audit_board_id=audit_board_id).all()
+    for ballot in ballots:
+        ballot.vote = "YES"
+    db.session.commit()
+
+    return member_1, member_2
+
+
+def test_audit_boards_sign_off_happy_path(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    round_1_id: str,
+    audit_board_round_1_ids: List[str],
+):
+    def run_audit_board_flow(jurisdiction_id: str, audit_board_id: str):
+        member_1, member_2 = set_up_audit_board(
+            client, election_id, jurisdiction_id, audit_board_id
+        )
+        set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+        rv = post_json(
+            client,
+            f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_1_id}/audit-board/{audit_board_id}/sign-off",
+            {"memberName1": member_1, "memberName2": member_2},
+        )
+        assert_ok(rv)
+
+    run_audit_board_flow(jurisdiction_ids[0], audit_board_round_1_ids[0])
+
+    # After one audit board signs off, shouldn't end the round yet
+    round = Round.query.get(round_1_id)
+    assert round.ended_at is None
+
+    run_audit_board_flow(jurisdiction_ids[0], audit_board_round_1_ids[1])
+
+    # After second audit board signs off, shouldn't end the round yet because
+    # the other jurisdictions still didn't set up audit boards
+    round = Round.query.get(round_1_id)
+    assert round.ended_at is None
+
+    # Create an audit board for the other jurisdiction that had some ballots sampled
+    EMAIL = "ja1@example.com"
+    create_jurisdiction_admin(jurisdiction_ids[1], EMAIL)
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, EMAIL)
+    rv = post_json(
+        client,
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/audit-board",
+        [{"name": "Audit Board #1"}],
+    )
+    assert_ok(rv)
+    rv = client.get(
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/audit-board"
+    )
+    audit_board = json.loads(rv.data)["auditBoards"][0]
+
+    run_audit_board_flow(jurisdiction_ids[1], audit_board["id"])
+
+    # Now the round should be over
+    round = Round.query.get(round_1_id)
+    assert round.ended_at is not None
+
+    # Check that the risk measurements got calculated
+    round_contests = (
+        RoundContest.query.filter_by(round_id=round_1_id)
+        .join(Contest)
+        .filter_by(election_id=election_id)
+        .all()
+    )
+    for round_contest in round_contests:
+        assert round_contest.end_p_value is not None
+        assert round_contest.is_complete is not None
+
+
+def test_audit_boards_sign_off_missing_name(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    round_1_id: str,
+    audit_board_round_1_ids: List[str],
+):
+    audit_board_id = audit_board_round_1_ids[0]
+    member_1, member_2 = set_up_audit_board(
+        client, election_id, jurisdiction_ids[0], audit_board_id
+    )
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+
+    for missing_field in ["memberName1", "memberName2"]:
+        sign_off_request_body = {"memberName1": member_1, "memberName2": member_2}
+        del sign_off_request_body[missing_field]
+
+        rv = post_json(
+            client,
+            f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board/{audit_board_id}/sign-off",
+            sign_off_request_body,
+        )
+
+        assert rv.status_code == 400
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Bad Request",
+                    "message": f"'{missing_field}' is a required property",
+                }
+            ]
+        }
+
+
+def test_audit_boards_sign_off_wrong_name(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    round_1_id: str,
+    audit_board_round_1_ids: List[str],
+):
+    audit_board_id = audit_board_round_1_ids[0]
+    member_1, member_2 = set_up_audit_board(
+        client, election_id, jurisdiction_ids[0], audit_board_id
+    )
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+
+    for wrong_field in ["memberName1", "memberName2"]:
+        wrong_name = f"Wrong Name {wrong_field}"
+        sign_off_request_body = {"memberName1": member_1, "memberName2": member_2}
+        sign_off_request_body[wrong_field] = wrong_name
+
+        rv = post_json(
+            client,
+            f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board/{audit_board_id}/sign-off",
+            sign_off_request_body,
+        )
+
+        assert rv.status_code == 400
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Bad Request",
+                    "message": f"Audit board member name did not match: {wrong_name}",
+                }
+            ]
+        }
+
+
+def test_audit_boards_sign_off_before_finished(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    round_1_id: str,
+    audit_board_round_1_ids: List[str],
+):
+    audit_board_id = audit_board_round_1_ids[0]
+    member_1, member_2 = set_up_audit_board(
+        client, election_id, jurisdiction_ids[0], audit_board_id
+    )
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+
+    # Undo some of the ballot auditing done by set_up_audit_board
+    ballots = SampledBallot.query.filter_by(audit_board_id=audit_board_id).all()
+    for ballot in ballots[:10]:
+        ballot.vote = None
+    db.session.commit()
+
+    rv = post_json(
+        client,
+        f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board/{audit_board_id}/sign-off",
+        {"memberName1": member_1, "memberName2": member_2},
+    )
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Conflict",
+                "message": "Audit board is not finished auditing all assigned ballots",
+            }
+        ]
+    }


### PR DESCRIPTION
**Description**

Adds `POST /election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board/<audit_board_id>/sign-off` (whew, that's a mouthful). This endpoint allows an audit board to finalize their audit results. When the last audit board in all the jurisdictions with sampled ballots signs off, the round ends and the risk measurements are calculated for each contest.

**Testing**

Added some new tests to check:
- The endpoint works
- Validation for the POST body (proper format, contains the right names)
- The audit board can't sign off til they finish auditing their ballots
- The round doesn't end until all jurisdictions set up audit boards and all audit boards sign off

**Progress**

Ready for review.