### PR TITLE
After audit launch, wait for round to get created before redirecting

### DIFF
--- a/arlo-client/src/components/MultiJurisdictionAudit/Setup/Review/index.tsx
+++ b/arlo-client/src/components/MultiJurisdictionAudit/Setup/Review/index.tsx
@@ -71,9 +71,9 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
     })()
   }, [electionId])
 
-  const submit = () => {
+  const submit = async () => {
     try {
-      const result = api(`/election/${electionId}/round`, {
+      const result = await api(`/election/${electionId}/round`, {
         method: 'POST',
         body: JSON.stringify({
           sampleSize: Number(sampleSize),

--- a/arlo_server/rounds.py
+++ b/arlo_server/rounds.py
@@ -134,8 +134,6 @@ def sample_ballots(election: Election, round: Round, sample_size: int):
         )
         db.session.add(sampled_ballot_draw)
 
-    db.session.commit()
-
 
 @app.route("/election/<election_id>/round", methods=["GET"])
 @with_election_access
@@ -182,8 +180,8 @@ def create_round(election: Election):
         )
         db.session.add(round_contest)
 
-    db.session.commit()
-
     sample_ballots(election, round, sample_size)
+
+    db.session.commit()
 
     return jsonify({"status": "ok"})


### PR DESCRIPTION
**Description**

After launch, we were redirecting to the audit progress screen before the round got created/the ballots got sampled. This adds an `await` to the request to create the round before redirecting.

Also, while I was investigating, I realized that the backend was accidentally using two db transactions to create the round and sample the ballots, so I combined them into one.

**Testing**

Manually tested

**Progress**

Ready