### PR TITLE
fix: detect CSV file encoding

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ black = "==19.10b0"
 
 [packages]
 authlib = "*"
+chardet = "*"
 consistent_sampler = "*"
 cryptorandom = "*"
 flask = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5bee999ce2b05e233e972a3174490c63cc1609c31f1b9d2620828b1b8e785509"
+            "sha256": "8ff69ab83c0fa8ac0543d6bf808917e39f5c9423ad95cc50f5d83fe02697cd13"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,11 +25,11 @@
         },
         "authlib": {
             "hashes": [
-                "sha256:89d55b14362f8acee450f9d153645e438e3a38be99b599190718c4406f575b05",
-                "sha256:b6d3f59f609d352bff26dce2c7969cff7204213fae1c21742037b7aa8d7360a6"
+                "sha256:94958661bd9e1c236a43719f00c5e6da2b7a773bd7350961be9fd9f3298da658",
+                "sha256:f07f373fd08994a1638f8f09ffc09d4f13c5eab4d070c5c9307745fb178a65ec"
             ],
             "index": "pypi",
-            "version": "==0.14.1"
+            "version": "==0.14.2"
         },
         "certifi": {
             "hashes": [
@@ -76,14 +76,15 @@
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
+            "index": "pypi",
             "version": "==3.0.4"
         },
         "click": {
             "hashes": [
-                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
-                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "version": "==7.1.1"
+            "version": "==7.1.2"
         },
         "consistent-sampler": {
             "hashes": [
@@ -135,11 +136,11 @@
         },
         "flask-httpauth": {
             "hashes": [
-                "sha256:0149953720489407e51ec24bc2f86273597b7973d71cd51f9443bd0e2a89bd72",
-                "sha256:6ef8b761332e780f9ff74d5f9056c2616f52babc1998b01d9f361a1e439e61b9"
+                "sha256:067768dbed7b68b2a0172453eaad64648cd6b004b8a2a3912f363050532d11c3",
+                "sha256:47d62edc33ff16798ed28e06a7387ed10a15f21249c5f61515b41351356a6afc"
             ],
             "index": "pypi",
-            "version": "==3.3.0"
+            "version": "==4.0.0"
         },
         "flask-sqlalchemy": {
             "hashes": [
@@ -242,30 +243,30 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:0aa2b318cf81eb1693fcfcbb8007e95e231d7e1aa24288137f3b19905736c3ee",
-                "sha256:163c78c04f47f26ca1b21068cea25ed7c5ecafe5f5ab2ea4895656a750582b56",
-                "sha256:1e37626bcb8895c4b3873fcfd54e9bfc5ffec8d0f525651d6985fcc5c6b6003c",
-                "sha256:264fd15590b3f02a1fbc095e7e1f37cdac698ff3829e12ffdcffdce3772f9d44",
-                "sha256:3d9e1554cd9b5999070c467b18e5ae3ebd7369f02706a8850816f576a954295f",
-                "sha256:40c24960cd5cec55222963f255858a1c47c6fa50a65a5b03fd7de75e3700eaaa",
-                "sha256:46f404314dbec78cb342904f9596f25f9b16e7cf304030f1339e553c8e77f51c",
-                "sha256:4847f0c993298b82fad809ea2916d857d0073dc17b0510fbbced663b3265929d",
-                "sha256:48e15612a8357393d176638c8f68a19273676877caea983f8baf188bad430379",
-                "sha256:6725d2797c65598778409aba8cd67077bb089d5b7d3d87c2719b206dc84ec05e",
-                "sha256:99f0ba97e369f02a21bb95faa3a0de55991fd5f0ece2e30a9e2eaebeac238921",
-                "sha256:a41f303b3f9157a31ce7203e3ca757a0c40c96669e72d9b6ee1bce8507638970",
-                "sha256:a4305564e93f5c4584f6758149fd446df39fd1e0a8c89ca0deb3cce56106a027",
-                "sha256:a551d8cc267c634774830086da42e4ba157fa41dd3b93982bc9501b284b0c689",
-                "sha256:a6bc9432c2640b008d5f29bad737714eb3e14bb8854878eacf3d7955c4e91c36",
-                "sha256:c60175d011a2e551a2f74c84e21e7c982489b96b6a5e4b030ecdeacf2914da68",
-                "sha256:e46e2384209c91996d5ec16744234d1c906ab79a701ce1a26155c9ec890b8dc8",
-                "sha256:e607b8cdc2ae5d5a63cd1bec30a15b5ed583ac6a39f04b7ba0f03fcfbf29c05b",
-                "sha256:e94a39d5c40fffe7696009dbd11bc14a349b377e03a384ed011e03d698787dd3",
-                "sha256:eb2286249ebfe8fcb5b425e5ec77e4736d53ee56d3ad296f8947f67150f495e3",
-                "sha256:fdee7540d12519865b423af411bd60ddb513d2eb2cd921149b732854995bbf8b"
+                "sha256:00d7b54c025601e28f468953d065b9b121ddca7fff30bed7be082d3656dd798d",
+                "sha256:02ec9582808c4e48be4e93cd629c855e644882faf704bc2bd6bbf58c08a2a897",
+                "sha256:0e6f72f7bb08f2f350ed4408bb7acdc0daba637e73bce9f5ea2b207039f3af88",
+                "sha256:1be2e96314a66f5f1ce7764274327fd4fb9da58584eaff00b5a5221edefee7d6",
+                "sha256:2466fbcf23711ebc5daa61d28ced319a6159b260a18839993d871096d66b93f7",
+                "sha256:2b573fcf6f9863ce746e4ad00ac18a948978bb3781cffa4305134d31801f3e26",
+                "sha256:3f0dae97e1126f529ebb66f3c63514a0f72a177b90d56e4bce8a0b5def34627a",
+                "sha256:50fb72bcbc2cf11e066579cb53c4ca8ac0227abb512b6cbc1faa02d1595a2a5d",
+                "sha256:57aea170fb23b1fd54fa537359d90d383d9bf5937ee54ae8045a723caa5e0961",
+                "sha256:709c2999b6bd36cdaf85cf888d8512da7433529f14a3689d6e37ab5242e7add5",
+                "sha256:7d59f21e43bbfd9a10953a7e26b35b6849d888fc5a331fa84a2d9c37bd9fe2a2",
+                "sha256:904b513ab8fbcbdb062bed1ce2f794ab20208a1b01ce9bd90776c6c7e7257032",
+                "sha256:96dd36f5cdde152fd6977d1bbc0f0561bccffecfde63cd397c8e6033eb66baba",
+                "sha256:9933b81fecbe935e6a7dc89cbd2b99fea1bf362f2790daf9422a7bb1dc3c3085",
+                "sha256:bbcc85aaf4cd84ba057decaead058f43191cc0e30d6bc5d44fe336dc3d3f4509",
+                "sha256:dccd380d8e025c867ddcb2f84b439722cf1f23f3a319381eac45fd077dee7170",
+                "sha256:e22cd0f72fc931d6abc69dc7764484ee20c6a60b0d0fee9ce0426029b1c1bdae",
+                "sha256:ed722aefb0ebffd10b32e67f48e8ac4c5c4cf5d3a785024fdf0e9eb17529cd9d",
+                "sha256:efb7ac5572c9a57159cf92c508aad9f856f1cb8e8302d7fdb99061dbe52d712c",
+                "sha256:efdba339fffb0e80fcc19524e4fdbda2e2b5772ea46720c44eaac28096d60720",
+                "sha256:f22273dd6a403ed870207b853a856ff6327d5cbce7a835dfa0645b3fc00273ec"
             ],
             "index": "pypi",
-            "version": "==1.18.3"
+            "version": "==1.18.4"
         },
         "psycopg2-binary": {
             "hashes": [
@@ -359,34 +360,43 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:083e383a1dca8384d0ea6378bd182d83c600ed4ff4ec8247d3b2442cf70db1ad",
-                "sha256:0a690a6486658d03cc6a73536d46e796b6570ac1f8a7ec133f9e28c448b69828",
-                "sha256:114b6ace30001f056e944cebd46daef38fdb41ebb98f5e5940241a03ed6cad43",
-                "sha256:128f6179325f7597a46403dde0bf148478f868df44841348dfc8d158e00db1f9",
-                "sha256:13d48cd8b925b6893a4e59b2dfb3e59a5204fd8c98289aad353af78bd214db49",
-                "sha256:211a1ce7e825f7142121144bac76f53ac28b12172716a710f4bf3eab477e730b",
-                "sha256:2dc57ee80b76813759cccd1a7affedf9c4dbe5b065a91fb6092c9d8151d66078",
-                "sha256:3e625e283eecc15aee5b1ef77203bfb542563fa4a9aa622c7643c7b55438ff49",
-                "sha256:43078c7ec0457387c79b8d52fff90a7ad352ca4c7aa841c366238c3e2cf52fdf",
-                "sha256:5b1bf3c2c2dca738235ce08079783ef04f1a7fc5b21cf24adaae77f2da4e73c3",
-                "sha256:6056b671aeda3fc451382e52ab8a753c0d5f66ef2a5ccc8fa5ba7abd20988b4d",
-                "sha256:68d78cf4a9dfade2e6cf57c4be19f7b82ed66e67dacf93b32bb390c9bed12749",
-                "sha256:7025c639ce7e170db845e94006cf5f404e243e6fc00d6c86fa19e8ad8d411880",
-                "sha256:7224e126c00b8178dfd227bc337ba5e754b197a3867d33b9f30dc0208f773d70",
-                "sha256:7d98e0785c4cd7ae30b4a451416db71f5724a1839025544b4edbd92e00b91f0f",
-                "sha256:8d8c21e9d4efef01351bf28513648ceb988031be4159745a7ad1b3e28c8ff68a",
-                "sha256:bbb545da054e6297242a1bb1ba88e7a8ffb679f518258d66798ec712b82e4e07",
-                "sha256:d00b393f05dbd4ecd65c989b7f5a81110eae4baea7a6a4cdd94c20a908d1456e",
-                "sha256:e18752cecaef61031252ca72031d4d6247b3212ebb84748fc5d1a0d2029c23ea"
+                "sha256:128bc917ed20d78143a45024455ff0aed7d3b96772eba13d5dbaf9cc57e5c41b",
+                "sha256:156a27548ba4e1fed944ff9fcdc150633e61d350d673ae7baaf6c25c04ac1f71",
+                "sha256:27e2efc8f77661c9af2681755974205e7462f1ae126f498f4fe12a8b24761d15",
+                "sha256:2a12f8be25b9ea3d1d5b165202181f2b7da4b3395289000284e5bb86154ce87c",
+                "sha256:31c043d5211aa0e0773821fcc318eb5cbe2ec916dfbc4c6eea0c5188971988eb",
+                "sha256:65eb3b03229f684af0cf0ad3bcc771970c1260a82a791a8d07bffb63d8c95bcc",
+                "sha256:6cd157ce74a911325e164441ff2d9b4e244659a25b3146310518d83202f15f7a",
+                "sha256:703c002277f0fbc3c04d0ae4989a174753a7554b2963c584ce2ec0cddcf2bc53",
+                "sha256:869bbb637de58ab0a912b7f20e9192132f9fbc47fc6b5111cd1e0f6cdf5cf9b0",
+                "sha256:8a0e0cd21da047ea10267c37caf12add400a92f0620c8bc09e4a6531a765d6d7",
+                "sha256:8d01e949a5d22e5c4800d59b50617c56125fc187fbeb8fa423e99858546de616",
+                "sha256:925b4fe5e7c03ed76912b75a9a41dfd682d59c0be43bce88d3b27f7f5ba028fb",
+                "sha256:9cb1819008f0225a7c066cac8bb0cf90847b2c4a6eb9ebb7431dbd00c56c06c5",
+                "sha256:a87d496884f40c94c85a647c385f4fd5887941d2609f71043e2b73f2436d9c65",
+                "sha256:a9030cd30caf848a13a192c5e45367e3c6f363726569a56e75dc1151ee26d859",
+                "sha256:a9e75e49a0f1583eee0ce93270232b8e7bb4b1edc89cc70b07600d525aef4f43",
+                "sha256:b50f45d0e82b4562f59f0e0ca511f65e412f2a97d790eea5f60e34e5f1aabc9a",
+                "sha256:b7878e59ec31f12d54b3797689402ee3b5cfcb5598f2ebf26491732758751908",
+                "sha256:ce1ddaadee913543ff0154021d31b134551f63428065168e756d90bdc4c686f5",
+                "sha256:ce2646e4c0807f3461be0653502bb48c6e91a5171d6e450367082c79e12868bf",
+                "sha256:ce6c3d18b2a8ce364013d47b9cad71db815df31d55918403f8db7d890c9d07ae",
+                "sha256:e4e2664232005bd306f878b0f167a31f944a07c4de0152c444f8c61bbe3cfb38",
+                "sha256:e8aa395482728de8bdcca9cc0faf3765ab483e81e01923aaa736b42f0294f570",
+                "sha256:eb4fcf7105bf071c71068c6eee47499ab8d4b8f5a11fc35147c934f0faa60f23",
+                "sha256:ed375a79f06cad285166e5be74745df1ed6845c5624aafadec4b7a29c25866ef",
+                "sha256:f35248f7e0d63b234a109dd72fbfb4b5cb6cb6840b221d0df0ecbf54ab087654",
+                "sha256:f502ef245c492b391e0e23e94cba030ab91722dcc56963c85bfd7f3441ea2bbe",
+                "sha256:fe01bac7226499aedf472c62fa3b85b2c619365f3f14dd222ffe4f3aa91e5f98"
             ],
-            "version": "==1.3.16"
+            "version": "==1.3.17"
         },
         "sqlalchemy-utils": {
             "hashes": [
-                "sha256:f268af5bc03597fe7690d60df3e5f1193254a83e07e4686f720f61587ec4493a"
+                "sha256:680068c4b671225c183815e19b6f4adc765a9989dd5d9e8e9c900ede30cc7434"
             ],
             "index": "pypi",
-            "version": "==0.36.3"
+            "version": "==0.36.5"
         },
         "urllib3": {
             "hashes": [
@@ -427,17 +437,17 @@
     "develop": {
         "appdirs": {
             "hashes": [
-                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
-                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
             ],
-            "version": "==1.4.3"
+            "version": "==1.4.4"
         },
         "astroid": {
             "hashes": [
-                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
-                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
+                "sha256:4c17cea3e592c21b6e222f673868961bad77e1f985cb1694ed077475a89229c1",
+                "sha256:d8506842a3faf734b81599c8b98dcc423de863adcc1999248480b18bd31a0f38"
             ],
-            "version": "==2.3.3"
+            "version": "==2.4.1"
         },
         "attrs": {
             "hashes": [
@@ -456,10 +466,10 @@
         },
         "click": {
             "hashes": [
-                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
-                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "version": "==7.1.1"
+            "version": "==7.1.2"
         },
         "coverage": {
             "hashes": [
@@ -581,7 +591,7 @@
         },
         "numpy-stubs": {
             "git": "https://github.com/numpy/numpy-stubs",
-            "ref": "26757ab88e1699b394a22cae5a5d524244525e68"
+            "ref": "caef6251077468ef31af62a45c795eb9269d89bd"
         },
         "packaging": {
             "hashes": [
@@ -613,11 +623,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
-                "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
+                "sha256:b95e31850f3af163c2283ed40432f053acbc8fc6eba6a069cb518d9dbf71848c",
+                "sha256:dd506acce0427e9e08fb87274bcaa953d38b50a58207170dbf5b36cf3e16957b"
             ],
             "index": "pypi",
-            "version": "==2.4.4"
+            "version": "==2.5.2"
         },
         "pyparsing": {
             "hashes": [
@@ -628,11 +638,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
-                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+                "sha256:95c710d0a72d91c13fae35dce195633c929c3792f54125919847fdcdf7caa0d3",
+                "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"
             ],
             "index": "pypi",
-            "version": "==5.4.1"
+            "version": "==5.4.2"
         },
         "pytest-cov": {
             "hashes": [
@@ -644,29 +654,29 @@
         },
         "regex": {
             "hashes": [
-                "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b",
-                "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8",
-                "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3",
-                "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e",
-                "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683",
-                "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1",
-                "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142",
-                "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3",
-                "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468",
-                "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e",
-                "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3",
-                "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a",
-                "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f",
-                "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6",
-                "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156",
-                "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b",
-                "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db",
-                "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd",
-                "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a",
-                "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948",
-                "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"
+                "sha256:1386e75c9d1574f6aa2e4eb5355374c8e55f9aac97e224a8a5a6abded0f9c927",
+                "sha256:27ff7325b297fb6e5ebb70d10437592433601c423f5acf86e5bc1ee2919b9561",
+                "sha256:329ba35d711e3428db6b45a53b1b13a0a8ba07cbbcf10bbed291a7da45f106c3",
+                "sha256:3a9394197664e35566242686d84dfd264c07b20f93514e2e09d3c2b3ffdf78fe",
+                "sha256:51f17abbe973c7673a61863516bdc9c0ef467407a940f39501e786a07406699c",
+                "sha256:579ea215c81d18da550b62ff97ee187b99f1b135fd894a13451e00986a080cad",
+                "sha256:70c14743320a68c5dac7fc5a0f685be63bc2024b062fe2aaccc4acc3d01b14a1",
+                "sha256:7e61be8a2900897803c293247ef87366d5df86bf701083b6c43119c7c6c99108",
+                "sha256:8044d1c085d49673aadb3d7dc20ef5cb5b030c7a4fa253a593dda2eab3059929",
+                "sha256:89d76ce33d3266173f5be80bd4efcbd5196cafc34100fdab814f9b228dee0fa4",
+                "sha256:99568f00f7bf820c620f01721485cad230f3fb28f57d8fbf4a7967ec2e446994",
+                "sha256:a7c37f048ec3920783abab99f8f4036561a174f1314302ccfa4e9ad31cb00eb4",
+                "sha256:c2062c7d470751b648f1cacc3f54460aebfc261285f14bc6da49c6943bd48bdd",
+                "sha256:c9bce6e006fbe771a02bda468ec40ffccbf954803b470a0345ad39c603402577",
+                "sha256:ce367d21f33e23a84fb83a641b3834dd7dd8e9318ad8ff677fbfae5915a239f7",
+                "sha256:ce450ffbfec93821ab1fea94779a8440e10cf63819be6e176eb1973a6017aff5",
+                "sha256:ce5cc53aa9fbbf6712e92c7cf268274eaff30f6bd12a0754e8133d85a8fb0f5f",
+                "sha256:d466967ac8e45244b9dfe302bbe5e3337f8dc4dec8d7d10f5e950d83b140d33a",
+                "sha256:d881c2e657c51d89f02ae4c21d9adbef76b8325fe4d5cf0e9ad62f850f3a98fd",
+                "sha256:e565569fc28e3ba3e475ec344d87ed3cd8ba2d575335359749298a0899fe122e",
+                "sha256:ea55b80eb0d1c3f1d8d784264a6764f931e172480a2f1868f2536444c5f01e01"
             ],
-            "version": "==2020.4.4"
+            "version": "==2020.5.14"
         },
         "six": {
             "hashes": [
@@ -685,10 +695,10 @@
         },
         "toml": {
             "hashes": [
-                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
-                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
             ],
-            "version": "==0.10.0"
+            "version": "==0.10.1"
         },
         "typed-ast": {
             "hashes": [
@@ -734,9 +744,9 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
             ],
-            "version": "==1.11.2"
+            "version": "==1.12.1"
         },
         "zipp": {
             "hashes": [

--- a/mypy.ini
+++ b/mypy.ini
@@ -40,3 +40,6 @@ ignore_missing_imports = True
 
 [mypy-pytest]
 ignore_missing_imports = True
+
+[mypy-chardet]
+ignore_missing_imports = True

--- a/tests/util_tests/windows1252-encoded.csv
+++ b/tests/util_tests/windows1252-encoded.csv
@@ -1,0 +1,246 @@
+Batch Name,Number of Ballots
+"  City of Ann Arbor, Ward 1, Precinct 1",431
+"  City of Ann Arbor, Ward 1, Precinct 2",294
+"  City of Ann Arbor, Ward 1, Precinct 3",266
+"  City of Ann Arbor, Ward 1, Precinct 4",212
+"  City of Ann Arbor, Ward 1, Precinct 5",480
+"  City of Ann Arbor, Ward 1, Precinct 6",255
+"  City of Ann Arbor, Ward 1, Precinct 7",359
+"  City of Ann Arbor, Ward 1, Precinct 8",403
+"  City of Ann Arbor, Ward 1, Precinct 9",404
+"  City of Ann Arbor, Ward 1, Precinct 10",473
+"  City of Ann Arbor, Ward 1, Precinct 11",254
+"  City of Ann Arbor, Ward 1, Precinct 12",147
+"  City of Ann Arbor, Ward 2, Precinct 1",255
+"  City of Ann Arbor, Ward 2, Precinct 2",484
+"  City of Ann Arbor, Ward 2, Precinct 3",321
+"  City of Ann Arbor, Ward 2, Precinct 4",288
+"  City of Ann Arbor, Ward 2, Precinct 5",395
+"  City of Ann Arbor, Ward 2, Precinct 6",479
+"  City of Ann Arbor, Ward 2, Precinct 7",253
+"  City of Ann Arbor, Ward 2, Precinct 8",292
+"  City of Ann Arbor, Ward 2, Precinct 9",512
+"  City of Ann Arbor, Ward 3, Precinct 1",352
+"  City of Ann Arbor, Ward 3, Precinct 2",306
+"  City of Ann Arbor, Ward 3, Precinct 3",326
+"  City of Ann Arbor, Ward 3, Precinct 4",295
+"  City of Ann Arbor, Ward 3, Precinct 5",666
+"  City of Ann Arbor, Ward 3, Precinct 6",500
+"  City of Ann Arbor, Ward 3, Precinct 7",346
+"  City of Ann Arbor, Ward 3, Precinct 8",700
+"  City of Ann Arbor, Ward 3, Precinct 9",498
+"  City of Ann Arbor, Ward 3, Precinct 10",361
+"  City of Ann Arbor, Ward 4, Precinct 1",343
+"  City of Ann Arbor, Ward 4, Precinct 2",346
+"  City of Ann Arbor, Ward 4, Precinct 3",479
+"  City of Ann Arbor, Ward 4, Precinct 4",502
+"  City of Ann Arbor, Ward 4, Precinct 5",588
+"  City of Ann Arbor, Ward 4, Precinct 6",521
+"  City of Ann Arbor, Ward 4, Precinct 7",619
+"  City of Ann Arbor, Ward 4, Precinct 8",493
+"  City of Ann Arbor, Ward 4, Precinct 9",454
+"  City of Ann Arbor, Ward 4, Precinct 10",155
+"  City of Ann Arbor, Ward 5, Precinct 1",342
+"  City of Ann Arbor, Ward 5, Precinct 2",723
+"  City of Ann Arbor, Ward 5, Precinct 3",330
+"  City of Ann Arbor, Ward 5, Precinct 4",499
+"  City of Ann Arbor, Ward 5, Precinct 5",563
+"  City of Ann Arbor, Ward 5, Precinct 6",615
+"  City of Ann Arbor, Ward 5, Precinct 7",401
+"  City of Ann Arbor, Ward 5, Precinct 8",319
+"  City of Ann Arbor, Ward 5, Precinct 9",632
+"  City of Ann Arbor, Ward 5, Precinct 10",716
+"  City of Ann Arbor, Ward 5, Precinct 11",493
+"  City of Ann Arbor, Ward 5, Precinct 12",383
+City of Ann Arbor AVCB 1: 1-3,87
+City of Ann Arbor AVCB 1: 1-4,105
+City of Ann Arbor AVCB 1: 1-5,170
+City of Ann Arbor AVCB 1: 1-6,155
+City of Ann Arbor AVCB 1: 1-7,77
+City of Ann Arbor AVCB 1: 1-8,303
+City of Ann Arbor AVCB 1: 1-11,113
+City of Ann Arbor AVCB 1: 1-12,73
+City of Ann Arbor AVCB 2: 2-1,110
+City of Ann Arbor AVCB 2: 2-2,103
+City of Ann Arbor AVCB 2: 2-3,104
+City of Ann Arbor AVCB 2: 2-4,326
+City of Ann Arbor AVCB 2: 1-9,167
+City of Ann Arbor AVCB 2: 1-10,257
+City of Ann Arbor AVCB 3: 2-5,255
+City of Ann Arbor AVCB 3: 2-6,253
+City of Ann Arbor AVCB 3: 2-7,384
+City of Ann Arbor AVCB 4: 2-8,285
+City of Ann Arbor AVCB 4: 2-9,270
+City of Ann Arbor AVCB 4: 3-1,132
+City of Ann Arbor AVCB 4: 3-2,152
+City of Ann Arbor AVCB 5: 3-5,92
+City of Ann Arbor AVCB 5: 3-7,231
+City of Ann Arbor AVCB 5: 3-10,247
+City of Ann Arbor AVCB 6: 1-1,103
+City of Ann Arbor AVCB 6: 1-2,172
+City of Ann Arbor AVCB 6: 3-4,307
+City of Ann Arbor AVCB 6: 3-6,103
+City of Ann Arbor AVCB 6: 3-8,179
+City of Ann Arbor AVCB 6: 3-9,192
+City of Ann Arbor AVCB 6: 4-1,121
+City of Ann Arbor AVCB 6: 4-2,55
+City of Ann Arbor AVCB 6: 4-3,183
+City of Ann Arbor AVCB 6: 4-5,241
+City of Ann Arbor AVCB 7: 4-4,303
+City of Ann Arbor AVCB 7: 4-6,266
+City of Ann Arbor AVCB 7: 4-8,180
+City of Ann Arbor AVCB 7: 5-2,287
+City of Ann Arbor AVCB 8: 4-7,262
+City of Ann Arbor AVCB 8: 5-4,348
+City of Ann Arbor AVCB 8: 5-5,300
+City of Ann Arbor AVCB 9: 4-9,214
+City of Ann Arbor AVCB 9: 4-10,153
+City of Ann Arbor AVCB 9: 5-1,108
+City of Ann Arbor AVCB 9: 5-3,165
+City of Ann Arbor AVCB 9: 5-6,238
+City of Ann Arbor AVCB 9: 5-8,156
+City of Ann Arbor AVCB 10: 5-7,95
+City of Ann Arbor AVCB 10: 5-10,250
+City of Ann Arbor AVCB 10: 5-11,191
+City of Ann Arbor AVCB 10: 5-12,129
+" City of Chelsea, Precinct 1",1163
+" City of Chelsea, Precinct 2",932
+" City of Dexter, Precinct 1",360
+" City of Dexter, Precinct 2",442
+" City of Dexter, Precinct 3",267
+"City of Dexter, AVCB1 Precinct 1",154
+"City of Dexter, AVCB1 Precinct 2",231
+"City of Dexter, AVCB1 Precinct 3",162
+"City of Milan, Precinct 1W",1135
+"City of Saline, Precinct 1",667
+"City of Saline, Precinct 2",549
+"City of Saline, Precinct 3",817
+"City of Saline, AVCB1 Precinct 1",329
+"City of Saline, AVCB1 Precinct 2",335
+"City of Saline, AVCB1 Precinct 3",323
+"City of Ypsilanti, Ward 1, Precinct 1",346
+"City of Ypsilanti, Ward 1, Precinct 2",601
+"City of Ypsilanti, Ward 1, Precinct 3",388
+"City of Ypsilanti, Ward 2, Precinct 1",405
+"City of Ypsilanti, Ward 2, Precinct 2",521
+"City of Ypsilanti, Ward 2, Precinct 3",466
+"City of Ypsilanti, Ward 2, Precinct 4",197
+"City of Ypsilanti, Ward 3, Precinct 1",421
+"City of Ypsilanti, Ward 3, Precinct 2",561
+"City of Ypsilanti, Ward 3, Precinct 3",659
+City of Ypsilanti AVCB1,1129
+"Ann Arbor Township, Precinct 1",857
+"Ann Arbor Township, Precinct 2",900
+"Augusta Township, Precinct 1",402
+"Augusta Township, Precinct 2",249
+"Augusta Township, Precinct 3",325
+"Augusta  Township, AVCB1",983
+"Bridgewater Township, Precinct 1",461
+"Dexter Township, Precinct 1",599
+"Dexter Township, Precinct 2",439
+"Dexter Township, Precinct 3",298
+"Dexter Township, AVCB1 Precinct 1",394
+"Dexter Township, AVCB1 Precinct 2",330
+"Dexter Township, AVCB1 Precinct 3",203
+"Freedom Township, Precinct 1",472
+"Lima Township, Precinct 1",401
+"Lima Township, Precinct 2",394
+"Lima Township, AVCB1",523
+"Lodi Township, Precinct 1",767
+"Lodi Township, Precinct 2",921
+"Lodi Township, Precinct 3",498
+"Lyndon Township, Precinct 1 ",441
+"Lyndon Township, AVCB1",556
+"Manchester Township, Precinct 1",633
+"Manchester Township, Precinct 2",676
+"Northfield Township, Precinct 1",629
+"Northfield Township, Precinct 2",462
+"Northfield Township, Precinct 3",343
+"Northfield Towsnhip, AVCB1",854
+"Pittsfield Charter Township, Precinct 1",603
+"Pittsfield Charter Township, Precinct 2",569
+"Pittsfield Charter Township, Precinct 3",660
+"Pittsfield Charter Township, Precinct 4",595
+"Pittsfield Charter Township, Precinct 5",458
+"Pittsfield Charter Township, Precinct 6",672
+"Pittsfield Charter Township, Precinct 7",681
+"Pittsfield Charter Township, Precinct 8",330
+"Pittsfield Charter Township, Precinct 9",589
+"Pittsfield Charter Township, Precinct 10",733
+"Pittsfield Charter Township, Precinct 11",554
+"Pittsfield Charter Township, Precinct 12 ",506
+"Pittsfield Charter Township, Precinct 13",588
+Pittsfield Township AVCB 1 – Precinct 1,237
+Pittsfield Township AVCB 1 – Precinct 2,234
+Pittsfield Township AVCB 1 – Precinct 3,312
+Pittsfield Township AVCB 1 – Precinct 4,203
+Pittsfield Township AVCB 1 – Precinct 5,157
+Pittsfield Township AVCB 1 – Precinct 6,394
+Pittsfield Township AVCB 2 – Precinct 7,403
+Pittsfield Township AVCB 2 – Precinct 8,172
+Pittsfield Township AVCB 2 – Precinct 9,543
+Pittsfield Township AVCB 3 – Precinct 10,263
+Pittsfield Township AVCB 3 – Precinct 11,514
+Pittsfield Township AVCB 3 – Precinct 12,357
+Pittsfield Township AVCB 3 – Precinct 13,167
+"Salem Township, Precinct 1",636
+"Salem Township, Precinct 2",606
+"Salem Township, Precinct 3",542
+"Saline Township, Precinct 1",566
+"Scio Township, Precinct 1",640
+"Scio Township, Precinct 2",491
+"Scio Township, Precinct 3",540
+"Scio Township, Precinct 4",512
+"Scio Township, Precinct 5",406
+"Scio Township, Precinct 6",614
+"Scio Township, Precinct 7",893
+"Scio Township, Precinct 8",716
+"Scio Township, AVCB1",1230
+"Scio Township, AVCB2",773
+"Sharon Township, Precinct 1",414
+"Sharon Township, AVCB1",134
+"Superior Township, Precinct 1",547
+"Superior Township, Precinct 2",719
+"Superior Township, Precinct 3",393
+"Superior Township, Precinct 4",512
+"Superior Township, Precinct 5",667
+"Superior Township, AVCB1 Precinct 1",305
+"Superior Township, AVCB1 Precinct 2",353
+"Superior Township, AVCB1 Precinct 3",110
+"Superior Township, AVCB1 Precinct 4",205
+"Superior Township, AVCB1 Precinct 5",463
+"Sylvan Township, Precinct 1",687
+"Sylvan Township, AVCB1",459
+"Webster Township, Precinct 1",469
+"Webster Township, Precinct 2",437
+"Webster Township, Precinct 3",626
+"Webster Township, AVCB1 Precinct 1",254
+"Webster Township, AVCB1 Precinct 2",245
+"Webster Township, AVCB1 Precinct 3",292
+"York Township, Precinct 1",449
+"York Township, Precinct 2",506
+"York Township, Precinct 3",390
+"York Township, AVCB1 Precinct 1",381
+"York Township, AVCB1 Precinct 2",266
+"York Township, AVCB1 Precinct 3",222
+"Ypsilanti Township, Precinct 1",661
+"Ypsilanti Township, Precinct 2",555
+"Ypsilanti Township, Precinct 3",518
+"Ypsilanti Township, Precinct 4",636
+"Ypsilanti Township, Precinct 5",366
+"Ypsilanti Township, Precinct 6",293
+"Ypsilanti Township, Precinct 7",380
+"Ypsilanti Township, Precinct 8",411
+"Ypsilanti Township, Precinct 9",696
+"Ypsilanti Township, Precinct 10",363
+"Ypsilanti Township, Precinct 11",393
+"Ypsilanti Township, Precinct 12",586
+"Ypsilanti Township, Precinct 13",632
+"Ypsilanti Township, Precinct 14",589
+"Ypsilanti Township, Precinct 15",427
+"Ypsilanti Township, Precinct 17",803
+"Ypsilanti Township, Precinct 18",854
+"Ypsilanti Township, Precinct 19",818
+"Ypsilanti Township, Precinct 20",524
+Ypsilanti Township AVCB 1,2259
+Ypsilanti Township AVCB 2,2256

--- a/util/csv_parse.py
+++ b/util/csv_parse.py
@@ -1,4 +1,4 @@
-import io, itertools, re, locale
+import io, itertools, re, locale, chardet
 from enum import Enum
 from typing import List, Tuple, Iterator, Dict, Any
 import csv as py_csv
@@ -201,8 +201,16 @@ def pluralize(word: str, n: int) -> str:
 
 def decode_csv_file(file: bytes) -> str:
     try:
+        detect_result = chardet.detect(file)
+
+        if detect_result["confidence"] > 0:
+            try:
+                return file.decode(detect_result["encoding"])
+            except UnicodeDecodeError:
+                pass
+
         return file.decode("utf-8-sig")
-    except Exception:
+    except UnicodeDecodeError:
         raise BadRequest(
             "Please submit a valid CSV."
             " If you are working with an Excel spreadsheet,"

--- a/util/csv_parse.py
+++ b/util/csv_parse.py
@@ -201,15 +201,13 @@ def pluralize(word: str, n: int) -> str:
 
 def decode_csv_file(file: bytes) -> str:
     try:
-        detect_result = chardet.detect(file)
-
-        if detect_result["confidence"] > 0:
-            try:
-                return file.decode(detect_result["encoding"])
-            except UnicodeDecodeError:
-                pass
-
-        return file.decode("utf-8-sig")
+        try:
+            return file.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            detect_result = chardet.detect(file)
+            if not detect_result["encoding"]:
+                raise
+            return file.decode(detect_result["encoding"])
     except UnicodeDecodeError:
         raise BadRequest(
             "Please submit a valid CSV."


### PR DESCRIPTION
**Description**

This allows files that do not have UTF-8 encoding to be uploaded. The check for confidence greater than zero is probably not needed, but I figured it wouldn't hurt since in that case we probably want to just try UTF-8.

**Testing**

Added the `windows-1252`-encoded CSV that triggered this bug as a test case.

**Progress**

I'm sure there are more CSV and encoding issues lurking, but we'll squash them as we find them.