### PR TITLE
Toggle to show sample vs ballot counts on jurisdiction progress screen

### DIFF
--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`App renders properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-ktHwxA eVyuZn"
+    class="sc-hEsumM gnGovj"
   >
     <div
       class="bp3-navbar sc-EHOje kGnsSl"

--- a/client/src/components/Atoms/Table.tsx
+++ b/client/src/components/Atoms/Table.tsx
@@ -1,26 +1,7 @@
 import React from 'react'
-import {
-  useTable,
-  useSortBy,
-  useFilters,
-  Column,
-  Row,
-  ColumnInstance,
-} from 'react-table'
+import { useTable, useSortBy, Column, Row } from 'react-table'
 import styled from 'styled-components'
 import { Icon } from '@blueprintjs/core'
-
-const Wrapper = styled.div``
-
-const FilterWrapper = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 0.5rem;
-
-  > div {
-    width: 50%;
-  }
-`
 
 const StyledTable = styled.table`
   width: 100%;
@@ -45,26 +26,26 @@ const StyledTable = styled.table`
 `
 
 interface IFilterInputProps<T extends object> {
-  column: ColumnInstance<T>
   placeholder: string
+  value: string
+  onChange: (value: string) => void
 }
 
 export const FilterInput = <T extends object>({
-  column: { filterValue, setFilter },
   placeholder,
+  value,
+  onChange,
 }: IFilterInputProps<T>) => (
-  <FilterWrapper>
-    <div className="bp3-input-group .modifier">
-      <span className="bp3-icon bp3-icon-filter"></span>
-      <input
-        type="text"
-        className="bp3-input"
-        placeholder={placeholder}
-        value={filterValue || ''}
-        onChange={e => setFilter(e.target.value || undefined)}
-      />
-    </div>
-  </FilterWrapper>
+  <div className="bp3-input-group .modifier">
+    <span className="bp3-icon bp3-icon-filter"></span>
+    <input
+      type="text"
+      className="bp3-input"
+      placeholder={placeholder}
+      value={value}
+      onChange={e => onChange(e.target.value)}
+    />
+  </div>
 )
 
 interface ITableProps<T extends object> {
@@ -83,62 +64,52 @@ export const Table = <T extends object>({ data, columns }: ITableProps<T>) => {
     {
       data: React.useMemo(() => data, [data]),
       columns: React.useMemo(() => columns, [columns]),
-      defaultColumn: React.useMemo(() => ({ Filter: FilterInput }), []),
     },
-    useFilters,
     useSortBy
   )
 
   /* eslint-disable react/jsx-key */
   /* All the keys are added automatically by react-table */
 
-  const filterableColumns = headers.filter(column => column.filter)
-  if (filterableColumns.length > 1)
-    throw Error('Only allowed to have one filterable column max')
-  const [filterColumn] = filterableColumns
-
   return (
-    <Wrapper>
-      {filterColumn && filterColumn.render('Filter')}
-      <StyledTable {...getTableProps()}>
-        <thead>
-          <tr>
-            {headers.map(column => (
-              <th
-                {...column.getHeaderProps(
-                  column.getSortByToggleProps({ title: column.Header })
-                )}
-              >
-                {column.render('Header')}
-                <span>
-                  {column.isSorted ? (
-                    column.isSortedDesc ? (
-                      <Icon icon="caret-down" />
-                    ) : (
-                      <Icon icon="caret-up" />
-                    )
+    <StyledTable {...getTableProps()}>
+      <thead>
+        <tr>
+          {headers.map(column => (
+            <th
+              {...column.getHeaderProps(
+                column.getSortByToggleProps({ title: column.Header })
+              )}
+            >
+              {column.render('Header')}
+              <span>
+                {column.isSorted ? (
+                  column.isSortedDesc ? (
+                    <Icon icon="caret-down" />
                   ) : (
-                    <Icon icon="double-caret-vertical" />
-                  )}
-                </span>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody {...getTableBodyProps()}>
-          {rows.map(row => {
-            prepareRow(row)
-            return (
-              <tr {...row.getRowProps()}>
-                {row.cells.map(cell => (
-                  <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
-                ))}
-              </tr>
-            )
-          })}
-        </tbody>
-      </StyledTable>
-    </Wrapper>
+                    <Icon icon="caret-up" />
+                  )
+                ) : (
+                  <Icon icon="double-caret-vertical" />
+                )}
+              </span>
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody {...getTableBodyProps()}>
+        {rows.map(row => {
+          prepareRow(row)
+          return (
+            <tr {...row.getRowProps()}>
+              {row.cells.map(cell => (
+                <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
+              ))}
+            </tr>
+          )
+        })}
+      </tbody>
+    </StyledTable>
   )
 }
 

--- a/client/src/components/MultiJurisdictionAudit/Progress/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Progress/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Progress screen shows ballot manifest upload status 1`] = `
 <div>
   <div
-    class="sc-bZQynM jYrSMi"
+    class="sc-ifAKCX iABumv"
   >
     <h2
       class="bp3-heading sc-bdVaJa ibVpPq"
@@ -16,242 +16,250 @@ exports[`Progress screen shows ballot manifest upload status 1`] = `
        To view a single jurisdiction's data, click the name of the jurisdiction.
     </p>
     <div
-      class="sc-bxivhb bUZGRr"
+      class="sc-EHOje enakgn"
     >
+      <label
+        class="bp3-control bp3-switch"
+      >
+        <input
+          checked=""
+          type="checkbox"
+        />
+        <span
+          class="bp3-control-indicator"
+        />
+        Count unique sampled ballots
+      </label>
       <div
-        class="sc-ifAKCX hmrdRS"
+        class="bp3-input-group .modifier"
       >
-        <div
-          class="bp3-input-group .modifier"
-        >
-          <span
-            class="bp3-icon bp3-icon-filter"
-          />
-          <input
-            class="bp3-input"
-            placeholder="Filter by jurisdiction name..."
-            type="text"
-            value=""
-          />
-        </div>
+        <span
+          class="bp3-icon bp3-icon-filter"
+        />
+        <input
+          class="bp3-input"
+          placeholder="Filter by jurisdiction name..."
+          type="text"
+          value=""
+        />
       </div>
-      <table
-        class="sc-EHOje kCOsXm"
-        role="table"
-      >
-        <thead>
-          <tr>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Jurisdiction Name"
-            >
-              Jurisdiction Name
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Status"
-            >
-              Status
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Total Audited"
-            >
-              Total Audited
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Remaining in Round"
-            >
-              Remaining in Round
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody
-          role="rowgroup"
-        >
-          <tr
-            role="row"
-          >
-            <td
-              role="cell"
-            >
-              <button
-                class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
-                type="button"
-              >
-                <span
-                  class="bp3-button-text"
-                >
-                  Jurisdiction 1
-                </span>
-              </button>
-            </td>
-            <td
-              role="cell"
-            >
-              Manifest upload failed: Invalid CSV
-            </td>
-            <td
-              role="cell"
-            />
-            <td
-              role="cell"
-            />
-          </tr>
-          <tr
-            role="row"
-          >
-            <td
-              role="cell"
-            >
-              <button
-                class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
-                type="button"
-              >
-                <span
-                  class="bp3-button-text"
-                >
-                  Jurisdiction 2
-                </span>
-              </button>
-            </td>
-            <td
-              role="cell"
-            >
-              No manifest uploaded
-            </td>
-            <td
-              role="cell"
-            />
-            <td
-              role="cell"
-            />
-          </tr>
-          <tr
-            role="row"
-          >
-            <td
-              role="cell"
-            >
-              <button
-                class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
-                type="button"
-              >
-                <span
-                  class="bp3-button-text"
-                >
-                  Jurisdiction 3
-                </span>
-              </button>
-            </td>
-            <td
-              role="cell"
-            >
-              Manifest received
-            </td>
-            <td
-              role="cell"
-            />
-            <td
-              role="cell"
-            />
-          </tr>
-        </tbody>
-      </table>
     </div>
+    <table
+      class="sc-bxivhb eaTstv"
+      role="table"
+    >
+      <thead>
+        <tr>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Jurisdiction Name"
+          >
+            Jurisdiction Name
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Status"
+          >
+            Status
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Total Audited"
+          >
+            Total Audited
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Remaining in Round"
+          >
+            Remaining in Round
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        role="rowgroup"
+      >
+        <tr
+          role="row"
+        >
+          <td
+            role="cell"
+          >
+            <button
+              class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
+              type="button"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                Jurisdiction 1
+              </span>
+            </button>
+          </td>
+          <td
+            role="cell"
+          >
+            Manifest upload failed: Invalid CSV
+          </td>
+          <td
+            role="cell"
+          />
+          <td
+            role="cell"
+          />
+        </tr>
+        <tr
+          role="row"
+        >
+          <td
+            role="cell"
+          >
+            <button
+              class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
+              type="button"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                Jurisdiction 2
+              </span>
+            </button>
+          </td>
+          <td
+            role="cell"
+          >
+            No manifest uploaded
+          </td>
+          <td
+            role="cell"
+          />
+          <td
+            role="cell"
+          />
+        </tr>
+        <tr
+          role="row"
+        >
+          <td
+            role="cell"
+          >
+            <button
+              class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
+              type="button"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                Jurisdiction 3
+              </span>
+            </button>
+          </td>
+          <td
+            role="cell"
+          >
+            Manifest received
+          </td>
+          <td
+            role="cell"
+          />
+          <td
+            role="cell"
+          />
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -259,7 +267,7 @@ exports[`Progress screen shows ballot manifest upload status 1`] = `
 exports[`Progress screen shows round status 1`] = `
 <div>
   <div
-    class="sc-bZQynM jYrSMi"
+    class="sc-ifAKCX iABumv"
   >
     <h2
       class="bp3-heading sc-bdVaJa ibVpPq"
@@ -272,254 +280,262 @@ exports[`Progress screen shows round status 1`] = `
        To view a single jurisdiction's data, click the name of the jurisdiction.
     </p>
     <div
-      class="sc-bxivhb bUZGRr"
+      class="sc-EHOje enakgn"
     >
+      <label
+        class="bp3-control bp3-switch"
+      >
+        <input
+          checked=""
+          type="checkbox"
+        />
+        <span
+          class="bp3-control-indicator"
+        />
+        Count unique sampled ballots
+      </label>
       <div
-        class="sc-ifAKCX hmrdRS"
+        class="bp3-input-group .modifier"
       >
-        <div
-          class="bp3-input-group .modifier"
-        >
-          <span
-            class="bp3-icon bp3-icon-filter"
-          />
-          <input
-            class="bp3-input"
-            placeholder="Filter by jurisdiction name..."
-            type="text"
-            value=""
-          />
-        </div>
+        <span
+          class="bp3-icon bp3-icon-filter"
+        />
+        <input
+          class="bp3-input"
+          placeholder="Filter by jurisdiction name..."
+          type="text"
+          value=""
+        />
       </div>
-      <table
-        class="sc-EHOje kCOsXm"
-        role="table"
-      >
-        <thead>
-          <tr>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Jurisdiction Name"
-            >
-              Jurisdiction Name
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Status"
-            >
-              Status
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Total Audited"
-            >
-              Total Audited
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Remaining in Round"
-            >
-              Remaining in Round
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody
-          role="rowgroup"
-        >
-          <tr
-            role="row"
-          >
-            <td
-              role="cell"
-            >
-              <button
-                class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
-                type="button"
-              >
-                <span
-                  class="bp3-button-text"
-                >
-                  Jurisdiction 1
-                </span>
-              </button>
-            </td>
-            <td
-              role="cell"
-            >
-              In progress
-            </td>
-            <td
-              role="cell"
-            >
-              4
-            </td>
-            <td
-              role="cell"
-            >
-              6
-            </td>
-          </tr>
-          <tr
-            role="row"
-          >
-            <td
-              role="cell"
-            >
-              <button
-                class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
-                type="button"
-              >
-                <span
-                  class="bp3-button-text"
-                >
-                  Jurisdiction 2
-                </span>
-              </button>
-            </td>
-            <td
-              role="cell"
-            >
-              Not started
-            </td>
-            <td
-              role="cell"
-            >
-              0
-            </td>
-            <td
-              role="cell"
-            >
-              20
-            </td>
-          </tr>
-          <tr
-            role="row"
-          >
-            <td
-              role="cell"
-            >
-              <button
-                class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
-                type="button"
-              >
-                <span
-                  class="bp3-button-text"
-                >
-                  Jurisdiction 3
-                </span>
-              </button>
-            </td>
-            <td
-              role="cell"
-            >
-              Complete
-            </td>
-            <td
-              role="cell"
-            >
-              30
-            </td>
-            <td
-              role="cell"
-            >
-              0
-            </td>
-          </tr>
-        </tbody>
-      </table>
     </div>
+    <table
+      class="sc-bxivhb eaTstv"
+      role="table"
+    >
+      <thead>
+        <tr>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Jurisdiction Name"
+          >
+            Jurisdiction Name
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Status"
+          >
+            Status
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Total Audited"
+          >
+            Total Audited
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Remaining in Round"
+          >
+            Remaining in Round
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        role="rowgroup"
+      >
+        <tr
+          role="row"
+        >
+          <td
+            role="cell"
+          >
+            <button
+              class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
+              type="button"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                Jurisdiction 1
+              </span>
+            </button>
+          </td>
+          <td
+            role="cell"
+          >
+            In progress
+          </td>
+          <td
+            role="cell"
+          >
+            4
+          </td>
+          <td
+            role="cell"
+          >
+            6
+          </td>
+        </tr>
+        <tr
+          role="row"
+        >
+          <td
+            role="cell"
+          >
+            <button
+              class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
+              type="button"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                Jurisdiction 2
+              </span>
+            </button>
+          </td>
+          <td
+            role="cell"
+          >
+            Not started
+          </td>
+          <td
+            role="cell"
+          >
+            0
+          </td>
+          <td
+            role="cell"
+          >
+            20
+          </td>
+        </tr>
+        <tr
+          role="row"
+        >
+          <td
+            role="cell"
+          >
+            <button
+              class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
+              type="button"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                Jurisdiction 3
+              </span>
+            </button>
+          </td>
+          <td
+            role="cell"
+          >
+            Complete
+          </td>
+          <td
+            role="cell"
+          >
+            30
+          </td>
+          <td
+            role="cell"
+          >
+            0
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -527,7 +543,7 @@ exports[`Progress screen shows round status 1`] = `
 exports[`Progress screen shows the detail modal 1`] = `
 <div>
   <div
-    class="sc-bZQynM jYrSMi"
+    class="sc-ifAKCX iABumv"
   >
     <h2
       class="bp3-heading sc-bdVaJa ibVpPq"
@@ -540,242 +556,250 @@ exports[`Progress screen shows the detail modal 1`] = `
        To view a single jurisdiction's data, click the name of the jurisdiction.
     </p>
     <div
-      class="sc-bxivhb bUZGRr"
+      class="sc-EHOje enakgn"
     >
+      <label
+        class="bp3-control bp3-switch"
+      >
+        <input
+          checked=""
+          type="checkbox"
+        />
+        <span
+          class="bp3-control-indicator"
+        />
+        Count unique sampled ballots
+      </label>
       <div
-        class="sc-ifAKCX hmrdRS"
+        class="bp3-input-group .modifier"
       >
-        <div
-          class="bp3-input-group .modifier"
-        >
-          <span
-            class="bp3-icon bp3-icon-filter"
-          />
-          <input
-            class="bp3-input"
-            placeholder="Filter by jurisdiction name..."
-            type="text"
-            value=""
-          />
-        </div>
+        <span
+          class="bp3-icon bp3-icon-filter"
+        />
+        <input
+          class="bp3-input"
+          placeholder="Filter by jurisdiction name..."
+          type="text"
+          value=""
+        />
       </div>
-      <table
-        class="sc-EHOje kCOsXm"
-        role="table"
-      >
-        <thead>
-          <tr>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Jurisdiction Name"
-            >
-              Jurisdiction Name
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Status"
-            >
-              Status
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Total Audited"
-            >
-              Total Audited
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-            <th
-              colspan="1"
-              role="columnheader"
-              style="cursor: pointer;"
-              title="Remaining in Round"
-            >
-              Remaining in Round
-              <span>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody
-          role="rowgroup"
-        >
-          <tr
-            role="row"
-          >
-            <td
-              role="cell"
-            >
-              <button
-                class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
-                type="button"
-              >
-                <span
-                  class="bp3-button-text"
-                >
-                  Jurisdiction 1
-                </span>
-              </button>
-            </td>
-            <td
-              role="cell"
-            >
-              Manifest upload failed: Invalid CSV
-            </td>
-            <td
-              role="cell"
-            />
-            <td
-              role="cell"
-            />
-          </tr>
-          <tr
-            role="row"
-          >
-            <td
-              role="cell"
-            >
-              <button
-                class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
-                type="button"
-              >
-                <span
-                  class="bp3-button-text"
-                >
-                  Jurisdiction 2
-                </span>
-              </button>
-            </td>
-            <td
-              role="cell"
-            >
-              No manifest uploaded
-            </td>
-            <td
-              role="cell"
-            />
-            <td
-              role="cell"
-            />
-          </tr>
-          <tr
-            role="row"
-          >
-            <td
-              role="cell"
-            >
-              <button
-                class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
-                type="button"
-              >
-                <span
-                  class="bp3-button-text"
-                >
-                  Jurisdiction 3
-                </span>
-              </button>
-            </td>
-            <td
-              role="cell"
-            >
-              Manifest received
-            </td>
-            <td
-              role="cell"
-            />
-            <td
-              role="cell"
-            />
-          </tr>
-        </tbody>
-      </table>
     </div>
+    <table
+      class="sc-bxivhb eaTstv"
+      role="table"
+    >
+      <thead>
+        <tr>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Jurisdiction Name"
+          >
+            Jurisdiction Name
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Status"
+          >
+            Status
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Total Audited"
+          >
+            Total Audited
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Remaining in Round"
+          >
+            Remaining in Round
+            <span>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        role="rowgroup"
+      >
+        <tr
+          role="row"
+        >
+          <td
+            role="cell"
+          >
+            <button
+              class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
+              type="button"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                Jurisdiction 1
+              </span>
+            </button>
+          </td>
+          <td
+            role="cell"
+          >
+            Manifest upload failed: Invalid CSV
+          </td>
+          <td
+            role="cell"
+          />
+          <td
+            role="cell"
+          />
+        </tr>
+        <tr
+          role="row"
+        >
+          <td
+            role="cell"
+          >
+            <button
+              class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
+              type="button"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                Jurisdiction 2
+              </span>
+            </button>
+          </td>
+          <td
+            role="cell"
+          >
+            No manifest uploaded
+          </td>
+          <td
+            role="cell"
+          />
+          <td
+            role="cell"
+          />
+        </tr>
+        <tr
+          role="row"
+        >
+          <td
+            role="cell"
+          >
+            <button
+              class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
+              type="button"
+            >
+              <span
+                class="bp3-button-text"
+              >
+                Jurisdiction 3
+              </span>
+            </button>
+          </td>
+          <td
+            role="cell"
+          >
+            Manifest received
+          </td>
+          <td
+            role="cell"
+          />
+          <td
+            role="cell"
+          />
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
@@ -59,6 +59,31 @@ describe('Progress screen', () => {
     expect(container).toMatchSnapshot()
   })
 
+  it('toggles between ballots and samples', () => {
+    render(<Progress jurisdictions={jurisdictionMocks.oneComplete} />)
+
+    const ballotsSwitch = screen.getByRole('checkbox', {
+      name: 'Count unique sampled ballots',
+    })
+    userEvent.click(ballotsSwitch)
+    let rows = screen.getAllByRole('row')
+    within(rows[1]).getByRole('cell', { name: '5' })
+    within(rows[1]).getByRole('cell', { name: '6' })
+    within(rows[2]).getByRole('cell', { name: '0' })
+    within(rows[2]).getByRole('cell', { name: '22' })
+    within(rows[3]).getByRole('cell', { name: '31' })
+    within(rows[3]).getByRole('cell', { name: '0' })
+
+    userEvent.click(ballotsSwitch)
+    rows = screen.getAllByRole('row')
+    within(rows[1]).getByRole('cell', { name: '4' })
+    within(rows[1]).getByRole('cell', { name: '6' })
+    within(rows[2]).getByRole('cell', { name: '0' })
+    within(rows[2]).getByRole('cell', { name: '20' })
+    within(rows[3]).getByRole('cell', { name: '30' })
+    within(rows[3]).getByRole('cell', { name: '0' })
+  })
+
   it('shows the detail modal', () => {
     const { container } = render(
       <Progress jurisdictions={jurisdictionMocks.oneManifest} />

--- a/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
         </ul>
       </div>
       <div
-        class="sc-eHgmQL enmkoj"
+        class="sc-iAyFgw iuVrZJ"
       >
         <h2
           class="bp3-heading sc-htpNat fysvnw"
@@ -71,213 +71,221 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
            To view a single jurisdiction's data, click the name of the jurisdiction.
         </p>
         <div
-          class="sc-kkGfuU gqJIVH"
+          class="sc-hSdWYo iKUdPX"
         >
+          <label
+            class="bp3-control bp3-switch"
+          >
+            <input
+              checked=""
+              type="checkbox"
+            />
+            <span
+              class="bp3-control-indicator"
+            />
+            Count unique sampled ballots
+          </label>
           <div
-            class="sc-iAyFgw jfmcmh"
+            class="bp3-input-group .modifier"
           >
-            <div
-              class="bp3-input-group .modifier"
-            >
-              <span
-                class="bp3-icon bp3-icon-filter"
-              />
-              <input
-                class="bp3-input"
-                placeholder="Filter by jurisdiction name..."
-                type="text"
-                value=""
-              />
-            </div>
+            <span
+              class="bp3-icon bp3-icon-filter"
+            />
+            <input
+              class="bp3-input"
+              placeholder="Filter by jurisdiction name..."
+              type="text"
+              value=""
+            />
           </div>
-          <table
-            class="sc-hSdWYo eEBssg"
-            role="table"
-          >
-            <thead>
-              <tr>
-                <th
-                  colspan="1"
-                  role="columnheader"
-                  style="cursor: pointer;"
-                  title="Jurisdiction Name"
-                >
-                  Jurisdiction Name
-                  <span>
-                    <span
-                      class="bp3-icon bp3-icon-double-caret-vertical"
-                      icon="double-caret-vertical"
-                    >
-                      <svg
-                        data-icon="double-caret-vertical"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        width="16"
-                      >
-                        <desc>
-                          double-caret-vertical
-                        </desc>
-                        <path
-                          d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </span>
-                  </span>
-                </th>
-                <th
-                  colspan="1"
-                  role="columnheader"
-                  style="cursor: pointer;"
-                  title="Status"
-                >
-                  Status
-                  <span>
-                    <span
-                      class="bp3-icon bp3-icon-double-caret-vertical"
-                      icon="double-caret-vertical"
-                    >
-                      <svg
-                        data-icon="double-caret-vertical"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        width="16"
-                      >
-                        <desc>
-                          double-caret-vertical
-                        </desc>
-                        <path
-                          d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </span>
-                  </span>
-                </th>
-                <th
-                  colspan="1"
-                  role="columnheader"
-                  style="cursor: pointer;"
-                  title="Total Audited"
-                >
-                  Total Audited
-                  <span>
-                    <span
-                      class="bp3-icon bp3-icon-double-caret-vertical"
-                      icon="double-caret-vertical"
-                    >
-                      <svg
-                        data-icon="double-caret-vertical"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        width="16"
-                      >
-                        <desc>
-                          double-caret-vertical
-                        </desc>
-                        <path
-                          d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </span>
-                  </span>
-                </th>
-                <th
-                  colspan="1"
-                  role="columnheader"
-                  style="cursor: pointer;"
-                  title="Remaining in Round"
-                >
-                  Remaining in Round
-                  <span>
-                    <span
-                      class="bp3-icon bp3-icon-double-caret-vertical"
-                      icon="double-caret-vertical"
-                    >
-                      <svg
-                        data-icon="double-caret-vertical"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        width="16"
-                      >
-                        <desc>
-                          double-caret-vertical
-                        </desc>
-                        <path
-                          d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </span>
-                  </span>
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              role="rowgroup"
-            >
-              <tr
-                role="row"
-              >
-                <td
-                  role="cell"
-                >
-                  <button
-                    class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
-                    type="button"
-                  >
-                    <span
-                      class="bp3-button-text"
-                    >
-                      Jurisdiction One
-                    </span>
-                  </button>
-                </td>
-                <td
-                  role="cell"
-                >
-                  No manifest uploaded
-                </td>
-                <td
-                  role="cell"
-                />
-                <td
-                  role="cell"
-                />
-              </tr>
-              <tr
-                role="row"
-              >
-                <td
-                  role="cell"
-                >
-                  <button
-                    class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
-                    type="button"
-                  >
-                    <span
-                      class="bp3-button-text"
-                    >
-                      Jurisdiction Two
-                    </span>
-                  </button>
-                </td>
-                <td
-                  role="cell"
-                >
-                  No manifest uploaded
-                </td>
-                <td
-                  role="cell"
-                />
-                <td
-                  role="cell"
-                />
-              </tr>
-            </tbody>
-          </table>
         </div>
+        <table
+          class="sc-kkGfuU eKXmGD"
+          role="table"
+        >
+          <thead>
+            <tr>
+              <th
+                colspan="1"
+                role="columnheader"
+                style="cursor: pointer;"
+                title="Jurisdiction Name"
+              >
+                Jurisdiction Name
+                <span>
+                  <span
+                    class="bp3-icon bp3-icon-double-caret-vertical"
+                    icon="double-caret-vertical"
+                  >
+                    <svg
+                      data-icon="double-caret-vertical"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                    >
+                      <desc>
+                        double-caret-vertical
+                      </desc>
+                      <path
+                        d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </th>
+              <th
+                colspan="1"
+                role="columnheader"
+                style="cursor: pointer;"
+                title="Status"
+              >
+                Status
+                <span>
+                  <span
+                    class="bp3-icon bp3-icon-double-caret-vertical"
+                    icon="double-caret-vertical"
+                  >
+                    <svg
+                      data-icon="double-caret-vertical"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                    >
+                      <desc>
+                        double-caret-vertical
+                      </desc>
+                      <path
+                        d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </th>
+              <th
+                colspan="1"
+                role="columnheader"
+                style="cursor: pointer;"
+                title="Total Audited"
+              >
+                Total Audited
+                <span>
+                  <span
+                    class="bp3-icon bp3-icon-double-caret-vertical"
+                    icon="double-caret-vertical"
+                  >
+                    <svg
+                      data-icon="double-caret-vertical"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                    >
+                      <desc>
+                        double-caret-vertical
+                      </desc>
+                      <path
+                        d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </th>
+              <th
+                colspan="1"
+                role="columnheader"
+                style="cursor: pointer;"
+                title="Remaining in Round"
+              >
+                Remaining in Round
+                <span>
+                  <span
+                    class="bp3-icon bp3-icon-double-caret-vertical"
+                    icon="double-caret-vertical"
+                  >
+                    <svg
+                      data-icon="double-caret-vertical"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                    >
+                      <desc>
+                        double-caret-vertical
+                      </desc>
+                      <path
+                        d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            role="rowgroup"
+          >
+            <tr
+              role="row"
+            >
+              <td
+                role="cell"
+              >
+                <button
+                  class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
+                  type="button"
+                >
+                  <span
+                    class="bp3-button-text"
+                  >
+                    Jurisdiction One
+                  </span>
+                </button>
+              </td>
+              <td
+                role="cell"
+              >
+                No manifest uploaded
+              </td>
+              <td
+                role="cell"
+              />
+              <td
+                role="cell"
+              />
+            </tr>
+            <tr
+              role="row"
+            >
+              <td
+                role="cell"
+              >
+                <button
+                  class="bp3-button bp3-minimal bp3-small bp3-intent-primary"
+                  type="button"
+                >
+                  <span
+                    class="bp3-button-text"
+                  >
+                    Jurisdiction Two
+                  </span>
+                </button>
+              </td>
+              <td
+                role="cell"
+              >
+                No manifest uploaded
+              </td>
+              <td
+                role="cell"
+              />
+              <td
+                role="cell"
+              />
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/client/src/components/MultiJurisdictionAudit/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/_mocks.ts
@@ -200,7 +200,9 @@ export const jurisdictionMocks: { [key: string]: IJurisdiction[] } = {
       currentRoundStatus: {
         status: JurisdictionRoundStatus.IN_PROGRESS,
         numBallotsAudited: 4,
-        numBallotsSampled: 10,
+        numBallots: 10,
+        numSamplesAudited: 5,
+        numSamples: 11,
       },
     },
     {
@@ -210,7 +212,9 @@ export const jurisdictionMocks: { [key: string]: IJurisdiction[] } = {
       currentRoundStatus: {
         status: JurisdictionRoundStatus.NOT_STARTED,
         numBallotsAudited: 0,
-        numBallotsSampled: 20,
+        numBallots: 20,
+        numSamplesAudited: 0,
+        numSamples: 22,
       },
     },
     {
@@ -220,7 +224,9 @@ export const jurisdictionMocks: { [key: string]: IJurisdiction[] } = {
       currentRoundStatus: {
         status: JurisdictionRoundStatus.COMPLETE,
         numBallotsAudited: 30,
-        numBallotsSampled: 30,
+        numBallots: 30,
+        numSamplesAudited: 31,
+        numSamples: 31,
       },
     },
   ],
@@ -232,7 +238,9 @@ export const jurisdictionMocks: { [key: string]: IJurisdiction[] } = {
       currentRoundStatus: {
         status: JurisdictionRoundStatus.COMPLETE,
         numBallotsAudited: 10,
-        numBallotsSampled: 10,
+        numBallots: 10,
+        numSamplesAudited: 11,
+        numSamples: 11,
       },
     },
     {
@@ -242,7 +250,9 @@ export const jurisdictionMocks: { [key: string]: IJurisdiction[] } = {
       currentRoundStatus: {
         status: JurisdictionRoundStatus.COMPLETE,
         numBallotsAudited: 20,
-        numBallotsSampled: 20,
+        numBallots: 20,
+        numSamplesAudited: 22,
+        numSamples: 22,
       },
     },
     {
@@ -252,7 +262,9 @@ export const jurisdictionMocks: { [key: string]: IJurisdiction[] } = {
       currentRoundStatus: {
         status: JurisdictionRoundStatus.COMPLETE,
         numBallotsAudited: 30,
-        numBallotsSampled: 30,
+        numBallots: 30,
+        numSamplesAudited: 31,
+        numSamples: 31,
       },
     },
   ],

--- a/client/src/components/MultiJurisdictionAudit/useJurisdictions.ts
+++ b/client/src/components/MultiJurisdictionAudit/useJurisdictions.ts
@@ -39,7 +39,9 @@ export interface IJurisdiction {
   ballotManifest: IBallotManifestInfo
   currentRoundStatus: {
     status: JurisdictionRoundStatus
-    numBallotsSampled: number
+    numSamples: number
+    numSamplesAudited: number
+    numBallots: number
     numBallotsAudited: number
   } | null
 }

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -16,10 +16,12 @@ from ..models import *  # pylint: disable=wildcard-import
 from ..api.audit_boards import end_round
 
 SAMPLE_SIZE_ROUND_1 = 119  # Bravo sample size
+BALLOTS_ROUND_1 = 110
 J1_SAMPLES_ROUND_1 = 81
 J1_BALLOTS_ROUND_1 = 75
 J1_SAMPLES_ROUND_2 = 281  # 90% probability sample size
 J1_BALLOTS_ROUND_2 = 234
+AB1_SAMPLES_ROUND_1 = 54
 AB1_BALLOTS_ROUND_1 = 50
 AB2_BALLOTS_ROUND_1 = 25
 AB1_BALLOTS_ROUND_2 = 151


### PR DESCRIPTION
JA and AB users only know about the ballot counts. AA users get to know about both the ballot counts and the sample counts.

This PR adds a toggle to the jurisdiction progress view to let the AA user switch which count they want to see.

Also updates the API to return both counts (previously just returned sample counts).

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/530106/82268646-63c5c800-9924-11ea-8c38-435bc91764b6.gif)



