### PR TITLE
Fixing the download sheets

### DIFF
--- a/arlo-client/src/components/Audit/RoundManagement/QRs.tsx
+++ b/arlo-client/src/components/Audit/RoundManagement/QRs.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import QRCode from 'qrcode.react'
+import styled from 'styled-components'
+
+const QRroot = styled.div`
+  display: none;
+`
+
+const QRs: React.FC<{ electionId: string; boardIds: string[] }> = ({
+  electionId,
+  boardIds,
+}: {
+  electionId: string
+  boardIds: string[]
+}) => {
+  return (
+    <QRroot id="qr-root">
+      {boardIds.map(id => (
+        <span key={id} id={`qr-${id}`}>
+          <QRCode
+            value={`${window.location.origin}/election/${electionId}/audit-board/${id}`}
+            size={200}
+          />
+        </span>
+      ))}
+    </QRroot>
+  )
+}
+
+export default QRs

--- a/arlo-client/src/components/Audit/RoundManagement/QRs.tsx
+++ b/arlo-client/src/components/Audit/RoundManagement/QRs.tsx
@@ -6,19 +6,17 @@ const QRroot = styled.div`
   display: none;
 `
 
-const QRs: React.FC<{ electionId: string; boardIds: string[] }> = ({
-  electionId,
-  boardIds,
+const QRs: React.FC<{ passphrases: string[] }> = ({
+  passphrases,
 }: {
-  electionId: string
-  boardIds: string[]
+  passphrases: string[]
 }) => {
   return (
     <QRroot id="qr-root">
-      {boardIds.map(id => (
-        <span key={id} id={`qr-${id}`}>
+      {passphrases.map(passphrase => (
+        <span key={passphrase} id={`qr-${passphrase}`}>
           <QRCode
-            value={`${window.location.origin}/election/${electionId}/audit-board/${id}`}
+            value={`${window.location.origin}/auditboard/${passphrase}`}
             size={200}
           />
         </span>

--- a/arlo-client/src/components/Audit/RoundManagement/generateSheets.ts
+++ b/arlo-client/src/components/Audit/RoundManagement/generateSheets.ts
@@ -75,7 +75,7 @@ export const downloadDataEntry = (auditBoards: IAuditBoard[]): void => {
   const auditBoardCreds = new jsPDF({ format: 'letter' })
   auditBoards.forEach((board, i) => {
     const qr: HTMLCanvasElement | null = document.querySelector(
-      `#qr-${board.id} > canvas`
+      `#qr-${board.passphrase} > canvas`
     )
     /* istanbul ignore else */
     if (qr) {

--- a/arlo-client/src/components/Audit/RoundManagement/index.tsx
+++ b/arlo-client/src/components/Audit/RoundManagement/index.tsx
@@ -17,6 +17,7 @@ import {
   downloadDataEntry,
 } from './generateSheets'
 import { IAuditBoard } from '../useAuditBoards'
+import QRs from './QRs'
 
 interface IProps {
   round: IRound
@@ -34,13 +35,13 @@ const RoundManagement = ({ round, auditBoards, createAuditBoards }: IProps) => {
   useEffect(() => {
     ;(async () => {
       try {
-        const response: { ballots: IBallot[] } | IErrorResponse = await api(
+        const response: { ballotDraws: IBallot[] } | IErrorResponse = await api(
           `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${round.id}/ballot-draws`
         )
         // checkAndToast left here for consistency and reference but not tested since it's vestigial
         /* istanbul ignore next */
         if (checkAndToast(response)) return
-        setBallots(response.ballots)
+        setBallots(response.ballotDraws)
       } catch (err) /* istanbul ignore next */ {
         // TEST TODO
         toast.error(err.message)
@@ -84,6 +85,10 @@ const RoundManagement = ({ round, auditBoards, createAuditBoards }: IProps) => {
               Download Ballot Labels for Round {roundNum}
             </FormButton>
             {/* make conditional on online */}
+            <QRs
+              electionId={electionId}
+              boardIds={auditBoards.map(b => b.id)}
+            />
             <FormButton
               verticalSpaced
               onClick={() => downloadDataEntry(auditBoards)}

--- a/arlo-client/src/components/Audit/RoundManagement/index.tsx
+++ b/arlo-client/src/components/Audit/RoundManagement/index.tsx
@@ -85,10 +85,7 @@ const RoundManagement = ({ round, auditBoards, createAuditBoards }: IProps) => {
               Download Ballot Labels for Round {roundNum}
             </FormButton>
             {/* make conditional on online */}
-            <QRs
-              electionId={electionId}
-              boardIds={auditBoards.map(b => b.id)}
-            />
+            <QRs passphrases={auditBoards.map(b => b.passphrase)} />
             <FormButton
               verticalSpaced
               onClick={() => downloadDataEntry(auditBoards)}


### PR DESCRIPTION
**Description**

- Added in the invisible QR code element so it could be grabbed and injected into the sheet.
- Corrected the expected return from `/ballot-draws` to have `{ ballotDraws: [] }` instead of `{ ballots: [] }` so the other sheets would generate.

**Testing**

- none yet

**Progress**

- It works for me.
