### PR TITLE
Replace SampledBallot composite primary key with SampledBallot.id

### DIFF
--- a/arlo_server/contests.py
+++ b/arlo_server/contests.py
@@ -13,6 +13,7 @@ from arlo_server.models import (
     Round,
     RoundContest,
     SampledBallotDraw,
+    SampledBallot,
     Batch,
 )
 from arlo_server.rounds import get_current_round
@@ -132,6 +133,7 @@ def round_status_by_contest(
 
     sampled_ballot_count_by_contest = dict(
         SampledBallotDraw.query.filter_by(round_id=round.id)
+        .join(SampledBallot)
         .join(Batch)
         .join(Jurisdiction)
         .join(Jurisdiction.contests)

--- a/arlo_server/jurisdictions.py
+++ b/arlo_server/jurisdictions.py
@@ -65,6 +65,7 @@ def round_status_by_jurisdiction(
 
     sampled_ballot_count_by_jurisdiction = dict(
         SampledBallotDraw.query.filter_by(round_id=round.id)
+        .join(SampledBallot)
         .join(Batch)
         .group_by(Batch.jurisdiction_id)
         .values(Batch.jurisdiction_id, func.count())

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -174,9 +174,6 @@ class Batch(BaseModel):
     tabulator = db.Column(db.String(200), nullable=True)
 
     ballots = relationship("SampledBallot", backref="batch", passive_deletes=True)
-    ballot_draws = relationship(
-        "SampledBallotDraw", backref="batch", passive_deletes=True
-    )
 
     __table_args__ = (db.UniqueConstraint("jurisdiction_id", "name"),)
 
@@ -281,15 +278,18 @@ class Round(BaseModel):
     audit_boards = relationship("AuditBoard", backref="round", passive_deletes=True)
 
 
+# Represents a physical ballot. A ballot only gets interpreted by an audit
+# board once per audit.
 class SampledBallot(BaseModel):
+    id = db.Column(db.String(200), primary_key=True)
+
     batch_id = db.Column(
         db.String(200), db.ForeignKey("batch.id", ondelete="cascade"), nullable=False
     )
-
     # this ballot position should be 1-indexed
     ballot_position = db.Column(db.Integer, nullable=False)
 
-    __table_args__ = (db.PrimaryKeyConstraint("batch_id", "ballot_position"),)
+    __table_args__ = (db.UniqueConstraint("batch_id", "ballot_position"),)
 
     draws = relationship(
         "SampledBallotDraw", backref="sampled_ballot", passive_deletes=True
@@ -304,26 +304,22 @@ class SampledBallot(BaseModel):
     comment = db.Column(db.Text, nullable=True)
 
 
+# Represents one sampling of a ballot in a specific round. A ballot can get
+# drawn multiple times per round, so a ticket number is assigned to identify
+# each draw.
 class SampledBallotDraw(BaseModel):
-    batch_id = db.Column(
-        db.String(200), db.ForeignKey("batch.id", ondelete="cascade"), nullable=False
+    ballot_id = db.Column(
+        db.String(200),
+        db.ForeignKey("sampled_ballot.id", ondelete="cascade"),
+        nullable=False,
     )
-    ballot_position = db.Column(db.Integer, nullable=False)
-
     round_id = db.Column(
         db.String(200), db.ForeignKey("round.id", ondelete="cascade"), nullable=False
     )
     ticket_number = db.Column(db.String(200), nullable=False)
 
     __table_args__ = (
-        db.PrimaryKeyConstraint(
-            "batch_id", "ballot_position", "round_id", "ticket_number"
-        ),
-        db.ForeignKeyConstraint(
-            ["batch_id", "ballot_position"],
-            ["sampled_ballot.batch_id", "sampled_ballot.ballot_position"],
-            ondelete="cascade",
-        ),
+        db.PrimaryKeyConstraint("ballot_id", "round_id", "ticket_number"),
     )
 
 

--- a/arlo_server/rounds.py
+++ b/arlo_server/rounds.py
@@ -105,15 +105,18 @@ def sample_ballots(election: Election, round: Round, sample_size: int):
         batch_id = batch_key_to_id[batch_key]
         if times_sampled == 1:
             sampled_ballot = SampledBallot(
-                batch_id=batch_id, ballot_position=ballot_position,
+                id=str(uuid.uuid4()),
+                batch_id=batch_id,
+                ballot_position=ballot_position,
             )
             db.session.add(sampled_ballot)
+        else:
+            sampled_ballot = SampledBallot.query.filter_by(
+                batch_id=batch_id, ballot_position=ballot_position
+            ).one()
 
         sampled_ballot_draw = SampledBallotDraw(
-            batch_id=batch_id,
-            ballot_position=ballot_position,
-            round_id=round.id,
-            ticket_number=ticket_number,
+            ballot_id=sampled_ballot.id, round_id=round.id, ticket_number=ticket_number,
         )
         db.session.add(sampled_ballot_draw)
 


### PR DESCRIPTION
**Description**

Instead of using `SampledBallot.batch_id` and `SampledBallot.ballot_position` as a primary key, use a new field, `SampledBallot.id`. `SampledBallotDraw` is updated to reference this new primary key.

This is trading off having to do a few more joins for an easier to understand data model.

This sets up my next PR which adds a new model that references `SampledBallot`.

Also replaced some calls to `joinedload` with the even cooler `contains_eager`, which just tells Sqlalchemy that the joins needed for accessing relationship properties on the returned model instances are already in the query.

**Testing**

Existing tests cover (with minor modifications)

**Progress**

Ready for review.