### PR TITLE
Fix static url path

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -20,7 +20,7 @@ if FLASK_ENV not in DEVELOPMENT_ENVS:
     # throw an exception if it doesn't match one of the values in this list.
     Request.trusted_hosts = [str(urlparse(HTTP_ORIGIN).hostname)]
 
-app = Flask(__name__, static_folder=STATIC_FOLDER)
+app = Flask(__name__, static_folder=STATIC_FOLDER, static_url_path="")
 app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore
 app.testing = FLASK_ENV == "test"
 T = Talisman(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -28,7 +28,7 @@ def test_index(client):
 
 
 def test_static_logo(client):
-    rv = client.get("/public/arlo.png")
+    rv = client.get("/arlo.png")
     assert rv.status_code == 200
 
 


### PR DESCRIPTION
**Description**

`static_url_path` is set to the directory name of `static_folder` by
default. But our app already expects static files to be served from
root. This was working fine before
https://github.com/votingworks/arlo/pull/450/files.

**Testing**

Reset the existing test case to previous behavior (shouldn't have changed in the first place)

**Progress**

Ready for review.