### PR TITLE
Audit board list ballots endpoint

### DIFF
--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -259,7 +259,7 @@ class AuditBoard(BaseModel):
         "SampledBallot",
         backref="audit_board",
         passive_deletes=True,
-        order_by="SampledBallot.batch_id, SampledBallot.ballot_position",
+        order_by="SampledBallot.id",
     )
 
     __table_args__ = (db.UniqueConstraint("jurisdiction_id", "round_id", "name"),)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -31,6 +31,9 @@ from arlo_server.audit_boards import end_round
 SAMPLE_SIZE_ROUND_1 = 119  # Bravo sample size
 J1_SAMPLES_ROUND_1 = 81
 J1_SAMPLES_ROUND_2 = 280  # 90% probability sample size
+AB1_BALLOTS_ROUND_1 = 50
+AB2_BALLOTS_ROUND_1 = 25
+AB1_BALLOTS_ROUND_2 = 150
 
 DEFAULT_AA_EMAIL = "admin@example.com"
 DEFAULT_JA_EMAIL = "jurisdiction.admin@example.com"


### PR DESCRIPTION
**Description**

A new endpoint that returns the sampled ballots, not sampled ballot draws, for an audit board. They only need to know about the unique ballots, not the samples (which might include the same ballot multiple times).

**Testing**

Added new tests

**Progress**

Ready