### PR TITLE
LinkButton component

### DIFF
--- a/client/src/components/Atoms/LinkButton.tsx
+++ b/client/src/components/Atoms/LinkButton.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Link, LinkProps } from 'react-router-dom'
+import { Button } from '@blueprintjs/core'
+
+interface ILinkButtonProps extends LinkProps {
+  disabled?: boolean
+}
+
+// LinkButton creates a React Router Link that uses a BlueprintJS button instead
+// of an anchor tag. This allows us to disable links (and gives us nice button
+// styling).
+const LinkButton = (props: ILinkButtonProps) => {
+  return (
+    <Link
+      {...props}
+      component={({ navigate, ...rest }) => (
+        <Button onClick={navigate} {...rest} />
+      )}
+    />
+  )
+}
+
+export default LinkButton

--- a/client/src/components/DataEntry/BoardTable.test.tsx
+++ b/client/src/components/DataEntry/BoardTable.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { StaticRouter } from 'react-router-dom'
 import BoardTable from './BoardTable'
 import { doneDummyBallots } from './_mocks'
 
 describe('BoardTable', () => {
   it('enables the submit button when all ballots are done', async () => {
-    const { container, getByText } = render(
+    const { container } = render(
       <StaticRouter>
         <BoardTable
           boardName="Audit Board #1"
@@ -15,19 +15,11 @@ describe('BoardTable', () => {
         />
       </StaticRouter>
     )
-    await waitFor(() => {
-      expect(getByText('Audit Board #1: Ballot Cards to Audit')).toBeTruthy()
+    await screen.findByText('Audit Board #1: Ballot Cards to Audit')
 
-      const notFound = getByText('Not Found')
-      expect(notFound).toBeTruthy()
+    screen.getByText('Not Found')
+    expect(screen.getByText('Auditing Complete - Submit Results')).toBeEnabled()
 
-      const button = getByText('Auditing Complete - Submit Results').closest(
-        'a'
-      )
-      expect(button).toBeTruthy()
-      expect(button!.getAttribute('disabled')).toBeFalsy()
-
-      expect(container).toMatchSnapshot()
-    })
+    expect(container).toMatchSnapshot()
   })
 })

--- a/client/src/components/DataEntry/BoardTable.tsx
+++ b/client/src/components/DataEntry/BoardTable.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { Table as BPTable, Column, Cell as BPCell } from '@blueprintjs/table'
-import { H1, AnchorButton } from '@blueprintjs/core'
+import { H1 } from '@blueprintjs/core'
 import { Link } from 'react-router-dom'
 import { IAuditBoard, BallotStatus } from '../../types'
 import { IBallot } from './Ballot'
+import LinkButton from '../Atoms/LinkButton'
 
 const RightWrapper = styled.div`
   display: flex;
@@ -143,8 +144,8 @@ const BoardTable: React.FC<IProps> = ({ boardName, ballots, url }: IProps) => {
         </strong>
       </p>
       <RightWrapper>
-        <AnchorButton
-          href={
+        <LinkButton
+          to={
             unauditedBallot
               ? `${url}/batch/${unauditedBallot.batch.id}/ballot/${unauditedBallot.position}`
               : ''
@@ -152,10 +153,10 @@ const BoardTable: React.FC<IProps> = ({ boardName, ballots, url }: IProps) => {
           disabled={roundComplete}
         >
           Start Auditing
-        </AnchorButton>
-        <AnchorButton href={`${url}/signoff`} disabled={!roundComplete}>
+        </LinkButton>
+        <LinkButton to={`${url}/signoff`} disabled={!roundComplete}>
           Auditing Complete - Submit Results
-        </AnchorButton>
+        </LinkButton>
       </RightWrapper>
       {/* <ActionWrapper> // commented out until feature is added
         {!roundComplete && (

--- a/client/src/components/DataEntry/__snapshots__/BoardTable.test.tsx.snap
+++ b/client/src/components/DataEntry/__snapshots__/BoardTable.test.tsx.snap
@@ -21,30 +21,30 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
     <div
       class="sc-bdVaJa gKZTDn"
     >
-      <a
+      <button
         class="bp3-button bp3-disabled"
         disabled=""
-        role="button"
+        href="/"
         tabindex="-1"
+        type="button"
       >
         <span
           class="bp3-button-text"
         >
           Start Auditing
         </span>
-      </a>
-      <a
+      </button>
+      <button
         class="bp3-button"
         href="/home/signoff"
-        role="button"
-        tabindex="0"
+        type="button"
       >
         <span
           class="bp3-button-text"
         >
           Auditing Complete - Submit Results
         </span>
-      </a>
+      </button>
     </div>
     <div
       class="bp3-table-container bp3-table-selection-enabled sc-htpNat dCryYg"

--- a/client/src/components/DataEntry/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/DataEntry/__snapshots__/index.test.tsx.snap
@@ -290,30 +290,30 @@ exports[`DataEntry ballot interaction renders board table with ballots 1`] = `
         <div
           class="sc-bdVaJa gKZTDn"
         >
-          <a
+          <button
             class="bp3-button"
             href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
-            role="button"
-            tabindex="0"
+            type="button"
           >
             <span
               class="bp3-button-text"
             >
               Start Auditing
             </span>
-          </a>
-          <a
+          </button>
+          <button
             class="bp3-button bp3-disabled"
             disabled=""
-            role="button"
+            href="/election/1/audit-board/audit-board-1/signoff"
             tabindex="-1"
+            type="button"
           >
             <span
               class="bp3-button-text"
             >
               Auditing Complete - Submit Results
             </span>
-          </a>
+          </button>
         </div>
         <div
           class="bp3-table-container bp3-table-selection-enabled sc-htpNat dCryYg"
@@ -890,30 +890,30 @@ exports[`DataEntry ballot interaction renders board table with large container s
         <div
           class="sc-bdVaJa gKZTDn"
         >
-          <a
+          <button
             class="bp3-button"
             href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
-            role="button"
-            tabindex="0"
+            type="button"
           >
             <span
               class="bp3-button-text"
             >
               Start Auditing
             </span>
-          </a>
-          <a
+          </button>
+          <button
             class="bp3-button bp3-disabled"
             disabled=""
-            role="button"
+            href="/election/1/audit-board/audit-board-1/signoff"
             tabindex="-1"
+            type="button"
           >
             <span
               class="bp3-button-text"
             >
               Auditing Complete - Submit Results
             </span>
-          </a>
+          </button>
         </div>
         <div
           class="bp3-table-container bp3-table-selection-enabled sc-htpNat dCryYg"
@@ -1490,30 +1490,30 @@ exports[`DataEntry ballot interaction renders board table with no ballots 1`] = 
         <div
           class="sc-bdVaJa gKZTDn"
         >
-          <a
+          <button
             class="bp3-button bp3-disabled"
             disabled=""
-            role="button"
+            href="/"
             tabindex="-1"
+            type="button"
           >
             <span
               class="bp3-button-text"
             >
               Start Auditing
             </span>
-          </a>
-          <a
+          </button>
+          <button
             class="bp3-button"
             href="/election/1/audit-board/audit-board-1/signoff"
-            role="button"
-            tabindex="0"
+            type="button"
           >
             <span
               class="bp3-button-text"
             >
               Auditing Complete - Submit Results
             </span>
-          </a>
+          </button>
         </div>
         <div
           class="bp3-table-container bp3-table-no-rows sc-htpNat dCryYg"
@@ -2169,30 +2169,30 @@ exports[`DataEntry member form submits and goes to ballot table 1`] = `
         <div
           class="sc-bdVaJa gKZTDn"
         >
-          <a
+          <button
             class="bp3-button"
             href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
-            role="button"
-            tabindex="0"
+            type="button"
           >
             <span
               class="bp3-button-text"
             >
               Start Auditing
             </span>
-          </a>
-          <a
+          </button>
+          <button
             class="bp3-button bp3-disabled"
             disabled=""
-            role="button"
+            href="/election/1/audit-board/audit-board-1/signoff"
             tabindex="-1"
+            type="button"
           >
             <span
               class="bp3-button-text"
             >
               Auditing Complete - Submit Results
             </span>
-          </a>
+          </button>
         </div>
         <div
           class="bp3-table-container bp3-table-selection-enabled sc-htpNat dCryYg"

--- a/client/src/components/DataEntry/index.test.tsx
+++ b/client/src/components/DataEntry/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { StaticRouter } from 'react-router-dom'
 import { routerTestProps } from '../testUtilities'
 import DataEntry from './index'
@@ -134,20 +134,22 @@ describe('DataEntry', () => {
     })
 
     it('renders board table with ballots', async () => {
-      const { container, getByText } = render(
+      const { container } = render(
         <StaticRouter {...staticRouteProps}>
           <DataEntry {...routeProps} />
         </StaticRouter>
       )
-      await waitFor(() => {
-        expect(apiMock).toBeCalledTimes(3)
-        expect(getByText('Audit Board #1: Ballot Cards to Audit')).toBeTruthy()
-        expect(getByText('Start Auditing').closest('a')).toBeEnabled()
-        expect(
-          getByText('Auditing Complete - Submit Results').closest('a')
-        ).toHaveAttribute('disabled') // eslint-disable-line jest-dom/prefer-enabled-disabled
-        expect(container).toMatchSnapshot()
-      })
+      await screen.findByText('Audit Board #1: Ballot Cards to Audit')
+      expect(
+        screen.getByRole('button', { name: 'Start Auditing' })
+      ).toBeEnabled()
+      expect(
+        screen.getByRole('button', {
+          name: 'Auditing Complete - Submit Results',
+        })
+      ).toBeDisabled()
+      expect(container).toMatchSnapshot()
+      expect(apiMock).toBeCalledTimes(3)
     })
 
     it('renders board table with large container size', async () => {


### PR DESCRIPTION
Adds a LinkButton component that renders a React Router Link using a
BlueprintJS Button component. This makes the link look like a button and
allows it to be disabled.

Two advantages:
- If we just used AnchorButton from BlueprintJS, we can't actually test
clicking it, since our testing environment doesn't support actual
browser navigation, just React Router navigation.
- Anchor links can't actually be disabled, so before we had to hack around that
to test that they were getting disabled.
