### PR TITLE
Remove create audit form on login screen

### DIFF
--- a/arlo-client/src/App.tsx
+++ b/arlo-client/src/App.tsx
@@ -21,6 +21,7 @@ import CreateAudit from './components/CreateAudit'
 import 'react-toastify/dist/ReactToastify.css'
 import AuthDataProvider, { AuthDataContext } from './components/UserContext'
 import { IUserMeta } from './types'
+import CreateSingleJurisdictionAudit from './CreateSingleJurisdictionAudit'
 
 const Main = styled.div`
   display: flex;
@@ -68,6 +69,11 @@ const App: React.FC = () => {
           <Route path="/" component={Header} />
           <Switch>
             <Route exact path="/" component={CreateAudit} />
+            <Route
+              exact
+              path="/audit"
+              component={CreateSingleJurisdictionAudit}
+            />
             <Route
               path="/audit/:electionId"
               component={SingleJurisdictionAudit}

--- a/arlo-client/src/CreateSingleJurisdictionAudit.tsx
+++ b/arlo-client/src/CreateSingleJurisdictionAudit.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react'
+import { toast } from 'react-toastify'
+import { Formik, FormikProps, Field } from 'formik'
+import { RouteComponentProps } from 'react-router-dom'
+import styled from 'styled-components'
+import FormSection from './components/Atoms/Form/FormSection'
+import FormField from './components/Atoms/Form/FormField'
+import { api } from './components/utilities'
+import FormButton from './components/Atoms/Form/FormButton'
+
+interface IValues {
+  auditName: string
+}
+
+const Button = styled(FormButton)`
+  margin: 30px 0 0 0;
+`
+
+const CenterField = styled(FormField)`
+  width: 100%;
+`
+
+const Wrapper = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  @media (min-width: 500px) {
+    width: 400px;
+  }
+`
+
+const CreateSingleJurisdictionAudit = ({ history }: RouteComponentProps) => {
+  const [loading, setLoading] = useState(false)
+  const onSubmit = async ({ auditName }: IValues) => {
+    try {
+      setLoading(true)
+      const response: { electionId: string } = await api('/election/new', {
+        method: 'POST',
+        body: JSON.stringify({ auditName, isMultiJurisdiction: false }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+      const { electionId } = response
+      history.push(`/audit/${electionId}/setup`)
+    } catch (err) {
+      toast.error(err.message)
+      setLoading(false)
+    }
+  }
+  return (
+    <Wrapper>
+      <img height="50px" src="/arlo.png" alt="Arlo, by VotingWorks" />
+      <Formik onSubmit={onSubmit} initialValues={{ auditName: '' }}>
+        {({ handleSubmit }: FormikProps<IValues>) => (
+          <>
+            <FormSection>
+              {/* eslint-disable jsx-a11y/label-has-associated-control */}
+              <label htmlFor="audit-name" id="audit-name-label">
+                Give your new audit a unique name.
+                <Field
+                  id="audit-name"
+                  aria-labelledby="audit-name-label"
+                  name="auditName"
+                  disabled={loading}
+                  validate={(v: string) => (v ? undefined : 'Required')}
+                  component={CenterField}
+                />
+              </label>
+            </FormSection>
+            <Button
+              type="button"
+              intent="primary"
+              fill
+              large
+              onClick={handleSubmit}
+              loading={loading}
+              disabled={loading}
+            >
+              Create a New Audit
+            </Button>
+          </>
+        )}
+      </Formik>
+    </Wrapper>
+  )
+}
+
+export default CreateSingleJurisdictionAudit

--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -4,8 +4,8 @@ import { toast } from 'react-toastify'
 import { RouteComponentProps, Link } from 'react-router-dom'
 import { Formik, FormikProps, Field } from 'formik'
 import FormButton from './Atoms/Form/FormButton'
-import { api, checkAndToast } from './utilities'
-import { ICreateAuditParams, IErrorResponse } from '../types'
+import { api } from './utilities'
+import { ICreateAuditParams } from '../types'
 import { useAuthDataContext } from './UserContext'
 import FormSection from './Atoms/Form/FormSection'
 import FormField from './Atoms/Form/FormField'
@@ -49,34 +49,22 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
   const onSubmit = async ({ auditName }: IValues) => {
     try {
       setLoading(true)
-      const data = isAuthenticated
-        ? {
-            organizationId: meta!.organizations[0].id,
-            auditName,
-            isMultiJurisdiction: true,
-          }
-        : { auditName, isMultiJurisdiction: false }
-      const response: { electionId: string } | IErrorResponse = await api(
-        '/election/new',
-        {
-          method: 'POST',
-          body: JSON.stringify(data),
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
-      )
-      if (checkAndToast(response)) {
-        return
-      }
+      const response: { electionId: string } = await api('/election/new', {
+        method: 'POST',
+        body: JSON.stringify({
+          organizationId: meta!.organizations[0].id,
+          auditName,
+          isMultiJurisdiction: true,
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
       const { electionId } = response
-      if (isAuthenticated) {
-        history.push(`/election/${electionId}/setup`)
-      } else {
-        history.push(`/audit/${electionId}/setup`)
-      }
+      history.push(`/election/${electionId}/setup`)
     } catch (err) {
       toast.error(err.message)
+      setLoading(false)
     }
   }
 
@@ -87,8 +75,7 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
   return (
     <Wrapper>
       <img height="50px" src="/arlo.png" alt="Arlo, by VotingWorks" />
-      {(!isAuthenticated ||
-        (isAuthenticated && meta!.type === 'audit_admin')) && (
+      {isAuthenticated && meta!.type === 'audit_admin' && (
         <Formik onSubmit={onSubmit} initialValues={{ auditName: '' }}>
           {({ handleSubmit }: FormikProps<IValues>) => (
             <>


### PR DESCRIPTION

**Description**

Now the single-jurisdiction flow create audit form lives at `/audit`.

**Testing**

Manually tested

**Progress**

Ready