### PR TITLE
Audit navigation fixes

### DIFF
--- a/arlo-client/src/components/DataEntry/Ballot.tsx
+++ b/arlo-client/src/components/DataEntry/Ballot.tsx
@@ -138,10 +138,6 @@ const Ballot: React.FC<IProps> = ({
           interpretations={interpretations}
           goAudit={() => setAuditing(true)}
           nextBallot={nextBallot}
-          previousBallot={() => {
-            setAuditing(true)
-            previousBallot()
-          }}
           submitBallot={submitBallot}
         />
       )}

--- a/arlo-client/src/components/DataEntry/BallotReview.tsx
+++ b/arlo-client/src/components/DataEntry/BallotReview.tsx
@@ -49,7 +49,6 @@ interface IProps {
   goAudit: () => void
   interpretations: IBallotInterpretation[]
   nextBallot: () => void
-  previousBallot: () => void
   submitBallot: (interpretations: IBallotInterpretation[]) => void
 }
 
@@ -58,7 +57,6 @@ const BallotReview: React.FC<IProps> = ({
   goAudit,
   interpretations,
   nextBallot,
-  previousBallot,
   submitBallot,
 }: IProps) => {
   const handleSubmit = async () => {
@@ -93,7 +91,7 @@ const BallotReview: React.FC<IProps> = ({
           <FormButton type="submit" onClick={handleSubmit} intent="success">
             Submit &amp; Next Ballot
           </FormButton>
-          <Button onClick={previousBallot} minimal>
+          <Button onClick={goAudit} minimal>
             Back
           </Button>
         </ProgressActions>

--- a/arlo-client/src/components/DataEntry/index.tsx
+++ b/arlo-client/src/components/DataEntry/index.tsx
@@ -195,6 +195,7 @@ const DataEntry: React.FC<IProps> = ({
       /* istanbul ignore next */ // covered in end to end testing
       history.push(url)
     }
+    window.scrollTo(0, 0)
   }
 
   const previousBallot = (batchId: string, ballot: number) => () => {
@@ -209,6 +210,7 @@ const DataEntry: React.FC<IProps> = ({
       /* istanbul ignore next */ // covered in end to end testing
       history.push(url)
     }
+    window.scrollTo(0, 0)
   }
 
   const submitBallot = (batchId: string, ballotPosition: number) => async (


### PR DESCRIPTION
**Description**

- Scroll to top when switching between ballots
- Change the back button from the ballot review screen to go back to the ballot audit screen (before it went to the previous ballot)

**Testing**

Manually tested

**Progress**

Ready