### PR TITLE
Ignore wdio specs in test coverage

### DIFF
--- a/arlo-client/package.json
+++ b/arlo-client/package.json
@@ -53,7 +53,8 @@
       "!src/**/*.d.ts",
       "!src/index.tsx",
       "!src/contexts/ballotContext.ts",
-      "!src/serviceWorker.ts"
+      "!src/serviceWorker.ts",
+      "!src/test/specs/*"
     ],
     "coverageReporters": [
       "text",
@@ -66,12 +67,6 @@
         "branches": 100,
         "lines": 100,
         "functions": 100
-      },
-      "./src/test/specs/": {
-        "statements": 0,
-        "branches": 0,
-        "lines": 0,
-        "functions": 0
       }
     }
   },


### PR DESCRIPTION
**Description**

Previously, they were set to have a coverage threshold of 0%, which
was a bit confusing because they still showed up in the coverage report
as uncovered.

**Testing**

Ran coverage

**Progress**

Ready