### PR TITLE
Endpoint to set audit board members

### DIFF
--- a/arlo-client/src/components/DataEntry/MemberForm.tsx
+++ b/arlo-client/src/components/DataEntry/MemberForm.tsx
@@ -35,7 +35,16 @@ const MemberForm: React.FC<IProps> = ({
             affiliation: '',
           },
         ]}
-        onSubmit={submitMembers}
+        onSubmit={members =>
+          submitMembers(
+            members
+              .filter(({ name }) => name)
+              .map(({ name, affiliation }) => ({
+                name,
+                affiliation: affiliation || null,
+              }))
+          )
+        }
         render={({
           setFieldValue,
           values,

--- a/arlo-client/src/components/DataEntry/index.test.tsx
+++ b/arlo-client/src/components/DataEntry/index.test.tsx
@@ -80,7 +80,7 @@ describe('DataEntry', () => {
         switch (endpoint) {
           case '/auth/me':
             return posted ? dummyBoards()[0] : dummyBoards()[1]
-          case '/election/1/jurisdiction/jurisdiction-1/audit-board/audit-board-1':
+          case '/election/1/jurisdiction/jurisdiction-1/round/round-1/audit-board/audit-board-1':
             posted = true
             return { status: 'ok' }
           default:

--- a/arlo-client/src/components/DataEntry/index.test.tsx
+++ b/arlo-client/src/components/DataEntry/index.test.tsx
@@ -80,7 +80,7 @@ describe('DataEntry', () => {
         switch (endpoint) {
           case '/auth/me':
             return posted ? dummyBoards()[0] : dummyBoards()[1]
-          case '/election/1/jurisdiction/jurisdiction-1/round/round-1/audit-board/audit-board-1':
+          case '/election/1/jurisdiction/jurisdiction-1/round/round-1/audit-board/audit-board-1/members':
             posted = true
             return { status: 'ok' }
           default:

--- a/arlo-client/src/components/DataEntry/index.tsx
+++ b/arlo-client/src/components/DataEntry/index.tsx
@@ -59,18 +59,19 @@ const loadBallots = async (
   return ballots
 }
 
-const saveMembers = async (
+const putMembers = async (
   electionId: string,
   jurisdictionId: string,
+  roundId: string,
   auditBoardId: string,
   members: IAuditBoardMember[]
 ) => {
   try {
     await api(
-      `/election/${electionId}/jurisdiction/${jurisdictionId}/audit-board/${auditBoardId}`,
+      `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/audit-board/${auditBoardId}`,
       {
-        method: 'POST',
-        body: JSON.stringify({ members }),
+        method: 'PUT',
+        body: JSON.stringify(members),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -160,9 +161,10 @@ const DataEntry: React.FC<IProps> = ({
   }, [electionId, auditBoard])
 
   const submitMembers = async (members: IAuditBoardMember[]) => {
-    await saveMembers(
+    await putMembers(
       electionId,
       auditBoard!.jurisdictionId,
+      auditBoard!.roundId,
       auditBoardId,
       members
     )

--- a/arlo-client/src/components/DataEntry/index.tsx
+++ b/arlo-client/src/components/DataEntry/index.tsx
@@ -68,7 +68,7 @@ const putMembers = async (
 ) => {
   try {
     await api(
-      `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/audit-board/${auditBoardId}`,
+      `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/audit-board/${auditBoardId}/members`,
       {
         method: 'PUT',
         body: JSON.stringify(members),

--- a/arlo-client/src/types.ts
+++ b/arlo-client/src/types.ts
@@ -79,7 +79,7 @@ export interface IBallot {
 
 export interface IAuditBoardMember {
   name: string
-  affiliation: string
+  affiliation: string | null
 }
 
 export interface IAuditBoard {

--- a/arlo_server/audit_boards.py
+++ b/arlo_server/audit_boards.py
@@ -227,7 +227,7 @@ def validate_members(members: List[JSONDict]):
 
 
 @app.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board/<audit_board_id>",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board/<audit_board_id>/members",
     methods=["PUT"],
 )
 @with_audit_board_access
@@ -242,7 +242,7 @@ def set_audit_board_members(
 
     audit_board.member_1 = members[0]["name"]
     audit_board.member_1_affiliation = members[0]["affiliation"]
-    if len(members) == 2:
+    if len(members) > 1:
         audit_board.member_2 = members[1]["name"]
         audit_board.member_2_affiliation = members[1]["affiliation"]
 

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -241,6 +241,16 @@ contest_jurisdiction = db.Table(
 )
 
 
+# TODO we should use this enum in the AuditBoard schema, but that would require
+# a data model change and db migration
+class Affiliation(str, Enum):
+    DEMOCRAT = "DEM"
+    REPUBLICAN = "REP"
+    LIBERTARIAN = "LIB"
+    INDEPENDENT = "IND"
+    OTHER = "OTH"
+
+
 class AuditBoard(BaseModel):
     id = db.Column(db.String(200), primary_key=True)
     jurisdiction_id = db.Column(

--- a/arlo_server/models.py
+++ b/arlo_server/models.py
@@ -241,8 +241,6 @@ contest_jurisdiction = db.Table(
 )
 
 
-# TODO we should use this enum in the AuditBoard schema, but that would require
-# a data model change and db migration
 class Affiliation(str, Enum):
     DEMOCRAT = "DEM"
     REPUBLICAN = "REP"
@@ -262,9 +260,9 @@ class AuditBoard(BaseModel):
 
     name = db.Column(db.String(200))
     member_1 = db.Column(db.String(200))
-    member_1_affiliation = db.Column(db.String(200))
+    member_1_affiliation = db.Column(db.Enum(Affiliation))
     member_2 = db.Column(db.String(200))
-    member_2_affiliation = db.Column(db.String(200))
+    member_2_affiliation = db.Column(db.Enum(Affiliation))
     passphrase = db.Column(db.String(1000), unique=True)
     signed_off_at = db.Column(db.DateTime)
 

--- a/arlo_server/reports.py
+++ b/arlo_server/reports.py
@@ -13,6 +13,7 @@ from arlo_server.models import (
     Interpretation,
     Contest,
     RoundContest,
+    Affiliation,
 )
 from arlo_server.auth import with_election_access, with_jurisdiction_access
 from util.csv_download import csv_response, election_timestamp_name
@@ -20,13 +21,13 @@ from util.isoformat import isoformat
 from util.group_by import group_by
 
 
-def pretty_affiliation(affiliation: str) -> str:
+def pretty_affiliation(affiliation: Affiliation) -> str:
     mapping = {
-        "DEM": "Democrat",
-        "REP": "Republican",
-        "LIB": "Libertarian",
-        "IND": "Independent",
-        "OTH": "Other",
+        Affiliation.DEMOCRAT: "Democrat",
+        Affiliation.REPUBLICAN: "Republican",
+        Affiliation.LIBERTARIAN: "Libertarian",
+        Affiliation.INDEPENDENT: "Independent",
+        Affiliation.OTHER: "Other",
     }
     return mapping.get(affiliation, "")
 

--- a/tests/routes_tests/test_audit_boards.py
+++ b/tests/routes_tests/test_audit_boards.py
@@ -529,7 +529,7 @@ def test_audit_boards_set_members_valid(
     for member_request in member_requests:
         rv = put_json(
             client,
-            f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board/{audit_board_round_1_ids[0]}",
+            f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board/{audit_board_round_1_ids[0]}/members",
             member_request,
         )
         assert_ok(rv)
@@ -573,7 +573,7 @@ def test_audit_boards_set_members_invalid(
         set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_round_1_ids[0])
         rv = put_json(
             client,
-            f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board/{audit_board_round_1_ids[0]}",
+            f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board/{audit_board_round_1_ids[0]}/members",
             invalid_member_request,
         )
         assert rv.status_code == 400
@@ -614,7 +614,7 @@ def set_up_audit_board(
     set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
     rv = put_json(
         client,
-        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/audit-board/{audit_board_id}",
+        f"/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/audit-board/{audit_board_id}/members",
         member_names,
     )
     assert_ok(rv)

--- a/tests/routes_tests/test_audit_status.py
+++ b/tests/routes_tests/test_audit_status.py
@@ -67,7 +67,7 @@ def test_audit_status(client, election_id):
                             "id": audit_board_id_1,
                             "members": [
                                 {"affiliation": "REP", "name": "Joe Schmo"},
-                                {"affiliation": "", "name": "Jane Plain"},
+                                {"affiliation": None, "name": "Jane Plain"},
                             ],
                             "name": "Audit Board #1",
                             "passphrase": assert_is_passphrase,

--- a/tests/routes_tests/test_reports.py
+++ b/tests/routes_tests/test_reports.py
@@ -2,6 +2,8 @@ import re
 from typing import List
 from flask.testing import FlaskClient
 from tests.routes_tests.test_audit_boards import set_up_audit_board
+from tests.helpers import set_logged_in_user, DEFAULT_JA_EMAIL
+from arlo_server.auth import UserType
 
 DATETIME_REGEX = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}")
 
@@ -11,12 +13,18 @@ def test_audit_admin_report(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],
+    round_1_id: str,
     contest_ids: List[str],
     audit_board_round_1_ids: List[str],
 ):
     for audit_board_id in audit_board_round_1_ids:
         set_up_audit_board(
-            client, election_id, jurisdiction_ids[0], contest_ids[0], audit_board_id,
+            client,
+            election_id,
+            jurisdiction_ids[0],
+            round_1_id,
+            contest_ids[0],
+            audit_board_id,
         )
     rv = client.get(f"/election/{election_id}/report")
     report = rv.data.decode("utf-8")
@@ -28,13 +36,20 @@ def test_jurisdiction_admin_report(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],
+    round_1_id,
     contest_ids: List[str],
     audit_board_round_1_ids: List[str],
 ):
     for audit_board_id in audit_board_round_1_ids:
         set_up_audit_board(
-            client, election_id, jurisdiction_ids[0], contest_ids[0], audit_board_id,
+            client,
+            election_id,
+            jurisdiction_ids[0],
+            round_1_id,
+            contest_ids[0],
+            audit_board_id,
         )
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
     rv = client.get(
         f"/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/report"
     )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -75,7 +75,7 @@ def setup_audit_board(client, election_id, jurisdiction_id, audit_board_id):
             "name": "Audit Board #1",
             "members": [
                 {"name": "Joe Schmo", "affiliation": "REP"},
-                {"name": "Jane Plain", "affiliation": ""},
+                {"name": "Jane Plain", "affiliation": None},
             ],
         },
     )
@@ -1246,8 +1246,8 @@ def test_audit_board(client, election_id):
         {
             "name": "Awesome Audit Board",
             "members": [
-                {"name": "Darth Vader", "affiliation": "EMP"},
-                {"name": "Leia Organa", "affiliation": "REB"},
+                {"name": "Darth Vader", "affiliation": "REP"},
+                {"name": "Leia Organa", "affiliation": "DEM"},
             ],
         },
     )
@@ -1262,8 +1262,8 @@ def test_audit_board(client, election_id):
     assert response["id"] == audit_board_id_1
     assert response["name"] == "Awesome Audit Board"
     assert response["members"] == [
-        {"name": "Darth Vader", "affiliation": "EMP"},
-        {"name": "Leia Organa", "affiliation": "REB"},
+        {"name": "Darth Vader", "affiliation": "REP"},
+        {"name": "Leia Organa", "affiliation": "DEM"},
     ]
 
 


### PR DESCRIPTION
Adds a new endpoint that requires audit board authorization to set up
the audit board members (name and party affiliation). Updates the frontend to use this endpoint.

Also creates an Affiliation enum to lock in the values we expect.