### PR TITLE
Count ballots not sample draws for opportunistic contests

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -452,6 +452,7 @@ class RoundContest(BaseModel):
     contest_id = Column(
         String(200), ForeignKey("contest.id", ondelete="cascade"), nullable=False,
     )
+    contest = relationship("Contest")
 
     # Used in the single-jurisdiction flow to store pre-computed estimated sample sizes
     sample_size_options = Column(String(1000))

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -147,8 +147,9 @@ def audit_ballot(
     choices: List[ContestChoice] = None,
     is_overvote: bool = False,
 ):
-    if ballot.status != BallotStatus.AUDITED:
-        db_session.add(
+    # Make sure we don't try to audit this ballot twice for this contest
+    if not any(i for i in ballot.interpretations if i.contest_id == contest_id):
+        ballot.interpretations = list(ballot.interpretations) + [
             BallotInterpretation(
                 ballot_id=ballot.id,
                 contest_id=contest_id,
@@ -156,7 +157,7 @@ def audit_ballot(
                 selected_choices=choices or [],
                 is_overvote=is_overvote,
             )
-        )
+        ]
         ballot.status = BallotStatus.AUDITED
 
 


### PR DESCRIPTION
Previously, we counted votes for targeted and opportunistic contests the
same way - using the sample draws. This was incorrect. For targeted
contests, we should count the sample draws. For opportunistic, we should
count distinct ballots.

This will make more a difference when we have multiple contests with
distinct sample draws that may refer to the same ballots.