### PR TITLE
Don't allow updating jurisdictions/contests/settings after audit starts

### DIFF
--- a/server/api/routes.py
+++ b/server/api/routes.py
@@ -295,6 +295,9 @@ ADMIN_EMAIL = "Admin Email"
 @api.route("/election/<election_id>/jurisdiction/file", methods=["PUT"])
 @with_election_access
 def update_jurisdictions_file(election: Election):
+    if len(election.rounds) > 0:
+        raise Conflict("Cannot update jurisdictions after audit has started.")
+
     if "jurisdictions" not in request.files:
         return (
             jsonify(


### PR DESCRIPTION
The frontend already disables these forms, but we also want guards in
the backend API to prevent this from happening.
