### PR TITLE
Better error message for duplicate batch names in ballot manifest

### DIFF
--- a/arlo_server/ballot_manifest.py
+++ b/arlo_server/ballot_manifest.py
@@ -19,7 +19,7 @@ from util.process_file import (
     serialize_file_processing,
 )
 from util.csv_download import csv_response
-from util.csv_parse import decode_csv_file, parse_csv, CSVValueType
+from util.csv_parse import decode_csv_file, parse_csv, CSVValueType, CSVColumnType
 
 BATCH_NAME = "Batch Name"
 NUMBER_OF_BALLOTS = "Number of Ballots"
@@ -27,10 +27,10 @@ STORAGE_LOCATION = "Storage Location"
 TABULATOR = "Tabulator"
 
 BALLOT_MANIFEST_COLUMNS = [
-    (BATCH_NAME, CSVValueType.TEXT, True),
-    (NUMBER_OF_BALLOTS, CSVValueType.NUMBER, True),
-    (STORAGE_LOCATION, CSVValueType.TEXT, False),
-    (TABULATOR, CSVValueType.TEXT, False),
+    CSVColumnType(BATCH_NAME, CSVValueType.TEXT, unique=True),
+    CSVColumnType(NUMBER_OF_BALLOTS, CSVValueType.NUMBER),
+    CSVColumnType(STORAGE_LOCATION, CSVValueType.TEXT, required=False),
+    CSVColumnType(TABULATOR, CSVValueType.TEXT, required=False),
 ]
 
 

--- a/bgcompute.py
+++ b/bgcompute.py
@@ -6,8 +6,6 @@ from arlo_server.routes import compute_sample_sizes
 from arlo_server.ballot_manifest import process_ballot_manifest_file
 from util.jurisdiction_bulk_update import process_jurisdictions_file
 
-from sqlalchemy.exc import SQLAlchemyError
-
 
 def bgcompute():
     bgcompute_compute_round_contests_sample_sizes()
@@ -70,8 +68,6 @@ def bgcompute_update_ballot_manifest_file() -> int:
         try:
             jurisdiction = Jurisdiction.query.filter_by(manifest_file_id=file.id).one()
             process_ballot_manifest_file(db.session, jurisdiction, file)
-        except SQLAlchemyError as e:
-            raise e
         except:
             print("ERROR updating ballot manifest file")
 

--- a/tests/routes_tests/test_jurisdictions.py
+++ b/tests/routes_tests/test_jurisdictions.py
@@ -1,5 +1,3 @@
-import pytest
-from sqlalchemy.exc import SQLAlchemyError
 from flask.testing import FlaskClient
 
 import json, io, uuid
@@ -12,7 +10,6 @@ from tests.helpers import (
     post_json,
     compare_json,
     assert_is_date,
-    asserts_startswith,
     set_logged_in_user,
     DEFAULT_JA_EMAIL,
     SAMPLE_SIZE_ROUND_1,
@@ -167,10 +164,7 @@ def test_duplicate_batch_name(client, election_id, jurisdiction_ids):
     )
     assert_ok(rv)
 
-    with pytest.raises(SQLAlchemyError):
-        bgcompute_update_ballot_manifest_file()
-
-    db.session.rollback()
+    bgcompute_update_ballot_manifest_file()
 
     rv = client.get(f"/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)
@@ -185,9 +179,7 @@ def test_duplicate_batch_name(client, election_id, jurisdiction_ids):
                         "status": "ERRORED",
                         "startedAt": assert_is_date,
                         "completedAt": assert_is_date,
-                        "error": asserts_startswith(
-                            '(psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "batch_jurisdiction_id_name_key"'
-                        ),
+                        "error": "Values in column Batch Name must be unique. Found duplicate value: 1.",
                     },
                     "numBallots": None,
                     "numBatches": None,

--- a/util/jurisdiction_bulk_update.py
+++ b/util/jurisdiction_bulk_update.py
@@ -9,15 +9,15 @@ from arlo_server.models import (
     Jurisdiction,
 )
 from util.process_file import process_file
-from util.csv_parse import parse_csv, CSVValueType
+from util.csv_parse import parse_csv, CSVValueType, CSVColumnType
 
 
 JURISDICTION_NAME = "Jurisdiction"
 ADMIN_EMAIL = "Admin Email"
 
 JURISDICTIONS_COLUMNS = [
-    ("Jurisdiction", CSVValueType.TEXT, True),
-    ("Admin Email", CSVValueType.EMAIL, True),
+    CSVColumnType("Jurisdiction", CSVValueType.TEXT),
+    CSVColumnType("Admin Email", CSVValueType.EMAIL),
 ]
 
 


### PR DESCRIPTION
**Description**
Previously, we were relying on the db unique constraint on `Batch.name`,
which produced a gnarly error message. So we implement uniqueness
checking in our own csv validation module in order to provide a useful
error message.

**Testing**

Added new tests and updated existing

**Progress**

Ready