### PR TITLE
Add .csv suffix to ballot retrieval list

### DIFF
--- a/arlo_server/ballots.py
+++ b/arlo_server/ballots.py
@@ -106,7 +106,7 @@ def get_retrieval_list(election: Election, jurisdiction: Jurisdiction, round_id:
     retrieval_list_csv = ballot_retrieval_list(jurisdiction, round)
     return csv_response(
         retrieval_list_csv,
-        filename=f"ballot-retrieval-{election_timestamp_name(election)}",
+        filename=f"ballot-retrieval-{election_timestamp_name(election)}.csv",
     )
 
 

--- a/arlo_server/routes.py
+++ b/arlo_server/routes.py
@@ -920,7 +920,7 @@ def jurisdiction_retrieval_list(election_id, jurisdiction_id, round_num):
     retrieval_list_csv = ballot_retrieval_list(jurisdiction, round)
     return csv_response(
         retrieval_list_csv,
-        filename=f"ballot-retrieval-{election_timestamp_name(election)}",
+        filename=f"ballot-retrieval-{election_timestamp_name(election)}.csv",
     )
 
 

--- a/tests/routes_tests/test_ballots.py
+++ b/tests/routes_tests/test_ballots.py
@@ -315,6 +315,7 @@ def test_ja_ballot_retrieval_list_round_1(
     )
     assert rv.status_code == 200
     assert "attachment; filename=" in rv.headers["Content-Disposition"]
+    assert ".csv" in rv.headers["Content-Disposition"]
 
     retrieval_list = rv.data.decode("utf-8").replace("\r\n", "\n")
     assert len(retrieval_list.splitlines()) == J1_BALLOTS_ROUND_1 + 1


### PR DESCRIPTION
**Description**

Users' computers didn't know how to open the file because it lacked a filetype suffix.

**Testing**

Updated existing test

**Progress**

Ready