### PR TITLE
Move ts excludes to .slugignore

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,4 @@
+arlo-client/**/_mocks.ts
+arlo-client/**/*.test.*
+arlo-client/**/testUtilities.ts
+arlo-client/src/test/**

--- a/arlo-client/tsconfig.json
+++ b/arlo-client/tsconfig.json
@@ -22,11 +22,5 @@
     ],
     "jsx": "preserve"
   },
-  "include": ["src"],
-  "exclude": [
-    "**/_mocks.ts",
-    "**/*.test.*",
-    "**/testUtilities.ts",
-    "src/test/**"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Allow ts to typecheck test files locally but ignore them when building
on Heroku.
