### PR TITLE
remove default static folder handling

### DIFF
--- a/arlo_server/__init__.py
+++ b/arlo_server/__init__.py
@@ -19,7 +19,7 @@ if FLASK_ENV not in DEVELOPMENT_ENVS:
     # throw an exception if it doesn't match one of the values in this list.
     Request.trusted_hosts = [str(urlparse(HTTP_ORIGIN).hostname)]
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder=None)
 app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore
 app.testing = FLASK_ENV == "test"
 T = Talisman(


### PR DESCRIPTION

Mixing our static handling and Flask's was a bad idea. Turning off Flask's.