### PR TITLE
Reload ballots after audit board creation

### DIFF
--- a/arlo-client/src/components/Audit/RoundManagement/generateSheets.ts
+++ b/arlo-client/src/components/Audit/RoundManagement/generateSheets.ts
@@ -31,7 +31,7 @@ export const downloadLabels = async (
         y[0]
       )
       labels.text(
-        labels.splitTextToSize(`Batch Name: ${ballot.batch!.name}`, 60),
+        labels.splitTextToSize(`Batch Name: ${ballot.batch.name}`, 60),
         x,
         y[1]
       )
@@ -59,7 +59,7 @@ export const downloadPlaceholders = async (
         20
       )
       placeholders.text(
-        placeholders.splitTextToSize(`Batch Name: ${ballot.batch!.name}`, 180),
+        placeholders.splitTextToSize(`Batch Name: ${ballot.batch.name}`, 180),
         20,
         40
       )

--- a/arlo-client/src/components/Audit/RoundManagement/index.tsx
+++ b/arlo-client/src/components/Audit/RoundManagement/index.tsx
@@ -47,7 +47,14 @@ const RoundManagement = ({ round, auditBoards, createAuditBoards }: IProps) => {
         toast.error(err.message)
       }
     })()
-  }, [electionId, jurisdictionId, round])
+  }, [
+    electionId,
+    jurisdictionId,
+    round,
+    // We need to reload the ballots after we create the audit boards in order
+    // to populate ballot.auditBoard
+    auditBoards,
+  ])
 
   // const [{ online }] = useAuditSettings(electionId!)
 


### PR DESCRIPTION


**Description**

`ballot.auditBoard` is null until the audit boards get created, so we
need to reload the ballots after we create the audit boards.

**Testing**

Manually tested

**Progress**

Ready