### PR TITLE
Return audit board passphrase in JA audit board list endpoint

### DIFF
--- a/arlo_server/audit_boards.py
+++ b/arlo_server/audit_boards.py
@@ -164,6 +164,7 @@ def serialize_audit_board(audit_board: AuditBoard, round_status: JSONDict) -> JS
     return {
         "id": audit_board.id,
         "name": audit_board.name,
+        "passphrase": audit_board.passphrase,
         "signedOffAt": isoformat(audit_board.signed_off_at),
         "currentRoundStatus": round_status,
     }

--- a/tests/routes_tests/test_audit_boards.py
+++ b/tests/routes_tests/test_audit_boards.py
@@ -10,6 +10,7 @@ from tests.helpers import (
     compare_json,
     assert_is_id,
     assert_is_date,
+    assert_is_passphrase,
     create_jurisdiction_admin,
     set_logged_in_user,
     DEFAULT_JA_EMAIL,
@@ -120,6 +121,7 @@ def test_audit_boards_list_one(
                 {
                     "id": assert_is_id,
                     "name": "Audit Board #1",
+                    "passphrase": assert_is_passphrase,
                     "signedOffAt": None,
                     "currentRoundStatus": {
                         "numSampledBallots": J1_SAMPLES,
@@ -149,6 +151,7 @@ def test_audit_boards_list_one(
                 {
                     "id": assert_is_id,
                     "name": "Audit Board #1",
+                    "passphrase": assert_is_passphrase,
                     "signedOffAt": None,
                     "currentRoundStatus": {
                         "numSampledBallots": J1_SAMPLES,
@@ -177,6 +180,7 @@ def test_audit_boards_list_one(
                 {
                     "id": assert_is_id,
                     "name": "Audit Board #1",
+                    "passphrase": assert_is_passphrase,
                     "signedOffAt": assert_is_date,
                     "currentRoundStatus": {
                         "numSampledBallots": J1_SAMPLES,
@@ -231,6 +235,7 @@ def test_audit_boards_list_two(
                     "id": assert_is_id,
                     "name": "Audit Board #1",
                     "signedOffAt": None,
+                    "passphrase": assert_is_passphrase,
                     "currentRoundStatus": {
                         "numSampledBallots": AB1_SAMPLES,
                         "numAuditedBallots": 0,
@@ -239,6 +244,7 @@ def test_audit_boards_list_two(
                 {
                     "id": assert_is_id,
                     "name": "Audit Board #2",
+                    "passphrase": assert_is_passphrase,
                     "signedOffAt": None,
                     "currentRoundStatus": {
                         "numSampledBallots": J1_SAMPLES - AB1_SAMPLES,
@@ -357,6 +363,7 @@ def test_audit_boards_list_round_2(
                 {
                     "id": assert_is_id,
                     "name": "Audit Board #1",
+                    "passphrase": assert_is_passphrase,
                     "signedOffAt": None,
                     "currentRoundStatus": {
                         "numSampledBallots": AB1_SAMPLES_ROUND_2,
@@ -366,6 +373,7 @@ def test_audit_boards_list_round_2(
                 {
                     "id": assert_is_id,
                     "name": "Audit Board #2",
+                    "passphrase": assert_is_passphrase,
                     "signedOffAt": None,
                     "currentRoundStatus": {
                         "numSampledBallots": AB2_SAMPLES_ROUND_2,
@@ -375,6 +383,7 @@ def test_audit_boards_list_round_2(
                 {
                     "id": assert_is_id,
                     "name": "Audit Board #3",
+                    "passphrase": assert_is_passphrase,
                     "signedOffAt": None,
                     "currentRoundStatus": {
                         "numSampledBallots": J1_SAMPLES_ROUND_2


### PR DESCRIPTION
**Description**

The passphrase is needed for the frontend to create the audit board login PDFs.

**Testing**

Updated existing tests.

**Progress**

Ready for review.