### PR TITLE
Upgrade testing-library and fix all test warnings

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -106,7 +106,7 @@
   },
   "devDependencies": {
     "@babel/register": "^7.6.2",
-    "@testing-library/react": "^10.0.4",
+    "@testing-library/react": "^10.3.0",
     "@testing-library/react-hooks": "^3.2.1",
     "@testing-library/user-event": "^11.3.1",
     "@types/jsdom": "^12.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -63,10 +63,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 83,
-        "branches": 84,
+        "statements": 82,
+        "branches": 83,
         "functions": 82,
-        "lines": 83
+        "lines": 82
       }
     }
   },

--- a/client/package.json
+++ b/client/package.json
@@ -107,7 +107,7 @@
   "devDependencies": {
     "@babel/register": "^7.6.2",
     "@testing-library/react": "^10.3.0",
-    "@testing-library/react-hooks": "^3.2.1",
+    "@testing-library/react-hooks": "^3.3.0",
     "@testing-library/user-event": "^11.3.1",
     "@types/jsdom": "^12.2.4",
     "@types/node": "12.0.7",

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -1,19 +1,15 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import App from './App'
+import * as utilities from './components/utilities'
 
 jest.unmock('react-toastify')
+jest.spyOn(utilities, 'api')
 
 describe('App', () => {
-  it('renders without crashing', () => {
-    const div = document.createElement('div')
-    ReactDOM.render(<App />, div)
-    ReactDOM.unmountComponentAtNode(div)
-  })
-
-  it('renders properly', () => {
+  it('renders properly', async () => {
     const { container } = render(<App />)
+    await screen.findByAltText('Arlo, by VotingWorks')
     expect(container).toMatchSnapshot()
   })
 })

--- a/client/src/components/DataEntry/index.test.tsx
+++ b/client/src/components/DataEntry/index.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { render, waitFor, fireEvent } from '@testing-library/react'
 import { StaticRouter } from 'react-router-dom'
-import { routerTestProps, asyncActRender } from '../testUtilities'
+import { routerTestProps } from '../testUtilities'
 import DataEntry from './index'
 import { dummyBoards, dummyBallots, contest } from './_mocks'
 import * as utilities from '../utilities'
+
+window.scrollTo = jest.fn()
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
@@ -64,13 +66,13 @@ describe('DataEntry', () => {
         }
       })
 
-      const { container, getByText } = await asyncActRender(
+      const { container, findByText } = render(
         <StaticRouter {...staticRouteProps}>
           <DataEntry {...routeProps} />
         </StaticRouter>
       )
+      await findByText('Audit Board #2: Member Sign-in')
       expect(apiMock).toBeCalledTimes(1)
-      expect(getByText('Audit Board #2: Member Sign-in')).toBeTruthy()
       expect(container).toMatchSnapshot()
     })
 
@@ -87,14 +89,14 @@ describe('DataEntry', () => {
             return ballotingMock(endpoint)
         }
       })
-      const { container, getByText, getAllByLabelText } = await asyncActRender(
+      const { container, getByText, findAllByLabelText } = render(
         <StaticRouter {...staticRouteProps}>
           <DataEntry {...routeProps} />
         </StaticRouter>
       )
 
+      const nameInputs = await findAllByLabelText('Full Name')
       expect(apiMock).toBeCalledTimes(1)
-      const nameInputs = getAllByLabelText('Full Name')
       expect(nameInputs).toHaveLength(2)
 
       nameInputs.forEach((nameInput, i) =>
@@ -120,7 +122,7 @@ describe('DataEntry', () => {
             return ballotingMock(endpoint)
         }
       })
-      const { container } = await asyncActRender(
+      const { container } = render(
         <StaticRouter {...staticRouteProps}>
           <DataEntry {...routeProps} />
         </StaticRouter>
@@ -203,14 +205,14 @@ describe('DataEntry', () => {
         .spyOn(ballotRouteProps.history, 'push')
         .mockImplementation()
       ballotRouteProps.match.url = '/election/1/audit-board/audit-board-1'
-      const { getByText } = await asyncActRender(
+      const { findByText, getByText } = render(
         <StaticRouter {...staticBallotRouteProps}>
           <DataEntry {...ballotRouteProps} />
         </StaticRouter>
       )
 
       fireEvent.click(
-        getByText('Ballot 2112 not found - move to next ballot'),
+        await findByText('Ballot 2112 not found - move to next ballot'),
         {
           bubbles: true,
         }
@@ -244,13 +246,13 @@ describe('DataEntry', () => {
       )
       const { history, ...staticBallotRouteProps } = ballotRouteProps // eslint-disable-line @typescript-eslint/no-unused-vars
       ballotRouteProps.match.url = '/election/1/audit-board/audit-board-1'
-      const { getByText, getByTestId } = await asyncActRender(
+      const { getByText, findByTestId, getByTestId } = render(
         <StaticRouter {...staticBallotRouteProps}>
           <DataEntry {...ballotRouteProps} />
         </StaticRouter>
       )
 
-      fireEvent.click(getByTestId('choice-id-1'), { bubbles: true })
+      fireEvent.click(await findByTestId('choice-id-1'), { bubbles: true })
       await waitFor(() =>
         fireEvent.click(getByTestId('enabled-review'), { bubbles: true })
       )

--- a/client/src/components/Header.test.tsx
+++ b/client/src/components/Header.test.tsx
@@ -3,7 +3,6 @@ import { render, waitFor } from '@testing-library/react'
 import { BrowserRouter as Router } from 'react-router-dom'
 import Header from './Header'
 import * as utilities from './utilities'
-import { asyncActRender } from './testUtilities'
 import AuthDataProvider from './UserContext'
 
 const apiMock: jest.SpyInstance<
@@ -50,7 +49,7 @@ describe('Header', () => {
       jurisdictions: [],
       organizations: [],
     }))
-    const { queryByText } = await asyncActRender(
+    const { findByText } = render(
       <Router>
         <AuthDataProvider>
           <Header />
@@ -58,17 +57,14 @@ describe('Header', () => {
       </Router>
     )
 
-    const loginButton = queryByText('Log out')
-    await waitFor(() => {
-      expect(apiMock).toHaveBeenCalledTimes(1)
-      expect(apiMock).toHaveBeenCalledWith('/me')
-      expect(loginButton).toBeTruthy()
-    })
+    await findByText('Log out')
+    expect(apiMock).toHaveBeenCalledTimes(1)
+    expect(apiMock).toHaveBeenCalledWith('/me')
   })
 
   it('does not show logout button if not authenticated', async () => {
     apiMock.mockRejectedValue(async () => ({}))
-    const { queryByText } = await asyncActRender(
+    const { queryByText } = render(
       <Router>
         <AuthDataProvider>
           <Header />
@@ -87,7 +83,7 @@ describe('Header', () => {
   it('does not show logout button if the authentication verification has a server error', async () => {
     checkAndToastMock.mockReturnValue(true)
     apiMock.mockRejectedValue(async () => ({}))
-    const { queryByText } = await asyncActRender(
+    const { queryByText } = render(
       <Router>
         <AuthDataProvider>
           <Header />

--- a/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Contests/index.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, waitFor, render } from '@testing-library/react'
 import { toast } from 'react-toastify'
 import { useParams } from 'react-router-dom'
-import { regexpEscape, asyncActRender } from '../../../testUtilities'
+import { regexpEscape } from '../../../testUtilities'
 import * as utilities from '../../../utilities'
 import Contests from './index'
 import relativeStages from '../_mocks'
@@ -90,13 +90,14 @@ afterEach(() => {
 
 describe('Audit Setup > Contests', () => {
   it('renders empty targeted state correctly', async () => {
-    const { container } = await asyncActRender(
+    const { container, findByText } = render(
       <Contests
         locked={false}
         isTargeted
         {...relativeStages('Target Contests')}
       />
     )
+    await findByText('Target Contests')
     expect(container).toMatchSnapshot()
   })
 
@@ -104,13 +105,14 @@ describe('Audit Setup > Contests', () => {
     apiMock.mockImplementation(
       generateApiMock(contestMocks.emptyOpportunistic, { jurisdictions: [] })
     )
-    const { container } = await asyncActRender(
+    const { container, findByText } = render(
       <Contests
         locked={false}
         isTargeted={false}
         {...relativeStages('Opportunistic Contests')}
       />
     )
+    await findByText('Opportunistic Contests')
     expect(container).toMatchSnapshot()
   })
 
@@ -118,13 +120,14 @@ describe('Audit Setup > Contests', () => {
     apiMock.mockImplementation(
       generateApiMock(contestMocks.filledTargeted, { jurisdictions: [] })
     )
-    const { container } = await asyncActRender(
+    const { container, findByText } = render(
       <Contests
         locked={false}
         isTargeted
         {...relativeStages('Target Contests')}
       />
     )
+    await findByText('Target Contests')
     expect(container).toMatchSnapshot()
   })
 
@@ -132,19 +135,20 @@ describe('Audit Setup > Contests', () => {
     apiMock.mockImplementation(
       generateApiMock(contestMocks.filledOpportunistic, { jurisdictions: [] })
     )
-    const { container } = await asyncActRender(
+    const { container, findByText } = render(
       <Contests
         locked={false}
         isTargeted={false}
         {...relativeStages('Opportunistic Contests')}
       />
     )
+    await findByText('Opportunistic Contests')
     expect(container).toMatchSnapshot()
   })
 
   it.skip('adds and removes contests', async () => {
     // skip until feature is complete in backend
-    const { getByText, getAllByText, queryByText } = await asyncActRender(
+    const { getByText, getAllByText, queryByText } = render(
       <Contests
         locked={false}
         isTargeted
@@ -178,7 +182,7 @@ describe('Audit Setup > Contests', () => {
     apiMock.mockImplementation(
       generateApiMock(contestMocks.emptyTargeted, { jurisdictions: [] })
     )
-    const { getByText, getAllByText, queryAllByText } = await asyncActRender(
+    const { findByText, getByText, getAllByText, queryAllByText } = render(
       <Contests
         locked={false}
         isTargeted
@@ -186,7 +190,9 @@ describe('Audit Setup > Contests', () => {
       />
     )
 
-    fireEvent.click(getByText('Add a new candidate/choice'), { bubbles: true })
+    fireEvent.click(await findByText('Add a new candidate/choice'), {
+      bubbles: true,
+    })
 
     expect(getAllByText(/Name of Candidate\/Choice \d/i).length).toBe(3)
     expect(getAllByText(/Votes for Candidate\/Choice \d/i).length).toBe(3)
@@ -205,7 +211,7 @@ describe('Audit Setup > Contests', () => {
     apiMock.mockImplementation(
       generateApiMock(contestMocks.emptyTargeted, { jurisdictions: [] })
     )
-    const { getByLabelText, getByText } = await asyncActRender(
+    const { findByText, getByLabelText, getByText } = render(
       <Contests
         locked={false}
         isTargeted
@@ -214,6 +220,7 @@ describe('Audit Setup > Contests', () => {
       />
     )
 
+    await findByText('Target Contests')
     contestsInputMocks.inputs.forEach(inputData => {
       const input = getByLabelText(new RegExp(regexpEscape(inputData.key)), {
         selector: 'input',
@@ -246,7 +253,7 @@ describe('Audit Setup > Contests', () => {
   })
 
   it('displays errors', async () => {
-    const { getByLabelText, getByTestId, getByText } = await asyncActRender(
+    const { getByLabelText, getByTestId, getByText, findByText } = render(
       <Contests
         locked={false}
         isTargeted
@@ -255,6 +262,7 @@ describe('Audit Setup > Contests', () => {
       />
     )
 
+    await findByText('Target Contests')
     await utilities.asyncForEach(
       contestsInputMocks.errorInputs,
       async (inputData: { key: string; value: string; error: string }) => {
@@ -283,7 +291,7 @@ describe('Audit Setup > Contests', () => {
   })
 
   it('displays an error when the total votes are greater than the allowed votes and more than one vote is allowed per contest', async () => {
-    const { getByLabelText, getByTestId } = await asyncActRender(
+    const { getByLabelText, findByLabelText, getByTestId } = render(
       <Contests
         locked={false}
         isTargeted
@@ -292,7 +300,7 @@ describe('Audit Setup > Contests', () => {
     )
 
     typeInto(
-      getByLabelText('Votes Allowed', {
+      await findByLabelText('Votes Allowed', {
         selector: 'input',
       }),
       '2'
@@ -327,7 +335,7 @@ describe('Audit Setup > Contests', () => {
   })
 
   it('displays no error when the total votes are greater than the ballot count, but less than the total allowed votes for a contest', async () => {
-    const { getByLabelText, queryByTestId } = await asyncActRender(
+    const { findByLabelText, getByLabelText, queryByTestId } = render(
       <Contests
         locked={false}
         isTargeted
@@ -336,7 +344,7 @@ describe('Audit Setup > Contests', () => {
     )
 
     typeInto(
-      getByLabelText('Votes Allowed', {
+      await findByLabelText('Votes Allowed', {
         selector: 'input',
       }),
       '2'
@@ -373,7 +381,7 @@ describe('Audit Setup > Contests', () => {
     apiMock.mockImplementation(
       generateApiMock(new Error('Network error'), { jurisdictions: [] })
     )
-    const { container } = await asyncActRender(
+    const { container } = render(
       <Contests
         locked={false}
         isTargeted
@@ -400,7 +408,7 @@ describe('Audit Setup > Contests', () => {
       .mockImplementation(
         generateApiMock(new Error('Network error'), { jurisdictions: [] })
       )
-    const { getByLabelText, getByText, container } = await asyncActRender(
+    const { getByLabelText, getByText, container } = render(
       <Contests
         locked={false}
         isTargeted
@@ -441,7 +449,7 @@ describe('Audit Setup > Contests', () => {
       .mockImplementation(
         generateApiMock({ status: 'ok' }, { jurisdictions: [] })
       )
-    const { getAllByLabelText, getAllByText } = await asyncActRender(
+    const { getAllByLabelText, getAllByText, findByText } = render(
       <Contests
         locked={false}
         isTargeted
@@ -450,6 +458,7 @@ describe('Audit Setup > Contests', () => {
       />
     )
 
+    await findByText('Target Contests')
     contestsInputMocks.inputs.forEach(inputData => {
       const input = getAllByLabelText(new RegExp(regexpEscape(inputData.key)), {
         selector: 'input',
@@ -487,26 +496,20 @@ describe('Audit Setup > Contests', () => {
         jurisdictions: jurisdictionMocks.noManifests,
       })
     )
-    const { getByText, queryByLabelText } = await asyncActRender(
+    const { getByText, findByText, findByLabelText } = render(
       <Contests
         locked={false}
         isTargeted
         {...relativeStages('Target Contests')}
       />
     )
-    const dropDown = getByText('Select Jurisdictions')
+    const dropDown = await findByText('Select Jurisdictions')
     fireEvent.click(dropDown, { bubbles: true })
-    const jurisdictionOne = queryByLabelText('Jurisdiction 1')
-    const jurisdictionTwo = queryByLabelText('Jurisdiction 2')
-    await waitFor(() => {
-      expect(jurisdictionOne).toBeTruthy()
-      expect(jurisdictionTwo).toBeTruthy()
-    })
-    if (jurisdictionOne && jurisdictionTwo) {
-      fireEvent.click(jurisdictionOne, { bubbles: true })
-      fireEvent.click(jurisdictionTwo, { bubbles: true })
-      fireEvent.click(jurisdictionOne, { bubbles: true })
-    }
+    const jurisdictionOne = await findByLabelText('Jurisdiction 1')
+    const jurisdictionTwo = await findByLabelText('Jurisdiction 2')
+    fireEvent.click(jurisdictionOne, { bubbles: true })
+    fireEvent.click(jurisdictionTwo, { bubbles: true })
+    fireEvent.click(jurisdictionOne, { bubbles: true })
 
     fireEvent.click(getByText('Save & Next'), { bubbles: true })
     await waitFor(() => {
@@ -518,13 +521,11 @@ describe('Audit Setup > Contests', () => {
           'Content-Type': 'application/json',
         },
       })
-      if (apiMock.mock.calls[2][1]!.body) {
-        const submittedBody: IContestNumbered[] = JSON.parse(apiMock.mock
-          .calls[2][1]!.body as string)
-        expect(submittedBody[0].jurisdictionIds).toMatchObject([
-          'jurisdiction-id-2',
-        ])
-      }
+      const submittedBody: IContestNumbered[] = JSON.parse(apiMock.mock
+        .calls[2][1]!.body as string)
+      expect(submittedBody[0].jurisdictionIds).toMatchObject([
+        'jurisdiction-id-2',
+      ])
     })
   })
 })

--- a/client/src/components/MultiJurisdictionAudit/Setup/Participants/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Participants/index.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, waitFor, render } from '@testing-library/react'
 import { BrowserRouter as Router, useParams } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import relativeStages from '../_mocks'
 import Participants from './index'
 import jurisdictionFile from './_mocks'
 import * as utilities from '../../../utilities'
-import { asyncActRender } from '../../../testUtilities'
 import useAuditSettings from '../../useAuditSettings'
 
 const auditSettingsMock = useAuditSettings as jest.Mock
@@ -51,18 +50,18 @@ const { nextStage } = relativeStages('Participants')
 
 const fillAndSubmit = async () => {
   const {
+    findByTestId,
     getByText,
     getByLabelText,
     queryByLabelText,
     queryByText,
-    getByTestId,
-  } = await asyncActRender(
+  } = render(
     <Router>
       <Participants locked={false} nextStage={nextStage} />
     </Router>
   )
 
-  fireEvent.change(getByTestId('state-field'), {
+  fireEvent.change(await findByTestId('state-field'), {
     target: { value: 'WA' },
   })
 
@@ -104,14 +103,13 @@ describe('Audit Setup > Participants', () => {
   })
 
   it('renders empty state correctly', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <Router>
         <Participants locked={false} nextStage={nextStage} />
       </Router>
     )
-    await waitFor(() => {
-      expect(container).toMatchSnapshot()
-    })
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
+    expect(container).toMatchSnapshot()
   })
 
   it('selects a state and submits it', async () => {

--- a/client/src/components/MultiJurisdictionAudit/Setup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Review/index.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, waitFor, render } from '@testing-library/react'
 import { BrowserRouter as Router, useParams } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import relativeStages from '../_mocks'
 import Review from './index'
 import * as utilities from '../../../utilities'
-import { asyncActRender } from '../../../testUtilities'
 import useAuditSettings from '../../useAuditSettings'
 import { settingsMock, sampleSizeMock } from './_mocks'
 import { IJurisdiction } from '../../useJurisdictions'
@@ -82,21 +81,23 @@ beforeEach(() => {
 
 describe('Audit Setup > Review & Launch', () => {
   it('renders empty state', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <Router>
         <Review locked={false} prevStage={prevStage} refresh={jest.fn()} />
       </Router>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
   it('renders full state', async () => {
     auditSettingsMock.mockReturnValue(settingsMock.full)
-    const { container } = await asyncActRender(
+    const { container } = render(
       <Router>
         <Review locked={false} prevStage={prevStage} refresh={jest.fn()} />
       </Router>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
@@ -109,11 +110,12 @@ describe('Audit Setup > Review & Launch', () => {
       )
     )
     auditSettingsMock.mockReturnValue(settingsMock.full)
-    const { container } = await asyncActRender(
+    const { container } = render(
       <Router>
         <Review locked={false} prevStage={prevStage} refresh={jest.fn()} />
       </Router>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
@@ -126,11 +128,12 @@ describe('Audit Setup > Review & Launch', () => {
       )
     )
     auditSettingsMock.mockReturnValue(settingsMock.full)
-    const { container } = await asyncActRender(
+    const { container } = render(
       <Router>
         <Review locked={false} prevStage={prevStage} refresh={jest.fn()} />
       </Router>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
@@ -145,11 +148,12 @@ describe('Audit Setup > Review & Launch', () => {
       )
     )
     auditSettingsMock.mockReturnValue(settingsMock.full)
-    const { container } = await asyncActRender(
+    const { container } = render(
       <Router>
         <Review locked={false} prevStage={prevStage} refresh={jest.fn()} />
       </Router>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
@@ -164,11 +168,12 @@ describe('Audit Setup > Review & Launch', () => {
       )
     )
     auditSettingsMock.mockReturnValue(settingsMock.full)
-    const { container } = await asyncActRender(
+    const { container } = render(
       <Router>
         <Review locked={false} prevStage={prevStage} refresh={jest.fn()} />
       </Router>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
@@ -180,7 +185,7 @@ describe('Audit Setup > Review & Launch', () => {
         { jurisdictions: jurisdictionMocks.allManifests }
       )
     )
-    const { findByText, getAllByText } = await asyncActRender(
+    const { findByText, getAllByText } = render(
       <Router>
         <Review locked={false} prevStage={prevStage} refresh={jest.fn()} />
       </Router>
@@ -213,12 +218,12 @@ describe('Audit Setup > Review & Launch', () => {
         { jurisdictions: jurisdictionMocks.allManifests }
       )
     )
-    const { getByText, findByText, getAllByText } = await asyncActRender(
+    const { getByText, findByText, getAllByText } = render(
       <Router>
         <Review locked={false} prevStage={prevStage} refresh={jest.fn()} />
       </Router>
     )
-    const newSampleSize = getByText(
+    const newSampleSize = await findByText(
       '67 samples (70% chance of reaching risk limit and completing the audit in one round)'
     )
     fireEvent.click(newSampleSize, { bubbles: true })

--- a/client/src/components/MultiJurisdictionAudit/Setup/Settings/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Settings/index.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, waitFor, render } from '@testing-library/react'
 import { BrowserRouter as Router, useParams } from 'react-router-dom'
 import relativeStages from '../_mocks'
 import Settings from './index'
-import { asyncActRender } from '../../../testUtilities'
 import useAuditSettings from '../../useAuditSettings'
 
 jest.mock('react-router-dom', () => ({
@@ -32,7 +31,7 @@ auditSettingsMock.mockReturnValue([
 const { nextStage, prevStage } = relativeStages('Audit Settings')
 
 const fillAndSubmit = async () => {
-  const { getByText, getByLabelText, getByTestId } = await asyncActRender(
+  const { getByText, getByLabelText, getByTestId } = render(
     <Router>
       <Settings locked={false} nextStage={nextStage} prevStage={prevStage} />
     </Router>

--- a/client/src/components/MultiJurisdictionAudit/Setup/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/index.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { useParams, MemoryRouter } from 'react-router-dom'
+import { render, waitFor } from '@testing-library/react'
 import { auditSettings } from '../_mocks'
 import * as utilities from '../../utilities'
-import { asyncActRender } from '../../testUtilities'
 import Setup from './index'
 import relativeStages from './_mocks'
 import { contestMocks } from './Contests/_mocks'
@@ -54,7 +54,7 @@ afterEach(() => {
 
 describe('Setup', () => {
   it('renders Participants stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -64,10 +64,11 @@ describe('Setup', () => {
       </MemoryRouter>
     )
     expect(container).toMatchSnapshot()
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
   })
 
   it('renders Participants stage with locked next stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -76,11 +77,12 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
   it('renders Participants stage with processing next stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -89,11 +91,12 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
   it('renders Target Contests stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -102,11 +105,12 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
   it('renders Target Contests stage with locked next stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -115,11 +119,12 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
   it('renders Target Contests stage with processing next stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -128,6 +133,7 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
@@ -136,7 +142,7 @@ describe('Setup', () => {
       contestMocks.emptyOpportunistic.contests,
       jest.fn(),
     ])
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -145,6 +151,7 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
@@ -153,7 +160,7 @@ describe('Setup', () => {
       contestMocks.emptyOpportunistic.contests,
       jest.fn(),
     ])
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -164,6 +171,7 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
@@ -172,7 +180,7 @@ describe('Setup', () => {
       contestMocks.emptyOpportunistic.contests,
       jest.fn(),
     ])
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -183,11 +191,12 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
   it('renders Audit Settings stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -200,7 +209,7 @@ describe('Setup', () => {
   })
 
   it('renders Audit Settings stage with locked next stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -213,7 +222,7 @@ describe('Setup', () => {
   })
 
   it('renders Audit Settings stage with processing next stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -226,7 +235,7 @@ describe('Setup', () => {
   })
 
   it('renders Review & Launch stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -235,11 +244,12 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
   it('renders Review & Launch stage with locked next stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -248,11 +258,12 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
   it('renders Review & Launch stage with processing next stage', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <MemoryRouter>
         <Setup
           refresh={jest.fn()}
@@ -261,6 +272,7 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 })

--- a/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
@@ -852,6 +852,614 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
           <div
             class="sc-dnqmqq HzlIh"
           >
+            <label
+              class="bp3-file-input"
+            >
+              <input
+                accept=".csv"
+                name="csv"
+                type="file"
+              />
+              <span
+                class="bp3-file-upload-input"
+              >
+                Select a CSV...
+              </span>
+            </label>
+          </div>
+        </div>
+        <div
+          class="bp3-spinner"
+        >
+          <div
+            class="bp3-spinner-animation"
+          >
+            <svg
+              height="50"
+              stroke-width="8.00"
+              viewBox="1.00 1.00 98.00 98.00"
+              width="50"
+            >
+              <path
+                class="bp3-spinner-track"
+                d="M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90"
+              />
+              <path
+                class="bp3-spinner-head"
+                d="M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90"
+                pathLength="280"
+                stroke-dasharray="280 280"
+                stroke-dashoffset="210"
+              />
+            </svg>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AA setup flow renders sidebar when authenticated on /setup 2`] = `
+<div>
+  <div
+    class="sc-bdVaJa AANBu"
+  >
+    <div
+      class="bp3-callout sc-hMqMXs gvJKSa"
+    >
+      <div
+        class="sc-bwzfXH iqXUnX"
+      >
+        <div
+          class="text"
+        >
+          <h4
+            class="bp3-heading"
+          >
+            The audit has not started.
+          </h4>
+          <p>
+            Audit setup is complete.
+          </p>
+          <p>
+            0 of 2 jurisdictions have completed file uploads.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sc-bwzfXH iqXUnX"
+    >
+      <div
+        class="sc-bxivhb jyZAjn"
+      >
+        <h2
+          class="bp3-heading sc-htpNat fysvnw"
+        >
+          Audit Setup
+        </h2>
+        <ul
+          class="bp3-menu"
+        >
+          <li
+            class=""
+          >
+            <a
+              class="bp3-menu-item bp3-active bp3-intent-primary bp3-popover-dismiss"
+            >
+              <div
+                class="bp3-text-overflow-ellipsis bp3-fill"
+              >
+                Participants
+              </div>
+            </a>
+          </li>
+          <li
+            class="bp3-menu-divider"
+          />
+          <li
+            class=""
+          >
+            <a
+              class="bp3-menu-item bp3-disabled"
+              tabindex="-1"
+            >
+              <div
+                class="bp3-text-overflow-ellipsis bp3-fill"
+              >
+                Target Contests
+              </div>
+              <span
+                class="bp3-menu-item-label"
+              >
+                <div
+                  class="bp3-spinner"
+                >
+                  <div
+                    class="bp3-spinner-animation"
+                  >
+                    <svg
+                      height="20"
+                      stroke-width="16.00"
+                      viewBox="-3.00 -3.00 106.00 106.00"
+                      width="20"
+                    >
+                      <path
+                        class="bp3-spinner-track"
+                        d="M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90"
+                      />
+                      <path
+                        class="bp3-spinner-head"
+                        d="M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90"
+                        pathLength="280"
+                        stroke-dasharray="280 280"
+                        stroke-dashoffset="210"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </span>
+            </a>
+          </li>
+          <li
+            class="bp3-menu-divider"
+          />
+          <li
+            class=""
+          >
+            <a
+              class="bp3-menu-item bp3-disabled"
+              tabindex="-1"
+            >
+              <div
+                class="bp3-text-overflow-ellipsis bp3-fill"
+              >
+                Opportunistic Contests
+              </div>
+              <span
+                class="bp3-menu-item-label"
+              >
+                <div
+                  class="bp3-spinner"
+                >
+                  <div
+                    class="bp3-spinner-animation"
+                  >
+                    <svg
+                      height="20"
+                      stroke-width="16.00"
+                      viewBox="-3.00 -3.00 106.00 106.00"
+                      width="20"
+                    >
+                      <path
+                        class="bp3-spinner-track"
+                        d="M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90"
+                      />
+                      <path
+                        class="bp3-spinner-head"
+                        d="M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90"
+                        pathLength="280"
+                        stroke-dasharray="280 280"
+                        stroke-dashoffset="210"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </span>
+            </a>
+          </li>
+          <li
+            class="bp3-menu-divider"
+          />
+          <li
+            class=""
+          >
+            <a
+              class="bp3-menu-item bp3-popover-dismiss"
+            >
+              <div
+                class="bp3-text-overflow-ellipsis bp3-fill"
+              >
+                Audit Settings
+              </div>
+            </a>
+          </li>
+          <li
+            class="bp3-menu-divider"
+          />
+          <li
+            class=""
+          >
+            <a
+              class="bp3-menu-item bp3-popover-dismiss"
+            >
+              <div
+                class="bp3-text-overflow-ellipsis bp3-fill"
+              >
+                Review & Launch
+              </div>
+            </a>
+          </li>
+        </ul>
+      </div>
+      <form
+        data-testid="form-one"
+      >
+        <div
+          class="sc-ifAKCX dUfgxM"
+        >
+          <h2
+            class="bp3-heading sc-htpNat fysvnw"
+          >
+            Participants
+          </h2>
+          <label
+            for="state"
+          >
+            Choose your state from the options below
+            <br />
+            <div
+              class="bp3-html-select sc-gqjmRU kmMPEy"
+            >
+              <select
+                data-testid="state-field"
+                field="[object Object]"
+                form="[object Object]"
+                id="state"
+              >
+                <option
+                  value=""
+                />
+                <option
+                  label="Alabama"
+                  value="AL"
+                >
+                  Alabama
+                </option>
+                <option
+                  label="Alaska"
+                  value="AK"
+                >
+                  Alaska
+                </option>
+                <option
+                  label="Arizona"
+                  value="AZ"
+                >
+                  Arizona
+                </option>
+                <option
+                  label="Arkansas"
+                  value="AR"
+                >
+                  Arkansas
+                </option>
+                <option
+                  label="California"
+                  value="CA"
+                >
+                  California
+                </option>
+                <option
+                  label="Colorado"
+                  value="CO"
+                >
+                  Colorado
+                </option>
+                <option
+                  label="Connecticut"
+                  value="CT"
+                >
+                  Connecticut
+                </option>
+                <option
+                  label="Delaware"
+                  value="DE"
+                >
+                  Delaware
+                </option>
+                <option
+                  label="District Of Columbia"
+                  value="DC"
+                >
+                  District Of Columbia
+                </option>
+                <option
+                  label="Florida"
+                  value="FL"
+                >
+                  Florida
+                </option>
+                <option
+                  label="Georgia"
+                  value="GA"
+                >
+                  Georgia
+                </option>
+                <option
+                  label="Hawaii"
+                  value="HI"
+                >
+                  Hawaii
+                </option>
+                <option
+                  label="Idaho"
+                  value="ID"
+                >
+                  Idaho
+                </option>
+                <option
+                  label="Illinois"
+                  value="IL"
+                >
+                  Illinois
+                </option>
+                <option
+                  label="Indiana"
+                  value="IN"
+                >
+                  Indiana
+                </option>
+                <option
+                  label="Iowa"
+                  value="IA"
+                >
+                  Iowa
+                </option>
+                <option
+                  label="Kansas"
+                  value="KS"
+                >
+                  Kansas
+                </option>
+                <option
+                  label="Kentucky"
+                  value="KY"
+                >
+                  Kentucky
+                </option>
+                <option
+                  label="Louisiana"
+                  value="LA"
+                >
+                  Louisiana
+                </option>
+                <option
+                  label="Maine"
+                  value="ME"
+                >
+                  Maine
+                </option>
+                <option
+                  label="Maryland"
+                  value="MD"
+                >
+                  Maryland
+                </option>
+                <option
+                  label="Massachusetts"
+                  value="MA"
+                >
+                  Massachusetts
+                </option>
+                <option
+                  label="Michigan"
+                  value="MI"
+                >
+                  Michigan
+                </option>
+                <option
+                  label="Minnesota"
+                  value="MN"
+                >
+                  Minnesota
+                </option>
+                <option
+                  label="Mississippi"
+                  value="MS"
+                >
+                  Mississippi
+                </option>
+                <option
+                  label="Missouri"
+                  value="MO"
+                >
+                  Missouri
+                </option>
+                <option
+                  label="Montana"
+                  value="MT"
+                >
+                  Montana
+                </option>
+                <option
+                  label="Nebraska"
+                  value="NE"
+                >
+                  Nebraska
+                </option>
+                <option
+                  label="Nevada"
+                  value="NV"
+                >
+                  Nevada
+                </option>
+                <option
+                  label="New Hampshire"
+                  value="NH"
+                >
+                  New Hampshire
+                </option>
+                <option
+                  label="New Jersey"
+                  value="NJ"
+                >
+                  New Jersey
+                </option>
+                <option
+                  label="New Mexico"
+                  value="NM"
+                >
+                  New Mexico
+                </option>
+                <option
+                  label="New York"
+                  value="NY"
+                >
+                  New York
+                </option>
+                <option
+                  label="North Carolina"
+                  value="NC"
+                >
+                  North Carolina
+                </option>
+                <option
+                  label="North Dakota"
+                  value="ND"
+                >
+                  North Dakota
+                </option>
+                <option
+                  label="Ohio"
+                  value="OH"
+                >
+                  Ohio
+                </option>
+                <option
+                  label="Oklahoma"
+                  value="OK"
+                >
+                  Oklahoma
+                </option>
+                <option
+                  label="Oregon"
+                  value="OR"
+                >
+                  Oregon
+                </option>
+                <option
+                  label="Pennsylvania"
+                  value="PA"
+                >
+                  Pennsylvania
+                </option>
+                <option
+                  label="Rhode Island"
+                  value="RI"
+                >
+                  Rhode Island
+                </option>
+                <option
+                  label="South Carolina"
+                  value="SC"
+                >
+                  South Carolina
+                </option>
+                <option
+                  label="South Dakota"
+                  value="SD"
+                >
+                  South Dakota
+                </option>
+                <option
+                  label="Tennessee"
+                  value="TN"
+                >
+                  Tennessee
+                </option>
+                <option
+                  label="Texas"
+                  value="TX"
+                >
+                  Texas
+                </option>
+                <option
+                  label="Utah"
+                  value="UT"
+                >
+                  Utah
+                </option>
+                <option
+                  label="Vermont"
+                  value="VT"
+                >
+                  Vermont
+                </option>
+                <option
+                  label="Virginia"
+                  value="VA"
+                >
+                  Virginia
+                </option>
+                <option
+                  label="Washington"
+                  value="WA"
+                >
+                  Washington
+                </option>
+                <option
+                  label="West Virginia"
+                  value="WV"
+                >
+                  West Virginia
+                </option>
+                <option
+                  label="Wisconsin"
+                  value="WI"
+                >
+                  Wisconsin
+                </option>
+                <option
+                  label="Wyoming"
+                  value="WY"
+                >
+                  Wyoming
+                </option>
+              </select>
+              <span
+                class="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </div>
+          </label>
+          <div
+            class="sc-dnqmqq HzlIh"
+          >
+            <div
+              class="sc-iwsKbI bncGzX"
+            >
+              Click "Browse" to choose the appropriate file from your computer. This file should be a comma-separated list of all the jurisdictions participating in the audit, plus email addresses for audit administrators in each participating jurisdiction.
+              <br />
+              <br />
+              <a
+                href="http://localhost/sample_jurisdiction_filesheet.csv"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                (Click here to view a sample file in the correct format.)
+              </a>
+            </div>
+          </div>
+          <div
+            class="sc-dnqmqq HzlIh"
+          >
             <span>
               file name
                

--- a/client/src/components/MultiJurisdictionAudit/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.test.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react'
-import { waitFor, fireEvent } from '@testing-library/react'
+import { waitFor, fireEvent, render } from '@testing-library/react'
 import {
   BrowserRouter as Router,
   Router as RegularRouter,
@@ -8,7 +8,7 @@ import {
 import { AuditAdminView } from './index'
 import { auditSettings } from './_mocks'
 import * as utilities from '../utilities'
-import { asyncActRender, routerTestProps } from '../testUtilities'
+import { routerTestProps } from '../testUtilities'
 import AuthDataProvider, { AuthDataContext } from '../UserContext'
 import getJurisdictionFileStatus, {
   FileProcessingStatus,
@@ -124,7 +124,7 @@ describe('AA setup flow', () => {
   )
 
   it('sidebar changes stages', async () => {
-    const { queryAllByText, getByText } = await asyncActRender(
+    const { queryAllByText, getByText } = render(
       <AuthDataProvider>
         <Router>
           <AuditAdminViewWithAuth />
@@ -144,7 +144,7 @@ describe('AA setup flow', () => {
   })
 
   it('next and back buttons change stages', async () => {
-    const { queryAllByText, getByText } = await asyncActRender(
+    const { queryAllByText, getByText } = render(
       <AuthDataProvider>
         <Router>
           <AuditAdminViewWithAuth />
@@ -173,7 +173,7 @@ describe('AA setup flow', () => {
   })
 
   it('renders sidebar when authenticated on /setup', async () => {
-    const { container, queryAllByText } = await asyncActRender(
+    const { container, queryAllByText } = render(
       <AuthDataProvider>
         <Router>
           <AuditAdminViewWithAuth />
@@ -192,7 +192,7 @@ describe('AA setup flow', () => {
       electionId: '1',
       view: 'progress',
     })
-    const { container, queryAllByText } = await asyncActRender(
+    const { container, queryAllByText } = render(
       <AuthDataProvider>
         <Router>
           <AuditAdminViewWithAuth />
@@ -212,7 +212,7 @@ describe('AA setup flow', () => {
       electionId: '1',
       view: '',
     })
-    await asyncActRender(
+    render(
       <AuthDataProvider>
         <RegularRouter {...routeProps}>
           <AuditAdminViewWithAuth />

--- a/client/src/components/MultiJurisdictionAudit/useAuditSettings.test.ts
+++ b/client/src/components/MultiJurisdictionAudit/useAuditSettings.test.ts
@@ -27,8 +27,10 @@ describe('useAuditSettings', () => {
       result: {
         current: [settings],
       },
+      waitForNextUpdate,
     } = renderHook(() => useAuditSettings('1'))
 
+    await waitForNextUpdate()
     expect(settings).toStrictEqual(auditSettings.blank)
   })
 
@@ -75,7 +77,10 @@ describe('useAuditSettings', () => {
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(true)
-    const { result } = renderHook(() => useAuditSettings('1'))
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAuditSettings('1')
+    )
+    await waitForNextUpdate()
     const success = await result.current[1](auditSettings.all)
 
     expect(success).toBeFalsy()

--- a/client/src/components/MultiJurisdictionAudit/useSetupMenuItems.test.ts
+++ b/client/src/components/MultiJurisdictionAudit/useSetupMenuItems.test.ts
@@ -1,5 +1,4 @@
 import { renderHook, act } from '@testing-library/react-hooks'
-import { waitFor } from '@testing-library/react'
 import { toast } from 'react-toastify'
 import * as utilities from '../utilities'
 import useSetupMenuItems from './useSetupMenuItems/index'
@@ -50,7 +49,7 @@ afterEach(() => {
 })
 
 describe('useSetupMenuItems', () => {
-  it('returns initial state', () => {
+  it('returns initial state', async () => {
     const {
       result: {
         current: [menuItems],
@@ -59,15 +58,18 @@ describe('useSetupMenuItems', () => {
     expect(menuItems).toBeTruthy()
   })
 
-  it('calls the getters', () => {
+  it('calls the getters', async () => {
     const {
       result: {
         current: [, refresh],
       },
+      waitForNextUpdate,
     } = renderHook(() => useSetupMenuItems('Participants', jest.fn(), '1'))
     act(() => refresh())
+    await waitForNextUpdate()
     expect(apiMock).toHaveBeenCalledTimes(2)
     act(() => refresh())
+    await waitForNextUpdate()
     expect(apiMock).toHaveBeenCalledTimes(4)
   })
 
@@ -85,9 +87,7 @@ describe('useSetupMenuItems', () => {
     )
     act(() => result.current[1]())
     await waitForNextUpdate()
-    await waitFor(() =>
-      expect(result.current[0].every(i => i.state === 'locked')).toBeTruthy()
-    )
+    expect(result.current[0].every(i => i.state === 'locked')).toBeTruthy()
   })
 
   it('handles ERRORED response from /jurisdiction/file api', async () => {
@@ -110,10 +110,8 @@ describe('useSetupMenuItems', () => {
     )
     act(() => result.current[1]())
     await waitForNextUpdate()
-    await waitFor(() => {
-      expect(result.current[0][1].state === 'locked').toBeTruthy()
-      expect(result.current[0][2].state === 'locked').toBeTruthy()
-    })
+    expect(result.current[0][1].state === 'locked').toBeTruthy()
+    expect(result.current[0][2].state === 'locked').toBeTruthy()
   })
 
   it('handles NULL response from /jurisdiction/file api', async () => {
@@ -131,14 +129,13 @@ describe('useSetupMenuItems', () => {
         }
       )
     )
-    const { result } = renderHook(() =>
+    const { result, waitForNextUpdate } = renderHook(() =>
       useSetupMenuItems('Participants', jest.fn(), '1')
     )
     act(() => result.current[1]())
-    await waitFor(() => {
-      expect(result.current[0][1].state === 'locked').toBeTruthy()
-      expect(result.current[0][2].state === 'locked').toBeTruthy()
-    })
+    await waitForNextUpdate()
+    expect(result.current[0][1].state === 'locked').toBeTruthy()
+    expect(result.current[0][2].state === 'locked').toBeTruthy()
   })
 
   it('handles PROCESSING response from /jurisdiction/file api', async () => {
@@ -161,10 +158,8 @@ describe('useSetupMenuItems', () => {
     )
     act(() => result.current[1]())
     await waitForNextUpdate()
-    await waitFor(() => {
-      expect(result.current[0][1].state === 'processing').toBeTruthy()
-      expect(result.current[0][2].state === 'processing').toBeTruthy()
-    })
+    expect(result.current[0][1].state === 'processing').toBeTruthy()
+    expect(result.current[0][2].state === 'processing').toBeTruthy()
   })
 
   it('handles change of PROCESSING to PROCESSED response from /jurisdiction/file api', async () => {
@@ -202,10 +197,8 @@ describe('useSetupMenuItems', () => {
     )
     act(() => result.current[1]())
     await waitForNextUpdate()
-    await waitFor(() => {
-      expect(result.current[0][1].state).toBe('live')
-      expect(result.current[0][2].state).toBe('live')
-    })
+    expect(result.current[0][1].state).toBe('live')
+    expect(result.current[0][2].state).toBe('live')
   })
 
   it('handles PROCESSED response from /jurisdiction/file api', async () => {
@@ -223,14 +216,13 @@ describe('useSetupMenuItems', () => {
         }
       )
     )
-    const { result } = renderHook(() =>
+    const { result, waitForNextUpdate } = renderHook(() =>
       useSetupMenuItems('Participants', jest.fn(), '1')
     )
     act(() => result.current[1]())
-    await waitFor(() => {
-      expect(result.current[0][1].state === 'live').toBeTruthy()
-      expect(result.current[0][2].state === 'live').toBeTruthy()
-    })
+    await waitForNextUpdate()
+    expect(result.current[0][1].state === 'live').toBeTruthy()
+    expect(result.current[0][2].state === 'live').toBeTruthy()
   })
 
   it('handles READY_TO_PROCESS response from /jurisdiction/file api', async () => {
@@ -248,17 +240,16 @@ describe('useSetupMenuItems', () => {
         }
       )
     )
-    const { result } = renderHook(() =>
+    const { result, waitForNextUpdate } = renderHook(() =>
       useSetupMenuItems('Participants', jest.fn(), '1')
     )
     act(() => result.current[1]())
-    await waitFor(() => {
-      expect(result.current[0][1].state === 'processing').toBeTruthy()
-      expect(result.current[0][2].state === 'processing').toBeTruthy()
-    })
+    await waitForNextUpdate()
+    expect(result.current[0][1].state === 'processing').toBeTruthy()
+    expect(result.current[0][2].state === 'processing').toBeTruthy()
   })
 
-  it('handles background process timeout', async () => {
+  it.only('handles background process timeout', async () => {
     const toastSpy = jest.spyOn(toast, 'error').mockImplementation()
     const dateIncrementor = (function* incr() {
       let i = 10
@@ -289,12 +280,10 @@ describe('useSetupMenuItems', () => {
     )
     act(() => result.current[1]())
     await waitForNextUpdate()
-    await waitFor(() => {
-      expect(apiMock).toHaveBeenCalledTimes(3)
-      expect(dateSpy).toHaveBeenCalled()
-      expect(toastSpy).toHaveBeenCalledTimes(1)
-      expect(result.current[0][1].state === 'processing').toBeTruthy()
-      expect(result.current[0][2].state === 'processing').toBeTruthy()
-    })
+    expect(apiMock).toHaveBeenCalledTimes(3)
+    expect(dateSpy).toHaveBeenCalled()
+    expect(toastSpy).toHaveBeenCalledTimes(1)
+    expect(result.current[0][1].state === 'processing').toBeTruthy()
+    expect(result.current[0][2].state === 'processing').toBeTruthy()
   })
 })

--- a/client/src/components/ResetButton.test.tsx
+++ b/client/src/components/ResetButton.test.tsx
@@ -33,7 +33,7 @@ describe('ResetButton', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('does not render when authenticated', () => {
+  it('does not render when authenticated', async () => {
     apiMock.mockImplementation(async () => ({
       type: 'audit_admin',
       name: 'Joe',
@@ -53,6 +53,7 @@ describe('ResetButton', () => {
         <ResetButton electionId="1" updateAudit={updateAuditMock} />
       </AuthDataProvider>
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(queryAllByText('Clear & Restart').length).toBe(0)
     expect(container).toMatchSnapshot()
   })

--- a/client/src/components/SingleJurisdictionAudit/CalculateRiskMeasurement.test.tsx
+++ b/client/src/components/SingleJurisdictionAudit/CalculateRiskMeasurement.test.tsx
@@ -5,7 +5,6 @@ import jsPDF from 'jspdf'
 import CalculateRiskMeasurement from './CalculateRiskMeasurement'
 import { statusStates, dummyBallots, incompleteDummyBallots } from './_mocks'
 import * as utilities from '../utilities'
-import { asyncActRender } from '../testUtilities'
 
 statusStates.jurisdictionsInitial.online = false
 statusStates.ballotManifestProcessed.online = false
@@ -473,7 +472,7 @@ describe('CalculateRiskMeasurement', () => {
   it('renders online mode progress bar', async () => {
     statusStates.ballotManifestProcessed.online = true
     apiMock.mockImplementationOnce(async () => incompleteDummyBallots)
-    const { container } = await asyncActRender(
+    const { container } = render(
       <CalculateRiskMeasurement
         audit={statusStates.ballotManifestProcessed}
         isLoading
@@ -483,13 +482,14 @@ describe('CalculateRiskMeasurement', () => {
         electionId="1"
       />
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 
   it('renders online mode progress bar in multiple rounds', async () => {
     statusStates.multiAuditBoardsAndRounds.online = true
     apiMock.mockImplementationOnce(async () => incompleteDummyBallots)
-    const { container } = await asyncActRender(
+    const { container } = render(
       <CalculateRiskMeasurement
         audit={statusStates.multiAuditBoardsAndRounds}
         isLoading
@@ -499,6 +499,7 @@ describe('CalculateRiskMeasurement', () => {
         electionId="1"
       />
     )
+    await waitFor(() => expect(apiMock).toHaveBeenCalled())
     expect(container).toMatchSnapshot()
   })
 })

--- a/client/src/components/SingleJurisdictionAudit/index.test.tsx
+++ b/client/src/components/SingleJurisdictionAudit/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { waitFor } from '@testing-library/react'
+import { waitFor, render } from '@testing-library/react'
 import {
   BrowserRouter as Router,
   useParams,
@@ -8,7 +8,7 @@ import {
 import SingleJurisdictionAudit from './index'
 import { statusStates, dummyBallots } from './_mocks'
 import * as utilities from '../utilities'
-import { asyncActRender, routerTestProps } from '../testUtilities'
+import { routerTestProps } from '../testUtilities'
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
@@ -44,7 +44,7 @@ afterEach(() => {
 describe('RiskLimitingAuditForm', () => {
   it('fetches initial state from api', async () => {
     apiMock.mockImplementation(async () => statusStates.empty)
-    const { container } = await asyncActRender(
+    const { container } = render(
       <Router>
         <SingleJurisdictionAudit />
       </Router>
@@ -61,32 +61,39 @@ describe('RiskLimitingAuditForm', () => {
   })
 
   it('renders correctly with initialData', async () => {
-    const { container } = await asyncActRender(
+    const { container } = render(
       <Router>
         <SingleJurisdictionAudit />
       </Router>
     )
     expect(container).toMatchSnapshot()
+    await waitFor(() => {
+      expect(apiMock).toBeCalledTimes(1)
+    })
   })
 
   it('still renders if there is a server error', async () => {
     checkAndToastMock.mockReturnValueOnce(true)
-    await asyncActRender(
+    render(
       <Router>
         <SingleJurisdictionAudit />
       </Router>
     )
+    await waitFor(() => {
+      expect(apiMock).toBeCalledTimes(1)
+    })
     expect(checkAndToastMock).toBeCalledTimes(1)
   })
 
   it('does not render SelectBallotsToAudit when /audit/status is processing samplesizes', async () => {
     apiMock.mockImplementation(async () => statusStates.contestFirstRound)
-    const { container, queryByTestId } = await asyncActRender(
+    const { container, findByText, queryByTestId } = render(
       <Router>
         <SingleJurisdictionAudit />
       </Router>
     )
 
+    await findByText('Estimate Sample Size')
     expect(queryByTestId('form-two')).toBeNull()
     expect(container).toMatchSnapshot()
     await waitFor(() => {
@@ -102,7 +109,7 @@ describe('RiskLimitingAuditForm', () => {
 
   it('renders SelectBallotsToAudit when /audit/status returns contest data', async () => {
     apiMock.mockImplementation(async () => statusStates.sampleSizeOptions)
-    const { container, findByTestId } = await asyncActRender(
+    const { container, findByTestId } = render(
       <Router>
         <SingleJurisdictionAudit />
       </Router>
@@ -123,7 +130,7 @@ describe('RiskLimitingAuditForm', () => {
 
   it('does not render CalculateRiskMeasurement when audit.jurisdictions has length but audit.rounds does not', async () => {
     apiMock.mockImplementation(async () => statusStates.jurisdictionsInitial)
-    const { container, findByTestId, queryByTestId } = await asyncActRender(
+    const { container, findByTestId, queryByTestId } = render(
       <Router>
         <SingleJurisdictionAudit />
       </Router>
@@ -147,7 +154,7 @@ describe('RiskLimitingAuditForm', () => {
     apiMock
       .mockImplementationOnce(async () => statusStates.ballotManifestProcessed)
       .mockImplementationOnce(async () => dummyBallots)
-    const { container, findByTestId } = await asyncActRender(
+    const { container, findByTestId } = render(
       <Router>
         <SingleJurisdictionAudit />
       </Router>
@@ -173,7 +180,7 @@ describe('RiskLimitingAuditForm', () => {
       electionId: '1',
       view: 'setup',
     })
-    await asyncActRender(
+    render(
       <RegularRouter {...routeProps}>
         <SingleJurisdictionAudit />
       </RegularRouter>

--- a/client/src/components/testUtilities.ts
+++ b/client/src/components/testUtilities.ts
@@ -1,5 +1,3 @@
-import React from 'react'
-import { RenderResult, act, render } from '@testing-library/react'
 import { createLocation, createMemoryHistory } from 'history'
 import { match as routerMatch } from 'react-router-dom'
 
@@ -45,16 +43,6 @@ export const routerTestProps = <Params extends MatchParameter<Params> = {}>(
 export const regexpEscape = (s: string) => {
   /* eslint-disable no-useless-escape */
   return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
-}
-
-export const asyncActRender = async (
-  component: React.ReactElement
-): Promise<RenderResult> => {
-  let result: RenderResult
-  await act(() => {
-    result = render(component)
-  })
-  return result!
 }
 
 export default {

--- a/client/src/components/testUtilities.ts
+++ b/client/src/components/testUtilities.ts
@@ -51,7 +51,7 @@ export const asyncActRender = async (
   component: React.ReactElement
 ): Promise<RenderResult> => {
   let result: RenderResult
-  await act(async () => {
+  await act(() => {
     result = render(component)
   })
   return result!

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1644,10 +1644,10 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.2.1.tgz#19b6caa048ef15faa69d439c469033873ea01294"
-  integrity sha512-1OB6Ksvlk6BCJA1xpj8/WWz0XVd1qRcgqdaFAq+xeC6l61Ucj0P6QpA5u+Db/x9gU4DCX8ziR5b66Mlfg0M2RA==
+"@testing-library/react-hooks@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.3.0.tgz#dc217bfce8e7c34a99c811d73d23feef957b7c1d"
+  integrity sha512-rE9geI1+HJ6jqXkzzJ6abREbeud6bLF8OmF+Vyc7gBoPwZAEVBYjbC1up5nNoVfYBhO5HUwdD4u9mTehAUeiyw==
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@types/testing-library__react-hooks" "^3.0.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1063,7 +1063,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.7.4", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
+"@babel/runtime@^7.7.4", "@babel/runtime@^7.9.2":
   version "7.10.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.0.tgz#2cdcd6d7a391c24f7154235134c830cfb58ac0b1"
   integrity sha512-tgYb3zVApHbLHYOPWtVwg25sBqHhfBXRKeKoTIyoheIxln1nA7oBl7SfHfiTG2GhDPI8EUBkOD/0wJCP/3HN4Q==
@@ -1619,10 +1619,10 @@
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
   integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
 
-"@testing-library/dom@^7.2.2":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.11.0.tgz#db8678bc55aef7cd6091d1510e8d0949d77d79fd"
-  integrity sha512-2j+zfA6dwnzozReA2XrbZs3e9DD9UdetONrWmumIY2QdGH0h08hRW+SaLE8kIytM6KPO5yzypHZhK5AZNFEtiw==
+"@testing-library/dom@^7.14.2":
+  version "7.16.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.16.2.tgz#f7a20b5548817e5c7ed26077913372d977be90af"
+  integrity sha512-4fT5l5L+5gfNhUZVCg0wnSszbRJ7A1ZHEz32v7OzH3mcY5lUsK++brI3IB2L9F5zO4kSDc2TRGEVa8v2hgl9vA==
   dependencies:
     "@babel/runtime" "^7.10.2"
     aria-query "^4.0.2"
@@ -1652,14 +1652,13 @@
     "@babel/runtime" "^7.5.4"
     "@types/testing-library__react-hooks" "^3.0.0"
 
-"@testing-library/react@^10.0.4":
-  version "10.0.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.0.4.tgz#8e0e299cd91acc626d81ed8489fdc13df864c31d"
-  integrity sha512-2e1B5debfuiIGbvUuiSXybskuh7ZTVJDDvG/IxlzLOY9Co/mKFj9hIklAe2nGZYcOUxFaiqWrRZ9vCVGzJfRlQ==
+"@testing-library/react@^10.3.0":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.3.0.tgz#d615385b8d86ef4d76142a423755d471b3673295"
+  integrity sha512-Rhn5uJK6lYHWzlGVbK6uAvheAW8AUoFYxTLGdDxgsJDaK/PYy5drWfW/6YpMMOKMw+u6jHHl4MNHlt5qLHnm0Q==
   dependencies:
-    "@babel/runtime" "^7.9.6"
-    "@testing-library/dom" "^7.2.2"
-    "@types/testing-library__react" "^10.0.1"
+    "@babel/runtime" "^7.10.2"
+    "@testing-library/dom" "^7.14.2"
 
 "@testing-library/user-event@^11.3.1":
   version "11.3.1"
@@ -1831,13 +1830,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@*":
-  version "16.9.4"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.4.tgz#0b58df09a60961dcb77f62d4f1832427513420df"
-  integrity sha512-fya9xteU/n90tda0s+FtN5Ym4tbgxpq/hb/Af24dvs6uYnYn+fspaxw5USlw0R8apDNwxsqumdRoCoKitckQqw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-dom@16.8.4":
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.4.tgz#7fb7ba368857c7aa0f4e4511c4710ca2c5a12a88"
@@ -1929,13 +1921,6 @@
     "@types/react-native" "*"
     csstype "^2.2.0"
 
-"@types/testing-library__dom@*":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.10.0.tgz#590d76e3875a7c536dc744eb530cbf51b6483404"
-  integrity sha512-mL/GMlyQxiZplbUuFNwA0vAI3k3uJNSf6slr5AVve9TXmfLfyefNT0uHHnxwdYuPMxYD5gI/+dgAvc/5opW9JQ==
-  dependencies:
-    pretty-format "^24.3.0"
-
 "@types/testing-library__jest-dom@^5.0.2":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.7.0.tgz#078790bf4dc89152a74428591a228ec5f9433251"
@@ -1950,15 +1935,6 @@
   dependencies:
     "@types/react" "*"
     "@types/react-test-renderer" "*"
-
-"@types/testing-library__react@^10.0.1":
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-10.0.1.tgz#92bb4a02394bf44428e35f1da2970ed77f803593"
-  integrity sha512-RbDwmActAckbujLZeVO/daSfdL1pnjVqas25UueOkAY5r7vriavWf0Zqg7ghXMHa8ycD/kLkv8QOj31LmSYwww==
-  dependencies:
-    "@types/react-dom" "*"
-    "@types/testing-library__dom" "*"
-    pretty-format "^25.1.0"
 
 "@types/tough-cookie@*":
   version "2.3.5"
@@ -11291,7 +11267,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^24.3.0, pretty-format@^24.9.0:
+pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -11301,7 +11277,7 @@ pretty-format@^24.3.0, pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-pretty-format@^25.1.0, pretty-format@^25.2.1, pretty-format@^25.5.0:
+pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
   integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==


### PR DESCRIPTION
Some package upgrades:
- @testing-library/react-hooks v3.3.0
- @testing-library/react v10.3.0

I started these upgrades to get some performance optimizations that I hoped would speed up some tests I was writing.

These broke some tests, specifically the ones using `asyncActRender`, since `act` no longer supports taking an async function (caused a type error).

Looking into this deeper, I discovered that since many of our components make some API calls when they render, we often need the tests to wait for those calls to get made before we can assert anything about the resulting DOM. I think `asyncActRender` was causing this to happen.

Reading some docs, I found out that testing-library's `render` already calls `act` internally, so that part wasn't necessary. So I replaced the calls to `asyncActRender` with calls to `render` (which broke a bunch of tests). To fix the tests, I made sure there was some `waitFor` (or other async helper) to ensure the API calls completed before checking assertions.

While I was at it, I realized that a similar issue was causing the warnings about certain calls not being wrapped in `act`. This warning was a result of API calls happening after the test had already completed (see https://kentcdodds.com/blog/fix-the-not-wrapped-in-act-warning#how-to-fix-the-act-warning). So I applied a similar fix.

Now we are warning free and using the latest versions! And we know how to prevent those warnings in the future.
