### PR TITLE
Allow only one audit board member

### DIFF
--- a/arlo-client/src/components/DataEntry/MemberForm.tsx
+++ b/arlo-client/src/components/DataEntry/MemberForm.tsx
@@ -66,7 +66,12 @@ const MemberForm: React.FC<IProps> = ({
                 </RadioGroup>
               </FormSection>
             ))}
-            <FormButton intent="primary" type="button" onClick={handleSubmit}>
+            <FormButton
+              intent="primary"
+              type="button"
+              disabled={!(values[0].name || (values[0].name && values[1].name))}
+              onClick={handleSubmit}
+            >
               Next
             </FormButton>
           </Form>

--- a/arlo-client/src/components/DataEntry/SignOff.tsx
+++ b/arlo-client/src/components/DataEntry/SignOff.tsx
@@ -6,14 +6,9 @@ import { LabelText, NameField } from './Atoms'
 import FormButton from '../Atoms/Form/FormButton'
 import { IAuditBoard } from '../../types'
 
-export interface IMemberNames {
-  memberName1: string
-  memberName2: string
-}
-
 export interface IProps {
   auditBoard: IAuditBoard
-  submitSignoff: (memberNames: IMemberNames) => void
+  submitSignoff: (memberNames: string[]) => void
 }
 
 const SignOff = ({ auditBoard, submitSignoff }: IProps) => {
@@ -31,32 +26,24 @@ const SignOff = ({ auditBoard, submitSignoff }: IProps) => {
         officials.
       </p>
       <Formik
-        initialValues={{ memberName1: '', memberName2: '' }}
+        initialValues={auditBoard.members.map(() => '')}
         onSubmit={submitSignoff}
         render={({ values, handleSubmit }) => (
           <Form>
-            <FormSection
-              label={`Audit Board Member: ${auditBoard.members[0].name}`}
-            >
-              <LabelText htmlFor="memberName1">Full Name</LabelText>
-              <NameField name="memberName1" />
-            </FormSection>
-            <FormSection
-              label={`Audit Board Member: ${auditBoard.members[1].name}`}
-            >
-              <LabelText htmlFor="memberName2">Full Name</LabelText>
-              <NameField name="memberName2" />
-            </FormSection>
+            {auditBoard.members.map((member, i) => (
+              <FormSection
+                key={member.name}
+                label={`Audit Board Member: ${member.name}`}
+              >
+                <LabelText htmlFor={`[${i}]`}>Full Name</LabelText>
+                <NameField name={`[${i}]`} />
+              </FormSection>
+            ))}
             <FormButton
               intent="primary"
               type="button"
               onClick={handleSubmit}
-              disabled={
-                !(
-                  values.memberName1 === auditBoard.members[0].name &&
-                  values.memberName2 === auditBoard.members[1].name
-                )
-              }
+              disabled={auditBoard.members.some((_, i) => !values[i])}
             >
               Sign Off
             </FormButton>

--- a/arlo-client/src/components/DataEntry/index.tsx
+++ b/arlo-client/src/components/DataEntry/index.tsx
@@ -15,7 +15,7 @@ import { api } from '../utilities'
 import BoardTable from './BoardTable'
 import MemberForm from './MemberForm'
 import Ballot, { IBallot } from './Ballot'
-import SignOff, { IMemberNames } from './SignOff'
+import SignOff from './SignOff'
 import { Wrapper, Inner } from '../Atoms/Wrapper'
 
 const PaddedInner = styled(Inner)`
@@ -130,14 +130,17 @@ const postSignoff = async (
   jurisdictionId: string,
   roundId: string,
   auditBoardId: string,
-  memberNames: IMemberNames
+  memberNames: string[]
 ) => {
   try {
     await api(
       `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/audit-board/${auditBoardId}/sign-off`,
       {
         method: 'POST',
-        body: JSON.stringify(memberNames),
+        body: JSON.stringify({
+          memberName1: memberNames[0] || '',
+          memberName2: memberNames[1] || '',
+        }),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -254,7 +257,7 @@ const DataEntry: React.FC<IProps> = ({
     setBallots(await loadBallots(electionId, jurisdictionId, roundId, id))
   }
 
-  const submitSignoff = async (memberNames: IMemberNames) => {
+  const submitSignoff = async (memberNames: string[]) => {
     await postSignoff(
       electionId,
       auditBoard.jurisdictionId,

--- a/arlo_server/audit_boards.py
+++ b/arlo_server/audit_boards.py
@@ -280,9 +280,15 @@ SIGN_OFF_AUDIT_BOARD_REQUEST_SCHEMA = {
 def validate_sign_off(sign_off_request: JSONDict, audit_board: AuditBoard):
     validate(sign_off_request, SIGN_OFF_AUDIT_BOARD_REQUEST_SCHEMA)
 
-    for name in [sign_off_request["memberName1"], sign_off_request["memberName2"]]:
-        if name not in {audit_board.member_1, audit_board.member_2}:
-            raise BadRequest(f"Audit board member name did not match: {name}")
+    if sign_off_request["memberName1"] != audit_board.member_1:
+        raise BadRequest(
+            f"Audit board member name did not match: {sign_off_request['memberName1']}"
+        )
+
+    if audit_board.member_2 and sign_off_request["memberName2"] != audit_board.member_2:
+        raise BadRequest(
+            f"Audit board member name did not match: {sign_off_request['memberName2']}"
+        )
 
     if any(b.status == BallotStatus.NOT_AUDITED for b in audit_board.sampled_ballots):
         raise Conflict(f"Audit board is not finished auditing all assigned ballots")

--- a/tests/routes_tests/test_reports.py
+++ b/tests/routes_tests/test_reports.py
@@ -58,8 +58,8 @@ Test Audit,10%,1234567890,Yes
 
 ######## AUDIT BOARDS ########
 Jurisdiction Name,Audit Board Name,Member 1 Name,Member 1 Affiliation,Member 2 Name,Member 2 Affiliation
-J1,Audit Board #1,Bubbikin Republican,Democrat,Joe Schmo,Republican
-J1,Audit Board #2,Bubbikin Republican,Democrat,Joe Schmo,Republican
+J1,Audit Board #1,Bubbikin Republican,Democrat,Joe Schmo,
+J1,Audit Board #2,Bubbikin Republican,Democrat,Joe Schmo,
 
 ######## ROUNDS ########
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes


### PR DESCRIPTION
**Description**

The audit board member sign in form currently allows you to only sign in one member (either member 1 or member 2), but the sign off form expects both members.

This was causing the sign off form to break.

Two changes here:
- Only allow signing in for the first member _or_ both members
- If only one member signed in, only expect one member to sign out

**Testing**

Added some new API tests. Manually tested the frontend in both cases.

**Progress**

Ready