### PR TITLE
Fix jurisdiction url proxy patterns

### DIFF
--- a/arlo-client/src/setupProxy.js
+++ b/arlo-client/src/setupProxy.js
@@ -20,9 +20,9 @@ module.exports = function(app) {
   app.use(proxy('/election/*/sample-sizes', { target }))
   app.use(proxy('/election/*/contest', { target }))
   app.use(proxy('/election/*/round', { target }))
-  app.use(proxy('/election/*/jurisdiction', { target }))
-  app.use(proxy('/election/*/jurisdiction/**', { target }))
-  app.use(proxy('/election/*/jurisdictions/**', { target }))
+  app.use(proxy('/election/*/jurisdictions', { target }))
+  app.use(proxy('/election/*/jurisdiction/file', { target }))
+  app.use(proxy('/election/*/jurisdiction/*/**', { target }))
   app.use(proxy('/election/*/admin/**', { target }))
   app.use(proxy('/auditboard/*', { target }))
 }

--- a/arlo-client/src/setupProxy.js
+++ b/arlo-client/src/setupProxy.js
@@ -21,6 +21,7 @@ module.exports = function(app) {
   app.use(proxy('/election/*/contest', { target }))
   app.use(proxy('/election/*/round', { target }))
   app.use(proxy('/election/*/jurisdictions', { target }))
+  app.use(proxy('/election/*/jurisdiction', { target }))
   app.use(proxy('/election/*/jurisdiction/file', { target }))
   app.use(proxy('/election/*/jurisdiction/*/**', { target }))
   app.use(proxy('/election/*/admin/**', { target }))


### PR DESCRIPTION
**Description**

#491 introduced a bug because the new route it created for JAs `/election/:electionId/jurisdiction/:jurisdictionId` matched the proxy patterns. This updates the proxy patterns to exclude that route.

**Testing**

Manual test

**Progress**

Ready