### PR TITLE
Simplify pytest command using pytest.ini

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,21 +41,8 @@ test-client:
 	yarn --cwd arlo-client lint
 	yarn --cwd arlo-client test
 
-# To run tests matching a search string: TEST=<search string> make test-server
-# To run specific test files: FILE=<file path> make test-server
-# To pass in additional flags to pytest: FLAGS=<extra flags> make test-server
 test-server:
-	FLASK_ENV=test pipenv run pytest ${FILE} \
-		-k '${TEST}' --ignore=arlo-client -vv ${FLAGS}
+	pipenv run pytest
 
 test-server-coverage:
-	FLAGS='--cov=. ${FLAGS}' make test-server
-
-test-math:
-	FILE=tests/audit_math_tests make test-server
-
-test-utils:
-	FILE=tests/util_tests make test-server
-
-test-routes:
-	FILE=tests/routes_tests make test-server
+	pipenv run pytest --cov=.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -vv -x
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,13 @@
-import io, uuid, json
+import io, uuid, json, os
 from typing import List, Generator
 from flask.testing import FlaskClient
 from flask import jsonify, abort
 import pytest
+
+# Before we set up the Flask app, set the env. That way it will use the test
+# config and we can still run tests without setting the env var manually.
+os.environ["FLASK_ENV"] = "test"
+# pylint: disable=wrong-import-position
 
 from arlo_server import app, db
 from arlo_server.models import (


### PR DESCRIPTION
Adds a pytest.ini config file so that we don't have to put all the default settings in the Makefile command. This allows running `pipenv run pytest` if you want to add more flags to the command (`make` doesn't allow you to pass in more flags, so we had a hacky way to work around it before).

