### PR TITLE
added auth0 integration for superadmins

### DIFF
--- a/arlo-client/src/setupProxy.js
+++ b/arlo-client/src/setupProxy.js
@@ -13,6 +13,7 @@ const target = process.env.ARLO_BACKEND_URL || 'http://localhost:3001/'
 module.exports = function(app) {
   app.use(proxy('/auth/**', { target }))
   app.use(proxy('/admin', { target }))
+  app.use(proxy('/superadmin/**', { target }))
   app.use(proxy('/election/new', { target }))
   app.use(proxy('/election/*/audit/**', { target }))
   app.use(proxy('/election/*/settings', { target }))

--- a/arlo_server/auth.py
+++ b/arlo_server/auth.py
@@ -53,7 +53,7 @@ def set_superadmin():
 
 
 def clear_superadmin():
-    del session["_superadmin"]  # pragma: no cover
+    session["_superadmin"] = False  # pragma: no cover
 
 
 def is_superadmin():

--- a/arlo_server/auth.py
+++ b/arlo_server/auth.py
@@ -53,7 +53,7 @@ def set_superadmin():
 
 
 def clear_superadmin():
-    session["_superadmin"] = False  # pragma: no cover
+    del session["_superadmin"]  # pragma: no cover
 
 
 def is_superadmin():

--- a/arlo_server/superadmin.py
+++ b/arlo_server/superadmin.py
@@ -11,7 +11,7 @@ from arlo_server.auth import with_superadmin_access
 
 
 @app.route(
-    "/superadmin", methods=["GET"],
+    "/superadmin/", methods=["GET"],
 )
 @with_superadmin_access
 def superadmin_audits():

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -118,6 +118,23 @@ def read_http_origin() -> str:
 HTTP_ORIGIN = read_http_origin()
 
 
+def read_superadmin_auth0_creds() -> Tuple[str, str, str, str]:
+    return (
+        os.environ.get("ARLO_SUPERADMIN_AUTH0_BASE_URL", ""),
+        os.environ.get("ARLO_SUPERADMIN_AUTH0_CLIENT_ID", ""),
+        os.environ.get("ARLO_SUPERADMIN_AUTH0_CLIENT_SECRET", ""),
+        os.environ.get("ARLO_SUPERADMIN_EMAIL_DOMAIN", "voting.works"),
+    )
+
+
+(
+    SUPERADMIN_AUTH0_BASE_URL,
+    SUPERADMIN_AUTH0_CLIENT_ID,
+    SUPERADMIN_AUTH0_CLIENT_SECRET,
+    SUPERADMIN_EMAIL_DOMAIN,
+) = read_superadmin_auth0_creds()
+
+
 def read_auditadmin_auth0_creds() -> Tuple[str, str, str]:
     return (
         os.environ.get("ARLO_AUDITADMIN_AUTH0_BASE_URL", ""),

--- a/tests/routes_tests/test_auth.py
+++ b/tests/routes_tests/test_auth.py
@@ -114,6 +114,7 @@ def test_superadmin_callback(
 
     with client.session_transaction() as session:  # type: ignore
         assert session["_superadmin"]
+        assert list(session.keys()) == ["_superadmin"]
 
     assert auth0_sa.authorize_access_token.called
     assert auth0_sa.get.called
@@ -185,11 +186,13 @@ def test_audit_board_log_in(
 
 def test_logout(client: FlaskClient):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, AA_EMAIL)
+    set_superadmin(client)
 
     rv = client.get("/auth/logout")
 
     with client.session_transaction() as session:  # type: ignore
         assert session["_user"] is None
+        assert "_superadmin" not in session.keys()
 
     assert rv.status_code == 302
 


### PR DESCRIPTION
Same approach we've taken for OAuth URLs, now for superadmins, with its own independent tenant. Difference is this manages a separate session variable and sends the user to a different URL, `/superadmin/`.