### PR TITLE
Don't require audit boards with no ballots assigned to sign off

### DIFF
--- a/arlo_server/audit_boards.py
+++ b/arlo_server/audit_boards.py
@@ -254,6 +254,7 @@ def is_round_complete(election: Election, round: Round) -> bool:
     num_audit_boards_with_ballots_not_signed_off: int = (
         AuditBoard.query.filter_by(round_id=round.id, signed_off_at=None)
         .join(SampledBallot)
+        .group_by(AuditBoard.id)
         .count()
     )
     return (

--- a/tests/routes_tests/test_audit_boards.py
+++ b/tests/routes_tests/test_audit_boards.py
@@ -618,10 +618,23 @@ def test_audit_boards_sign_off_happy_path(
         [{"name": "Audit Board #1"}],
     )
     assert_ok(rv)
+
     rv = client.get(
         f"/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/audit-board"
     )
     audit_board = json.loads(rv.data)["auditBoards"][0]
+
+    # Create another audit board that doesn't have any ballots assigned. Even
+    # though this audit board doesn't sign off, it shouldn't stop the round
+    # from being completed.
+    audit_board_without_ballots = AuditBoard(
+        id="audit-board-without-ballots",
+        jurisdiction_id=jurisdiction_ids[1],
+        round_id=round_1_id,
+        name="Audit Board Without Ballots",
+    )
+    db.session.add(audit_board_without_ballots)
+    db.session.commit()
 
     run_audit_board_flow(jurisdiction_ids[1], audit_board["id"])
 

--- a/tests/routes_tests/test_audit_boards.py
+++ b/tests/routes_tests/test_audit_boards.py
@@ -1,4 +1,4 @@
-import json, random
+import json, random, uuid
 from typing import List, Tuple
 from datetime import datetime
 from collections import defaultdict
@@ -628,7 +628,7 @@ def test_audit_boards_sign_off_happy_path(
     # though this audit board doesn't sign off, it shouldn't stop the round
     # from being completed.
     audit_board_without_ballots = AuditBoard(
-        id="audit-board-without-ballots",
+        id=str(uuid.uuid4()),
         jurisdiction_id=jurisdiction_ids[1],
         round_id=round_1_id,
         name="Audit Board Without Ballots",


### PR DESCRIPTION
Whenever an audit board signs off, we check if the round is complete. This change modifies the check to omit any audit boards that didn't have any ballots assigned to them.

We might also want to change the UI, but this is the basic change needed.