### PR TITLE
Audit report - use new endpoints on frontend

### DIFF
--- a/arlo-client/src/components/MultiJurisdictionAudit/StatusBox.tsx
+++ b/arlo-client/src/components/MultiJurisdictionAudit/StatusBox.tsx
@@ -79,7 +79,7 @@ const createRound = async (electionId: string, roundNum: number) => {
 }
 
 const downloadAuditAdminReport = (electionId: string) => {
-  window.open(`/election/${electionId}/audit/report`)
+  window.open(`/election/${electionId}/report`)
 }
 
 const downloadJurisdictionAdminReport = (

--- a/arlo-client/src/setupProxy.js
+++ b/arlo-client/src/setupProxy.js
@@ -20,6 +20,7 @@ module.exports = function(app) {
   app.use(proxy('/election/*/sample-sizes', { target }))
   app.use(proxy('/election/*/contest', { target }))
   app.use(proxy('/election/*/round', { target }))
+  app.use(proxy('/election/*/report', { target }))
   app.use(proxy('/election/*/jurisdictions', { target }))
   app.use(proxy('/election/*/jurisdiction', { target }))
   app.use(proxy('/election/*/jurisdiction/file', { target }))


### PR DESCRIPTION
**Description**

Follow up to #527. Note that the correct URL was already being used for the jurisdiction admin report, so we didn't have to update anything.

**Testing**

Manually tested

**Progress**

Ready