### PR TITLE
Refactor audit math sample results

### DIFF
--- a/arlo_server/audit_boards.py
+++ b/arlo_server/audit_boards.py
@@ -8,7 +8,6 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy import func, and_
 
 from arlo_server import app, db
-from arlo_server.routes import sample_results
 from arlo_server.auth import with_jurisdiction_access, with_audit_board_access
 from arlo_server.rounds import get_current_round
 from arlo_server.models import (
@@ -21,6 +20,7 @@ from arlo_server.models import (
     Batch,
 )
 from arlo_server.errors import handle_unique_constraint_error
+from arlo_server.sample_sizes import cumulative_contest_results
 from util.jsonschema import validate, JSONDict
 from util.binpacking import BalancedBucketList, Bucket
 from util.group_by import group_by
@@ -194,13 +194,11 @@ def list_audit_boards(
 
 
 def calculate_risk_measurements(election: Election, round: Round):
-    results = sample_results(election)
-
     for contest in election.contests:
         risk, is_complete = bravo.compute_risk(
             election.risk_limit / 100,
             sampler_contest.from_db_contest(contest),
-            results[contest.id],
+            cumulative_contest_results(contest),
         )
 
         round_contest = next(

--- a/audit_math/bravo.py
+++ b/audit_math/bravo.py
@@ -13,7 +13,7 @@ from .sampler_contest import Contest
 
 
 def get_expected_sample_sizes(
-    risk_limit: float, contest: Contest, sample_results: Dict[str, Dict[str, int]]
+    risk_limit: float, contest: Contest, sample_results: Dict[str, int]
 ) -> int:
     """
     Returns the expected sample size for a BRAVO audit of <contest>
@@ -60,9 +60,7 @@ def get_expected_sample_sizes(
         z_w = math.log(2 * s_w)
         z_l = math.log(2 - 2 * s_w)
 
-        T = min(
-            get_test_statistics(contest.margins, sample_results[contest.name]).values()
-        )
+        T = min(get_test_statistics(contest.margins, sample_results).values())
 
         weighted_alpha = math.log((1.0 / risk_limit) / T)
         return math.ceil((weighted_alpha + (z_w / 2.0)) / (p_w * z_w + p_l * z_l))
@@ -271,7 +269,7 @@ def expected_prob(
 
 
 def get_sample_size(
-    risk_limit: float, contest: Contest, sample_results: Dict[str, Dict[str, int]]
+    risk_limit: float, contest: Contest, sample_results: Dict[str, int]
 ) -> Dict[str, Dict[str, Optional[Union[float, int, str]]]]:
     """
     Computes initial sample size parameterized by likelihood that the
@@ -355,8 +353,8 @@ def get_sample_size(
 
         return samples
 
-    sample_w = sample_results[contest.name][worse_winner]
-    sample_l = sample_results[contest.name][best_loser]
+    sample_w = sample_results[worse_winner]
+    sample_l = sample_results[best_loser]
 
     samples["asn"] = {
         "type": "ASN",

--- a/tests/audit_math_tests/test_bravo.py
+++ b/tests/audit_math_tests/test_bravo.py
@@ -36,7 +36,7 @@ def test_expected_sample_sizes(contests):
 
     for contest in true_asns:
         computed = bravo.get_expected_sample_sizes(
-            risk_limit, contests[contest], round0_sample_results
+            risk_limit, contests[contest], round0_sample_results[contest]
         )
         expected = true_asns[contest]
 
@@ -66,7 +66,7 @@ def test_expected_sample_sizes_second_round(contests):
     for contest in true_asns:
         expected = true_asns[contest]
         computed = bravo.get_expected_sample_sizes(
-            risk_limit, contests[contest], round1_sample_results
+            risk_limit, contests[contest], round1_sample_results[contest]
         )
 
         assert (
@@ -203,7 +203,7 @@ def test_get_sample_size(contests):
 
     for contest in contests:
         computed = bravo.get_sample_size(
-            risk_limit, contests[contest], round0_sample_results
+            risk_limit, contests[contest], round0_sample_results[contest]
         )
 
         expected = true_sample_sizes[contest]


### PR DESCRIPTION
**Description**

The `sample_results` argument in some places had an unnecessary level of nesting, and it was confusing me. All of the functions only use results for a single contest, so we standardize around that format.

Though maybe there's a reason for this that I'm missing...

**Testing**

Existing tests cover.

**Progress**

Ready for review.