### PR TITLE
Add ProxyFix middleware to set app http scheme to https

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_talisman import Talisman
 from werkzeug.wrappers import Request
+from werkzeug.middleware.proxy_fix import ProxyFix
 from urllib.parse import urlparse
 
 from config import (
@@ -20,6 +21,7 @@ if FLASK_ENV not in DEVELOPMENT_ENVS:
     Request.trusted_hosts = [str(urlparse(HTTP_ORIGIN).hostname)]
 
 app = Flask(__name__, static_folder=STATIC_FOLDER)
+app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore
 app.testing = FLASK_ENV == "test"
 T = Talisman(
     app,


### PR DESCRIPTION
**Description**

When our app is deployed on Heroku, the Heroku router terminates https
and sends requests to our app using http. This meant that our app
thought its url was using the http scheme rather than https, so when it
constructed redirect_uris for auth0, they used http.

Luckily, Heroku sets the `X-Forwarded-Proto` header to `https`, and this
middleware reads that header and configures the Flask app accordingly.

https://flask.palletsprojects.com/en/1.1.x/deploying/wsgi-standalone/?highlight=proxyfix#proxy-setups

**Testing**

Manually tested I could log in via auth0 on this PR's staging deploy (and locally).

**Progress**

Ready for review.
