### PR TITLE
Default to progress screen for AAs when audit setup complete

### DIFF
--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -147,7 +147,7 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
             meta!.organizations.map(o =>
               o.elections.map(election => (
                 <AuditLink
-                  to={`/election/${election.id}/setup`}
+                  to={`/election/${election.id}`}
                   key={election.id}
                   className="bp3-button bp3-intent-primary"
                 >

--- a/arlo-client/src/components/MultiJurisdictionAudit/Progress/index.tsx
+++ b/arlo-client/src/components/MultiJurisdictionAudit/Progress/index.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { Table, Column, Cell } from '@blueprintjs/table'
 import H2Title from '../../Atoms/H2Title'
-import useJurisdictions, {
+import {
   JurisdictionRoundStatus,
   IJurisdiction,
   prettifyStatus,
@@ -20,12 +20,11 @@ const PaddedCell = styled(Cell)`
 `
 
 interface IProps {
-  refreshId: string
+  jurisdictions: IJurisdiction[]
 }
 
-const Progress: React.FC<IProps> = ({ refreshId }: IProps) => {
+const Progress: React.FC<IProps> = ({ jurisdictions }: IProps) => {
   const { electionId } = useParams<{ electionId: string }>()
-  const jurisdictions = useJurisdictions(electionId, refreshId)
   const [
     jurisdictionDetail,
     setJurisdictionDetail,

--- a/arlo-client/src/components/MultiJurisdictionAudit/StatusBox.tsx
+++ b/arlo-client/src/components/MultiJurisdictionAudit/StatusBox.tsx
@@ -3,8 +3,7 @@ import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { Callout, H4 } from '@blueprintjs/core'
 import { toast } from 'react-toastify'
-import useRoundsAuditAdmin from './useRoundsAuditAdmin'
-import useJurisdictions, {
+import {
   IJurisdiction,
   FileProcessingStatus,
   JurisdictionRoundStatus,
@@ -14,8 +13,6 @@ import FormButton from '../Atoms/Form/FormButton'
 import { api } from '../utilities'
 import { Inner } from '../Atoms/Wrapper'
 import { IAuditSettings, IContest } from '../../types'
-import useAuditSettings from './useAuditSettings'
-import useContests from './useContests'
 import { IRound } from './useRoundsJurisdictionAdmin'
 import { IAuditBoard } from './useAuditBoards'
 
@@ -99,19 +96,19 @@ export const isSetupComplete = (
   Object.values(auditSettings).every(v => v !== null)
 
 interface IAuditAdminProps {
-  refreshId: string
+  rounds: IRound[]
+  jurisdictions: IJurisdiction[]
+  contests: IContest[]
+  auditSettings: IAuditSettings
 }
 
 export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
-  refreshId,
+  rounds,
+  jurisdictions,
+  contests,
+  auditSettings,
 }: IAuditAdminProps) => {
   const { electionId } = useParams<{ electionId: string }>()
-  const rounds = useRoundsAuditAdmin(electionId, refreshId)
-  const jurisdictions = useJurisdictions(electionId, refreshId)
-  const [contests] = useContests(electionId, refreshId)
-  const [auditSettings] = useAuditSettings(electionId, refreshId)
-
-  if (!rounds || !contests) return null // Still loading
 
   // Audit setup
   if (rounds.length === 0) {


### PR DESCRIPTION
**Description**

In order to make this change, we hoist data loading up to the top level AuditAdminView component. Note that we don't pass data down into the `Setup` component because it has it's own way of doing things and I don't wanna mess with it in this PR.

**Testing**

Manually tested

**Progress**

Ready