### PR TITLE
Audit board /auth/me

### DIFF
--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Tuple
 
 from flask import jsonify, request, Response, redirect, session
 from flask_httpauth import HTTPBasicAuth
-from werkzeug.exceptions import NotFound, Forbidden
+from werkzeug.exceptions import NotFound, Forbidden, Unauthorized
 
 from audit_math import bravo, sampler_contest, sampler
 from xkcdpass import xkcd_password as xp
@@ -1212,8 +1212,18 @@ def me():
                 for j in user.jurisdictions
             ],
         )
+    elif user_type == UserType.AUDIT_BOARD:
+        audit_board = AuditBoard.query.get(user_key)
+        return jsonify(
+            type=user_type,
+            id=audit_board.id,
+            jurisdictionId=audit_board.jurisdiction_id,
+            roundId=audit_board.round_id,
+            name=audit_board.name,
+            members=serialize_members(audit_board),
+        )
     else:
-        return jsonify()
+        return Unauthorized()
 
 
 @app.route("/auth/logout")

--- a/tests/routes_tests/test_auth.py
+++ b/tests/routes_tests/test_auth.py
@@ -230,8 +230,22 @@ def test_auth_me_audit_board(
 ):
     set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
     rv = client.get("/auth/me")
+    audit_board = AuditBoard.query.get(audit_board_id)
     assert rv.status_code == 200
-    assert json.loads(rv.data) == {}
+    assert json.loads(rv.data) == {
+        "type": UserType.AUDIT_BOARD,
+        "id": audit_board.id,
+        "jurisdictionId": audit_board.jurisdiction_id,
+        "roundId": audit_board.round_id,
+        "name": audit_board.name,
+        "members": [],
+    }
+
+
+def test_auth_me_not_logged_in(client: FlaskClient,):
+    clear_logged_in_user(client)
+    rv = client.get("/auth/me")
+    assert rv.status_code == 401
 
 
 # Tests for route decorators. We have added special routes to test the


### PR DESCRIPTION
**Description**

The audit board flow needs to load the audit board info as its first request when the page loads, so we implement `/auth/me` for audit board users.

**Testing**

Modified existing test and added new test for not logged in users hitting /auth/me.

**Progress**

Ready.