### PR TITLE
/sample-sizes always return round one sample size options

### DIFF
--- a/arlo_server/sample_sizes.py
+++ b/arlo_server/sample_sizes.py
@@ -17,7 +17,7 @@ def cumulative_contest_results(contest: Contest) -> Dict[str, int]:
     return results_by_choice
 
 
-def sample_size_options(election: Election) -> dict:
+def sample_size_options(election: Election, round_one=False) -> dict:
     if not election.contests:
         raise BadRequest("Cannot compute sample sizes until contests are set")
     if not election.risk_limit:
@@ -26,10 +26,20 @@ def sample_size_options(election: Election) -> dict:
     # For now, we only support one targeted contest
     contest = next(c for c in election.contests if c.is_targeted)
 
+    # Because the /sample-sizes endpoint is only used for the audit setup flow,
+    # we always want it to return the sample size options for the first round.
+    # So we support a flag in this function to compute the sample sizes for
+    # round one specifically, even if the audit has progressed further.
+    cumulative_results = (
+        {choice.id: 0 for choice in contest.choices}
+        if round_one
+        else cumulative_contest_results(contest)
+    )
+
     sample_sizes: dict = bravo.get_sample_size(
         election.risk_limit / 100,
         sampler_contest.from_db_contest(contest),
-        cumulative_contest_results(contest),
+        cumulative_results,
     )
     return sample_sizes
 
@@ -37,7 +47,7 @@ def sample_size_options(election: Election) -> dict:
 @app.route("/election/<election_id>/sample-sizes", methods=["GET"])
 @with_election_access
 def get_sample_sizes(election: Election):
-    sample_sizes = sample_size_options(election)
+    sample_sizes = sample_size_options(election, round_one=True)
 
     # Convert the results into a slightly more regular format
     json_sizes = list(sample_sizes.values())

--- a/tests/routes_tests/test_sample_sizes.py
+++ b/tests/routes_tests/test_sample_sizes.py
@@ -36,10 +36,28 @@ def test_sample_sizes_round_1(
     client: FlaskClient,
     election_id: str,
     contest_ids: str,  # pylint: disable=unused-argument
-    election_settings: None,  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
 ):
     rv = client.get(f"/election/{election_id}/sample-sizes")
     sample_sizes = json.loads(rv.data)
+    assert sample_sizes == {
+        "sampleSizes": [
+            {"prob": 0.52, "size": 119, "type": "ASN"},
+            {"prob": 0.7, "size": 184, "type": None},
+            {"prob": 0.8, "size": 244, "type": None},
+            {"prob": 0.9, "size": 351, "type": None},
+        ]
+    }
+
+
+def test_sample_sizes_round_2(
+    client: FlaskClient,
+    election_id: str,
+    round_2_id: str,  # pylint: disable=unused-argument
+):
+    rv = client.get(f"/election/{election_id}/sample-sizes")
+    sample_sizes = json.loads(rv.data)
+    # Should still return round 1 sample sizes
     assert sample_sizes == {
         "sampleSizes": [
             {"prob": 0.52, "size": 119, "type": "ASN"},


### PR DESCRIPTION
This endpoint is only used for the audit setup flow. Currently, if you
navigate back to the Review & Launch screen after starting an audit, the
sample sizes shown will reflect the current state of the audit. This fix
ensures that they will always show the initial sample size options that
the user chose from for round 1 when starting the audit.