### PR TITLE
Disable launch button when screen is locked

### DIFF
--- a/arlo-client/src/components/MultiJurisdictionAudit/Setup/Review/index.tsx
+++ b/arlo-client/src/components/MultiJurisdictionAudit/Setup/Review/index.tsx
@@ -256,6 +256,7 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
               <FormButton
                 intent="primary"
                 disabled={
+                  locked ||
                   !isSetupComplete(jurisdictions, contests, auditSettings)
                 }
                 onClick={handleSubmit}


### PR DESCRIPTION
**Description**

Otherwise you can try to launch the audit once the first round is already in progress, which is not allowed.

**Testing**

Manually tested

**Progress**

Ready