### PR TITLE
Remove unnecessary generators from test fixtures

### DIFF
--- a/tests/audit_math_tests/test_bravo.py
+++ b/tests/audit_math_tests/test_bravo.py
@@ -15,7 +15,7 @@ def contests():
     for contest in bravo_contests:
         contests[contest] = Contest(contest, bravo_contests[contest])
 
-    yield contests
+    return contests
 
 
 def test_expected_sample_sizes(contests):

--- a/tests/audit_math_tests/test_macro.py
+++ b/tests/audit_math_tests/test_macro.py
@@ -39,7 +39,7 @@ def contests():
     for contest in macro_contests:
         contests[contest] = Contest(contest, macro_contests[contest])
 
-    yield contests
+    return contests
 
 
 @pytest.fixture
@@ -97,7 +97,7 @@ def batches():
             "numWinners": 1,
         }
 
-    yield batches
+    return batches
 
 
 def test_max_error(contests, batches):

--- a/tests/audit_math_tests/test_sampler.py
+++ b/tests/audit_math_tests/test_sampler.py
@@ -21,7 +21,7 @@ def macro_batches():
             "test1": {"cand1": 20, "cand2": 30, "ballots": 50}
         }
 
-    yield batches
+    return batches
 
 
 @pytest.fixture
@@ -36,7 +36,7 @@ def macro_contest():
         "votesAllowed": 1,
     }
 
-    yield Contest(name, info_dict)
+    return Contest(name, info_dict)
 
 
 def test_draw_sample():

--- a/tests/audit_math_tests/test_sampler_contest.py
+++ b/tests/audit_math_tests/test_sampler_contest.py
@@ -10,7 +10,7 @@ def contests():
     for contest in bravo_contests:
         contests.append(Contest(contest, bravo_contests[contest]))
 
-    yield contests
+    return contests
 
 
 def test_compute_margins(contests):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,14 +54,12 @@ def client() -> Generator[FlaskClient, None, None]:
 
 
 @pytest.fixture
-def election_id(client: FlaskClient) -> Generator[str, None, None]:
-    yield create_election(client)
+def election_id(client: FlaskClient) -> str:
+    return create_election(client)
 
 
 @pytest.fixture
-def jurisdiction_ids(
-    client: FlaskClient, election_id: str
-) -> Generator[List[str], None, None]:
+def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
     rv = client.put(
         f"/election/{election_id}/jurisdiction/file",
         data={
@@ -87,7 +85,7 @@ def jurisdiction_ids(
         .order_by(Jurisdiction.name)
         .all()
     )
-    yield [j.id for j in jurisdictions]
+    return [j.id for j in jurisdictions]
 
 
 @pytest.fixture
@@ -129,7 +127,7 @@ def contest_ids(
 
 
 @pytest.fixture
-def election_settings(client: FlaskClient, election_id: str) -> None:
+def election_settings(client: FlaskClient, election_id: str):
     settings = {
         "electionName": "Test Election",
         "online": True,
@@ -187,7 +185,7 @@ def round_1_id(
     contest_ids: str,  # pylint: disable=unused-argument
     election_settings,  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
-) -> Generator[str, None, None]:
+) -> str:
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = post_json(
         client,
@@ -197,7 +195,7 @@ def round_1_id(
     assert_ok(rv)
     rv = client.get(f"/election/{election_id}/round",)
     rounds = json.loads(rv.data)["rounds"]
-    yield rounds[0]["id"]
+    return str(rounds[0]["id"])
 
 
 @pytest.fixture
@@ -207,7 +205,7 @@ def round_2_id(
     contest_ids: str,
     round_1_id: str,
     audit_board_round_1_ids: List[str],  # pylint: disable=unused-argument
-) -> Generator[str, None, None]:
+) -> str:
     run_audit_round(round_1_id, contest_ids[0], 0.5)
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
@@ -216,13 +214,13 @@ def round_2_id(
 
     rv = client.get(f"/election/{election_id}/round",)
     rounds = json.loads(rv.data)["rounds"]
-    yield rounds[1]["id"]
+    return str(rounds[1]["id"])
 
 
 @pytest.fixture
 def audit_board_round_1_ids(
     client: FlaskClient, election_id: str, jurisdiction_ids: str, round_1_id: str,
-) -> Generator[List[str], None, None]:
+) -> List[str]:
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
     rv = post_json(
         client,
@@ -234,13 +232,13 @@ def audit_board_round_1_ids(
         f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board"
     )
     audit_boards = json.loads(rv.data)["auditBoards"]
-    yield [ab["id"] for ab in audit_boards]
+    return [ab["id"] for ab in audit_boards]
 
 
 @pytest.fixture
 def audit_board_round_2_ids(
     client: FlaskClient, election_id: str, jurisdiction_ids: str, round_2_id: str,
-) -> Generator[List[str], None, None]:
+) -> List[str]:
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
     rv = post_json(
         client,
@@ -256,7 +254,7 @@ def audit_board_round_2_ids(
         f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/audit-board"
     )
     audit_boards = json.loads(rv.data)["auditBoards"]
-    yield [ab["id"] for ab in audit_boards]
+    return [ab["id"] for ab in audit_boards]
 
 
 # Add special routes to test our auth decorators. This fixture will run once before

--- a/tests/routes_tests/test_audit_status.py
+++ b/tests/routes_tests/test_audit_status.py
@@ -1,7 +1,6 @@
 import json
 import pytest
 from flask.testing import FlaskClient
-from typing import Generator
 
 from tests.helpers import (
     compare_json,
@@ -15,8 +14,8 @@ from util.process_file import ProcessingStatus
 
 
 @pytest.fixture()
-def election_id(client: FlaskClient) -> Generator[str, None, None]:
-    yield create_election(client, is_multi_jurisdiction=False)
+def election_id(client: FlaskClient) -> str:
+    return create_election(client, is_multi_jurisdiction=False)
 
 
 def test_audit_status(client, election_id):

--- a/tests/routes_tests/test_single_jurisdiction_ballot_list.py
+++ b/tests/routes_tests/test_single_jurisdiction_ballot_list.py
@@ -1,6 +1,5 @@
 import json
 from flask.testing import FlaskClient
-from typing import Generator
 import pytest
 
 from tests.helpers import assert_ok, post_json, create_election
@@ -9,8 +8,8 @@ import bgcompute
 
 
 @pytest.fixture()
-def election_id(client: FlaskClient) -> Generator[str, None, None]:
-    yield create_election(client, is_multi_jurisdiction=False)
+def election_id(client: FlaskClient) -> str:
+    return create_election(client, is_multi_jurisdiction=False)
 
 
 def test_ballot_list_jurisdiction_two_rounds(client, election_id):

--- a/tests/routes_tests/test_superadmin.py
+++ b/tests/routes_tests/test_superadmin.py
@@ -1,5 +1,4 @@
 from flask.testing import FlaskClient
-from typing import Generator
 import pytest, json
 
 from arlo_server.auth import UserType
@@ -21,19 +20,19 @@ SA_TEST_JA_EMAIL = "sa-test-ja-email@example.com"
 
 
 @pytest.fixture()
-def organization_id() -> Generator[str, None, None]:
+def organization_id() -> str:
     org_id, audit_admin_id = create_org_and_admin(user_email=SA_TEST_AA_EMAIL)
-    yield org_id
+    return org_id
 
 
 @pytest.fixture()
-def election_id(client: FlaskClient, organization_id) -> Generator[str, None, None]:
+def election_id(client: FlaskClient, organization_id) -> str:
     set_logged_in_user(client, UserType.AUDIT_ADMIN, SA_TEST_AA_EMAIL)
     election_id = create_election(
         client, organization_id=organization_id, is_multi_jurisdiction=True
     )
     clear_logged_in_user(client)
-    yield election_id
+    return election_id
 
 
 def assert_superadmin_access(client: FlaskClient, url):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,6 @@
 import os, math, uuid
 import json, csv, io
 from flask.testing import FlaskClient
-from typing import Generator
 import pytest
 
 from tests.helpers import assert_ok, post_json, create_election
@@ -12,8 +11,8 @@ small_manifest_file_path = os.path.join(os.path.dirname(__file__), "small-manife
 
 
 @pytest.fixture()
-def election_id(client: FlaskClient) -> Generator[str, None, None]:
-    yield create_election(client, is_multi_jurisdiction=False)
+def election_id(client: FlaskClient) -> str:
+    return create_election(client, is_multi_jurisdiction=False)
 
 
 def test_index(client):

--- a/tests/util_tests/test_binpacking.py
+++ b/tests/util_tests/test_binpacking.py
@@ -4,7 +4,7 @@ from util.binpacking import Bucket, BucketList, BalancedBucketList
 
 @pytest.fixture
 def bucket():
-    yield Bucket("1")
+    return Bucket("1")
 
 
 @pytest.fixture
@@ -31,7 +31,7 @@ def bucketlist():
     b.add_batch("8", 200)
     buckets.append(b)
 
-    yield BucketList(buckets)
+    return BucketList(buckets)
 
 
 @pytest.fixture
@@ -58,7 +58,7 @@ def balancedbucketlist():
     b.add_batch("8", 200)
     buckets.append(b)
 
-    yield BalancedBucketList(buckets)
+    return BalancedBucketList(buckets)
 
 
 class TestBucket:


### PR DESCRIPTION
**Description**

For some reason, we all thought that fixtures had to yield their
results. But really they can return results - yielding is only necessary
if you want to do some teardown after the test runs.

