### PR TITLE
docs: fe_sendauth issue can require IPv6 trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,4 +173,9 @@ For testing:
 - `pipenv install` can hang attempting to get [a lock on the packages it's installing](https://github.com/pypa/pipenv/issues/3827). To get around this, add the `--skip-lock` flag in the Makefile (the first line should be `pipenv install --skip-lock`).
 - A password may have to be set in `config/database.cfg` depending on your install of postgres. To do this, change `postgres://postgres@localhost:5432/arlo` to `postgres://postgres:{PASSWORD}@localhost:5432/arlo`, replacing `{PASSWORD}` with the password.
 - You may need to create `arlo` and `arlo-test` databases manually [via postgres](https://www.postgresql.org/docs/9.0/sql-createdatabase.html).
-- If you run into the error `fe_sendauth: no password supplied` when running `make dev-environment`, it means there's no password set for the default postgres user. You can change the postgres authentication method to not require a password by editing `/etc/postgresql/10/main/pg_hba.conf` and changing `md5` to `trust` for the IPv4 local connections setting.
+- If you run into the error `fe_sendauth: no password supplied` when running
+  `make dev-environment`, it means there's no password set for the default
+  postgres user. You can change the postgres authentication method to not
+  require a password by editing `/etc/postgresql/10/main/pg_hba.conf` and
+  changing `md5` to `trust` for both the IPv4 and IPv6 local connections
+  settings, and then restart postgres via `sudo systemctl restart postgresql`.


### PR DESCRIPTION
**Description**

When running `make resetdb` on a Chromebook Crostini virtual environment with
the default Debian 10.2 Linux, I ran into the `fe_sendauth: no password supplied`
error noted in the README. But changing to `trust` for just IPv4 in 
`/etc/postgresql/11/main/pg_hba.conf` didn't resolve the issue.
When I changed to `trust` for IPv6 also, the make succeeded.
So I guess connections are being made via IPv6 in some configurations.
Note also that this was with Postgresql version 11, default on Debian.

The troubleshooting tip now also describes one way to reload the postgres configs,
which is also necessary.

**Testing**
Documentation-only change