### PR TITLE
Jurisdiction file upload error handling

### DIFF
--- a/arlo-client/src/components/Audit/useSetupMenuItems/getJurisdictionFileStatus.ts
+++ b/arlo-client/src/components/Audit/useSetupMenuItems/getJurisdictionFileStatus.ts
@@ -1,6 +1,4 @@
-import { toast } from 'react-toastify'
-import { api, checkAndToast } from '../../utilities'
-import { IErrorResponse } from '../../../types'
+import { api } from '../../utilities'
 
 export enum FileProcessingStatus {
   Blank = 'NULL', // only returned from getJurisdictionFileStatus, represents the null state from the server
@@ -26,27 +24,14 @@ export interface IJurisdictionsFileResponse {
 
 const getJurisdictionFileStatus = async (
   electionId: string
-): Promise<FileProcessingStatus> => {
+): Promise<{ status: FileProcessingStatus; error: string | null } | null> => {
   try {
-    const jurisdictionsOrError:
-      | IJurisdictionsFileResponse
-      | IErrorResponse = await api(`/election/${electionId}/jurisdiction/file`)
-    if (checkAndToast(jurisdictionsOrError)) {
-      return FileProcessingStatus.Errored
-    }
-    if (jurisdictionsOrError.processing) {
-      if (
-        jurisdictionsOrError.processing!.status ===
-        FileProcessingStatus.ReadyToProcess
-      ) {
-        return FileProcessingStatus.Processing
-      }
-      return jurisdictionsOrError.processing!.status
-    }
-    return FileProcessingStatus.Blank
+    const fileStatus: IJurisdictionsFileResponse = await api(
+      `/election/${electionId}/jurisdiction/file`
+    )
+    return fileStatus.processing
   } catch (err) {
-    toast.error(err.message)
-    return FileProcessingStatus.Errored
+    return { status: FileProcessingStatus.Errored, error: err.message }
   }
 }
 

--- a/arlo-client/src/components/utilities.ts
+++ b/arlo-client/src/components/utilities.ts
@@ -37,13 +37,17 @@ export const poll = (
   const endTime = Date.now() + timeout
   ;(async function p() {
     const time = Date.now()
-    const done = await condition()
-    if (done) {
-      callback()
-    } else if (time < endTime) {
-      setTimeout(p, interval)
-    } else {
-      errback(new Error(`Timed out`))
+    try {
+      const done = await condition()
+      if (done) {
+        callback()
+      } else if (time < endTime) {
+        setTimeout(p, interval)
+      } else {
+        errback(new Error(`Timed out`))
+      }
+    } catch (err) {
+      errback(err)
     }
   })()
 }


### PR DESCRIPTION
**Description**

- Make sure the polling stops when an error happens on the backend 
- Bubble up the error to somewhere where it can get toasted

Doesn't get rid of the spinners on error, but that would take more refactoring.

**Testing**

Manually tested

**Progress**

Ready