### PR TITLE
Add test coverage to backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: backend tests
           command: |
-            make test-server
+            make test-server-coverage
       - run:
           name: frontend tests
           command: |

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+omit = 
+    app.py
+    test/*
+    create.py
+    create-org.py
+    create-admin.py
+    resetdb.py
+    config/*
+
+[report]
+fail_under = 97.47
+precision = 2
+skip_covered = true
+show_missing = true

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .mypy_cache
 .pytest_cache
 config/database.cfg
+.coverage
 
 # vim temp files
 *~

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ test-server:
 	FLASK_ENV=test ${PIPENV} run python -m pytest ${FILE} \
 		-k '${TEST}' --ignore=arlo-client -vv ${FLAGS}
 
+test-server-coverage:
+	FLAGS='--cov=. ${FLAGS}' make test-server
+
 test-math:
 	FILE=tests/audit_math_tests make test-server
 

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ mypy = "*"
 numpy-stubs = {git = "https://github.com/numpy/numpy-stubs"}
 sqlalchemy-stubs = "*"
 pytest = "*"
+pytest-cov = "*"
 pylint = "*"
 # black only has pre-releases available, so we have to specify a specific version
 # for now (or enable pre-releases for all packages, which we don't want)

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "39178746b53f8f2d856971696021a70d1de46553d4e7250b8f9ae90dcf009da5"
+            "sha256": "5bee999ce2b05e233e972a3174490c63cc1609c31f1b9d2620828b1b8e785509"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -461,6 +461,42 @@
             ],
             "version": "==7.1.1"
         },
+        "coverage": {
+            "hashes": [
+                "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a",
+                "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355",
+                "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65",
+                "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7",
+                "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9",
+                "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1",
+                "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0",
+                "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55",
+                "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c",
+                "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6",
+                "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef",
+                "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019",
+                "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e",
+                "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0",
+                "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf",
+                "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24",
+                "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2",
+                "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c",
+                "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4",
+                "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0",
+                "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd",
+                "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04",
+                "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e",
+                "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730",
+                "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2",
+                "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768",
+                "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796",
+                "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7",
+                "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a",
+                "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489",
+                "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"
+            ],
+            "version": "==5.1"
+        },
         "importlib-metadata": {
             "hashes": [
                 "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
@@ -597,6 +633,14 @@
             ],
             "index": "pypi",
             "version": "==5.4.1"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b",
+                "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"
+            ],
+            "index": "pypi",
+            "version": "==2.8.1"
         },
         "regex": {
             "hashes": [


### PR DESCRIPTION


**Description**

Sets up `pytest-cov`, and then locks in the coverage at a 97.47% coverage
threshold. Any regressions below that threshold will fail the tests on
CI.

**Testing**

N/A

**Progress**

Ready