### PR TITLE
Fix Request.trusted_hosts to take host, not entire http origin url

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_talisman import Talisman
 from werkzeug.wrappers import Request
+from urllib.parse import urlparse
 
 from config import (
     STATIC_FOLDER,
@@ -16,7 +17,7 @@ if FLASK_ENV not in DEVELOPMENT_ENVS:
     # Restrict which hosts we trust when not in dev/test. This works by causing
     # anything accessing the request URL (i.e. `request.url` or similar) to
     # throw an exception if it doesn't match one of the values in this list.
-    Request.trusted_hosts = [HTTP_ORIGIN]
+    Request.trusted_hosts = [str(urlparse(HTTP_ORIGIN).hostname)]
 
 app = Flask(__name__, static_folder=STATIC_FOLDER)
 app.testing = FLASK_ENV == "test"

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -106,8 +106,10 @@ def read_http_origin() -> str:
     if not http_origin:
         if FLASK_ENV in DEVELOPMENT_ENVS:
             http_origin = "http://localhost:3000"
-        elif FLASK_ENV == "staging" and "HEROKU_PR_NUMBER" in os.environ:
-            http_origin = f"https://vx-arlo-staging-pr-{os.environ.get('HEROKU_PR_NUMBER')}.herokuapp.com"
+        # For Heroku Review Apps, which get created automatically for each pull
+        # request, we need to create the http origin based on the app name.
+        elif FLASK_ENV == "staging":
+            http_origin = f"https://{os.environ.get('HEROKU_APP_NAME')}.herokuapp.com"
         else:
             raise Exception(
                 "ARLO_HTTP_ORIGIN env var, e.g. https://arlo.example.com, is missing"


### PR DESCRIPTION
**Description**

`Request.trusted_hosts` expects a hostname (e.g. foo.com), and was previously being given a full url (e.g. https://foo.com). This resulted in the app returning the error: `Host \"foo.com\" is not trusted"` when trying to access `request.host` in the audit admin login endpoint handler.

Also added a fix to the configuration of the `HTTP_ORIGIN` env var for the Heroku Review Apps flow.

**Testing**

Manually tested on this branch's staging deploy, which now works.

**Progress**

Ready for review.