### PR TITLE
Download paths for jurisdictions file and ballot manifest in API

### DIFF
--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -340,11 +340,22 @@ def get_jurisdictions_file(election: Election):
 
     if jurisdictions_file:
         return jsonify(
-            file=serialize_file(jurisdictions_file, contents=True),
+            file=serialize_file(jurisdictions_file),
             processing=serialize_file_processing(jurisdictions_file),
         )
     else:
         return jsonify(file=None, processing=None)
+
+
+@app.route("/election/<election_id>/jurisdiction/file/csv", methods=["GET"])
+@with_election_access
+def download_jurisdictions_file(election: Election):
+    if not election.jurisdictions_file:
+        return NotFound()
+
+    return csv_response(
+        election.jurisdictions_file.contents, election.jurisdictions_file.name
+    )
 
 
 @app.route("/election/<election_id>/jurisdiction/file", methods=["PUT"])

--- a/util/process_file.py
+++ b/util/process_file.py
@@ -47,16 +47,11 @@ def process_file(session: Session, file: File, callback: Callable[[], None]) -> 
         return True
 
 
-def serialize_file(file: File, contents=False) -> Dict[str, Any]:
-    result = {
+def serialize_file(file: File) -> Dict[str, Any]:
+    return {
         "name": file.name,
         "uploadedAt": isoformat(file.uploaded_at),
     }
-
-    if contents:
-        result["contents"] = file.contents
-
-    return result
 
 
 def serialize_file_processing(file: File) -> Dict[str, Any]:


### PR DESCRIPTION
**Description**

Adds two new endpoints, both with AA permissions:
- `GET /election/<election_id>/jurisdiction/file/csv` - downloads the jurisdictions file
- `GET /election/<election_id>/jurisdiction/<jurisdiction_id>/ballot-manifest/csv` - downloads the jurisdiction's ballot manifest file

**Testing**

Added tests to cover

**Progress**

Ready