### PR TITLE
Remove Python path from vscode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "python.pythonPath": "/usr/bin/python3.7",
   "files.exclude": {
     "arlo-client": true
   }


### PR DESCRIPTION
Better to set it on your own using your pipenv virtualenv (which is a
path specific to your computer). That way VSCode can find imports from the virtualenv. Instructions here: https://code.visualstudio.com/docs/python/environments