### PR TITLE
Fix test coverage blob to exclude tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 omit = 
     app.py
-    test/*
+    tests/*
     create.py
     create-org.py
     create-admin.py
@@ -9,7 +9,7 @@ omit =
     config/*
 
 [report]
-fail_under = 97.47
+fail_under = 95.79
 precision = 2
 skip_covered = true
 show_missing = true


### PR DESCRIPTION
**Description**
Messed up the blob for excluding test files themselves from coverage checking.

Had to update the coverage percentage as well because a lot more code just got
excluded (previously, the tests were accidentally getting checked and
included in the total number of lines, which made the coverage
percentage appear higher than it actually was).

**Testing**

N/A

**Progress**

Ready 