### PR TITLE
Activating multiple contests

### DIFF
--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`App renders properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-tilXH blZhYR"
+    class="sc-hEsumM gnGovj"
   >
     <div
       class="bp3-navbar sc-EHOje kGnsSl"

--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`App renders properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-hEsumM gnGovj"
+    class="sc-ktHwxA eVyuZn"
   >
     <div
       class="bp3-navbar sc-EHOje kGnsSl"

--- a/client/src/components/Atoms/Form/FormButtonBar.tsx
+++ b/client/src/components/Atoms/Form/FormButtonBar.tsx
@@ -6,12 +6,22 @@ const ButtonBar = styled.div`
   text-align: center;
 `
 
+const RightButtonBar = styled.div`
+  margin: 0;
+  text-align: right;
+`
+
 interface IProps {
+  right?: boolean
   children: ReactNode
 }
 
-const FormButtonBar: React.FC<IProps> = ({ children }: IProps) => {
-  return <ButtonBar>{children}</ButtonBar>
+const FormButtonBar: React.FC<IProps> = ({ children, right }: IProps) => {
+  return right ? (
+    <RightButtonBar>{children}</RightButtonBar>
+  ) : (
+    <ButtonBar>{children}</ButtonBar>
+  )
 }
 
 export default FormButtonBar

--- a/client/src/components/Atoms/Form/FormWrapper.tsx
+++ b/client/src/components/Atoms/Form/FormWrapper.tsx
@@ -5,7 +5,7 @@ import H2Title from '../H2Title'
 const StyledFormWrapper = styled.div`
   display: block;
   position: relative;
-  max-width: 20rem;
+  max-width: 30rem;
   text-align: left;
 `
 

--- a/client/src/components/Atoms/SpacedCard.tsx
+++ b/client/src/components/Atoms/SpacedCard.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Card, Elevation, ICardProps } from '@blueprintjs/core'
+
+const SpacedCard = styled(Card)`
+  &:not(:first-of-type) {
+    margin-top: 20px;
+  }
+`
+
+const ElevatedCard = (props: ICardProps) => (
+  <SpacedCard elevation={Elevation.TWO} {...props} />
+)
+
+export default ElevatedCard

--- a/client/src/components/MultiJurisdictionAudit/Setup/Contests/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Contests/__snapshots__/index.test.tsx.snap
@@ -560,7 +560,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -568,7 +568,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
+        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
       >
         <div
           class="sc-htpNat kLGmUl"
@@ -583,6 +583,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
           >
             Enter the name of the contest that will drive the audit.
           </div>
+          <br />
           <label
             for="contests[0].name"
           >
@@ -671,18 +672,18 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-fjdhpX ixwLIj"
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -697,12 +698,12 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -718,15 +719,15 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -741,12 +742,12 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -762,7 +763,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <p
-              class="sc-chPdSV loppqH"
+              class="sc-kgoBCf jCkIWs"
             >
               Add a new candidate/choice
             </p>
@@ -889,7 +890,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -897,7 +898,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
+        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
       >
         <div
           class="sc-htpNat kLGmUl"
@@ -912,6 +913,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           >
             Enter the name of the contest that will drive the audit.
           </div>
+          <br />
           <label
             for="contests[0].name"
           >
@@ -1000,18 +1002,18 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-fjdhpX ixwLIj"
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1026,12 +1028,12 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1047,15 +1049,15 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1070,12 +1072,12 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1091,7 +1093,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-chPdSV loppqH"
+              class="sc-kgoBCf jCkIWs"
             >
               Add a new candidate/choice
             </p>
@@ -1218,7 +1220,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -1226,7 +1228,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
+        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
       >
         <div
           class="sc-htpNat kLGmUl"
@@ -1241,6 +1243,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           >
             Enter the name of the contest that will drive the audit.
           </div>
+          <br />
           <label
             for="contests[0].name"
           >
@@ -1329,18 +1332,18 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-fjdhpX ixwLIj"
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1355,12 +1358,12 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1376,15 +1379,15 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1399,12 +1402,12 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1420,7 +1423,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <p
-              class="sc-chPdSV loppqH"
+              class="sc-kgoBCf jCkIWs"
             >
               Add a new candidate/choice
             </p>
@@ -1547,7 +1550,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -1555,7 +1558,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
+        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
       >
         <div
           class="sc-htpNat kLGmUl"
@@ -1570,6 +1573,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
           >
             Enter the name of the contest that will drive the audit.
           </div>
+          <br />
           <label
             for="contests[0].name"
           >
@@ -1658,18 +1662,18 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-fjdhpX ixwLIj"
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1684,12 +1688,12 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1705,15 +1709,15 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1728,12 +1732,12 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                  class="sc-kAzzGY ekBBqo sc-EHOje bXavad"
                 >
                   <div
                     class="bp3-input-group sc-bZQynM fFGKEg"
@@ -1749,7 +1753,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-chPdSV loppqH"
+              class="sc-kgoBCf jCkIWs"
             >
               Add a new candidate/choice
             </p>

--- a/client/src/components/MultiJurisdictionAudit/Setup/Contests/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Contests/__snapshots__/index.test.tsx.snap
@@ -583,8 +583,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
         <label
           for="contests[0].name"
         >
-          Contest
-           
+          Contest 
           
            
           Name
@@ -833,6 +832,23 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             </button>
           </span>
         </span>
+      </div>
+      <div
+        class="sc-gqjmRU bEkPjh"
+      >
+        <button
+          class="bp3-button sc-gZMcBi eZVGYn"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Add another 
+            opportunistic
+             
+            contest
+          </span>
+        </button>
       </div>
     </div>
     <div
@@ -892,8 +908,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
         <label
           for="contests[0].name"
         >
-          Contest
-           
+          Contest 
           
            
           Name
@@ -1143,6 +1158,23 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           </span>
         </span>
       </div>
+      <div
+        class="sc-gqjmRU bEkPjh"
+      >
+        <button
+          class="bp3-button sc-gZMcBi eZVGYn"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Add another 
+            targeted
+             
+            contest
+          </span>
+        </button>
+      </div>
     </div>
     <div
       class="sc-gqjmRU bEkPjh"
@@ -1201,8 +1233,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
         <label
           for="contests[0].name"
         >
-          Contest
-           
+          Contest 
           
            
           Name
@@ -1452,6 +1483,23 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           </span>
         </span>
       </div>
+      <div
+        class="sc-gqjmRU bEkPjh"
+      >
+        <button
+          class="bp3-button sc-gZMcBi eZVGYn"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Add another 
+            opportunistic
+             
+            contest
+          </span>
+        </button>
+      </div>
     </div>
     <div
       class="sc-gqjmRU bEkPjh"
@@ -1510,8 +1558,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
         <label
           for="contests[0].name"
         >
-          Contest
-           
+          Contest 
           
            
           Name
@@ -1760,6 +1807,23 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             </button>
           </span>
         </span>
+      </div>
+      <div
+        class="sc-gqjmRU bEkPjh"
+      >
+        <button
+          class="bp3-button sc-gZMcBi eZVGYn"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Add another 
+            targeted
+             
+            contest
+          </span>
+        </button>
       </div>
     </div>
     <div

--- a/client/src/components/MultiJurisdictionAudit/Setup/Contests/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Contests/__snapshots__/index.test.tsx.snap
@@ -568,270 +568,274 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
         Opportunistic Contests
       </h2>
       <div
-        class="sc-htpNat kLGmUl"
+        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
       >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Contest  Info
-        </h3>
         <div
-          class="sc-bxivhb fbVQhV"
+          class="sc-htpNat kLGmUl"
         >
-          Enter the name of the contest that will drive the audit.
-        </div>
-        <label
-          for="contests[0].name"
-        >
-          Contest 
-          
-           
-          Name
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Contest  Info
+          </h3>
           <div
-            class="sc-EHOje bXavad"
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the name of the contest that will drive the audit.
+          </div>
+          <label
+            for="contests[0].name"
+          >
+            Contest 
+            
+             
+            Name
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].name"
+                  name="contests[0].name"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the number of winners for the contest.
+          </div>
+          <label
+            for="contests[0].numWinners"
+          >
+            Winners
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].numWinners"
+                  name="contests[0].numWinners"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Number of selections the voter can make in the contest.
+          </div>
+          <label
+            for="contests[0].votesAllowed"
+          >
+            Votes Allowed
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].votesAllowed"
+                  name="contests[0].votesAllowed"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="sc-htpNat kLGmUl"
+        >
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Candidates/Choices & Vote Totals
+          </h3>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the name of each candidate choice that appears on the ballot for this contest.
+          </div>
+          <div
+            class="sc-fjdhpX ixwLIj"
           >
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-jzJRlG dRtOsa"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].name"
-                name="contests[0].name"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Name of Candidate/Choice 
+                1
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Votes for Candidate/Choice 
+                1
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
-          </div>
-        </label>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the number of winners for the contest.
-        </div>
-        <label
-          for="contests[0].numWinners"
-        >
-          Winners
-          <div
-            class="sc-EHOje bXavad"
-          >
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-jzJRlG dRtOsa"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].numWinners"
-                name="contests[0].numWinners"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Name of Candidate/Choice 
+                2
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Votes for Candidate/Choice 
+                2
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
+            <p
+              class="sc-chPdSV loppqH"
+            >
+              Add a new candidate/choice
+            </p>
           </div>
-        </label>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Number of selections the voter can make in the contest.
         </div>
-        <label
-          for="contests[0].votesAllowed"
+        <div
+          class="sc-htpNat kLGmUl"
         >
-          Votes Allowed
-          <div
-            class="sc-EHOje bXavad"
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
           >
+            Total Ballots Cast
+          </h3>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+          </div>
+          <label
+            for="contests[0].totalBallotsCast"
+          >
+            Total Ballots for Contest
+             
+            
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-EHOje bXavad"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].votesAllowed"
-                name="contests[0].votesAllowed"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].totalBallotsCast"
+                  name="contests[0].totalBallotsCast"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Candidates/Choices & Vote Totals
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the name of each candidate choice that appears on the ballot for this contest.
+          </label>
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-htpNat kLGmUl"
         >
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Contest Universe
+          </h3>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-bxivhb fbVQhV"
           >
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Name of Candidate/Choice 
-              1
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Votes for Candidate/Choice 
-              1
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
+            Select the jurisdictions where this contest appeared on the ballot.
           </div>
-          <div
-            class="sc-jzJRlG dRtOsa"
-          >
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Name of Candidate/Choice 
-              2
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Votes for Candidate/Choice 
-              2
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-          </div>
-          <p
-            class="sc-chPdSV loppqH"
-          >
-            Add a new candidate/choice
-          </p>
-        </div>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Total Ballots Cast
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
-        </div>
-        <label
-          for="contests[0].totalBallotsCast"
-        >
-          Total Ballots for Contest
-           
-          
-          <div
-            class="sc-EHOje bXavad"
-          >
-            <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
-            >
-              <input
-                class="bp3-input"
-                id="contests[0].totalBallotsCast"
-                name="contests[0].totalBallotsCast"
-                style="padding-right: 10px;"
-                value=""
-              />
-            </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Contest Universe
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Select the jurisdictions where this contest appeared on the ballot.
-        </div>
-        <span
-          class="bp3-popover-wrapper"
-        >
           <span
-            class="bp3-popover-target"
+            class="bp3-popover-wrapper"
           >
-            <button
-              class="bp3-button sc-gZMcBi eZVGYn"
-              type="button"
+            <span
+              class="bp3-popover-target"
             >
-              <span
-                class="bp3-button-text"
+              <button
+                class="bp3-button sc-gZMcBi eZVGYn"
+                type="button"
               >
-                Select Jurisdictions
-              </span>
-            </button>
+                <span
+                  class="bp3-button-text"
+                >
+                  Select Jurisdictions
+                </span>
+              </button>
+            </span>
           </span>
-        </span>
+        </div>
       </div>
       <div
         class="sc-gqjmRU bEkPjh"
@@ -893,270 +897,274 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
         Target Contests
       </h2>
       <div
-        class="sc-htpNat kLGmUl"
+        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
       >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Contest  Info
-        </h3>
         <div
-          class="sc-bxivhb fbVQhV"
+          class="sc-htpNat kLGmUl"
         >
-          Enter the name of the contest that will drive the audit.
-        </div>
-        <label
-          for="contests[0].name"
-        >
-          Contest 
-          
-           
-          Name
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Contest  Info
+          </h3>
           <div
-            class="sc-EHOje bXavad"
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the name of the contest that will drive the audit.
+          </div>
+          <label
+            for="contests[0].name"
+          >
+            Contest 
+            
+             
+            Name
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].name"
+                  name="contests[0].name"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the number of winners for the contest.
+          </div>
+          <label
+            for="contests[0].numWinners"
+          >
+            Winners
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].numWinners"
+                  name="contests[0].numWinners"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Number of selections the voter can make in the contest.
+          </div>
+          <label
+            for="contests[0].votesAllowed"
+          >
+            Votes Allowed
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].votesAllowed"
+                  name="contests[0].votesAllowed"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="sc-htpNat kLGmUl"
+        >
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Candidates/Choices & Vote Totals
+          </h3>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the name of each candidate choice that appears on the ballot for this contest.
+          </div>
+          <div
+            class="sc-fjdhpX ixwLIj"
           >
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-jzJRlG dRtOsa"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].name"
-                name="contests[0].name"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Name of Candidate/Choice 
+                1
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Votes for Candidate/Choice 
+                1
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
-          </div>
-        </label>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the number of winners for the contest.
-        </div>
-        <label
-          for="contests[0].numWinners"
-        >
-          Winners
-          <div
-            class="sc-EHOje bXavad"
-          >
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-jzJRlG dRtOsa"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].numWinners"
-                name="contests[0].numWinners"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Name of Candidate/Choice 
+                2
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Votes for Candidate/Choice 
+                2
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
+            <p
+              class="sc-chPdSV loppqH"
+            >
+              Add a new candidate/choice
+            </p>
           </div>
-        </label>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Number of selections the voter can make in the contest.
         </div>
-        <label
-          for="contests[0].votesAllowed"
+        <div
+          class="sc-htpNat kLGmUl"
         >
-          Votes Allowed
-          <div
-            class="sc-EHOje bXavad"
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
           >
+            Total Ballots Cast
+          </h3>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+          </div>
+          <label
+            for="contests[0].totalBallotsCast"
+          >
+            Total Ballots for Contest
+             
+            
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-EHOje bXavad"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].votesAllowed"
-                name="contests[0].votesAllowed"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].totalBallotsCast"
+                  name="contests[0].totalBallotsCast"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Candidates/Choices & Vote Totals
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the name of each candidate choice that appears on the ballot for this contest.
+          </label>
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-htpNat kLGmUl"
         >
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Contest Universe
+          </h3>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-bxivhb fbVQhV"
           >
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Name of Candidate/Choice 
-              1
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Votes for Candidate/Choice 
-              1
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
+            Select the jurisdictions where this contest appeared on the ballot.
           </div>
-          <div
-            class="sc-jzJRlG dRtOsa"
-          >
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Name of Candidate/Choice 
-              2
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Votes for Candidate/Choice 
-              2
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-          </div>
-          <p
-            class="sc-chPdSV loppqH"
-          >
-            Add a new candidate/choice
-          </p>
-        </div>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Total Ballots Cast
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
-        </div>
-        <label
-          for="contests[0].totalBallotsCast"
-        >
-          Total Ballots for Contest
-           
-          
-          <div
-            class="sc-EHOje bXavad"
-          >
-            <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
-            >
-              <input
-                class="bp3-input"
-                id="contests[0].totalBallotsCast"
-                name="contests[0].totalBallotsCast"
-                style="padding-right: 10px;"
-                value=""
-              />
-            </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Contest Universe
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Select the jurisdictions where this contest appeared on the ballot.
-        </div>
-        <span
-          class="bp3-popover-wrapper"
-        >
           <span
-            class="bp3-popover-target"
+            class="bp3-popover-wrapper"
           >
-            <button
-              class="bp3-button sc-gZMcBi eZVGYn"
-              type="button"
+            <span
+              class="bp3-popover-target"
             >
-              <span
-                class="bp3-button-text"
+              <button
+                class="bp3-button sc-gZMcBi eZVGYn"
+                type="button"
               >
-                Select Jurisdictions
-              </span>
-            </button>
+                <span
+                  class="bp3-button-text"
+                >
+                  Select Jurisdictions
+                </span>
+              </button>
+            </span>
           </span>
-        </span>
+        </div>
       </div>
       <div
         class="sc-gqjmRU bEkPjh"
@@ -1218,270 +1226,274 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
         Opportunistic Contests
       </h2>
       <div
-        class="sc-htpNat kLGmUl"
+        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
       >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Contest  Info
-        </h3>
         <div
-          class="sc-bxivhb fbVQhV"
+          class="sc-htpNat kLGmUl"
         >
-          Enter the name of the contest that will drive the audit.
-        </div>
-        <label
-          for="contests[0].name"
-        >
-          Contest 
-          
-           
-          Name
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Contest  Info
+          </h3>
           <div
-            class="sc-EHOje bXavad"
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the name of the contest that will drive the audit.
+          </div>
+          <label
+            for="contests[0].name"
+          >
+            Contest 
+            
+             
+            Name
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].name"
+                  name="contests[0].name"
+                  style="padding-right: 10px;"
+                  value="Contest Name"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the number of winners for the contest.
+          </div>
+          <label
+            for="contests[0].numWinners"
+          >
+            Winners
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].numWinners"
+                  name="contests[0].numWinners"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Number of selections the voter can make in the contest.
+          </div>
+          <label
+            for="contests[0].votesAllowed"
+          >
+            Votes Allowed
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].votesAllowed"
+                  name="contests[0].votesAllowed"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="sc-htpNat kLGmUl"
+        >
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Candidates/Choices & Vote Totals
+          </h3>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the name of each candidate choice that appears on the ballot for this contest.
+          </div>
+          <div
+            class="sc-fjdhpX ixwLIj"
           >
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-jzJRlG dRtOsa"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].name"
-                name="contests[0].name"
-                style="padding-right: 10px;"
-                value="Contest Name"
-              />
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Name of Candidate/Choice 
+                1
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].name"
+                      style="padding-right: 10px;"
+                      value="Choice Three"
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Votes for Candidate/Choice 
+                1
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].numVotes"
+                      style="padding-right: 10px;"
+                      value="10"
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
-          </div>
-        </label>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the number of winners for the contest.
-        </div>
-        <label
-          for="contests[0].numWinners"
-        >
-          Winners
-          <div
-            class="sc-EHOje bXavad"
-          >
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-jzJRlG dRtOsa"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].numWinners"
-                name="contests[0].numWinners"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Name of Candidate/Choice 
+                2
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].name"
+                      style="padding-right: 10px;"
+                      value="Choice Four"
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Votes for Candidate/Choice 
+                2
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].numVotes"
+                      style="padding-right: 10px;"
+                      value="20"
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
+            <p
+              class="sc-chPdSV loppqH"
+            >
+              Add a new candidate/choice
+            </p>
           </div>
-        </label>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Number of selections the voter can make in the contest.
         </div>
-        <label
-          for="contests[0].votesAllowed"
+        <div
+          class="sc-htpNat kLGmUl"
         >
-          Votes Allowed
-          <div
-            class="sc-EHOje bXavad"
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
           >
+            Total Ballots Cast
+          </h3>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+          </div>
+          <label
+            for="contests[0].totalBallotsCast"
+          >
+            Total Ballots for Contest
+             
+            
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-EHOje bXavad"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].votesAllowed"
-                name="contests[0].votesAllowed"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].totalBallotsCast"
+                  name="contests[0].totalBallotsCast"
+                  style="padding-right: 10px;"
+                  value="30"
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Candidates/Choices & Vote Totals
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the name of each candidate choice that appears on the ballot for this contest.
+          </label>
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-htpNat kLGmUl"
         >
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Contest Universe
+          </h3>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-bxivhb fbVQhV"
           >
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Name of Candidate/Choice 
-              1
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].name"
-                    style="padding-right: 10px;"
-                    value="Choice Three"
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Votes for Candidate/Choice 
-              1
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].numVotes"
-                    style="padding-right: 10px;"
-                    value="10"
-                  />
-                </div>
-              </div>
-            </label>
+            Select the jurisdictions where this contest appeared on the ballot.
           </div>
-          <div
-            class="sc-jzJRlG dRtOsa"
-          >
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Name of Candidate/Choice 
-              2
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].name"
-                    style="padding-right: 10px;"
-                    value="Choice Four"
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Votes for Candidate/Choice 
-              2
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].numVotes"
-                    style="padding-right: 10px;"
-                    value="20"
-                  />
-                </div>
-              </div>
-            </label>
-          </div>
-          <p
-            class="sc-chPdSV loppqH"
-          >
-            Add a new candidate/choice
-          </p>
-        </div>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Total Ballots Cast
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
-        </div>
-        <label
-          for="contests[0].totalBallotsCast"
-        >
-          Total Ballots for Contest
-           
-          
-          <div
-            class="sc-EHOje bXavad"
-          >
-            <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
-            >
-              <input
-                class="bp3-input"
-                id="contests[0].totalBallotsCast"
-                name="contests[0].totalBallotsCast"
-                style="padding-right: 10px;"
-                value="30"
-              />
-            </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Contest Universe
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Select the jurisdictions where this contest appeared on the ballot.
-        </div>
-        <span
-          class="bp3-popover-wrapper"
-        >
           <span
-            class="bp3-popover-target"
+            class="bp3-popover-wrapper"
           >
-            <button
-              class="bp3-button sc-gZMcBi eZVGYn"
-              type="button"
+            <span
+              class="bp3-popover-target"
             >
-              <span
-                class="bp3-button-text"
+              <button
+                class="bp3-button sc-gZMcBi eZVGYn"
+                type="button"
               >
-                Select Jurisdictions
-              </span>
-            </button>
+                <span
+                  class="bp3-button-text"
+                >
+                  Select Jurisdictions
+                </span>
+              </button>
+            </span>
           </span>
-        </span>
+        </div>
       </div>
       <div
         class="sc-gqjmRU bEkPjh"
@@ -1543,270 +1555,274 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
         Target Contests
       </h2>
       <div
-        class="sc-htpNat kLGmUl"
+        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
       >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Contest  Info
-        </h3>
         <div
-          class="sc-bxivhb fbVQhV"
+          class="sc-htpNat kLGmUl"
         >
-          Enter the name of the contest that will drive the audit.
-        </div>
-        <label
-          for="contests[0].name"
-        >
-          Contest 
-          
-           
-          Name
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Contest  Info
+          </h3>
           <div
-            class="sc-EHOje bXavad"
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the name of the contest that will drive the audit.
+          </div>
+          <label
+            for="contests[0].name"
+          >
+            Contest 
+            
+             
+            Name
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].name"
+                  name="contests[0].name"
+                  style="padding-right: 10px;"
+                  value="Contest Name"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the number of winners for the contest.
+          </div>
+          <label
+            for="contests[0].numWinners"
+          >
+            Winners
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].numWinners"
+                  name="contests[0].numWinners"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Number of selections the voter can make in the contest.
+          </div>
+          <label
+            for="contests[0].votesAllowed"
+          >
+            Votes Allowed
+            <div
+              class="sc-EHOje bXavad"
+            >
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].votesAllowed"
+                  name="contests[0].votesAllowed"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="sc-htpNat kLGmUl"
+        >
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Candidates/Choices & Vote Totals
+          </h3>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the name of each candidate choice that appears on the ballot for this contest.
+          </div>
+          <div
+            class="sc-fjdhpX ixwLIj"
           >
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-jzJRlG dRtOsa"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].name"
-                name="contests[0].name"
-                style="padding-right: 10px;"
-                value="Contest Name"
-              />
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Name of Candidate/Choice 
+                1
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].name"
+                      style="padding-right: 10px;"
+                      value="Choice One"
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Votes for Candidate/Choice 
+                1
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].numVotes"
+                      style="padding-right: 10px;"
+                      value="10"
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
-          </div>
-        </label>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the number of winners for the contest.
-        </div>
-        <label
-          for="contests[0].numWinners"
-        >
-          Winners
-          <div
-            class="sc-EHOje bXavad"
-          >
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-jzJRlG dRtOsa"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].numWinners"
-                name="contests[0].numWinners"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Name of Candidate/Choice 
+                2
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].name"
+                      style="padding-right: 10px;"
+                      value="Choice Two"
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-kAzzGY kQOXij"
+              >
+                Votes for Candidate/Choice 
+                2
+                <div
+                  class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
+                >
+                  <div
+                    class="bp3-input-group sc-bZQynM fFGKEg"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].numVotes"
+                      style="padding-right: 10px;"
+                      value="20"
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
+            <p
+              class="sc-chPdSV loppqH"
+            >
+              Add a new candidate/choice
+            </p>
           </div>
-        </label>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Number of selections the voter can make in the contest.
         </div>
-        <label
-          for="contests[0].votesAllowed"
+        <div
+          class="sc-htpNat kLGmUl"
         >
-          Votes Allowed
-          <div
-            class="sc-EHOje bXavad"
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
           >
+            Total Ballots Cast
+          </h3>
+          <div
+            class="sc-bxivhb fbVQhV"
+          >
+            Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+          </div>
+          <label
+            for="contests[0].totalBallotsCast"
+          >
+            Total Ballots for Contest
+             
+            
             <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
+              class="sc-EHOje bXavad"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].votesAllowed"
-                name="contests[0].votesAllowed"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <div
+                class="bp3-input-group sc-bZQynM fFGKEg"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].totalBallotsCast"
+                  name="contests[0].totalBallotsCast"
+                  style="padding-right: 10px;"
+                  value="30"
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Candidates/Choices & Vote Totals
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the name of each candidate choice that appears on the ballot for this contest.
+          </label>
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-htpNat kLGmUl"
         >
+          <h3
+            class="bp3-heading sc-ifAKCX fYInwY"
+          >
+            Contest Universe
+          </h3>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-bxivhb fbVQhV"
           >
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Name of Candidate/Choice 
-              1
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].name"
-                    style="padding-right: 10px;"
-                    value="Choice One"
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Votes for Candidate/Choice 
-              1
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].numVotes"
-                    style="padding-right: 10px;"
-                    value="10"
-                  />
-                </div>
-              </div>
-            </label>
+            Select the jurisdictions where this contest appeared on the ballot.
           </div>
-          <div
-            class="sc-jzJRlG dRtOsa"
-          >
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Name of Candidate/Choice 
-              2
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].name"
-                    style="padding-right: 10px;"
-                    value="Choice Two"
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-kAzzGY kQOXij"
-            >
-              Votes for Candidate/Choice 
-              2
-              <div
-                class="sc-cSHVUG gnWAUj sc-EHOje bXavad"
-              >
-                <div
-                  class="bp3-input-group sc-bZQynM fFGKEg"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].numVotes"
-                    style="padding-right: 10px;"
-                    value="20"
-                  />
-                </div>
-              </div>
-            </label>
-          </div>
-          <p
-            class="sc-chPdSV loppqH"
-          >
-            Add a new candidate/choice
-          </p>
-        </div>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Total Ballots Cast
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
-        </div>
-        <label
-          for="contests[0].totalBallotsCast"
-        >
-          Total Ballots for Contest
-           
-          
-          <div
-            class="sc-EHOje bXavad"
-          >
-            <div
-              class="bp3-input-group sc-bZQynM fFGKEg"
-            >
-              <input
-                class="bp3-input"
-                id="contests[0].totalBallotsCast"
-                name="contests[0].totalBallotsCast"
-                style="padding-right: 10px;"
-                value="30"
-              />
-            </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-htpNat kLGmUl"
-      >
-        <h3
-          class="bp3-heading sc-ifAKCX fYInwY"
-        >
-          Contest Universe
-        </h3>
-        <div
-          class="sc-bxivhb fbVQhV"
-        >
-          Select the jurisdictions where this contest appeared on the ballot.
-        </div>
-        <span
-          class="bp3-popover-wrapper"
-        >
           <span
-            class="bp3-popover-target"
+            class="bp3-popover-wrapper"
           >
-            <button
-              class="bp3-button sc-gZMcBi eZVGYn"
-              type="button"
+            <span
+              class="bp3-popover-target"
             >
-              <span
-                class="bp3-button-text"
+              <button
+                class="bp3-button sc-gZMcBi eZVGYn"
+                type="button"
               >
-                Select Jurisdictions
-              </span>
-            </button>
+                <span
+                  class="bp3-button-text"
+                >
+                  Select Jurisdictions
+                </span>
+              </button>
+            </span>
           </span>
-        </span>
+        </div>
       </div>
       <div
         class="sc-gqjmRU bEkPjh"

--- a/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.test.tsx
@@ -146,8 +146,7 @@ describe('Audit Setup > Contests', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it.skip('adds and removes contests', async () => {
-    // skip until feature is complete in backend
+  it('adds and removes contests', async () => {
     const { getByText, getAllByText, queryByText } = render(
       <Contests
         locked={false}

--- a/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.test.tsx
@@ -154,9 +154,8 @@ describe('Audit Setup > Contests', () => {
         {...relativeStages('Target Contests')}
       />
     )
-    await screen.findByText('Add another targeted contest')
 
-    fireEvent.click(getByText('Add another targeted contest'))
+    fireEvent.click(await screen.findByText('Add another targeted contest'))
 
     expect(
       getAllByText('Enter the name of the contest that will drive the audit.')

--- a/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, waitFor, render } from '@testing-library/react'
+import { fireEvent, waitFor, render, screen } from '@testing-library/react'
 import { toast } from 'react-toastify'
 import { useParams } from 'react-router-dom'
 import { regexpEscape } from '../../../testUtilities'
@@ -154,6 +154,7 @@ describe('Audit Setup > Contests', () => {
         {...relativeStages('Target Contests')}
       />
     )
+    await screen.findByText('Add another targeted contest')
 
     fireEvent.click(getByText('Add another targeted contest'))
 

--- a/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.tsx
@@ -96,7 +96,7 @@ const Contests: React.FC<IProps> = ({
           >
             <FieldArray
               name="contests"
-              render={() => (
+              render={contestsArrayHelpers => (
                 <>
                   {values.contests.map((contest: IContest, i: number) => {
                     const jurisdictionOptions = jurisdictions.map(j => ({
@@ -108,22 +108,18 @@ const Contests: React.FC<IProps> = ({
                       /* eslint-disable react/no-array-index-key */
                       <React.Fragment key={i}>
                         {i > 0 && (
-                          /* istanbul ignore next */
                           <FormSection>
                             <hr />
                           </FormSection>
                         )}
                         <FormSection
                           label={`Contest ${
-                            /* istanbul ignore next */
                             values.contests.length > 1 ? i + 1 : ''
                           } Info`}
                           description="Enter the name of the contest that will drive the audit."
                         >
                           <label htmlFor={`contests[${i}].name`}>
-                            Contest{' '}
-                            {/* istanbul ignore next */
-                            values.contests.length > 1 ? i + 1 : ''}{' '}
+                            Contest {values.contests.length > 1 ? i + 1 : ''}{' '}
                             Name
                             <Field
                               id={`contests[${i}].name`}
@@ -157,14 +153,6 @@ const Contests: React.FC<IProps> = ({
                               component={FormField}
                             />
                           </label>
-                          {/* values.contests.length > 1 &&
-                            !audit.contests.length && (
-                              <Action
-                                onClick={() => contestsArrayHelpers.remove(i)}
-                              >
-                                Remove Contest {i + 1}
-                              </Action>
-                            ) */}
                         </FormSection>
                         <FieldArray
                           name={`contests[${i}].choices`}
@@ -252,21 +240,28 @@ const Contests: React.FC<IProps> = ({
                             contestIndex={i}
                           />
                         </FormSection>
+                        {values.contests.length > 1 && (
+                          <FormButton
+                            intent="danger"
+                            onClick={() => contestsArrayHelpers.remove(i)}
+                          >
+                            Remove Contest {i + 1}
+                          </FormButton>
+                        )}
                       </React.Fragment>
                     )
                   })}
-                  {/* <FormButtonBar>
-                    {!audit.contests.length && (
-                      <FormButton
-                        type="button"
-                        onClick={() =>
-                          contestsArrayHelpers.push({ ...contestValues[0] })
-                        }
-                      >
-                        Add another isTargeted contest
-                      </FormButton>
-                    )}
-                  </FormButtonBar> */}
+                  <FormButtonBar>
+                    <FormButton
+                      type="button"
+                      onClick={() =>
+                        contestsArrayHelpers.push({ ...contestValues[0] })
+                      }
+                    >
+                      Add another {isTargeted ? 'targeted' : 'opportunistic'}{' '}
+                      contest
+                    </FormButton>
+                  </FormButtonBar>
                 </>
               )}
             />

--- a/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.tsx
@@ -108,17 +108,13 @@ const Contests: React.FC<IProps> = ({
                     return (
                       /* eslint-disable react/no-array-index-key */
                       <Card key={i}>
-                        {i > 0 && (
-                          <FormSection>
-                            <hr />
-                          </FormSection>
-                        )}
                         <FormSection
                           label={`Contest ${
                             values.contests.length > 1 ? i + 1 : ''
                           } Info`}
                           description="Enter the name of the contest that will drive the audit."
                         >
+                          <br />
                           <label htmlFor={`contests[${i}].name`}>
                             Contest {values.contests.length > 1 ? i + 1 : ''}{' '}
                             Name
@@ -242,12 +238,14 @@ const Contests: React.FC<IProps> = ({
                           />
                         </FormSection>
                         {values.contests.length > 1 && (
-                          <FormButton
-                            intent="danger"
-                            onClick={() => contestsArrayHelpers.remove(i)}
-                          >
-                            Remove Contest {i + 1}
-                          </FormButton>
+                          <FormButtonBar right>
+                            <FormButton
+                              intent="danger"
+                              onClick={() => contestsArrayHelpers.remove(i)}
+                            >
+                              Remove Contest {i + 1}
+                            </FormButton>
+                          </FormButtonBar>
                         )}
                       </Card>
                     )

--- a/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.tsx
@@ -23,6 +23,7 @@ import useContests from '../../useContests'
 import useJurisdictions from '../../useJurisdictions'
 import { IContest, ICandidate } from '../../../../types'
 import DropdownCheckboxList from './DropdownCheckboxList'
+import Card from '../../../Atoms/SpacedCard'
 
 interface IProps {
   isTargeted: boolean
@@ -106,7 +107,7 @@ const Contests: React.FC<IProps> = ({
                     }))
                     return (
                       /* eslint-disable react/no-array-index-key */
-                      <React.Fragment key={i}>
+                      <Card key={i}>
                         {i > 0 && (
                           <FormSection>
                             <hr />
@@ -248,7 +249,7 @@ const Contests: React.FC<IProps> = ({
                             Remove Contest {i + 1}
                           </FormButton>
                         )}
-                      </React.Fragment>
+                      </Card>
                     )
                   })}
                   <FormButtonBar>

--- a/client/src/components/MultiJurisdictionAudit/Setup/Participants/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Participants/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Audit Setup > Participants renders empty state correctly 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -19,7 +19,7 @@ exports[`Audit Setup > Participants renders empty state correctly 1`] = `
         Choose your state from the options below
         <br />
         <div
-          class="bp3-html-select sc-dnqmqq kLRTmU"
+          class="bp3-html-select sc-iwsKbI iYAkEx"
         >
           <select
             data-testid="state-field"
@@ -359,10 +359,10 @@ exports[`Audit Setup > Participants renders empty state correctly 1`] = `
         </div>
       </label>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           Click "Browse" to choose the appropriate file from your computer. This file should be a comma-separated list of all the jurisdictions participating in the audit, plus email addresses for audit administrators in each participating jurisdiction.
           <br />
@@ -377,7 +377,7 @@ exports[`Audit Setup > Participants renders empty state correctly 1`] = `
         </div>
       </div>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <label
           class="bp3-file-input"
@@ -399,7 +399,7 @@ exports[`Audit Setup > Participants renders empty state correctly 1`] = `
       class="sc-htpNat gtULUV"
     >
       <button
-        class="bp3-button bp3-intent-primary sc-ifAKCX zdCNs"
+        class="bp3-button bp3-intent-primary sc-EHOje gmpgQN"
         type="submit"
       >
         <span

--- a/client/src/components/MultiJurisdictionAudit/Setup/Review/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Review/__snapshots__/index.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       Audit Settings
     </h4>
     <table
-      class="sc-dxgOiQ hcdlHA"
+      class="sc-ckVGcZ fmGFyg"
     >
       <tbody>
         <tr>
@@ -89,7 +89,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -104,7 +104,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       <tbody />
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -286,7 +286,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       Audit Settings
     </h4>
     <table
-      class="sc-dxgOiQ hcdlHA"
+      class="sc-ckVGcZ fmGFyg"
     >
       <tbody>
         <tr>
@@ -336,7 +336,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -360,7 +360,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -533,7 +533,7 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
       Audit Settings
     </h4>
     <table
-      class="sc-dxgOiQ hcdlHA"
+      class="sc-ckVGcZ fmGFyg"
     >
       <tbody>
         <tr>
@@ -583,7 +583,7 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -607,7 +607,7 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -778,7 +778,7 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
       Audit Settings
     </h4>
     <table
-      class="sc-dxgOiQ hcdlHA"
+      class="sc-ckVGcZ fmGFyg"
     >
       <tbody>
         <tr>
@@ -828,7 +828,7 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -852,7 +852,7 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -1023,7 +1023,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       Audit Settings
     </h4>
     <table
-      class="sc-dxgOiQ hcdlHA"
+      class="sc-ckVGcZ fmGFyg"
     >
       <tbody>
         <tr>
@@ -1073,7 +1073,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -1088,7 +1088,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       <tbody />
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -1270,7 +1270,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       Audit Settings
     </h4>
     <table
-      class="sc-dxgOiQ hcdlHA"
+      class="sc-ckVGcZ fmGFyg"
     >
       <tbody>
         <tr>
@@ -1320,7 +1320,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -1344,7 +1344,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>

--- a/client/src/components/MultiJurisdictionAudit/Setup/Review/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Review/__snapshots__/index.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       Audit Settings
     </h4>
     <table
-      class="sc-ckVGcZ fmGFyg"
+      class="sc-jKJlTe bkTFhC"
     >
       <tbody>
         <tr>
@@ -89,7 +89,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -104,7 +104,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       <tbody />
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -136,20 +136,20 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       data-testid="sample-size-form"
     >
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Estimated Sample Size
         </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
         </div>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           <div>
             <label
@@ -220,7 +220,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -230,7 +230,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
           </span>
         </button>
         <button
-          class="bp3-button bp3-disabled bp3-intent-primary sc-ifAKCX zdCNs"
+          class="bp3-button bp3-disabled bp3-intent-primary sc-EHOje gmpgQN"
           disabled=""
           tabindex="-1"
           type="button"
@@ -286,7 +286,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       Audit Settings
     </h4>
     <table
-      class="sc-ckVGcZ fmGFyg"
+      class="sc-jKJlTe bkTFhC"
     >
       <tbody>
         <tr>
@@ -336,7 +336,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -360,7 +360,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -383,20 +383,20 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       data-testid="sample-size-form"
     >
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Estimated Sample Size
         </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
         </div>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           <div>
             <label
@@ -467,7 +467,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -477,7 +477,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
           </span>
         </button>
         <button
-          class="bp3-button bp3-disabled bp3-intent-primary sc-ifAKCX zdCNs"
+          class="bp3-button bp3-disabled bp3-intent-primary sc-EHOje gmpgQN"
           disabled=""
           tabindex="-1"
           type="button"
@@ -533,7 +533,7 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
       Audit Settings
     </h4>
     <table
-      class="sc-ckVGcZ fmGFyg"
+      class="sc-jKJlTe bkTFhC"
     >
       <tbody>
         <tr>
@@ -583,7 +583,7 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -607,7 +607,7 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -630,20 +630,20 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
       data-testid="sample-size-form"
     >
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Estimated Sample Size
         </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
         </div>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           <div>
             <label
@@ -714,7 +714,7 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -724,7 +724,7 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
           </span>
         </button>
         <button
-          class="bp3-button bp3-intent-primary sc-ifAKCX zdCNs"
+          class="bp3-button bp3-intent-primary sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -778,7 +778,7 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
       Audit Settings
     </h4>
     <table
-      class="sc-ckVGcZ fmGFyg"
+      class="sc-jKJlTe bkTFhC"
     >
       <tbody>
         <tr>
@@ -828,7 +828,7 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -852,7 +852,7 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -875,20 +875,20 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
       data-testid="sample-size-form"
     >
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Estimated Sample Size
         </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
         </div>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           <div>
             <label
@@ -959,7 +959,7 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -969,7 +969,7 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
           </span>
         </button>
         <button
-          class="bp3-button bp3-intent-primary sc-ifAKCX zdCNs"
+          class="bp3-button bp3-intent-primary sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -1023,7 +1023,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       Audit Settings
     </h4>
     <table
-      class="sc-ckVGcZ fmGFyg"
+      class="sc-jKJlTe bkTFhC"
     >
       <tbody>
         <tr>
@@ -1073,7 +1073,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -1088,7 +1088,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       <tbody />
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -1120,20 +1120,20 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       data-testid="sample-size-form"
     >
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Estimated Sample Size
         </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
         </div>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           <div>
             <label
@@ -1204,7 +1204,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -1214,7 +1214,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
           </span>
         </button>
         <button
-          class="bp3-button bp3-disabled bp3-intent-primary sc-ifAKCX zdCNs"
+          class="bp3-button bp3-disabled bp3-intent-primary sc-EHOje gmpgQN"
           disabled=""
           tabindex="-1"
           type="button"
@@ -1270,7 +1270,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       Audit Settings
     </h4>
     <table
-      class="sc-ckVGcZ fmGFyg"
+      class="sc-jKJlTe bkTFhC"
     >
       <tbody>
         <tr>
@@ -1320,7 +1320,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -1344,7 +1344,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -1367,20 +1367,20 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       data-testid="sample-size-form"
     >
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Estimated Sample Size
         </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
         </div>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-htoDjs GlcDy"
         >
           <div>
             <label
@@ -1451,7 +1451,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -1461,7 +1461,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
           </span>
         </button>
         <button
-          class="bp3-button bp3-intent-primary sc-ifAKCX zdCNs"
+          class="bp3-button bp3-intent-primary sc-EHOje gmpgQN"
           type="button"
         >
           <span

--- a/client/src/components/MultiJurisdictionAudit/Setup/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Setup/__snapshots__/index.test.tsx.snap
@@ -764,8 +764,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
         <label
           for="contests[0].name"
         >
-          Contest
-           
+          Contest 
           
            
           Name
@@ -1015,6 +1014,23 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
           </span>
         </span>
       </div>
+      <div
+        class="sc-htpNat gtULUV"
+      >
+        <button
+          class="bp3-button sc-ifAKCX zdCNs"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Add another 
+            opportunistic
+             
+            contest
+          </span>
+        </button>
+      </div>
     </div>
     <div
       class="sc-htpNat gtULUV"
@@ -1073,8 +1089,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
         <label
           for="contests[0].name"
         >
-          Contest
-           
+          Contest 
           
            
           Name
@@ -1326,6 +1341,23 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
             </button>
           </span>
         </span>
+      </div>
+      <div
+        class="sc-htpNat gtULUV"
+      >
+        <button
+          class="bp3-button sc-ifAKCX zdCNs"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Add another 
+            opportunistic
+             
+            contest
+          </span>
+        </button>
       </div>
     </div>
     <div
@@ -1387,8 +1419,7 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
         <label
           for="contests[0].name"
         >
-          Contest
-           
+          Contest 
           
            
           Name
@@ -1637,6 +1668,23 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
             </button>
           </span>
         </span>
+      </div>
+      <div
+        class="sc-htpNat gtULUV"
+      >
+        <button
+          class="bp3-button sc-ifAKCX zdCNs"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Add another 
+            opportunistic
+             
+            contest
+          </span>
+        </button>
       </div>
     </div>
     <div
@@ -2193,8 +2241,7 @@ exports[`Setup renders Target Contests stage 1`] = `
         <label
           for="contests[0].name"
         >
-          Contest
-           
+          Contest 
           
            
           Name
@@ -2444,6 +2491,23 @@ exports[`Setup renders Target Contests stage 1`] = `
           </span>
         </span>
       </div>
+      <div
+        class="sc-htpNat gtULUV"
+      >
+        <button
+          class="bp3-button sc-ifAKCX zdCNs"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Add another 
+            targeted
+             
+            contest
+          </span>
+        </button>
+      </div>
     </div>
     <div
       class="sc-htpNat gtULUV"
@@ -2502,8 +2566,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
         <label
           for="contests[0].name"
         >
-          Contest
-           
+          Contest 
           
            
           Name
@@ -2755,6 +2818,23 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
             </button>
           </span>
         </span>
+      </div>
+      <div
+        class="sc-htpNat gtULUV"
+      >
+        <button
+          class="bp3-button sc-ifAKCX zdCNs"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Add another 
+            targeted
+             
+            contest
+          </span>
+        </button>
       </div>
     </div>
     <div
@@ -2816,8 +2896,7 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
         <label
           for="contests[0].name"
         >
-          Contest
-           
+          Contest 
           
            
           Name
@@ -3066,6 +3145,23 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
             </button>
           </span>
         </span>
+      </div>
+      <div
+        class="sc-htpNat gtULUV"
+      >
+        <button
+          class="bp3-button sc-ifAKCX zdCNs"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Add another 
+            targeted
+             
+            contest
+          </span>
+        </button>
       </div>
     </div>
     <div

--- a/client/src/components/MultiJurisdictionAudit/Setup/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Setup/__snapshots__/index.test.tsx.snap
@@ -749,270 +749,274 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
         Opportunistic Contests
       </h2>
       <div
-        class="sc-bZQynM ibvdum"
+        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
       >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest  Info
-        </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-bZQynM ibvdum"
         >
-          Enter the name of the contest that will drive the audit.
-        </div>
-        <label
-          for="contests[0].name"
-        >
-          Contest 
-          
-           
-          Name
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Contest  Info
+          </h3>
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of the contest that will drive the audit.
+          </div>
+          <label
+            for="contests[0].name"
+          >
+            Contest 
+            
+             
+            Name
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].name"
+                  name="contests[0].name"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the number of winners for the contest.
+          </div>
+          <label
+            for="contests[0].numWinners"
+          >
+            Winners
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].numWinners"
+                  name="contests[0].numWinners"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Number of selections the voter can make in the contest.
+          </div>
+          <label
+            for="contests[0].votesAllowed"
+          >
+            Votes Allowed
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].votesAllowed"
+                  name="contests[0].votesAllowed"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="sc-bZQynM ibvdum"
+        >
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Candidates/Choices & Vote Totals
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of each candidate choice that appears on the ballot for this contest.
+          </div>
+          <div
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].name"
-                name="contests[0].name"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
-          </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the number of winners for the contest.
-        </div>
-        <label
-          for="contests[0].numWinners"
-        >
-          Winners
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].numWinners"
-                name="contests[0].numWinners"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
+            <p
+              class="sc-kgoBCf jCkIWs"
+            >
+              Add a new candidate/choice
+            </p>
           </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Number of selections the voter can make in the contest.
         </div>
-        <label
-          for="contests[0].votesAllowed"
+        <div
+          class="sc-bZQynM ibvdum"
         >
-          Votes Allowed
-          <div
-            class="sc-iwsKbI dvOqsv"
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
           >
+            Total Ballots Cast
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+          </div>
+          <label
+            for="contests[0].totalBallotsCast"
+          >
+            Total Ballots for Contest
+             
+            
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-iwsKbI dvOqsv"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].votesAllowed"
-                name="contests[0].votesAllowed"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].totalBallotsCast"
+                  name="contests[0].totalBallotsCast"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Candidates/Choices & Vote Totals
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the name of each candidate choice that appears on the ballot for this contest.
+          </label>
         </div>
         <div
-          class="sc-jzJRlG hqJpHa"
+          class="sc-bZQynM ibvdum"
         >
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Contest Universe
+          </h3>
           <div
-            class="sc-cSHVUG jUKlPT"
+            class="sc-gzVnrw kvvweo"
           >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
+            Select the jurisdictions where this contest appeared on the ballot.
           </div>
-          <div
-            class="sc-cSHVUG jUKlPT"
-          >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-          </div>
-          <p
-            class="sc-kgoBCf jCkIWs"
-          >
-            Add a new candidate/choice
-          </p>
-        </div>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Total Ballots Cast
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
-        </div>
-        <label
-          for="contests[0].totalBallotsCast"
-        >
-          Total Ballots for Contest
-           
-          
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
-            <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
-            >
-              <input
-                class="bp3-input"
-                id="contests[0].totalBallotsCast"
-                name="contests[0].totalBallotsCast"
-                style="padding-right: 10px;"
-                value=""
-              />
-            </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest Universe
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Select the jurisdictions where this contest appeared on the ballot.
-        </div>
-        <span
-          class="bp3-popover-wrapper"
-        >
           <span
-            class="bp3-popover-target"
+            class="bp3-popover-wrapper"
           >
-            <button
-              class="bp3-button sc-ifAKCX zdCNs"
-              type="button"
+            <span
+              class="bp3-popover-target"
             >
-              <span
-                class="bp3-button-text"
+              <button
+                class="bp3-button sc-ifAKCX zdCNs"
+                type="button"
               >
-                Select Jurisdictions
-              </span>
-            </button>
+                <span
+                  class="bp3-button-text"
+                >
+                  Select Jurisdictions
+                </span>
+              </button>
+            </span>
           </span>
-        </span>
+        </div>
       </div>
       <div
         class="sc-htpNat gtULUV"
@@ -1074,273 +1078,277 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
         Opportunistic Contests
       </h2>
       <div
-        class="sc-bZQynM ibvdum"
+        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
       >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest  Info
-        </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-bZQynM ibvdum"
         >
-          Enter the name of the contest that will drive the audit.
-        </div>
-        <label
-          for="contests[0].name"
-        >
-          Contest 
-          
-           
-          Name
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Contest  Info
+          </h3>
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of the contest that will drive the audit.
+          </div>
+          <label
+            for="contests[0].name"
+          >
+            Contest 
+            
+             
+            Name
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  disabled=""
+                  id="contests[0].name"
+                  name="contests[0].name"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the number of winners for the contest.
+          </div>
+          <label
+            for="contests[0].numWinners"
+          >
+            Winners
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  disabled=""
+                  id="contests[0].numWinners"
+                  name="contests[0].numWinners"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Number of selections the voter can make in the contest.
+          </div>
+          <label
+            for="contests[0].votesAllowed"
+          >
+            Votes Allowed
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  disabled=""
+                  id="contests[0].votesAllowed"
+                  name="contests[0].votesAllowed"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="sc-bZQynM ibvdum"
+        >
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Candidates/Choices & Vote Totals
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of each candidate choice that appears on the ballot for this contest.
+          </div>
+          <div
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                disabled=""
-                id="contests[0].name"
-                name="contests[0].name"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      disabled=""
+                      name="contests[0].choices[0].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      disabled=""
+                      name="contests[0].choices[0].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
-          </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the number of winners for the contest.
-        </div>
-        <label
-          for="contests[0].numWinners"
-        >
-          Winners
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
             <div
-              class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                disabled=""
-                id="contests[0].numWinners"
-                name="contests[0].numWinners"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      disabled=""
+                      name="contests[0].choices[1].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      disabled=""
+                      name="contests[0].choices[1].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
           </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Number of selections the voter can make in the contest.
         </div>
-        <label
-          for="contests[0].votesAllowed"
+        <div
+          class="sc-bZQynM ibvdum"
         >
-          Votes Allowed
-          <div
-            class="sc-iwsKbI dvOqsv"
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
           >
+            Total Ballots Cast
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+          </div>
+          <label
+            for="contests[0].totalBallotsCast"
+          >
+            Total Ballots for Contest
+             
+            
             <div
-              class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              class="sc-iwsKbI dvOqsv"
             >
-              <input
-                class="bp3-input"
-                disabled=""
-                id="contests[0].votesAllowed"
-                name="contests[0].votesAllowed"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <div
+                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  disabled=""
+                  id="contests[0].totalBallotsCast"
+                  name="contests[0].totalBallotsCast"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Candidates/Choices & Vote Totals
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the name of each candidate choice that appears on the ballot for this contest.
+          </label>
         </div>
         <div
-          class="sc-jzJRlG hqJpHa"
+          class="sc-bZQynM ibvdum"
         >
-          <div
-            class="sc-cSHVUG jUKlPT"
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
           >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    disabled=""
-                    name="contests[0].choices[0].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    disabled=""
-                    name="contests[0].choices[0].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-          </div>
+            Contest Universe
+          </h3>
           <div
-            class="sc-cSHVUG jUKlPT"
+            class="sc-gzVnrw kvvweo"
           >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    disabled=""
-                    name="contests[0].choices[1].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    disabled=""
-                    name="contests[0].choices[1].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
+            Select the jurisdictions where this contest appeared on the ballot.
           </div>
-        </div>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Total Ballots Cast
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
-        </div>
-        <label
-          for="contests[0].totalBallotsCast"
-        >
-          Total Ballots for Contest
-           
-          
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
-            <div
-              class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
-            >
-              <input
-                class="bp3-input"
-                disabled=""
-                id="contests[0].totalBallotsCast"
-                name="contests[0].totalBallotsCast"
-                style="padding-right: 10px;"
-                value=""
-              />
-            </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest Universe
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Select the jurisdictions where this contest appeared on the ballot.
-        </div>
-        <span
-          class="bp3-popover-wrapper"
-        >
           <span
-            class="bp3-popover-target"
+            class="bp3-popover-wrapper"
           >
-            <button
-              class="bp3-button sc-ifAKCX zdCNs"
-              type="button"
+            <span
+              class="bp3-popover-target"
             >
-              <span
-                class="bp3-button-text"
+              <button
+                class="bp3-button sc-ifAKCX zdCNs"
+                type="button"
               >
-                Select Jurisdictions
-              </span>
-            </button>
+                <span
+                  class="bp3-button-text"
+                >
+                  Select Jurisdictions
+                </span>
+              </button>
+            </span>
           </span>
-        </span>
+        </div>
       </div>
       <div
         class="sc-htpNat gtULUV"
@@ -1404,270 +1412,274 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
         Opportunistic Contests
       </h2>
       <div
-        class="sc-bZQynM ibvdum"
+        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
       >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest  Info
-        </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-bZQynM ibvdum"
         >
-          Enter the name of the contest that will drive the audit.
-        </div>
-        <label
-          for="contests[0].name"
-        >
-          Contest 
-          
-           
-          Name
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Contest  Info
+          </h3>
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of the contest that will drive the audit.
+          </div>
+          <label
+            for="contests[0].name"
+          >
+            Contest 
+            
+             
+            Name
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].name"
+                  name="contests[0].name"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the number of winners for the contest.
+          </div>
+          <label
+            for="contests[0].numWinners"
+          >
+            Winners
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].numWinners"
+                  name="contests[0].numWinners"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Number of selections the voter can make in the contest.
+          </div>
+          <label
+            for="contests[0].votesAllowed"
+          >
+            Votes Allowed
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].votesAllowed"
+                  name="contests[0].votesAllowed"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="sc-bZQynM ibvdum"
+        >
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Candidates/Choices & Vote Totals
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of each candidate choice that appears on the ballot for this contest.
+          </div>
+          <div
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].name"
-                name="contests[0].name"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
-          </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the number of winners for the contest.
-        </div>
-        <label
-          for="contests[0].numWinners"
-        >
-          Winners
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].numWinners"
-                name="contests[0].numWinners"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
+            <p
+              class="sc-kgoBCf jCkIWs"
+            >
+              Add a new candidate/choice
+            </p>
           </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Number of selections the voter can make in the contest.
         </div>
-        <label
-          for="contests[0].votesAllowed"
+        <div
+          class="sc-bZQynM ibvdum"
         >
-          Votes Allowed
-          <div
-            class="sc-iwsKbI dvOqsv"
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
           >
+            Total Ballots Cast
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+          </div>
+          <label
+            for="contests[0].totalBallotsCast"
+          >
+            Total Ballots for Contest
+             
+            
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-iwsKbI dvOqsv"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].votesAllowed"
-                name="contests[0].votesAllowed"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].totalBallotsCast"
+                  name="contests[0].totalBallotsCast"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Candidates/Choices & Vote Totals
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the name of each candidate choice that appears on the ballot for this contest.
+          </label>
         </div>
         <div
-          class="sc-jzJRlG hqJpHa"
+          class="sc-bZQynM ibvdum"
         >
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Contest Universe
+          </h3>
           <div
-            class="sc-cSHVUG jUKlPT"
+            class="sc-gzVnrw kvvweo"
           >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
+            Select the jurisdictions where this contest appeared on the ballot.
           </div>
-          <div
-            class="sc-cSHVUG jUKlPT"
-          >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-          </div>
-          <p
-            class="sc-kgoBCf jCkIWs"
-          >
-            Add a new candidate/choice
-          </p>
-        </div>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Total Ballots Cast
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
-        </div>
-        <label
-          for="contests[0].totalBallotsCast"
-        >
-          Total Ballots for Contest
-           
-          
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
-            <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
-            >
-              <input
-                class="bp3-input"
-                id="contests[0].totalBallotsCast"
-                name="contests[0].totalBallotsCast"
-                style="padding-right: 10px;"
-                value=""
-              />
-            </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest Universe
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Select the jurisdictions where this contest appeared on the ballot.
-        </div>
-        <span
-          class="bp3-popover-wrapper"
-        >
           <span
-            class="bp3-popover-target"
+            class="bp3-popover-wrapper"
           >
-            <button
-              class="bp3-button sc-ifAKCX zdCNs"
-              type="button"
+            <span
+              class="bp3-popover-target"
             >
-              <span
-                class="bp3-button-text"
+              <button
+                class="bp3-button sc-ifAKCX zdCNs"
+                type="button"
               >
-                Select Jurisdictions
-              </span>
-            </button>
+                <span
+                  class="bp3-button-text"
+                >
+                  Select Jurisdictions
+                </span>
+              </button>
+            </span>
           </span>
-        </span>
+        </div>
       </div>
       <div
         class="sc-htpNat gtULUV"
@@ -1762,7 +1774,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
       Audit Settings
     </h4>
     <table
-      class="sc-dxgOiQ hcdlHA"
+      class="sc-ckVGcZ fmGFyg"
     >
       <tbody>
         <tr>
@@ -1812,7 +1824,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -1827,7 +1839,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
       <tbody />
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -1925,7 +1937,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
       Audit Settings
     </h4>
     <table
-      class="sc-dxgOiQ hcdlHA"
+      class="sc-ckVGcZ fmGFyg"
     >
       <tbody>
         <tr>
@@ -1975,7 +1987,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -1990,7 +2002,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
       <tbody />
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -2088,7 +2100,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
       Audit Settings
     </h4>
     <table
-      class="sc-dxgOiQ hcdlHA"
+      class="sc-ckVGcZ fmGFyg"
     >
       <tbody>
         <tr>
@@ -2138,7 +2150,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -2153,7 +2165,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
       <tbody />
     </table>
     <table
-      class="sc-kpOJdX bxgNte"
+      class="sc-dxgOiQ boEBcS"
     >
       <thead>
         <tr>
@@ -2226,270 +2238,274 @@ exports[`Setup renders Target Contests stage 1`] = `
         Target Contests
       </h2>
       <div
-        class="sc-bZQynM ibvdum"
+        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
       >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest  Info
-        </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-bZQynM ibvdum"
         >
-          Enter the name of the contest that will drive the audit.
-        </div>
-        <label
-          for="contests[0].name"
-        >
-          Contest 
-          
-           
-          Name
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Contest  Info
+          </h3>
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of the contest that will drive the audit.
+          </div>
+          <label
+            for="contests[0].name"
+          >
+            Contest 
+            
+             
+            Name
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].name"
+                  name="contests[0].name"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the number of winners for the contest.
+          </div>
+          <label
+            for="contests[0].numWinners"
+          >
+            Winners
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].numWinners"
+                  name="contests[0].numWinners"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Number of selections the voter can make in the contest.
+          </div>
+          <label
+            for="contests[0].votesAllowed"
+          >
+            Votes Allowed
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].votesAllowed"
+                  name="contests[0].votesAllowed"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="sc-bZQynM ibvdum"
+        >
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Candidates/Choices & Vote Totals
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of each candidate choice that appears on the ballot for this contest.
+          </div>
+          <div
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].name"
-                name="contests[0].name"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
-          </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the number of winners for the contest.
-        </div>
-        <label
-          for="contests[0].numWinners"
-        >
-          Winners
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].numWinners"
-                name="contests[0].numWinners"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
+            <p
+              class="sc-kgoBCf jCkIWs"
+            >
+              Add a new candidate/choice
+            </p>
           </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Number of selections the voter can make in the contest.
         </div>
-        <label
-          for="contests[0].votesAllowed"
+        <div
+          class="sc-bZQynM ibvdum"
         >
-          Votes Allowed
-          <div
-            class="sc-iwsKbI dvOqsv"
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
           >
+            Total Ballots Cast
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+          </div>
+          <label
+            for="contests[0].totalBallotsCast"
+          >
+            Total Ballots for Contest
+             
+            
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-iwsKbI dvOqsv"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].votesAllowed"
-                name="contests[0].votesAllowed"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].totalBallotsCast"
+                  name="contests[0].totalBallotsCast"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Candidates/Choices & Vote Totals
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the name of each candidate choice that appears on the ballot for this contest.
+          </label>
         </div>
         <div
-          class="sc-jzJRlG hqJpHa"
+          class="sc-bZQynM ibvdum"
         >
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Contest Universe
+          </h3>
           <div
-            class="sc-cSHVUG jUKlPT"
+            class="sc-gzVnrw kvvweo"
           >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
+            Select the jurisdictions where this contest appeared on the ballot.
           </div>
-          <div
-            class="sc-cSHVUG jUKlPT"
-          >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-          </div>
-          <p
-            class="sc-kgoBCf jCkIWs"
-          >
-            Add a new candidate/choice
-          </p>
-        </div>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Total Ballots Cast
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
-        </div>
-        <label
-          for="contests[0].totalBallotsCast"
-        >
-          Total Ballots for Contest
-           
-          
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
-            <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
-            >
-              <input
-                class="bp3-input"
-                id="contests[0].totalBallotsCast"
-                name="contests[0].totalBallotsCast"
-                style="padding-right: 10px;"
-                value=""
-              />
-            </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest Universe
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Select the jurisdictions where this contest appeared on the ballot.
-        </div>
-        <span
-          class="bp3-popover-wrapper"
-        >
           <span
-            class="bp3-popover-target"
+            class="bp3-popover-wrapper"
           >
-            <button
-              class="bp3-button sc-ifAKCX zdCNs"
-              type="button"
+            <span
+              class="bp3-popover-target"
             >
-              <span
-                class="bp3-button-text"
+              <button
+                class="bp3-button sc-ifAKCX zdCNs"
+                type="button"
               >
-                Select Jurisdictions
-              </span>
-            </button>
+                <span
+                  class="bp3-button-text"
+                >
+                  Select Jurisdictions
+                </span>
+              </button>
+            </span>
           </span>
-        </span>
+        </div>
       </div>
       <div
         class="sc-htpNat gtULUV"
@@ -2551,273 +2567,277 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
         Target Contests
       </h2>
       <div
-        class="sc-bZQynM ibvdum"
+        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
       >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest  Info
-        </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-bZQynM ibvdum"
         >
-          Enter the name of the contest that will drive the audit.
-        </div>
-        <label
-          for="contests[0].name"
-        >
-          Contest 
-          
-           
-          Name
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Contest  Info
+          </h3>
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of the contest that will drive the audit.
+          </div>
+          <label
+            for="contests[0].name"
+          >
+            Contest 
+            
+             
+            Name
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  disabled=""
+                  id="contests[0].name"
+                  name="contests[0].name"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the number of winners for the contest.
+          </div>
+          <label
+            for="contests[0].numWinners"
+          >
+            Winners
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  disabled=""
+                  id="contests[0].numWinners"
+                  name="contests[0].numWinners"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Number of selections the voter can make in the contest.
+          </div>
+          <label
+            for="contests[0].votesAllowed"
+          >
+            Votes Allowed
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  disabled=""
+                  id="contests[0].votesAllowed"
+                  name="contests[0].votesAllowed"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="sc-bZQynM ibvdum"
+        >
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Candidates/Choices & Vote Totals
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of each candidate choice that appears on the ballot for this contest.
+          </div>
+          <div
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                disabled=""
-                id="contests[0].name"
-                name="contests[0].name"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      disabled=""
+                      name="contests[0].choices[0].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      disabled=""
+                      name="contests[0].choices[0].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
-          </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the number of winners for the contest.
-        </div>
-        <label
-          for="contests[0].numWinners"
-        >
-          Winners
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
             <div
-              class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                disabled=""
-                id="contests[0].numWinners"
-                name="contests[0].numWinners"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      disabled=""
+                      name="contests[0].choices[1].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      disabled=""
+                      name="contests[0].choices[1].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
           </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Number of selections the voter can make in the contest.
         </div>
-        <label
-          for="contests[0].votesAllowed"
+        <div
+          class="sc-bZQynM ibvdum"
         >
-          Votes Allowed
-          <div
-            class="sc-iwsKbI dvOqsv"
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
           >
+            Total Ballots Cast
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+          </div>
+          <label
+            for="contests[0].totalBallotsCast"
+          >
+            Total Ballots for Contest
+             
+            
             <div
-              class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              class="sc-iwsKbI dvOqsv"
             >
-              <input
-                class="bp3-input"
-                disabled=""
-                id="contests[0].votesAllowed"
-                name="contests[0].votesAllowed"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <div
+                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  disabled=""
+                  id="contests[0].totalBallotsCast"
+                  name="contests[0].totalBallotsCast"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Candidates/Choices & Vote Totals
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the name of each candidate choice that appears on the ballot for this contest.
+          </label>
         </div>
         <div
-          class="sc-jzJRlG hqJpHa"
+          class="sc-bZQynM ibvdum"
         >
-          <div
-            class="sc-cSHVUG jUKlPT"
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
           >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    disabled=""
-                    name="contests[0].choices[0].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    disabled=""
-                    name="contests[0].choices[0].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-          </div>
+            Contest Universe
+          </h3>
           <div
-            class="sc-cSHVUG jUKlPT"
+            class="sc-gzVnrw kvvweo"
           >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    disabled=""
-                    name="contests[0].choices[1].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    disabled=""
-                    name="contests[0].choices[1].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
+            Select the jurisdictions where this contest appeared on the ballot.
           </div>
-        </div>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Total Ballots Cast
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
-        </div>
-        <label
-          for="contests[0].totalBallotsCast"
-        >
-          Total Ballots for Contest
-           
-          
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
-            <div
-              class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
-            >
-              <input
-                class="bp3-input"
-                disabled=""
-                id="contests[0].totalBallotsCast"
-                name="contests[0].totalBallotsCast"
-                style="padding-right: 10px;"
-                value=""
-              />
-            </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest Universe
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Select the jurisdictions where this contest appeared on the ballot.
-        </div>
-        <span
-          class="bp3-popover-wrapper"
-        >
           <span
-            class="bp3-popover-target"
+            class="bp3-popover-wrapper"
           >
-            <button
-              class="bp3-button sc-ifAKCX zdCNs"
-              type="button"
+            <span
+              class="bp3-popover-target"
             >
-              <span
-                class="bp3-button-text"
+              <button
+                class="bp3-button sc-ifAKCX zdCNs"
+                type="button"
               >
-                Select Jurisdictions
-              </span>
-            </button>
+                <span
+                  class="bp3-button-text"
+                >
+                  Select Jurisdictions
+                </span>
+              </button>
+            </span>
           </span>
-        </span>
+        </div>
       </div>
       <div
         class="sc-htpNat gtULUV"
@@ -2881,270 +2901,274 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
         Target Contests
       </h2>
       <div
-        class="sc-bZQynM ibvdum"
+        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
       >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest  Info
-        </h3>
         <div
-          class="sc-gzVnrw kvvweo"
+          class="sc-bZQynM ibvdum"
         >
-          Enter the name of the contest that will drive the audit.
-        </div>
-        <label
-          for="contests[0].name"
-        >
-          Contest 
-          
-           
-          Name
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Contest  Info
+          </h3>
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of the contest that will drive the audit.
+          </div>
+          <label
+            for="contests[0].name"
+          >
+            Contest 
+            
+             
+            Name
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].name"
+                  name="contests[0].name"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the number of winners for the contest.
+          </div>
+          <label
+            for="contests[0].numWinners"
+          >
+            Winners
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].numWinners"
+                  name="contests[0].numWinners"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Number of selections the voter can make in the contest.
+          </div>
+          <label
+            for="contests[0].votesAllowed"
+          >
+            Votes Allowed
+            <div
+              class="sc-iwsKbI dvOqsv"
+            >
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].votesAllowed"
+                  name="contests[0].votesAllowed"
+                  style="padding-right: 10px;"
+                  value="1"
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="sc-bZQynM ibvdum"
+        >
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Candidates/Choices & Vote Totals
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the name of each candidate choice that appears on the ballot for this contest.
+          </div>
+          <div
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].name"
-                name="contests[0].name"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                1
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[0].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
-          </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the number of winners for the contest.
-        </div>
-        <label
-          for="contests[0].numWinners"
-        >
-          Winners
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-cSHVUG jUKlPT"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].numWinners"
-                name="contests[0].numWinners"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Name of Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].name"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
+              <label
+                class="bp3-label sc-chPdSV ewyFtw"
+              >
+                Votes for Candidate/Choice 
+                2
+                <div
+                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                >
+                  <div
+                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="contests[0].choices[1].numVotes"
+                      style="padding-right: 10px;"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </label>
             </div>
+            <p
+              class="sc-kgoBCf jCkIWs"
+            >
+              Add a new candidate/choice
+            </p>
           </div>
-        </label>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Number of selections the voter can make in the contest.
         </div>
-        <label
-          for="contests[0].votesAllowed"
+        <div
+          class="sc-bZQynM ibvdum"
         >
-          Votes Allowed
-          <div
-            class="sc-iwsKbI dvOqsv"
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
           >
+            Total Ballots Cast
+          </h3>
+          <div
+            class="sc-gzVnrw kvvweo"
+          >
+            Enter the overall number of ballot cards cast in jurisdictions containing this contest.
+          </div>
+          <label
+            for="contests[0].totalBallotsCast"
+          >
+            Total Ballots for Contest
+             
+            
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="sc-iwsKbI dvOqsv"
             >
-              <input
-                class="bp3-input"
-                id="contests[0].votesAllowed"
-                name="contests[0].votesAllowed"
-                style="padding-right: 10px;"
-                value="1"
-              />
+              <div
+                class="bp3-input-group sc-gZMcBi fkRAtG"
+              >
+                <input
+                  class="bp3-input"
+                  id="contests[0].totalBallotsCast"
+                  name="contests[0].totalBallotsCast"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Candidates/Choices & Vote Totals
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the name of each candidate choice that appears on the ballot for this contest.
+          </label>
         </div>
         <div
-          class="sc-jzJRlG hqJpHa"
+          class="sc-bZQynM ibvdum"
         >
+          <h3
+            class="bp3-heading sc-htoDjs egbcjZ"
+          >
+            Contest Universe
+          </h3>
           <div
-            class="sc-cSHVUG jUKlPT"
+            class="sc-gzVnrw kvvweo"
           >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              1
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[0].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
+            Select the jurisdictions where this contest appeared on the ballot.
           </div>
-          <div
-            class="sc-cSHVUG jUKlPT"
-          >
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Name of Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].name"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-            <label
-              class="bp3-label sc-chPdSV ewyFtw"
-            >
-              Votes for Candidate/Choice 
-              2
-              <div
-                class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
-              >
-                <div
-                  class="bp3-input-group sc-gZMcBi fkRAtG"
-                >
-                  <input
-                    class="bp3-input"
-                    name="contests[0].choices[1].numVotes"
-                    style="padding-right: 10px;"
-                    value=""
-                  />
-                </div>
-              </div>
-            </label>
-          </div>
-          <p
-            class="sc-kgoBCf jCkIWs"
-          >
-            Add a new candidate/choice
-          </p>
-        </div>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Total Ballots Cast
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Enter the overall number of ballot cards cast in jurisdictions containing this contest.
-        </div>
-        <label
-          for="contests[0].totalBallotsCast"
-        >
-          Total Ballots for Contest
-           
-          
-          <div
-            class="sc-iwsKbI dvOqsv"
-          >
-            <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
-            >
-              <input
-                class="bp3-input"
-                id="contests[0].totalBallotsCast"
-                name="contests[0].totalBallotsCast"
-                style="padding-right: 10px;"
-                value=""
-              />
-            </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="sc-bZQynM ibvdum"
-      >
-        <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
-        >
-          Contest Universe
-        </h3>
-        <div
-          class="sc-gzVnrw kvvweo"
-        >
-          Select the jurisdictions where this contest appeared on the ballot.
-        </div>
-        <span
-          class="bp3-popover-wrapper"
-        >
           <span
-            class="bp3-popover-target"
+            class="bp3-popover-wrapper"
           >
-            <button
-              class="bp3-button sc-ifAKCX zdCNs"
-              type="button"
+            <span
+              class="bp3-popover-target"
             >
-              <span
-                class="bp3-button-text"
+              <button
+                class="bp3-button sc-ifAKCX zdCNs"
+                type="button"
               >
-                Select Jurisdictions
-              </span>
-            </button>
+                <span
+                  class="bp3-button-text"
+                >
+                  Select Jurisdictions
+                </span>
+              </button>
+            </span>
           </span>
-        </span>
+        </div>
       </div>
       <div
         class="sc-htpNat gtULUV"

--- a/client/src/components/MultiJurisdictionAudit/Setup/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Setup/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -14,7 +14,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
         Audit Settings
       </h2>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <label
           for="election-name"
@@ -22,10 +22,10 @@ exports[`Setup renders Audit Settings stage 1`] = `
         >
           Election Name
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gZMcBi ggdJUe"
           >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="bp3-input-group sc-gqjmRU kmAUGh"
             >
               <input
                 aria-labelledby="election-name-label"
@@ -40,7 +40,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
         </label>
       </div>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <label
           for="online"
@@ -78,10 +78,10 @@ exports[`Setup renders Audit Settings stage 1`] = `
         </label>
       </div>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Desired Risk Limit
         </h3>
@@ -90,7 +90,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select sc-fjdhpX jqDqiz"
+            class="bp3-html-select sc-jzJRlG kYjAMg"
           >
             <select
               data-testid="risk-limit"
@@ -182,10 +182,10 @@ exports[`Setup renders Audit Settings stage 1`] = `
         </label>
       </div>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Random Seed
         </h3>
@@ -195,10 +195,10 @@ exports[`Setup renders Audit Settings stage 1`] = `
         >
           Enter the random characters to seed the pseudo-random number generator.
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gZMcBi ggdJUe"
           >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="bp3-input-group sc-gqjmRU kmAUGh"
             >
               <input
                 aria-labelledby="random-seed-label"
@@ -218,7 +218,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
       class="sc-htpNat gtULUV"
     >
       <button
-        class="bp3-button sc-ifAKCX zdCNs"
+        class="bp3-button sc-EHOje gmpgQN"
         type="button"
       >
         <span
@@ -228,7 +228,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-intent-primary sc-ifAKCX zdCNs"
+        class="bp3-button bp3-intent-primary sc-EHOje gmpgQN"
         type="submit"
       >
         <span
@@ -248,7 +248,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -256,7 +256,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
         Audit Settings
       </h2>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <label
           for="election-name"
@@ -264,10 +264,10 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
         >
           Election Name
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gZMcBi ggdJUe"
           >
             <div
-              class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
             >
               <input
                 aria-labelledby="election-name-label"
@@ -283,7 +283,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
         </label>
       </div>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <label
           for="online"
@@ -323,10 +323,10 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
         </label>
       </div>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Desired Risk Limit
         </h3>
@@ -335,7 +335,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
+            class="bp3-html-select bp3-disabled sc-jzJRlG kYjAMg"
           >
             <select
               data-testid="risk-limit"
@@ -428,10 +428,10 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
         </label>
       </div>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Random Seed
         </h3>
@@ -441,10 +441,10 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
         >
           Enter the random characters to seed the pseudo-random number generator.
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gZMcBi ggdJUe"
           >
             <div
-              class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+              class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
             >
               <input
                 aria-labelledby="random-seed-label"
@@ -465,7 +465,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
       class="sc-htpNat gtULUV"
     >
       <button
-        class="bp3-button sc-ifAKCX zdCNs"
+        class="bp3-button sc-EHOje gmpgQN"
         type="button"
       >
         <span
@@ -475,7 +475,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-disabled bp3-intent-primary sc-ifAKCX zdCNs"
+        class="bp3-button bp3-disabled bp3-intent-primary sc-EHOje gmpgQN"
         disabled=""
         tabindex="-1"
         type="submit"
@@ -497,7 +497,7 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -505,7 +505,7 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
         Audit Settings
       </h2>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <label
           for="election-name"
@@ -513,10 +513,10 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
         >
           Election Name
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gZMcBi ggdJUe"
           >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="bp3-input-group sc-gqjmRU kmAUGh"
             >
               <input
                 aria-labelledby="election-name-label"
@@ -531,7 +531,7 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
         </label>
       </div>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <label
           for="online"
@@ -569,10 +569,10 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
         </label>
       </div>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Desired Risk Limit
         </h3>
@@ -581,7 +581,7 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select sc-fjdhpX jqDqiz"
+            class="bp3-html-select sc-jzJRlG kYjAMg"
           >
             <select
               data-testid="risk-limit"
@@ -673,10 +673,10 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
         </label>
       </div>
       <div
-        class="sc-bZQynM ibvdum"
+        class="sc-gzVnrw coBAaV"
       >
         <h3
-          class="bp3-heading sc-htoDjs egbcjZ"
+          class="bp3-heading sc-dnqmqq hlcOhg"
         >
           Random Seed
         </h3>
@@ -686,10 +686,10 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
         >
           Enter the random characters to seed the pseudo-random number generator.
           <div
-            class="sc-iwsKbI dvOqsv"
+            class="sc-gZMcBi ggdJUe"
           >
             <div
-              class="bp3-input-group sc-gZMcBi fkRAtG"
+              class="bp3-input-group sc-gqjmRU kmAUGh"
             >
               <input
                 aria-labelledby="random-seed-label"
@@ -741,7 +741,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -749,21 +749,22 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
       >
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest  Info
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of the contest that will drive the audit.
           </div>
+          <br />
           <label
             for="contests[0].name"
           >
@@ -772,10 +773,10 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
              
             Name
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -788,7 +789,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the number of winners for the contest.
           </div>
@@ -797,10 +798,10 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
           >
             Winners
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -813,7 +814,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -822,10 +823,10 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -839,34 +840,34 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Candidates/Choices & Vote Totals
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-cSHVUG cNFbaH"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -878,15 +879,15 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -899,18 +900,18 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -922,15 +923,15 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -943,22 +944,22 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
               </label>
             </div>
             <p
-              class="sc-kgoBCf jCkIWs"
+              class="sc-kGXeez hibFwE"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Total Ballots Cast
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -969,10 +970,10 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
              
             
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -986,15 +987,15 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest Universe
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -1005,7 +1006,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-ifAKCX zdCNs"
+                class="bp3-button sc-EHOje gmpgQN"
                 type="button"
               >
                 <span
@@ -1022,7 +1023,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -1040,7 +1041,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
       class="sc-htpNat gtULUV"
     >
       <button
-        class="bp3-button sc-ifAKCX zdCNs"
+        class="bp3-button sc-EHOje gmpgQN"
         type="button"
       >
         <span
@@ -1050,7 +1051,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-intent-primary sc-ifAKCX zdCNs"
+        class="bp3-button bp3-intent-primary sc-EHOje gmpgQN"
         type="submit"
       >
         <span
@@ -1070,7 +1071,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -1078,21 +1079,22 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
       >
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest  Info
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of the contest that will drive the audit.
           </div>
+          <br />
           <label
             for="contests[0].name"
           >
@@ -1101,10 +1103,10 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
              
             Name
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -1118,7 +1120,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the number of winners for the contest.
           </div>
@@ -1127,10 +1129,10 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
           >
             Winners
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -1144,7 +1146,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -1153,10 +1155,10 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
           >
             Votes Allowed
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -1171,34 +1173,34 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Candidates/Choices & Vote Totals
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-cSHVUG cNFbaH"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -1211,15 +1213,15 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -1233,18 +1235,18 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -1257,15 +1259,15 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -1281,15 +1283,15 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
           </div>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Total Ballots Cast
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -1300,10 +1302,10 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
              
             
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -1318,15 +1320,15 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest Universe
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -1337,7 +1339,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-ifAKCX zdCNs"
+                class="bp3-button sc-EHOje gmpgQN"
                 type="button"
               >
                 <span
@@ -1354,7 +1356,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -1372,7 +1374,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
       class="sc-htpNat gtULUV"
     >
       <button
-        class="bp3-button sc-ifAKCX zdCNs"
+        class="bp3-button sc-EHOje gmpgQN"
         type="button"
       >
         <span
@@ -1382,7 +1384,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
         </span>
       </button>
       <button
-        class="bp3-button bp3-disabled bp3-intent-primary sc-ifAKCX zdCNs"
+        class="bp3-button bp3-disabled bp3-intent-primary sc-EHOje gmpgQN"
         disabled=""
         tabindex="-1"
         type="submit"
@@ -1404,7 +1406,7 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -1412,21 +1414,22 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
       >
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest  Info
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of the contest that will drive the audit.
           </div>
+          <br />
           <label
             for="contests[0].name"
           >
@@ -1435,10 +1438,10 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
              
             Name
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -1451,7 +1454,7 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the number of winners for the contest.
           </div>
@@ -1460,10 +1463,10 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
           >
             Winners
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -1476,7 +1479,7 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -1485,10 +1488,10 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
           >
             Votes Allowed
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -1502,34 +1505,34 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Candidates/Choices & Vote Totals
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-cSHVUG cNFbaH"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -1541,15 +1544,15 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -1562,18 +1565,18 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -1585,15 +1588,15 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -1606,22 +1609,22 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
               </label>
             </div>
             <p
-              class="sc-kgoBCf jCkIWs"
+              class="sc-kGXeez hibFwE"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Total Ballots Cast
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -1632,10 +1635,10 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
              
             
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -1649,15 +1652,15 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest Universe
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -1668,7 +1671,7 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-ifAKCX zdCNs"
+                class="bp3-button sc-EHOje gmpgQN"
                 type="button"
               >
                 <span
@@ -1685,7 +1688,7 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -1774,7 +1777,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
       Audit Settings
     </h4>
     <table
-      class="sc-ckVGcZ fmGFyg"
+      class="sc-jKJlTe bkTFhC"
     >
       <tbody>
         <tr>
@@ -1824,7 +1827,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -1839,7 +1842,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
       <tbody />
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -1871,7 +1874,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -1881,7 +1884,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
           </span>
         </button>
         <button
-          class="bp3-button bp3-disabled bp3-intent-primary sc-ifAKCX zdCNs"
+          class="bp3-button bp3-disabled bp3-intent-primary sc-EHOje gmpgQN"
           disabled=""
           tabindex="-1"
           type="button"
@@ -1937,7 +1940,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
       Audit Settings
     </h4>
     <table
-      class="sc-ckVGcZ fmGFyg"
+      class="sc-jKJlTe bkTFhC"
     >
       <tbody>
         <tr>
@@ -1987,7 +1990,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -2002,7 +2005,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
       <tbody />
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -2034,7 +2037,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -2044,7 +2047,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
           </span>
         </button>
         <button
-          class="bp3-button bp3-disabled bp3-intent-primary sc-ifAKCX zdCNs"
+          class="bp3-button bp3-disabled bp3-intent-primary sc-EHOje gmpgQN"
           disabled=""
           tabindex="-1"
           type="button"
@@ -2100,7 +2103,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
       Audit Settings
     </h4>
     <table
-      class="sc-ckVGcZ fmGFyg"
+      class="sc-jKJlTe bkTFhC"
     >
       <tbody>
         <tr>
@@ -2150,7 +2153,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
       </tbody>
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -2165,7 +2168,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
       <tbody />
     </table>
     <table
-      class="sc-dxgOiQ boEBcS"
+      class="sc-ckVGcZ qPOwv"
     >
       <thead>
         <tr>
@@ -2197,7 +2200,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -2207,7 +2210,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
           </span>
         </button>
         <button
-          class="bp3-button bp3-disabled bp3-intent-primary sc-ifAKCX zdCNs"
+          class="bp3-button bp3-disabled bp3-intent-primary sc-EHOje gmpgQN"
           disabled=""
           tabindex="-1"
           type="button"
@@ -2230,7 +2233,7 @@ exports[`Setup renders Target Contests stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -2238,21 +2241,22 @@ exports[`Setup renders Target Contests stage 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
       >
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest  Info
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of the contest that will drive the audit.
           </div>
+          <br />
           <label
             for="contests[0].name"
           >
@@ -2261,10 +2265,10 @@ exports[`Setup renders Target Contests stage 1`] = `
              
             Name
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -2277,7 +2281,7 @@ exports[`Setup renders Target Contests stage 1`] = `
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the number of winners for the contest.
           </div>
@@ -2286,10 +2290,10 @@ exports[`Setup renders Target Contests stage 1`] = `
           >
             Winners
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -2302,7 +2306,7 @@ exports[`Setup renders Target Contests stage 1`] = `
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -2311,10 +2315,10 @@ exports[`Setup renders Target Contests stage 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -2328,34 +2332,34 @@ exports[`Setup renders Target Contests stage 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Candidates/Choices & Vote Totals
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-cSHVUG cNFbaH"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -2367,15 +2371,15 @@ exports[`Setup renders Target Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -2388,18 +2392,18 @@ exports[`Setup renders Target Contests stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -2411,15 +2415,15 @@ exports[`Setup renders Target Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -2432,22 +2436,22 @@ exports[`Setup renders Target Contests stage 1`] = `
               </label>
             </div>
             <p
-              class="sc-kgoBCf jCkIWs"
+              class="sc-kGXeez hibFwE"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Total Ballots Cast
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -2458,10 +2462,10 @@ exports[`Setup renders Target Contests stage 1`] = `
              
             
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -2475,15 +2479,15 @@ exports[`Setup renders Target Contests stage 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest Universe
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -2494,7 +2498,7 @@ exports[`Setup renders Target Contests stage 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-ifAKCX zdCNs"
+                class="bp3-button sc-EHOje gmpgQN"
                 type="button"
               >
                 <span
@@ -2511,7 +2515,7 @@ exports[`Setup renders Target Contests stage 1`] = `
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -2529,7 +2533,7 @@ exports[`Setup renders Target Contests stage 1`] = `
       class="sc-htpNat gtULUV"
     >
       <button
-        class="bp3-button sc-ifAKCX zdCNs"
+        class="bp3-button sc-EHOje gmpgQN"
         type="button"
       >
         <span
@@ -2539,7 +2543,7 @@ exports[`Setup renders Target Contests stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-intent-primary sc-ifAKCX zdCNs"
+        class="bp3-button bp3-intent-primary sc-EHOje gmpgQN"
         type="submit"
       >
         <span
@@ -2559,7 +2563,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -2567,21 +2571,22 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
       >
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest  Info
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of the contest that will drive the audit.
           </div>
+          <br />
           <label
             for="contests[0].name"
           >
@@ -2590,10 +2595,10 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
              
             Name
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -2607,7 +2612,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the number of winners for the contest.
           </div>
@@ -2616,10 +2621,10 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
           >
             Winners
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -2633,7 +2638,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -2642,10 +2647,10 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -2660,34 +2665,34 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Candidates/Choices & Vote Totals
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-cSHVUG cNFbaH"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -2700,15 +2705,15 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -2722,18 +2727,18 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -2746,15 +2751,15 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -2770,15 +2775,15 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
           </div>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Total Ballots Cast
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -2789,10 +2794,10 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
              
             
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gZMcBi fkRAtG"
+                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -2807,15 +2812,15 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest Universe
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -2826,7 +2831,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-ifAKCX zdCNs"
+                class="bp3-button sc-EHOje gmpgQN"
                 type="button"
               >
                 <span
@@ -2843,7 +2848,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -2861,7 +2866,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
       class="sc-htpNat gtULUV"
     >
       <button
-        class="bp3-button sc-ifAKCX zdCNs"
+        class="bp3-button sc-EHOje gmpgQN"
         type="button"
       >
         <span
@@ -2871,7 +2876,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-disabled bp3-intent-primary sc-ifAKCX zdCNs"
+        class="bp3-button bp3-disabled bp3-intent-primary sc-EHOje gmpgQN"
         disabled=""
         tabindex="-1"
         type="submit"
@@ -2893,7 +2898,7 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH hfheQC"
+      class="sc-bwzfXH jFbAHP"
     >
       <h2
         class="bp3-heading sc-bdVaJa ibVpPq"
@@ -2901,21 +2906,22 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
       >
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest  Info
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of the contest that will drive the audit.
           </div>
+          <br />
           <label
             for="contests[0].name"
           >
@@ -2924,10 +2930,10 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
              
             Name
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -2940,7 +2946,7 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the number of winners for the contest.
           </div>
@@ -2949,10 +2955,10 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
           >
             Winners
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -2965,7 +2971,7 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -2974,10 +2980,10 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -2991,34 +2997,34 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Candidates/Choices & Vote Totals
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-cSHVUG cNFbaH"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -3030,15 +3036,15 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -3051,18 +3057,18 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-kAzzGY gvpNKy"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -3074,15 +3080,15 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-kgoBCf eKfxQS"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-iwsKbI dvOqsv"
+                  class="sc-chPdSV knRDOr sc-gZMcBi ggdJUe"
                 >
                   <div
-                    class="bp3-input-group sc-gZMcBi fkRAtG"
+                    class="bp3-input-group sc-gqjmRU kmAUGh"
                   >
                     <input
                       class="bp3-input"
@@ -3095,22 +3101,22 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
               </label>
             </div>
             <p
-              class="sc-kgoBCf jCkIWs"
+              class="sc-kGXeez hibFwE"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Total Ballots Cast
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -3121,10 +3127,10 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
              
             
             <div
-              class="sc-iwsKbI dvOqsv"
+              class="sc-gZMcBi ggdJUe"
             >
               <div
-                class="bp3-input-group sc-gZMcBi fkRAtG"
+                class="bp3-input-group sc-gqjmRU kmAUGh"
               >
                 <input
                   class="bp3-input"
@@ -3138,15 +3144,15 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM ibvdum"
+          class="sc-gzVnrw coBAaV"
         >
           <h3
-            class="bp3-heading sc-htoDjs egbcjZ"
+            class="bp3-heading sc-dnqmqq hlcOhg"
           >
             Contest Universe
           </h3>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -3157,7 +3163,7 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-ifAKCX zdCNs"
+                class="bp3-button sc-EHOje gmpgQN"
                 type="button"
               >
                 <span
@@ -3174,7 +3180,7 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
         class="sc-htpNat gtULUV"
       >
         <button
-          class="bp3-button sc-ifAKCX zdCNs"
+          class="bp3-button sc-EHOje gmpgQN"
           type="button"
         >
           <span

--- a/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
     class="sc-bdVaJa AANBu"
   >
     <div
-      class="bp3-callout sc-hMqMXs gvJKSa"
+      class="bp3-callout sc-kEYyzF ejxvfy"
     >
       <div
         class="sc-bwzfXH iqXUnX"
@@ -58,7 +58,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
         </ul>
       </div>
       <div
-        class="sc-kkGfuU kxYEyN"
+        class="sc-iAyFgw iuVrZJ"
       >
         <h2
           class="bp3-heading sc-htpNat fysvnw"
@@ -71,7 +71,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
            To view a single jurisdiction's data, click the name of the jurisdiction.
         </p>
         <div
-          class="sc-iAyFgw ciCQxA"
+          class="sc-hSdWYo iKUdPX"
         >
           <label
             class="bp3-control bp3-switch"
@@ -100,7 +100,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
           </div>
         </div>
         <table
-          class="sc-kEYyzF gTKhLx"
+          class="sc-kkGfuU eKXmGD"
           role="table"
         >
           <thead>
@@ -298,7 +298,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
     class="sc-bdVaJa AANBu"
   >
     <div
-      class="bp3-callout sc-hMqMXs gvJKSa"
+      class="bp3-callout sc-kEYyzF ejxvfy"
     >
       <div
         class="sc-bwzfXH iqXUnX"
@@ -906,7 +906,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 2`] = `
     class="sc-bdVaJa AANBu"
   >
     <div
-      class="bp3-callout sc-hMqMXs gvJKSa"
+      class="bp3-callout sc-kEYyzF ejxvfy"
     >
       <div
         class="sc-bwzfXH iqXUnX"

--- a/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
     class="sc-bdVaJa AANBu"
   >
     <div
-      class="bp3-callout sc-kEYyzF ejxvfy"
+      class="bp3-callout sc-kkGfuU jfrnYf"
     >
       <div
         class="sc-bwzfXH iqXUnX"
@@ -58,7 +58,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
         </ul>
       </div>
       <div
-        class="sc-iAyFgw iuVrZJ"
+        class="sc-hSdWYo jmKYUK"
       >
         <h2
           class="bp3-heading sc-htpNat fysvnw"
@@ -71,7 +71,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
            To view a single jurisdiction's data, click the name of the jurisdiction.
         </p>
         <div
-          class="sc-hSdWYo iKUdPX"
+          class="sc-eHgmQL kyIlpv"
         >
           <label
             class="bp3-control bp3-switch"
@@ -100,7 +100,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
           </div>
         </div>
         <table
-          class="sc-kkGfuU eKXmGD"
+          class="sc-iAyFgw lbSVII"
           role="table"
         >
           <thead>
@@ -298,7 +298,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
     class="sc-bdVaJa AANBu"
   >
     <div
-      class="bp3-callout sc-kEYyzF ejxvfy"
+      class="bp3-callout sc-kkGfuU jfrnYf"
     >
       <div
         class="sc-bwzfXH iqXUnX"
@@ -479,7 +479,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
         data-testid="form-one"
       >
         <div
-          class="sc-ifAKCX dUfgxM"
+          class="sc-ifAKCX dOqzfM"
         >
           <h2
             class="bp3-heading sc-htpNat fysvnw"
@@ -492,7 +492,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
             Choose your state from the options below
             <br />
             <div
-              class="bp3-html-select sc-gqjmRU kmMPEy"
+              class="bp3-html-select sc-VigVT jXUwyP"
             >
               <select
                 data-testid="state-field"
@@ -832,10 +832,10 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
             </div>
           </label>
           <div
-            class="sc-dnqmqq HzlIh"
+            class="sc-iwsKbI iGsFgr"
           >
             <div
-              class="sc-iwsKbI bncGzX"
+              class="sc-gZMcBi bmHNeb"
             >
               Click "Browse" to choose the appropriate file from your computer. This file should be a comma-separated list of all the jurisdictions participating in the audit, plus email addresses for audit administrators in each participating jurisdiction.
               <br />
@@ -850,7 +850,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
             </div>
           </div>
           <div
-            class="sc-dnqmqq HzlIh"
+            class="sc-iwsKbI iGsFgr"
           >
             <label
               class="bp3-file-input"
@@ -906,7 +906,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 2`] = `
     class="sc-bdVaJa AANBu"
   >
     <div
-      class="bp3-callout sc-kEYyzF ejxvfy"
+      class="bp3-callout sc-kkGfuU jfrnYf"
     >
       <div
         class="sc-bwzfXH iqXUnX"
@@ -1087,7 +1087,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 2`] = `
         data-testid="form-one"
       >
         <div
-          class="sc-ifAKCX dUfgxM"
+          class="sc-ifAKCX dOqzfM"
         >
           <h2
             class="bp3-heading sc-htpNat fysvnw"
@@ -1100,7 +1100,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 2`] = `
             Choose your state from the options below
             <br />
             <div
-              class="bp3-html-select sc-gqjmRU kmMPEy"
+              class="bp3-html-select sc-VigVT jXUwyP"
             >
               <select
                 data-testid="state-field"
@@ -1440,10 +1440,10 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 2`] = `
             </div>
           </label>
           <div
-            class="sc-dnqmqq HzlIh"
+            class="sc-iwsKbI iGsFgr"
           >
             <div
-              class="sc-iwsKbI bncGzX"
+              class="sc-gZMcBi bmHNeb"
             >
               Click "Browse" to choose the appropriate file from your computer. This file should be a comma-separated list of all the jurisdictions participating in the audit, plus email addresses for audit administrators in each participating jurisdiction.
               <br />
@@ -1458,14 +1458,14 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 2`] = `
             </div>
           </div>
           <div
-            class="sc-dnqmqq HzlIh"
+            class="sc-iwsKbI iGsFgr"
           >
             <span>
               file name
                
             </span>
             <button
-              class="bp3-button sc-gzVnrw kdzzfK"
+              class="bp3-button sc-htoDjs dESvso"
               type="button"
             >
               <span

--- a/client/src/components/SingleJurisdictionAudit/__snapshots__/CalculateRiskMeasurement.test.tsx.snap
+++ b/client/src/components/SingleJurisdictionAudit/__snapshots__/CalculateRiskMeasurement.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CalculateRiskMeasurement handles inputs 1`] = `
     data-testid="form-three-1"
   >
     <div
-      class="sc-jzJRlG dbOHBu"
+      class="sc-cSHVUG jgYzBX"
       id="qr-root"
     >
       <span
@@ -21,7 +21,7 @@ exports[`CalculateRiskMeasurement handles inputs 1`] = `
     </div>
     <hr />
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -106,13 +106,13 @@ exports[`CalculateRiskMeasurement handles inputs 1`] = `
           1
         </div>
         <div
-          class="sc-VigVT gsoadH"
+          class="sc-jTzLTM dvnzHJ"
         >
           <div
-            class="sc-fjdhpX hUEYKL"
+            class="sc-jzJRlG kETAp"
           >
             <label
-              class="sc-jTzLTM nTHaA"
+              class="sc-fjdhpX ctsPJP"
               for="round-0-contest-0-choice-choice-1"
             >
               choice one
@@ -134,10 +134,10 @@ exports[`CalculateRiskMeasurement handles inputs 1`] = `
             </div>
           </div>
           <div
-            class="sc-fjdhpX hUEYKL"
+            class="sc-jzJRlG kETAp"
           >
             <label
-              class="sc-jTzLTM nTHaA"
+              class="sc-fjdhpX ctsPJP"
               for="round-0-contest-0-choice-choice-2"
             >
               choice two
@@ -205,7 +205,7 @@ Object {
         data-testid="form-three-1"
       >
         <div
-          class="sc-jzJRlG dbOHBu"
+          class="sc-cSHVUG jgYzBX"
           id="qr-root"
         >
           <span
@@ -220,7 +220,7 @@ Object {
         </div>
         <hr />
         <div
-          class="sc-ifAKCX dUfgxM"
+          class="sc-ifAKCX dOqzfM"
         >
           <h2
             class="bp3-heading sc-bxivhb jFEWwS"
@@ -297,13 +297,13 @@ Object {
               COMPLETE
             </h3>
             <div
-              class="sc-VigVT gsoadH"
+              class="sc-jTzLTM dvnzHJ"
             >
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                 >
                   Risk Limit: 
                 </label>
@@ -311,10 +311,10 @@ Object {
                 %
               </div>
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                 >
                   P-value: 
                 </label>
@@ -323,13 +323,13 @@ Object {
               </div>
             </div>
             <div
-              class="sc-VigVT gsoadH"
+              class="sc-jTzLTM dvnzHJ"
             >
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                   for="round-0-contest-0-choice-choice-1"
                 >
                   choice one
@@ -352,10 +352,10 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                   for="round-0-contest-0-choice-choice-2"
                 >
                   choice two
@@ -417,7 +417,7 @@ Object {
       data-testid="form-three-1"
     >
       <div
-        class="sc-jzJRlG dbOHBu"
+        class="sc-cSHVUG jgYzBX"
         id="qr-root"
       >
         <span
@@ -432,7 +432,7 @@ Object {
       </div>
       <hr />
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -509,13 +509,13 @@ Object {
             COMPLETE
           </h3>
           <div
-            class="sc-VigVT gsoadH"
+            class="sc-jTzLTM dvnzHJ"
           >
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
               >
                 Risk Limit: 
               </label>
@@ -523,10 +523,10 @@ Object {
               %
             </div>
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
               >
                 P-value: 
               </label>
@@ -535,13 +535,13 @@ Object {
             </div>
           </div>
           <div
-            class="sc-VigVT gsoadH"
+            class="sc-jTzLTM dvnzHJ"
           >
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
                 for="round-0-contest-0-choice-choice-1"
               >
                 choice one
@@ -564,10 +564,10 @@ Object {
               </div>
             </div>
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
                 for="round-0-contest-0-choice-choice-2"
               >
                 choice two
@@ -686,7 +686,7 @@ Object {
         data-testid="form-three-1"
       >
         <div
-          class="sc-jzJRlG dbOHBu"
+          class="sc-cSHVUG jgYzBX"
           id="qr-root"
         >
           <span
@@ -701,7 +701,7 @@ Object {
         </div>
         <hr />
         <div
-          class="sc-ifAKCX dUfgxM"
+          class="sc-ifAKCX dOqzfM"
         >
           <h2
             class="bp3-heading sc-bxivhb jFEWwS"
@@ -778,13 +778,13 @@ Object {
               COMPLETE
             </h3>
             <div
-              class="sc-VigVT gsoadH"
+              class="sc-jTzLTM dvnzHJ"
             >
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                 >
                   Risk Limit: 
                 </label>
@@ -792,10 +792,10 @@ Object {
                 %
               </div>
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                 >
                   P-value: 
                 </label>
@@ -804,13 +804,13 @@ Object {
               </div>
             </div>
             <div
-              class="sc-VigVT gsoadH"
+              class="sc-jTzLTM dvnzHJ"
             >
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                   for="round-0-contest-0-choice-choice-1"
                 >
                   choice one
@@ -833,10 +833,10 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                   for="round-0-contest-0-choice-choice-2"
                 >
                   choice two
@@ -924,7 +924,7 @@ Object {
       data-testid="form-three-1"
     >
       <div
-        class="sc-jzJRlG dbOHBu"
+        class="sc-cSHVUG jgYzBX"
         id="qr-root"
       >
         <span
@@ -939,7 +939,7 @@ Object {
       </div>
       <hr />
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -1016,13 +1016,13 @@ Object {
             COMPLETE
           </h3>
           <div
-            class="sc-VigVT gsoadH"
+            class="sc-jTzLTM dvnzHJ"
           >
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
               >
                 Risk Limit: 
               </label>
@@ -1030,10 +1030,10 @@ Object {
               %
             </div>
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
               >
                 P-value: 
               </label>
@@ -1042,13 +1042,13 @@ Object {
             </div>
           </div>
           <div
-            class="sc-VigVT gsoadH"
+            class="sc-jTzLTM dvnzHJ"
           >
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
                 for="round-0-contest-0-choice-choice-1"
               >
                 choice one
@@ -1071,10 +1071,10 @@ Object {
               </div>
             </div>
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
                 for="round-0-contest-0-choice-choice-2"
               >
                 choice two
@@ -1219,7 +1219,7 @@ Object {
         data-testid="form-three-1"
       >
         <div
-          class="sc-jzJRlG dbOHBu"
+          class="sc-cSHVUG jgYzBX"
           id="qr-root"
         >
           <span
@@ -1234,7 +1234,7 @@ Object {
         </div>
         <hr />
         <div
-          class="sc-ifAKCX dUfgxM"
+          class="sc-ifAKCX dOqzfM"
         >
           <h2
             class="bp3-heading sc-bxivhb jFEWwS"
@@ -1319,13 +1319,13 @@ Object {
               1
             </div>
             <div
-              class="sc-VigVT gsoadH"
+              class="sc-jTzLTM dvnzHJ"
             >
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                   for="round-0-contest-0-choice-choice-1"
                 >
                   choice one
@@ -1347,10 +1347,10 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                   for="round-0-contest-0-choice-choice-2"
                 >
                   choice two
@@ -1413,7 +1413,7 @@ Object {
       data-testid="form-three-1"
     >
       <div
-        class="sc-jzJRlG dbOHBu"
+        class="sc-cSHVUG jgYzBX"
         id="qr-root"
       >
         <span
@@ -1428,7 +1428,7 @@ Object {
       </div>
       <hr />
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -1513,13 +1513,13 @@ Object {
             1
           </div>
           <div
-            class="sc-VigVT gsoadH"
+            class="sc-jTzLTM dvnzHJ"
           >
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
                 for="round-0-contest-0-choice-choice-1"
               >
                 choice one
@@ -1541,10 +1541,10 @@ Object {
               </div>
             </div>
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
                 for="round-0-contest-0-choice-choice-2"
               >
                 choice two
@@ -1664,7 +1664,7 @@ Object {
         data-testid="form-three-1"
       >
         <div
-          class="sc-jzJRlG dbOHBu"
+          class="sc-cSHVUG jgYzBX"
           id="qr-root"
         >
           <span
@@ -1679,7 +1679,7 @@ Object {
         </div>
         <hr />
         <div
-          class="sc-ifAKCX dUfgxM"
+          class="sc-ifAKCX dOqzfM"
         >
           <h2
             class="bp3-heading sc-bxivhb jFEWwS"
@@ -1764,13 +1764,13 @@ Object {
               1
             </div>
             <div
-              class="sc-VigVT gsoadH"
+              class="sc-jTzLTM dvnzHJ"
             >
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                   for="round-0-contest-0-choice-choice-1"
                 >
                   choice one
@@ -1792,10 +1792,10 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-fjdhpX hUEYKL"
+                class="sc-jzJRlG kETAp"
               >
                 <label
-                  class="sc-jTzLTM nTHaA"
+                  class="sc-fjdhpX ctsPJP"
                   for="round-0-contest-0-choice-choice-2"
                 >
                   choice two
@@ -1870,7 +1870,7 @@ Object {
       data-testid="form-three-1"
     >
       <div
-        class="sc-jzJRlG dbOHBu"
+        class="sc-cSHVUG jgYzBX"
         id="qr-root"
       >
         <span
@@ -1885,7 +1885,7 @@ Object {
       </div>
       <hr />
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -1970,13 +1970,13 @@ Object {
             1
           </div>
           <div
-            class="sc-VigVT gsoadH"
+            class="sc-jTzLTM dvnzHJ"
           >
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
                 for="round-0-contest-0-choice-choice-1"
               >
                 choice one
@@ -1998,10 +1998,10 @@ Object {
               </div>
             </div>
             <div
-              class="sc-fjdhpX hUEYKL"
+              class="sc-jzJRlG kETAp"
             >
               <label
-                class="sc-jTzLTM nTHaA"
+                class="sc-fjdhpX ctsPJP"
                 for="round-0-contest-0-choice-choice-2"
               >
                 choice two
@@ -2130,7 +2130,7 @@ exports[`CalculateRiskMeasurement renders online mode progress bar 1`] = `
     data-testid="form-three-1"
   >
     <div
-      class="sc-jzJRlG dbOHBu"
+      class="sc-cSHVUG jgYzBX"
       id="qr-root"
     >
       <span
@@ -2145,7 +2145,7 @@ exports[`CalculateRiskMeasurement renders online mode progress bar 1`] = `
     </div>
     <hr />
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -2294,7 +2294,7 @@ exports[`CalculateRiskMeasurement renders online mode progress bar in multiple r
     data-testid="form-three-1"
   >
     <div
-      class="sc-jzJRlG dbOHBu"
+      class="sc-cSHVUG jgYzBX"
       id="qr-root"
     >
       <span
@@ -2327,7 +2327,7 @@ exports[`CalculateRiskMeasurement renders online mode progress bar in multiple r
     </div>
     <hr />
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -2445,7 +2445,7 @@ exports[`CalculateRiskMeasurement renders online mode progress bar in multiple r
   >
     <hr />
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"

--- a/client/src/components/SingleJurisdictionAudit/__snapshots__/EstimateSampleSize.test.tsx.snap
+++ b/client/src/components/SingleJurisdictionAudit/__snapshots__/EstimateSampleSize.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EstimateSampleSize renders Styled(Component) correctly 1`] = `
 <div>
   <label
-    class="bp3-label sc-kAzzGY kQOXij"
+    class="bp3-label sc-chPdSV ewyFtw"
   />
 </div>
 `;
@@ -14,7 +14,7 @@ exports[`EstimateSampleSize renders after contests creation correctly 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -153,18 +153,18 @@ exports[`EstimateSampleSize renders after contests creation correctly 1`] = `
           Enter the name of each candidate choice that appears on the ballot for this contest.
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-jzJRlG hqJpHa"
         >
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -180,12 +180,12 @@ exports[`EstimateSampleSize renders after contests creation correctly 1`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -202,15 +202,15 @@ exports[`EstimateSampleSize renders after contests creation correctly 1`] = `
             </label>
           </div>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -226,12 +226,12 @@ exports[`EstimateSampleSize renders after contests creation correctly 1`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -339,7 +339,7 @@ exports[`EstimateSampleSize renders after contests creation correctly 1`] = `
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+            class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
           >
             <select
               disabled=""
@@ -474,7 +474,7 @@ exports[`EstimateSampleSize renders after contests creation correctly 2`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -613,18 +613,18 @@ exports[`EstimateSampleSize renders after contests creation correctly 2`] = `
           Enter the name of each candidate choice that appears on the ballot for this contest.
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-jzJRlG hqJpHa"
         >
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -640,12 +640,12 @@ exports[`EstimateSampleSize renders after contests creation correctly 2`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -662,15 +662,15 @@ exports[`EstimateSampleSize renders after contests creation correctly 2`] = `
             </label>
           </div>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -686,12 +686,12 @@ exports[`EstimateSampleSize renders after contests creation correctly 2`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -799,7 +799,7 @@ exports[`EstimateSampleSize renders after contests creation correctly 2`] = `
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+            class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
           >
             <select
               disabled=""
@@ -960,7 +960,7 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -1099,18 +1099,18 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 1`] = `
           Enter the name of each candidate choice that appears on the ballot for this contest.
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-jzJRlG hqJpHa"
         >
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1126,12 +1126,12 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 1`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1148,15 +1148,15 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 1`] = `
             </label>
           </div>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1172,12 +1172,12 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 1`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1285,7 +1285,7 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 1`] = `
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+            class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
           >
             <select
               disabled=""
@@ -1420,7 +1420,7 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 2`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -1559,18 +1559,18 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 2`] = `
           Enter the name of each candidate choice that appears on the ballot for this contest.
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-jzJRlG hqJpHa"
         >
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1586,12 +1586,12 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 2`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1608,15 +1608,15 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 2`] = `
             </label>
           </div>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1632,12 +1632,12 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 2`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1745,7 +1745,7 @@ exports[`EstimateSampleSize renders after manifest is uploaded correctly 2`] = `
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+            class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
           >
             <select
               disabled=""
@@ -1906,7 +1906,7 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 1`]
     data-testid="form-one"
   >
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -2045,18 +2045,18 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 1`]
           Enter the name of each candidate choice that appears on the ballot for this contest.
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-jzJRlG hqJpHa"
         >
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2072,12 +2072,12 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 1`]
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2094,15 +2094,15 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 1`]
             </label>
           </div>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2118,12 +2118,12 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 1`]
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2231,7 +2231,7 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 1`]
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+            class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
           >
             <select
               disabled=""
@@ -2366,7 +2366,7 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 2`]
     data-testid="form-one"
   >
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -2505,18 +2505,18 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 2`]
           Enter the name of each candidate choice that appears on the ballot for this contest.
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-jzJRlG hqJpHa"
         >
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2532,12 +2532,12 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 2`]
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2554,15 +2554,15 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 2`]
             </label>
           </div>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2578,12 +2578,12 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 2`]
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2691,7 +2691,7 @@ exports[`EstimateSampleSize renders after sample size is estimated correctly 2`]
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+            class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
           >
             <select
               disabled=""
@@ -2852,7 +2852,7 @@ exports[`EstimateSampleSize renders during rounds stage correctly 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -2991,18 +2991,18 @@ exports[`EstimateSampleSize renders during rounds stage correctly 1`] = `
           Enter the name of each candidate choice that appears on the ballot for this contest.
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-jzJRlG hqJpHa"
         >
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -3018,12 +3018,12 @@ exports[`EstimateSampleSize renders during rounds stage correctly 1`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -3040,15 +3040,15 @@ exports[`EstimateSampleSize renders during rounds stage correctly 1`] = `
             </label>
           </div>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -3064,12 +3064,12 @@ exports[`EstimateSampleSize renders during rounds stage correctly 1`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -3177,7 +3177,7 @@ exports[`EstimateSampleSize renders during rounds stage correctly 1`] = `
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+            class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
           >
             <select
               disabled=""
@@ -3312,7 +3312,7 @@ exports[`EstimateSampleSize renders during rounds stage correctly 2`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -3451,18 +3451,18 @@ exports[`EstimateSampleSize renders during rounds stage correctly 2`] = `
           Enter the name of each candidate choice that appears on the ballot for this contest.
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-jzJRlG hqJpHa"
         >
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -3478,12 +3478,12 @@ exports[`EstimateSampleSize renders during rounds stage correctly 2`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -3500,15 +3500,15 @@ exports[`EstimateSampleSize renders during rounds stage correctly 2`] = `
             </label>
           </div>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -3524,12 +3524,12 @@ exports[`EstimateSampleSize renders during rounds stage correctly 2`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -3637,7 +3637,7 @@ exports[`EstimateSampleSize renders during rounds stage correctly 2`] = `
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+            class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
           >
             <select
               disabled=""
@@ -3798,7 +3798,7 @@ exports[`EstimateSampleSize renders empty state correctly 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -3933,18 +3933,18 @@ exports[`EstimateSampleSize renders empty state correctly 1`] = `
           Enter the name of each candidate choice that appears on the ballot for this contest.
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-jzJRlG hqJpHa"
         >
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group sc-htoDjs jVvDPF"
@@ -3959,12 +3959,12 @@ exports[`EstimateSampleSize renders empty state correctly 1`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group sc-htoDjs jVvDPF"
@@ -3980,15 +3980,15 @@ exports[`EstimateSampleSize renders empty state correctly 1`] = `
             </label>
           </div>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group sc-htoDjs jVvDPF"
@@ -4003,12 +4003,12 @@ exports[`EstimateSampleSize renders empty state correctly 1`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group sc-htoDjs jVvDPF"
@@ -4024,7 +4024,7 @@ exports[`EstimateSampleSize renders empty state correctly 1`] = `
             </label>
           </div>
           <p
-            class="sc-chPdSV loppqH"
+            class="sc-kgoBCf jCkIWs"
           >
             Add a new candidate/choice
           </p>
@@ -4117,7 +4117,7 @@ exports[`EstimateSampleSize renders empty state correctly 1`] = `
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select sc-jTzLTM dgTHzL"
+            class="bp3-html-select sc-fjdhpX jqDqiz"
           >
             <select
               field="[object Object]"
@@ -4264,7 +4264,7 @@ exports[`EstimateSampleSize renders empty state correctly 2`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -4399,18 +4399,18 @@ exports[`EstimateSampleSize renders empty state correctly 2`] = `
           Enter the name of each candidate choice that appears on the ballot for this contest.
         </div>
         <div
-          class="sc-fjdhpX ixwLIj"
+          class="sc-jzJRlG hqJpHa"
         >
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group sc-htoDjs jVvDPF"
@@ -4425,12 +4425,12 @@ exports[`EstimateSampleSize renders empty state correctly 2`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               1
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group sc-htoDjs jVvDPF"
@@ -4446,15 +4446,15 @@ exports[`EstimateSampleSize renders empty state correctly 2`] = `
             </label>
           </div>
           <div
-            class="sc-jzJRlG dRtOsa"
+            class="sc-cSHVUG jUKlPT"
           >
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Name of Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group sc-htoDjs jVvDPF"
@@ -4469,12 +4469,12 @@ exports[`EstimateSampleSize renders empty state correctly 2`] = `
               </div>
             </label>
             <label
-              class="bp3-label sc-kAzzGY kQOXij"
+              class="bp3-label sc-chPdSV ewyFtw"
             >
               Votes for Candidate/Choice 
               2
               <div
-                class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
               >
                 <div
                   class="bp3-input-group sc-htoDjs jVvDPF"
@@ -4490,7 +4490,7 @@ exports[`EstimateSampleSize renders empty state correctly 2`] = `
             </label>
           </div>
           <p
-            class="sc-chPdSV loppqH"
+            class="sc-kgoBCf jCkIWs"
           >
             Add a new candidate/choice
           </p>
@@ -4583,7 +4583,7 @@ exports[`EstimateSampleSize renders empty state correctly 2`] = `
         >
           Set the risk for the audit as a percentage (e.g. "5" = 5%)
           <div
-            class="bp3-html-select sc-jTzLTM dgTHzL"
+            class="bp3-html-select sc-fjdhpX jqDqiz"
           >
             <select
               field="[object Object]"
@@ -4739,7 +4739,7 @@ exports[`EstimateSampleSize renders empty state correctly 2`] = `
 exports[`EstimateSampleSize renders styled.div correctly 1`] = `
 <div>
   <div
-    class="sc-fjdhpX ixwLIj"
+    class="sc-jzJRlG hqJpHa"
   />
 </div>
 `;
@@ -4747,7 +4747,7 @@ exports[`EstimateSampleSize renders styled.div correctly 1`] = `
 exports[`EstimateSampleSize renders styled.div correctly 2`] = `
 <div>
   <div
-    class="sc-jzJRlG dRtOsa"
+    class="sc-cSHVUG jUKlPT"
   />
 </div>
 `;
@@ -4755,7 +4755,7 @@ exports[`EstimateSampleSize renders styled.div correctly 2`] = `
 exports[`EstimateSampleSize renders styled.p correctly 1`] = `
 <div>
   <p
-    class="sc-chPdSV loppqH"
+    class="sc-kgoBCf jCkIWs"
   />
 </div>
 `;

--- a/client/src/components/SingleJurisdictionAudit/__snapshots__/SelectBallotsToAudit.test.tsx.snap
+++ b/client/src/components/SingleJurisdictionAudit/__snapshots__/SelectBallotsToAudit.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`SelectBallotsToAudit changes number of audits 1`] = `
   >
     <hr />
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -31,7 +31,7 @@ exports[`SelectBallotsToAudit changes number of audits 1`] = `
         >
           Set the number of audit boards you wish to use.
           <div
-            class="bp3-html-select sc-jTzLTM dgTHzL"
+            class="bp3-html-select sc-fjdhpX jqDqiz"
           >
             <select
               field="[object Object]"
@@ -111,16 +111,16 @@ exports[`SelectBallotsToAudit changes number of audits 1`] = `
           Audit boards will enter data about each ballot:
         </div>
         <div
-          class="sc-fjdhpX kFhZUw"
+          class="sc-jzJRlG Jpdxv"
         >
           <div
-            class="sc-jzJRlG jYRjzo"
+            class="sc-cSHVUG dyClCA"
           />
           <div
-            class="sc-jzJRlG jYRjzo"
+            class="sc-cSHVUG dyClCA"
           />
           <div
-            class="sc-jzJRlG jYRjzo"
+            class="sc-cSHVUG dyClCA"
           />
         </div>
       </div>
@@ -179,7 +179,7 @@ exports[`SelectBallotsToAudit changes number of audits 2`] = `
   >
     <hr />
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -202,7 +202,7 @@ exports[`SelectBallotsToAudit changes number of audits 2`] = `
         >
           Set the number of audit boards you wish to use.
           <div
-            class="bp3-html-select sc-jTzLTM dgTHzL"
+            class="bp3-html-select sc-fjdhpX jqDqiz"
           >
             <select
               field="[object Object]"
@@ -282,13 +282,13 @@ exports[`SelectBallotsToAudit changes number of audits 2`] = `
           Audit boards will enter data about each ballot:
         </div>
         <div
-          class="sc-fjdhpX kFhZUw"
+          class="sc-jzJRlG Jpdxv"
         >
           <div
-            class="sc-jzJRlG jYRjzo"
+            class="sc-cSHVUG dyClCA"
           />
           <div
-            class="sc-jzJRlG jYRjzo"
+            class="sc-cSHVUG dyClCA"
           />
         </div>
       </div>
@@ -347,7 +347,7 @@ exports[`SelectBallotsToAudit renders correctly 1`] = `
   >
     <hr />
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -370,7 +370,7 @@ exports[`SelectBallotsToAudit renders correctly 1`] = `
         >
           Set the number of audit boards you wish to use.
           <div
-            class="bp3-html-select sc-jTzLTM dgTHzL"
+            class="bp3-html-select sc-fjdhpX jqDqiz"
           >
             <select
               field="[object Object]"
@@ -450,10 +450,10 @@ exports[`SelectBallotsToAudit renders correctly 1`] = `
           Audit boards will enter data about each ballot:
         </div>
         <div
-          class="sc-fjdhpX kFhZUw"
+          class="sc-jzJRlG Jpdxv"
         >
           <div
-            class="sc-jzJRlG jYRjzo"
+            class="sc-cSHVUG dyClCA"
           />
         </div>
       </div>
@@ -512,7 +512,7 @@ exports[`SelectBallotsToAudit renders correctly 2`] = `
   >
     <hr />
     <div
-      class="sc-ifAKCX dUfgxM"
+      class="sc-ifAKCX dOqzfM"
     >
       <h2
         class="bp3-heading sc-bxivhb jFEWwS"
@@ -535,7 +535,7 @@ exports[`SelectBallotsToAudit renders correctly 2`] = `
         >
           Set the number of audit boards you wish to use.
           <div
-            class="bp3-html-select sc-jTzLTM dgTHzL"
+            class="bp3-html-select sc-fjdhpX jqDqiz"
           >
             <select
               field="[object Object]"
@@ -615,10 +615,10 @@ exports[`SelectBallotsToAudit renders correctly 2`] = `
           Audit boards will enter data about each ballot:
         </div>
         <div
-          class="sc-fjdhpX kFhZUw"
+          class="sc-jzJRlG Jpdxv"
         >
           <div
-            class="sc-jzJRlG jYRjzo"
+            class="sc-cSHVUG dyClCA"
           />
         </div>
       </div>

--- a/client/src/components/SingleJurisdictionAudit/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/SingleJurisdictionAudit/__snapshots__/index.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when audit.jurisdictions has length but audit.rounds does not 1`] = `
 <div>
   <div
-    class="single-page sc-hMqMXs kivpAN"
+    class="single-page sc-kEYyzF eUtHUm"
   >
     <form
       data-testid="form-one"
     >
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -148,18 +148,18 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-fjdhpX ixwLIj"
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -175,12 +175,12 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -197,15 +197,15 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
               </label>
             </div>
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -221,12 +221,12 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -334,7 +334,7 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
           >
             Set the risk for the audit as a percentage (e.g. "5" = 5%)
             <div
-              class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+              class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
             >
               <select
                 disabled=""
@@ -466,7 +466,7 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
     >
       <hr />
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -568,7 +568,7 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
           >
             Set the number of audit boards you wish to use.
             <div
-              class="bp3-html-select sc-kgoBCf eMgYUl"
+              class="bp3-html-select sc-kGXeez gdFBeY"
             >
               <select
                 field="[object Object]"
@@ -648,10 +648,10 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
             Audit boards will enter data about each ballot:
           </div>
           <div
-            class="sc-kGXeez bMTBGr"
+            class="sc-kpOJdX mfXlX"
           >
             <div
-              class="sc-kpOJdX efRQKK"
+              class="sc-dxgOiQ kEWBcr"
             />
           </div>
         </div>
@@ -706,13 +706,13 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
 exports[`RiskLimitingAuditForm does not render SelectBallotsToAudit when /audit/status is processing samplesizes 1`] = `
 <div>
   <div
-    class="single-page sc-hMqMXs kivpAN"
+    class="single-page sc-kEYyzF eUtHUm"
   >
     <form
       data-testid="form-one"
     >
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -851,18 +851,18 @@ exports[`RiskLimitingAuditForm does not render SelectBallotsToAudit when /audit/
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-fjdhpX ixwLIj"
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -878,12 +878,12 @@ exports[`RiskLimitingAuditForm does not render SelectBallotsToAudit when /audit/
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -900,15 +900,15 @@ exports[`RiskLimitingAuditForm does not render SelectBallotsToAudit when /audit/
               </label>
             </div>
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -924,12 +924,12 @@ exports[`RiskLimitingAuditForm does not render SelectBallotsToAudit when /audit/
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1037,7 +1037,7 @@ exports[`RiskLimitingAuditForm does not render SelectBallotsToAudit when /audit/
           >
             Set the risk for the audit as a percentage (e.g. "5" = 5%)
             <div
-              class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+              class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
             >
               <select
                 disabled=""
@@ -1170,13 +1170,13 @@ exports[`RiskLimitingAuditForm does not render SelectBallotsToAudit when /audit/
 exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
 <div>
   <div
-    class="single-page sc-hMqMXs kivpAN"
+    class="single-page sc-kEYyzF eUtHUm"
   >
     <form
       data-testid="form-one"
     >
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -1311,18 +1311,18 @@ exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-fjdhpX ixwLIj"
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group sc-htoDjs jVvDPF"
@@ -1337,12 +1337,12 @@ exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group sc-htoDjs jVvDPF"
@@ -1358,15 +1358,15 @@ exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
               </label>
             </div>
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group sc-htoDjs jVvDPF"
@@ -1381,12 +1381,12 @@ exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group sc-htoDjs jVvDPF"
@@ -1402,7 +1402,7 @@ exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
               </label>
             </div>
             <p
-              class="sc-chPdSV loppqH"
+              class="sc-kgoBCf jCkIWs"
             >
               Add a new candidate/choice
             </p>
@@ -1495,7 +1495,7 @@ exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
           >
             Set the risk for the audit as a percentage (e.g. "5" = 5%)
             <div
-              class="bp3-html-select sc-jTzLTM dgTHzL"
+              class="bp3-html-select sc-fjdhpX jqDqiz"
             >
               <select
                 field="[object Object]"
@@ -1640,13 +1640,13 @@ exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
 exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/status returns round data 1`] = `
 <div>
   <div
-    class="single-page sc-hMqMXs kivpAN"
+    class="single-page sc-kEYyzF eUtHUm"
   >
     <form
       data-testid="form-one"
     >
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -1785,18 +1785,18 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-fjdhpX ixwLIj"
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1812,12 +1812,12 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1834,15 +1834,15 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
               </label>
             </div>
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1858,12 +1858,12 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -1971,7 +1971,7 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
           >
             Set the risk for the audit as a percentage (e.g. "5" = 5%)
             <div
-              class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+              class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
             >
               <select
                 disabled=""
@@ -2103,7 +2103,7 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
     >
       <hr />
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -2209,7 +2209,7 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
           >
             Set the number of audit boards you wish to use.
             <div
-              class="bp3-html-select bp3-disabled sc-kgoBCf eMgYUl"
+              class="bp3-html-select bp3-disabled sc-kGXeez gdFBeY"
             >
               <select
                 disabled=""
@@ -2290,10 +2290,10 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
             Audit boards will enter data about each ballot:
           </div>
           <div
-            class="sc-kGXeez bMTBGr"
+            class="sc-kpOJdX mfXlX"
           >
             <div
-              class="sc-kpOJdX efRQKK"
+              class="sc-dxgOiQ kEWBcr"
             >
               <a
                 class="bp3-text-small"
@@ -2346,7 +2346,7 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
       data-testid="form-three-1"
     >
       <div
-        class="sc-eNQAEJ jlmWxR"
+        class="sc-hMqMXs eSemHE"
         id="qr-root"
       >
         <span
@@ -2361,7 +2361,7 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
       </div>
       <hr />
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -2496,13 +2496,13 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
 exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status returns contest data 1`] = `
 <div>
   <div
-    class="single-page sc-hMqMXs kivpAN"
+    class="single-page sc-kEYyzF eUtHUm"
   >
     <form
       data-testid="form-one"
     >
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -2641,18 +2641,18 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-fjdhpX ixwLIj"
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2668,12 +2668,12 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2690,15 +2690,15 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
               </label>
             </div>
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2714,12 +2714,12 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-htoDjs jVvDPF"
@@ -2827,7 +2827,7 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
           >
             Set the risk for the audit as a percentage (e.g. "5" = 5%)
             <div
-              class="bp3-html-select bp3-disabled sc-jTzLTM dgTHzL"
+              class="bp3-html-select bp3-disabled sc-fjdhpX jqDqiz"
             >
               <select
                 disabled=""
@@ -2959,7 +2959,7 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
     >
       <hr />
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -3061,7 +3061,7 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
           >
             Set the number of audit boards you wish to use.
             <div
-              class="bp3-html-select sc-kgoBCf eMgYUl"
+              class="bp3-html-select sc-kGXeez gdFBeY"
             >
               <select
                 field="[object Object]"
@@ -3141,10 +3141,10 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
             Audit boards will enter data about each ballot:
           </div>
           <div
-            class="sc-kGXeez bMTBGr"
+            class="sc-kpOJdX mfXlX"
           >
             <div
-              class="sc-kpOJdX efRQKK"
+              class="sc-dxgOiQ kEWBcr"
             />
           </div>
         </div>
@@ -3199,13 +3199,13 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
 exports[`RiskLimitingAuditForm renders correctly with initialData 1`] = `
 <div>
   <div
-    class="single-page sc-hMqMXs kivpAN"
+    class="single-page sc-kEYyzF eUtHUm"
   >
     <form
       data-testid="form-one"
     >
       <div
-        class="sc-ifAKCX dUfgxM"
+        class="sc-ifAKCX dOqzfM"
       >
         <h2
           class="bp3-heading sc-bxivhb jFEWwS"
@@ -3340,18 +3340,18 @@ exports[`RiskLimitingAuditForm renders correctly with initialData 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-fjdhpX ixwLIj"
+            class="sc-jzJRlG hqJpHa"
           >
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group sc-htoDjs jVvDPF"
@@ -3366,12 +3366,12 @@ exports[`RiskLimitingAuditForm renders correctly with initialData 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group sc-htoDjs jVvDPF"
@@ -3387,15 +3387,15 @@ exports[`RiskLimitingAuditForm renders correctly with initialData 1`] = `
               </label>
             </div>
             <div
-              class="sc-jzJRlG dRtOsa"
+              class="sc-cSHVUG jUKlPT"
             >
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group sc-htoDjs jVvDPF"
@@ -3410,12 +3410,12 @@ exports[`RiskLimitingAuditForm renders correctly with initialData 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kAzzGY kQOXij"
+                class="bp3-label sc-chPdSV ewyFtw"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cSHVUG gnWAUj sc-gzVnrw jXfEBS"
+                  class="sc-kAzzGY ekBBqo sc-gzVnrw jXfEBS"
                 >
                   <div
                     class="bp3-input-group sc-htoDjs jVvDPF"
@@ -3431,7 +3431,7 @@ exports[`RiskLimitingAuditForm renders correctly with initialData 1`] = `
               </label>
             </div>
             <p
-              class="sc-chPdSV loppqH"
+              class="sc-kgoBCf jCkIWs"
             >
               Add a new candidate/choice
             </p>
@@ -3524,7 +3524,7 @@ exports[`RiskLimitingAuditForm renders correctly with initialData 1`] = `
           >
             Set the risk for the audit as a percentage (e.g. "5" = 5%)
             <div
-              class="bp3-html-select sc-jTzLTM dgTHzL"
+              class="bp3-html-select sc-fjdhpX jqDqiz"
             >
               <select
                 field="[object Object]"


### PR DESCRIPTION
**Description**

- Uncommented and updated the code related to adding and removing contests on the multi jurisdiction flow.

**Testing**

- Updated snapshots and unskipped the test related to adding and removing contests

**Progress**

- The backend sorts the contests alphabetically by name from what I can tell, so contests don't come back in the same order they were entered in. This might confuse end users, if they put a contest as 'contest one' but then it comes back as the second contest. Not sure if this is an issue or not, @mcchilders ?
