### PR TITLE
Adapt auth0 env vars for single tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Arlo is configured mostly through environment variables:
 
 - `ARLO_SESSION_SECRET`: the secret key used to encrypt/auth client-side cookie sessions
 - `ARLO_HTTP_ORIGIN`: the proper HTTP/HTTPS origin where this Arlo server is running, e.g. https://arlo.example.com:8443 (as any web origin, no trailing slash)
-- `ARLO_AUDITADMIN_AUTH0_BASE_URL`, `ARLO_AUDITADMIN_AUTH0_CLIENT_ID`, `ARLO_AUDITADMIN_AUTH0_CLIENT_SECRET`: base url, client id, and client secret for the auth0 app used for audit admins.
+- `ARLO_AUTH0_BASE_URL`: base url for the auth0 tenant used for user authentication
+- `ARLO_AUTH0_AUDITADMIN_CLIENT_ID`, `ARLO_AUTH0_AUDITADMIN_CLIENT_SECRET`: client id and client secret for the auth0 app used for audit admins
+- `ARLO_AUTH0_JURISDICTIONADMIN_CLIENT_ID`, `ARLO_AUTH0_JURISDICTIONADMIN_CLIENT_SECRET`: client id and client secret for the auth0 app used for jurisdiction admins
 
 ### Creating Organizations and Administrators
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -121,31 +121,20 @@ def read_http_origin() -> str:
 HTTP_ORIGIN = read_http_origin()
 
 
-def read_auditadmin_auth0_creds() -> Tuple[str, str, str]:
+def read_auth0_creds() -> Tuple[str, str, str, str, str]:
     return (
-        os.environ.get("ARLO_AUDITADMIN_AUTH0_BASE_URL", ""),
-        os.environ.get("ARLO_AUDITADMIN_AUTH0_CLIENT_ID", ""),
-        os.environ.get("ARLO_AUDITADMIN_AUTH0_CLIENT_SECRET", ""),
+        os.environ.get("ARLO_AUTH0_BASE_URL", ""),
+        os.environ.get("ARLO_AUTH0_AUDITADMIN_CLIENT_ID", ""),
+        os.environ.get("ARLO_AUTH0_AUDITADMIN_CLIENT_SECRET", ""),
+        os.environ.get("ARLO_AUTH0_JURISDICTIONADMIN_CLIENT_ID", ""),
+        os.environ.get("ARLO_AUTH0_JURISDICTIONADMIN_CLIENT_SECRET", ""),
     )
 
 
 (
-    AUDITADMIN_AUTH0_BASE_URL,
-    AUDITADMIN_AUTH0_CLIENT_ID,
-    AUDITADMIN_AUTH0_CLIENT_SECRET,
-) = read_auditadmin_auth0_creds()
-
-
-def read_jurisdictionadmin_auth0_creds() -> Tuple[str, str, str]:
-    return (
-        os.environ.get("ARLO_JURISDICTIONADMIN_AUTH0_BASE_URL", ""),
-        os.environ.get("ARLO_JURISDICTIONADMIN_AUTH0_CLIENT_ID", ""),
-        os.environ.get("ARLO_JURISDICTIONADMIN_AUTH0_CLIENT_SECRET", ""),
-    )
-
-
-(
-    JURISDICTIONADMIN_AUTH0_BASE_URL,
-    JURISDICTIONADMIN_AUTH0_CLIENT_ID,
-    JURISDICTIONADMIN_AUTH0_CLIENT_SECRET,
-) = read_jurisdictionadmin_auth0_creds()
+    AUTH0_BASE_URL,
+    AUTH0_AUDITADMIN_CLIENT_ID,
+    AUTH0_AUDITADMIN_CLIENT_SECRET,
+    AUTH0_JURISDICTIONADMIN_CLIENT_ID,
+    AUTH0_JURISDICTIONADMIN_CLIENT_SECRET,
+) = read_auth0_creds()


### PR DESCRIPTION
**Description**

Shifting from having a separate auth0 tenant for audit admins and jurisdiction admins to having one single tenant for both user types. This makes our configuration/code simpler and also is a more recommended way to handle multiple user types by auth0's docs.

**Testing**

Tested locally by logging in with each user type.

**Progress**

Ready for review.