### PR TITLE
resetdb.py: add --skip-table-creation flag

### DIFF
--- a/resetdb.py
+++ b/resetdb.py
@@ -6,8 +6,8 @@ from sqlalchemy import create_engine
 from sqlalchemy_utils import database_exists, create_database, drop_database
 
 if __name__ == "__main__":
-    # a simple flag to skip DB creation
     skip_db_creation = len(sys.argv) > 1 and sys.argv[1] == "--skip-db-creation"
+    skip_table_creation = len(sys.argv) > 1 and sys.argv[1] == "--skip-table-creation"
 
     engine = create_engine(DATABASE_URL)
     print(f"database: {engine.url}")
@@ -22,5 +22,8 @@ if __name__ == "__main__":
         print("creating database…")
         create_database(engine.url)
 
-    print("creating tables…")
-    init_db()
+    if skip_table_creation:
+        print("skipping creating tables ...")
+    else:
+        print("creating tables…")
+        init_db()


### PR DESCRIPTION
**Description**

When reloading a db snapshot exported with `pgdump`, you need to first reset the db but not recreate the tables. This is useful for quickly putting the database into a saved state for manual testing.

**Testing**

Ran it

**Progress**

Ready