### PR TITLE
Show login screen if logged in as audit board at root path

### DIFF
--- a/arlo-client/src/components/CreateAudit.tsx
+++ b/arlo-client/src/components/CreateAudit.tsx
@@ -69,9 +69,6 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
   }
 
   if (isAuthenticated === null) return null // Still loading
-  if (meta && meta.type === 'audit_board') {
-    return <div>404 Not Found</div>
-  }
   return (
     <Wrapper>
       <img height="50px" src="/arlo.png" alt="Arlo, by VotingWorks" />
@@ -108,7 +105,7 @@ const CreateAudit = ({ history }: RouteComponentProps<ICreateAuditParams>) => {
           )}
         </Formik>
       )}
-      {!isAuthenticated ? (
+      {!isAuthenticated || (meta && meta.type === 'audit_board') ? (
         <>
           <Button
             verticalSpaced


### PR DESCRIPTION
**Description**

If you're logged in as an audit board, you don't have access to any screens besides the audit board screens. All of the other screens except the home screen (at the root path( are protected routes, so it's not an issue.

Previously, we had a janky 404 message at the root path for audit board users. Now, we show the log in screen (though the audit board user is still logged in - which is a little odd).

**Testing**

Manually tested

**Progress**

Ready