### PR TITLE
Improve frontend api request error handling

### DIFF
--- a/arlo-client/src/components/utilities.ts
+++ b/arlo-client/src/components/utilities.ts
@@ -2,9 +2,9 @@ import { toast } from 'react-toastify'
 import number from '../utils/number-schema'
 import { IErrorResponse } from '../types'
 
-const tryJson = async (response: Response) => {
+const tryJson = (responseText: string) => {
   try {
-    return await response.json()
+    return JSON.parse(responseText)
   } catch (err) {
     return {}
   }
@@ -16,8 +16,12 @@ export const api = async <T>(
 ): Promise<T> => {
   const response = await fetch(endpoint, options)
   if (!response.ok) {
-    const { errors } = await tryJson(response)
-    const errorData = { ...errors[0], response }
+    const responseText = await response.text()
+    const { errors } = tryJson(responseText)
+    const error =
+      errors && errors.length ? errors[0] : { message: response.statusText }
+    const errorData = { ...error, responseText, response }
+    console.error(responseText)
     throw errorData
   }
   return response.json() as Promise<T>


### PR DESCRIPTION
**Description**

Not all errors come back in the same format from the server.

`4xx` errors have a body of the format: `{ errors: [{ message: "..." }]}`
`404` errors have an HTML body with a 404 page
`500` errors have an HTML body with a stack trace

This at least makes sure we can catch all of them, toast a relevant
message, and log the full response body to the console for debugging.


**Testing**

Manually tested

**Progress**

Ready