### PR TITLE
fix: ensure audit board names are sorted correctly

### DIFF
--- a/arlo-client/src/components/MultiJurisdictionAudit/RoundManagement/CreateAuditBoards.test.tsx
+++ b/arlo-client/src/components/MultiJurisdictionAudit/RoundManagement/CreateAuditBoards.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { render, wait, fireEvent } from '@testing-library/react'
+import CreateAuditBoards from './CreateAuditBoards'
+
+test('names audit boards numerically', async () => {
+  const createAuditBoards = jest.fn()
+  const { getByText, getByTestId } = render(
+    <CreateAuditBoards
+      auditBoards={[]}
+      numBallots={10}
+      roundNum={1}
+      createAuditBoards={createAuditBoards}
+    />
+  )
+
+  fireEvent.change(getByTestId('numAuditBoards'), { target: { value: '3' } })
+  fireEvent.click(getByText('Save & Next'))
+
+  await wait(() => {
+    expect(createAuditBoards).toHaveBeenCalledWith([
+      { name: 'Audit Board #1' },
+      { name: 'Audit Board #2' },
+      { name: 'Audit Board #3' },
+    ])
+  })
+})
+
+test('names audit boards such that the names sort sensibly', async () => {
+  const createAuditBoards = jest.fn()
+  const { getByText, getByTestId } = render(
+    <CreateAuditBoards
+      auditBoards={[]}
+      numBallots={10}
+      roundNum={1}
+      createAuditBoards={createAuditBoards}
+    />
+  )
+
+  fireEvent.change(getByTestId('numAuditBoards'), { target: { value: '10' } })
+  fireEvent.click(getByText('Save & Next'))
+
+  await wait(() => {
+    expect(createAuditBoards).toHaveBeenCalledWith([
+      { name: 'Audit Board #01' },
+      { name: 'Audit Board #02' },
+      { name: 'Audit Board #03' },
+      { name: 'Audit Board #04' },
+      { name: 'Audit Board #05' },
+      { name: 'Audit Board #06' },
+      { name: 'Audit Board #07' },
+      { name: 'Audit Board #08' },
+      { name: 'Audit Board #09' },
+      { name: 'Audit Board #10' },
+    ])
+  })
+})

--- a/arlo-client/src/components/MultiJurisdictionAudit/RoundManagement/CreateAuditBoards.tsx
+++ b/arlo-client/src/components/MultiJurisdictionAudit/RoundManagement/CreateAuditBoards.tsx
@@ -39,8 +39,11 @@ const CreateAuditBoards = ({
   roundNum,
 }: IProps) => {
   const submit = async ({ numAuditBoards }: IValues) => {
+    const maxAuditBoardsIndexLength = numAuditBoards.toString().length
     const boards = [...Array(numAuditBoards).keys()].map(i => ({
-      name: `Audit Board #${i + 1}`,
+      name: `Audit Board #${(i + 1)
+        .toString()
+        .padStart(maxAuditBoardsIndexLength, '0')}`,
     }))
     createAuditBoards(boards)
   }
@@ -67,6 +70,7 @@ const CreateAuditBoards = ({
             <AuditBoardsInput
               component={Select}
               id="numAuditBoards"
+              data-testid="numAuditBoards"
               name="numAuditBoards"
               onChange={(e: React.FormEvent<HTMLSelectElement>) =>
                 setFieldValue('numAuditBoards', Number(e.currentTarget.value))


### PR DESCRIPTION
**Description**

This won't fix any existing audit board names, but for new ones it will ensure that sorting lexicographically also sorts numerically. This was the simplest fix I could think of since the client controls the names, but the server does the sorting.

**Testing**

Adds some unit tests for `CreateAuditBoards` to make sure the names are as expected.

**Progress**

n/a
