### PR TITLE
Add ballot draws endpoint for jurisdiction admins

### DIFF
--- a/arlo_server/ballots.py
+++ b/arlo_server/ballots.py
@@ -1,6 +1,8 @@
 import io, csv
 from sqlalchemy import func, literal_column
+from sqlalchemy.orm import joinedload
 from sqlalchemy.dialects.postgresql import aggregate_order_by
+from flask import jsonify
 
 from arlo_server import app
 from arlo_server.auth import with_jurisdiction_access
@@ -14,6 +16,7 @@ from arlo_server.models import (
     Jurisdiction,
 )
 from util.csv_download import csv_response, election_timestamp_name
+from util.jsonschema import JSONDict
 
 
 def ballot_retrieval_list(jurisdiction: Jurisdiction, round: Round) -> str:
@@ -103,3 +106,54 @@ def get_retrieval_list(election: Election, jurisdiction: Jurisdiction, round_id:
         retrieval_list_csv,
         filename=f"ballot-retrieval-{election_timestamp_name(election)}",
     )
+
+
+def serialize_ballot_draw(ballot_draw: SampledBallotDraw) -> JSONDict:
+    # TODO separate status for ballots that were skipped by the audit board
+    ballot = ballot_draw.sampled_ballot
+    audit_board = ballot.audit_board
+    batch = ballot_draw.batch
+    return {
+        "ticketNumber": ballot_draw.ticket_number,
+        "status": "AUDITED" if ballot.vote is not None else None,
+        "vote": ballot.vote,
+        "comment": ballot.comment,
+        "position": ballot.ballot_position,
+        "batch": {"id": batch.id, "name": batch.name, "tabulator": batch.tabulator,},
+        "auditBoard": {"id": audit_board.id, "name": audit_board.name,},
+    }
+
+
+@app.route(
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/ballot-draws",
+    methods=["GET"],
+)
+@with_jurisdiction_access
+def list_ballot_draws_for_jurisdiction(
+    election: Election,  # pylint: disable=unused-argument
+    jurisdiction: Jurisdiction,
+    round_id: str,
+):
+    Round.query.get_or_404(round_id)
+    ballot_draws = (
+        SampledBallotDraw.query.filter_by(round_id=round_id)
+        .join(Batch)
+        .filter_by(jurisdiction_id=jurisdiction.id)
+        .join(SampledBallot)
+        .join(AuditBoard)
+        .order_by(
+            AuditBoard.name,
+            Batch.name,
+            SampledBallotDraw.ballot_position,
+            SampledBallotDraw.ticket_number,
+        )
+        .options(
+            joinedload(SampledBallotDraw.batch),
+            joinedload(SampledBallotDraw.sampled_ballot).joinedload(
+                SampledBallot.audit_board
+            ),
+        )
+        .all()
+    )
+    json_ballot_draws = [serialize_ballot_draw(b) for b in ballot_draws]
+    return jsonify({"ballotDraws": json_ballot_draws})

--- a/tests/routes_tests/test_audit_boards.py
+++ b/tests/routes_tests/test_audit_boards.py
@@ -360,7 +360,8 @@ def test_audit_boards_list_round_2(
                     "signedOffAt": None,
                     "currentRoundStatus": {
                         "numSampledBallots": AB1_SAMPLES_ROUND_2,
-                        "numAuditedBallots": 0,
+                        # Some ballots got audited in round 1 and sampled again in round 2
+                        "numAuditedBallots": 9,
                     },
                 },
                 {
@@ -369,7 +370,7 @@ def test_audit_boards_list_round_2(
                     "signedOffAt": None,
                     "currentRoundStatus": {
                         "numSampledBallots": AB2_SAMPLES_ROUND_2,
-                        "numAuditedBallots": 0,
+                        "numAuditedBallots": 3,
                     },
                 },
                 {
@@ -380,7 +381,7 @@ def test_audit_boards_list_round_2(
                         "numSampledBallots": J1_SAMPLES_ROUND_2
                         - AB1_SAMPLES_ROUND_2
                         - AB2_SAMPLES_ROUND_2,
-                        "numAuditedBallots": 0,
+                        "numAuditedBallots": 2,
                     },
                 },
             ]


### PR DESCRIPTION
**Description**

Adds a new endpoint `GET /election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/ballot-draws` that requires jurisdiction admin authorization (based on the `/ballot-list` endpoint).

**Testing**

Added some new tests.

**Progress**

Ready for review.