### PR TITLE
Only run tsc pre-commit hook when ts/tsx files change

### DIFF
--- a/arlo-client/package.json
+++ b/arlo-client/package.json
@@ -22,6 +22,9 @@
       "stylelint",
       "eslint --quiet --fix"
     ],
+    "*.+(ts|tsx)": [
+      "bash -c tsc"
+    ],
     "*.css": [
       "stylelint --config .stylelintrc-css.js --fix"
     ],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn --cwd arlo-client tsc && lint-staged && yarn --cwd arlo-client lint-staged && make typecheck-server"
+      "pre-commit": "lint-staged && yarn --cwd arlo-client lint-staged && make typecheck-server"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
**Description**

`tsc` is pretty slow. We shouldn't have to wait for it to typecheck the whole client if we only make changes to the server.

Note: we have to use `bash -c tsc` instead of just `tsc` because `lint-staged` passed in an array of filenames to `tsc` but `tsc` has to run on the whole project, so we want to ignore the arguments.

**Testing**

Manually tested that a staged tsx file with a type error causes tsc to fail on commit.

**Progress**

Ready for review.