### PR TITLE
default to serving react

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -5,7 +5,6 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from urllib.parse import urlparse
 
 from config import (
-    STATIC_FOLDER,
     SESSION_SECRET,
     DATABASE_URL,
     FLASK_ENV,
@@ -20,7 +19,7 @@ if FLASK_ENV not in DEVELOPMENT_ENVS:
     # throw an exception if it doesn't match one of the values in this list.
     Request.trusted_hosts = [str(urlparse(HTTP_ORIGIN).hostname)]
 
-app = Flask(__name__, static_folder=STATIC_FOLDER, static_url_path="")
+app = Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore
 app.testing = FLASK_ENV == "test"
 T = Talisman(
@@ -59,6 +58,9 @@ import arlo_server.rounds
 import arlo_server.audit_boards
 import arlo_server.ballots
 import arlo_server.superadmin
+
+# static
+import arlo_server.static
 
 # Error handlers
 import arlo_server.errors

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -1338,11 +1338,3 @@ def jurisdictionadmin_login_callback():
             set_loggedin_user(UserType.JURISDICTION_ADMIN, userinfo["email"])
 
     return redirect("/")
-
-
-# React App
-@app.route("/")
-@app.route("/election/<election_id>")
-@app.route("/election/<election_id>/board/<board_id>")
-def serve(election_id=None, board_id=None):  # pylint: disable=unused-argument
-    return app.send_static_file("index.html")

--- a/arlo_server/static.py
+++ b/arlo_server/static.py
@@ -1,0 +1,14 @@
+import os
+from flask import send_from_directory
+
+from config import STATIC_FOLDER
+from arlo_server import app
+
+# Serve the React App at remaining URLs that aren't static files
+@app.route("/")
+@app.route("/<path:path>")
+def serve(path="index.html"):
+    if os.path.exists(os.path.join(STATIC_FOLDER, path)):
+        return send_from_directory(STATIC_FOLDER, path)
+    else:
+        return send_from_directory(STATIC_FOLDER, "index.html")


### PR DESCRIPTION

I think we should move to all APIs served from `/api` to make this easier to manage over time, but I believe this approach will work just fine for now.