### PR TITLE
Independently targeted contests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -30,10 +30,13 @@ jsonschema = "*"
 numpy = "*"
 psycopg2-binary = "*"
 requests = "*"
-sqlalchemy-utils = "*"
+# sqlalchemy-utils 0.36.8 introduced a bug
+# Can probably reset this to * once the next patch comes out
+sqlalchemy-utils = "==0.36.7"
 uuid = "*"
 xkcdpass = "*"
 sqlalchemy = "*"
+typing-extensions = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9e4f7fae2d62bdc1c99458b36ee64b8e99a61665196a2147c31941c94afa3d86"
+            "sha256": "e659259a7c059a3a6403ae3a5fb7ea5f7cf7c83f4407fa6e36fb69b02faca677"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -391,6 +391,15 @@
             "index": "pypi",
             "version": "==0.36.7"
         },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
+                "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
+                "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
+            ],
+            "index": "pypi",
+            "version": "==3.7.4.2"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
@@ -700,11 +709,11 @@
         },
         "pytest-alembic": {
             "hashes": [
-                "sha256:512a1d7fd528a1dea6d6f9b2214cafcd1fa2821b0b5e8294ee06761f35cd819d",
-                "sha256:9f29accdc33fe4f691bc673156b4e5a64a55caae3ca582f1bc2c72a05f3bc85d"
+                "sha256:2de79755b30425acd44fb98458c019f682c5d27502ae6872de2283043d693d7e",
+                "sha256:c6da41f2c8ae0c50c9abe489586b5ae68287f4b1d728fc754f617d6528fbf4a1"
             ],
             "index": "pypi",
-            "version": "==0.2.4"
+            "version": "==0.2.5"
         },
         "pytest-cov": {
             "hashes": [
@@ -731,29 +740,29 @@
         },
         "regex": {
             "hashes": [
-                "sha256:08997a37b221a3e27d68ffb601e45abfb0093d39ee770e4257bd2f5115e8cb0a",
-                "sha256:112e34adf95e45158c597feea65d06a8124898bdeac975c9087fe71b572bd938",
-                "sha256:1700419d8a18c26ff396b3b06ace315b5f2a6e780dad387e4c48717a12a22c29",
-                "sha256:2f6f211633ee8d3f7706953e9d3edc7ce63a1d6aad0be5dcee1ece127eea13ae",
-                "sha256:52e1b4bef02f4040b2fd547357a170fc1146e60ab310cdbdd098db86e929b387",
-                "sha256:55b4c25cbb3b29f8d5e63aeed27b49fa0f8476b0d4e1b3171d85db891938cc3a",
-                "sha256:5aaa5928b039ae440d775acea11d01e42ff26e1561c0ffcd3d805750973c6baf",
-                "sha256:654cb773b2792e50151f0e22be0f2b6e1c3a04c5328ff1d9d59c0398d37ef610",
-                "sha256:690f858d9a94d903cf5cada62ce069b5d93b313d7d05456dbcd99420856562d9",
-                "sha256:6ad8663c17db4c5ef438141f99e291c4d4edfeaacc0ce28b5bba2b0bf273d9b5",
-                "sha256:89cda1a5d3e33ec9e231ece7307afc101b5217523d55ef4dc7fb2abd6de71ba3",
-                "sha256:92d8a043a4241a710c1cf7593f5577fbb832cf6c3a00ff3fc1ff2052aff5dd89",
-                "sha256:95fa7726d073c87141f7bbfb04c284901f8328e2d430eeb71b8ffdd5742a5ded",
-                "sha256:97712e0d0af05febd8ab63d2ef0ab2d0cd9deddf4476f7aa153f76feef4b2754",
-                "sha256:b2ba0f78b3ef375114856cbdaa30559914d081c416b431f2437f83ce4f8b7f2f",
-                "sha256:bae83f2a56ab30d5353b47f9b2a33e4aac4de9401fb582b55c42b132a8ac3868",
-                "sha256:c78e66a922de1c95a208e4ec02e2e5cf0bb83a36ceececc10a72841e53fbf2bd",
-                "sha256:cf59bbf282b627130f5ba68b7fa3abdb96372b24b66bdf72a4920e8153fc7910",
-                "sha256:e3cdc9423808f7e1bb9c2e0bdb1c9dc37b0607b30d646ff6faf0d4e41ee8fee3",
-                "sha256:e9b64e609d37438f7d6e68c2546d2cb8062f3adb27e6336bc129b51be20773ac",
-                "sha256:fbff901c54c22425a5b809b914a3bfaf4b9570eee0e5ce8186ac71eb2025191c"
+                "sha256:0dc64ee3f33cd7899f79a8d788abfbec168410be356ed9bd30bbd3f0a23a7204",
+                "sha256:1269fef3167bb52631ad4fa7dd27bf635d5a0790b8e6222065d42e91bede4162",
+                "sha256:14a53646369157baa0499513f96091eb70382eb50b2c82393d17d7ec81b7b85f",
+                "sha256:3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb",
+                "sha256:46bac5ca10fb748d6c55843a931855e2727a7a22584f302dd9bb1506e69f83f6",
+                "sha256:4c037fd14c5f4e308b8370b447b469ca10e69427966527edcab07f52d88388f7",
+                "sha256:51178c738d559a2d1071ce0b0f56e57eb315bcf8f7d4cf127674b533e3101f88",
+                "sha256:5ea81ea3dbd6767873c611687141ec7b06ed8bab43f68fad5b7be184a920dc99",
+                "sha256:6961548bba529cac7c07af2fd4d527c5b91bb8fe18995fed6044ac22b3d14644",
+                "sha256:75aaa27aa521a182824d89e5ab0a1d16ca207318a6b65042b046053cfc8ed07a",
+                "sha256:7a2dd66d2d4df34fa82c9dc85657c5e019b87932019947faece7983f2089a840",
+                "sha256:8a51f2c6d1f884e98846a0a9021ff6861bdb98457879f412fdc2b42d14494067",
+                "sha256:9c568495e35599625f7b999774e29e8d6b01a6fb684d77dee1f56d41b11b40cd",
+                "sha256:9eddaafb3c48e0900690c1727fba226c4804b8e6127ea409689c3bb492d06de4",
+                "sha256:bbb332d45b32df41200380fff14712cb6093b61bd142272a10b16778c418e98e",
+                "sha256:bc3d98f621898b4a9bc7fecc00513eec8f40b5b83913d74ccb445f037d58cd89",
+                "sha256:c11d6033115dc4887c456565303f540c44197f4fc1a2bfb192224a301534888e",
+                "sha256:c50a724d136ec10d920661f1442e4a8b010a4fe5aebd65e0c2241ea41dbe93dc",
+                "sha256:d0a5095d52b90ff38592bbdc2644f17c6d495762edf47d876049cfd2968fbccf",
+                "sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341",
+                "sha256:e46d13f38cfcbb79bfdb2964b0fe12561fe633caf964a77a5f8d4e45fe5d2ef7"
             ],
-            "version": "==2020.6.8"
+            "version": "==2020.7.14"
         },
         "six": {
             "hashes": [
@@ -857,6 +866,7 @@
                 "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
                 "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
             ],
+            "index": "pypi",
             "version": "==3.7.4.2"
         },
         "wasmer": {

--- a/client/package.json
+++ b/client/package.json
@@ -63,10 +63,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 87,
-        "branches": 85,
-        "functions": 86,
-        "lines": 86
+        "statements": 88,
+        "branches": 86,
+        "functions": 88,
+        "lines": 88
       }
     }
   },

--- a/client/src/components/MultiJurisdictionAudit/Setup/Review/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Review/__snapshots__/index.test.tsx.snap
@@ -38,99 +38,104 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
     >
       Audit Settings
     </h4>
-    <table
-      class="sc-jKJlTe bkTFhC"
+    <div
+      class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
     >
-      <tbody>
-        <tr>
-          <td>
-            Election Name:
-          </td>
-          <td>
-            Election Name
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Risk Limit:
-          </td>
-          <td>
-            10
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Random Seed:
-          </td>
-          <td>
-            12345
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Participating Jurisdictions:
-          </td>
-          <td>
-            <a
-              href="/api/election/1/jurisdiction/file/csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Audit Board Data Entry:
-          </td>
-          <td>
-            Online
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Target Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody />
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Opportunistic Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            Contest Name
-          </td>
-          <td>
-            , 
-          </td>
-        </tr>
-      </tbody>
-    </table>
+      <table
+        class="sc-jKJlTe bkTFhC"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Election Name:
+            </td>
+            <td>
+              Election Name
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Risk Limit:
+            </td>
+            <td>
+              10
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Random Seed:
+            </td>
+            <td>
+              12345
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Participating Jurisdictions:
+            </td>
+            <td>
+              <a
+                href="/api/election/1/jurisdiction/file/csv"
+                rel="noopener noreferrer"
+                target="_blank"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Audit Board Data Entry:
+            </td>
+            <td>
+              Online
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Target Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Opportunistic Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              Contest Name
+            </td>
+            <td>
+              , 
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <br />
     <h4
       class="bp3-heading"
     >
-      Sample Size Options
+      Sample Size
     </h4>
     <form
       data-testid="sample-size-form"
@@ -138,95 +143,10 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       <div
         class="sc-gzVnrw coBAaV"
       >
-        <h3
-          class="bp3-heading sc-dnqmqq hlcOhg"
-        >
-          Estimated Sample Size
-        </h3>
         <div
           class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
-        </div>
-        <div
-          class="sc-htoDjs GlcDy"
-        >
-          <div>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                checked=""
-                name="sampleSize"
-                type="radio"
-                value="46"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              BRAVO Average Sample Number: 
-              46 samples
-               (54% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="67"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              67 samples
-               (70% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="88"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              88 samples
-              
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="125"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              125 samples
-               (90% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="custom"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Enter your own sample size (not recommended)
-            </label>
-          </div>
         </div>
       </div>
       <div
@@ -298,99 +218,104 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
     >
       Audit Settings
     </h4>
-    <table
-      class="sc-jKJlTe bkTFhC"
+    <div
+      class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
     >
-      <tbody>
-        <tr>
-          <td>
-            Election Name:
-          </td>
-          <td>
-            Election Name
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Risk Limit:
-          </td>
-          <td>
-            10
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Random Seed:
-          </td>
-          <td>
-            12345
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Participating Jurisdictions:
-          </td>
-          <td>
-            <a
-              href="/api/election/1/jurisdiction/file/csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Audit Board Data Entry:
-          </td>
-          <td>
-            Online
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Target Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            Contest Name
-          </td>
-          <td>
-            , 
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Opportunistic Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody />
-    </table>
+      <table
+        class="sc-jKJlTe bkTFhC"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Election Name:
+            </td>
+            <td>
+              Election Name
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Risk Limit:
+            </td>
+            <td>
+              10
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Random Seed:
+            </td>
+            <td>
+              12345
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Participating Jurisdictions:
+            </td>
+            <td>
+              <a
+                href="/api/election/1/jurisdiction/file/csv"
+                rel="noopener noreferrer"
+                target="_blank"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Audit Board Data Entry:
+            </td>
+            <td>
+              Online
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Target Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              Contest Name
+            </td>
+            <td>
+              , 
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Opportunistic Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+    <br />
     <h4
       class="bp3-heading"
     >
-      Sample Size Options
+      Sample Size
     </h4>
     <form
       data-testid="sample-size-form"
@@ -398,94 +323,97 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
       <div
         class="sc-gzVnrw coBAaV"
       >
-        <h3
-          class="bp3-heading sc-dnqmqq hlcOhg"
-        >
-          Estimated Sample Size
-        </h3>
         <div
           class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
         </div>
         <div
-          class="sc-htoDjs GlcDy"
+          class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
         >
-          <div>
-            <label
-              class="bp3-control bp3-radio"
+          <div
+            class="sc-htoDjs GlcDy"
+          >
+            <h4
+              class="bp3-heading"
             >
-              <input
-                checked=""
-                name="sampleSize"
-                type="radio"
-                value="46"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              BRAVO Average Sample Number: 
-              46 samples
-               (54% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="67"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              67 samples
-               (70% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="88"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              88 samples
-              
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="125"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              125 samples
-               (90% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="custom"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Enter your own sample size (not recommended)
-            </label>
+              Contest Name
+            </h4>
+            <div>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="asn"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                BRAVO Average Sample Number: 
+                46 samples
+                 (54% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.7"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                67 samples
+                 (70% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.5"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                88 samples
+                 (50% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.9"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                125 samples
+                 (90% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="custom"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Enter your own sample size (not recommended)
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -558,99 +486,104 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
     >
       Audit Settings
     </h4>
-    <table
-      class="sc-jKJlTe bkTFhC"
+    <div
+      class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
     >
-      <tbody>
-        <tr>
-          <td>
-            Election Name:
-          </td>
-          <td>
-            Election Name
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Risk Limit:
-          </td>
-          <td>
-            10
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Random Seed:
-          </td>
-          <td>
-            12345
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Participating Jurisdictions:
-          </td>
-          <td>
-            <a
-              href="/api/election/1/jurisdiction/file/csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Audit Board Data Entry:
-          </td>
-          <td>
-            Online
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Target Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            Contest Name
-          </td>
-          <td>
-            Jurisdiction 1, Jurisdiction 2
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Opportunistic Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody />
-    </table>
+      <table
+        class="sc-jKJlTe bkTFhC"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Election Name:
+            </td>
+            <td>
+              Election Name
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Risk Limit:
+            </td>
+            <td>
+              10
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Random Seed:
+            </td>
+            <td>
+              12345
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Participating Jurisdictions:
+            </td>
+            <td>
+              <a
+                href="/api/election/1/jurisdiction/file/csv"
+                rel="noopener noreferrer"
+                target="_blank"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Audit Board Data Entry:
+            </td>
+            <td>
+              Online
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Target Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              Contest Name
+            </td>
+            <td>
+              Jurisdiction 1, Jurisdiction 2
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Opportunistic Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+    <br />
     <h4
       class="bp3-heading"
     >
-      Sample Size Options
+      Sample Size
     </h4>
     <form
       data-testid="sample-size-form"
@@ -658,94 +591,97 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
       <div
         class="sc-gzVnrw coBAaV"
       >
-        <h3
-          class="bp3-heading sc-dnqmqq hlcOhg"
-        >
-          Estimated Sample Size
-        </h3>
         <div
           class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
         </div>
         <div
-          class="sc-htoDjs GlcDy"
+          class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
         >
-          <div>
-            <label
-              class="bp3-control bp3-radio"
+          <div
+            class="sc-htoDjs GlcDy"
+          >
+            <h4
+              class="bp3-heading"
             >
-              <input
-                checked=""
-                name="sampleSize"
-                type="radio"
-                value="46"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              BRAVO Average Sample Number: 
-              46 samples
-               (54% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="67"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              67 samples
-               (70% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="88"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              88 samples
-              
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="125"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              125 samples
-               (90% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="custom"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Enter your own sample size (not recommended)
-            </label>
+              Contest Name
+            </h4>
+            <div>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="asn"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                BRAVO Average Sample Number: 
+                46 samples
+                 (54% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.7"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                67 samples
+                 (70% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.5"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                88 samples
+                 (50% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.9"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                125 samples
+                 (90% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="custom"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Enter your own sample size (not recommended)
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -816,99 +752,104 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
     >
       Audit Settings
     </h4>
-    <table
-      class="sc-jKJlTe bkTFhC"
+    <div
+      class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
     >
-      <tbody>
-        <tr>
-          <td>
-            Election Name:
-          </td>
-          <td>
-            Election Name
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Risk Limit:
-          </td>
-          <td>
-            10
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Random Seed:
-          </td>
-          <td>
-            12345
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Participating Jurisdictions:
-          </td>
-          <td>
-            <a
-              href="/api/election/1/jurisdiction/file/csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Audit Board Data Entry:
-          </td>
-          <td>
-            Online
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Target Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            Contest Name
-          </td>
-          <td>
-            Jurisdiction 1, Jurisdiction 2
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Opportunistic Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody />
-    </table>
+      <table
+        class="sc-jKJlTe bkTFhC"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Election Name:
+            </td>
+            <td>
+              Election Name
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Risk Limit:
+            </td>
+            <td>
+              10
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Random Seed:
+            </td>
+            <td>
+              12345
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Participating Jurisdictions:
+            </td>
+            <td>
+              <a
+                href="/api/election/1/jurisdiction/file/csv"
+                rel="noopener noreferrer"
+                target="_blank"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Audit Board Data Entry:
+            </td>
+            <td>
+              Online
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Target Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              Contest Name
+            </td>
+            <td>
+              Jurisdiction 1, Jurisdiction 2
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Opportunistic Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+    <br />
     <h4
       class="bp3-heading"
     >
-      Sample Size Options
+      Sample Size
     </h4>
     <form
       data-testid="sample-size-form"
@@ -916,94 +857,97 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
       <div
         class="sc-gzVnrw coBAaV"
       >
-        <h3
-          class="bp3-heading sc-dnqmqq hlcOhg"
-        >
-          Estimated Sample Size
-        </h3>
         <div
           class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
         </div>
         <div
-          class="sc-htoDjs GlcDy"
+          class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
         >
-          <div>
-            <label
-              class="bp3-control bp3-radio"
+          <div
+            class="sc-htoDjs GlcDy"
+          >
+            <h4
+              class="bp3-heading"
             >
-              <input
-                checked=""
-                name="sampleSize"
-                type="radio"
-                value="46"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              BRAVO Average Sample Number: 
-              46 samples
-               (54% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="67"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              67 samples
-               (70% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="88"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              88 samples
-              
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="125"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              125 samples
-               (90% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="custom"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Enter your own sample size (not recommended)
-            </label>
+              Contest Name
+            </h4>
+            <div>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="asn"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                BRAVO Average Sample Number: 
+                46 samples
+                 (54% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.7"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                67 samples
+                 (70% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.5"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                88 samples
+                 (50% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.9"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                125 samples
+                 (90% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="custom"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Enter your own sample size (not recommended)
+              </label>
+            </div>
           </div>
         </div>
       </div>
@@ -1074,99 +1018,104 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
     >
       Audit Settings
     </h4>
-    <table
-      class="sc-jKJlTe bkTFhC"
+    <div
+      class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
     >
-      <tbody>
-        <tr>
-          <td>
-            Election Name:
-          </td>
-          <td>
-            Election Name
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Risk Limit:
-          </td>
-          <td>
-            10
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Random Seed:
-          </td>
-          <td>
-            12345
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Participating Jurisdictions:
-          </td>
-          <td>
-            <a
-              href="/api/election/1/jurisdiction/file/csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Audit Board Data Entry:
-          </td>
-          <td>
-            Online
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Target Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody />
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Opportunistic Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            Contest Name
-          </td>
-          <td>
-            Jurisdiction 1, Jurisdiction 2
-          </td>
-        </tr>
-      </tbody>
-    </table>
+      <table
+        class="sc-jKJlTe bkTFhC"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Election Name:
+            </td>
+            <td>
+              Election Name
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Risk Limit:
+            </td>
+            <td>
+              10
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Random Seed:
+            </td>
+            <td>
+              12345
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Participating Jurisdictions:
+            </td>
+            <td>
+              <a
+                href="/api/election/1/jurisdiction/file/csv"
+                rel="noopener noreferrer"
+                target="_blank"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Audit Board Data Entry:
+            </td>
+            <td>
+              Online
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Target Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Opportunistic Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              Contest Name
+            </td>
+            <td>
+              Jurisdiction 1, Jurisdiction 2
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <br />
     <h4
       class="bp3-heading"
     >
-      Sample Size Options
+      Sample Size
     </h4>
     <form
       data-testid="sample-size-form"
@@ -1174,95 +1123,10 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       <div
         class="sc-gzVnrw coBAaV"
       >
-        <h3
-          class="bp3-heading sc-dnqmqq hlcOhg"
-        >
-          Estimated Sample Size
-        </h3>
         <div
           class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
-        </div>
-        <div
-          class="sc-htoDjs GlcDy"
-        >
-          <div>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                checked=""
-                name="sampleSize"
-                type="radio"
-                value="46"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              BRAVO Average Sample Number: 
-              46 samples
-               (54% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="67"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              67 samples
-               (70% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="88"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              88 samples
-              
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="125"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              125 samples
-               (90% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="custom"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Enter your own sample size (not recommended)
-            </label>
-          </div>
         </div>
       </div>
       <div
@@ -1296,7 +1160,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
 </div>
 `;
 
-exports[`Audit Setup > Review & Launch renders full state with jurisdictions on targeted contest 1`] = `
+exports[`Audit Setup > Review & Launch renders full state with offline setting 1`] = `
 <div>
   <div>
     <h2
@@ -1334,99 +1198,104 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
     >
       Audit Settings
     </h4>
-    <table
-      class="sc-jKJlTe bkTFhC"
+    <div
+      class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
     >
-      <tbody>
-        <tr>
-          <td>
-            Election Name:
-          </td>
-          <td>
-            Election Name
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Risk Limit:
-          </td>
-          <td>
-            10
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Random Seed:
-          </td>
-          <td>
-            12345
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Participating Jurisdictions:
-          </td>
-          <td>
-            <a
-              href="/api/election/1/jurisdiction/file/csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Audit Board Data Entry:
-          </td>
-          <td>
-            Online
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Target Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            Contest Name
-          </td>
-          <td>
-            Jurisdiction 1, Jurisdiction 2
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Opportunistic Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody />
-    </table>
+      <table
+        class="sc-jKJlTe bkTFhC"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Election Name:
+            </td>
+            <td>
+              Election Name
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Risk Limit:
+            </td>
+            <td>
+              10
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Random Seed:
+            </td>
+            <td>
+              12345
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Participating Jurisdictions:
+            </td>
+            <td>
+              <a
+                href="/api/election/1/jurisdiction/file/csv"
+                rel="noopener noreferrer"
+                target="_blank"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Audit Board Data Entry:
+            </td>
+            <td>
+              Offline
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Target Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              Contest Name
+            </td>
+            <td>
+              Jurisdiction 1, Jurisdiction 2
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Opportunistic Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+    <br />
     <h4
       class="bp3-heading"
     >
-      Sample Size Options
+      Sample Size
     </h4>
     <form
       data-testid="sample-size-form"
@@ -1434,94 +1303,97 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
       <div
         class="sc-gzVnrw coBAaV"
       >
-        <h3
-          class="bp3-heading sc-dnqmqq hlcOhg"
-        >
-          Estimated Sample Size
-        </h3>
         <div
           class="sc-htoDjs GlcDy"
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
         </div>
         <div
-          class="sc-htoDjs GlcDy"
+          class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
         >
-          <div>
-            <label
-              class="bp3-control bp3-radio"
+          <div
+            class="sc-htoDjs GlcDy"
+          >
+            <h4
+              class="bp3-heading"
             >
-              <input
-                checked=""
-                name="sampleSize"
-                type="radio"
-                value="46"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              BRAVO Average Sample Number: 
-              46 samples
-               (54% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="67"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              67 samples
-               (70% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="88"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              88 samples
-              
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="125"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              
-              125 samples
-               (90% chance of reaching risk limit and completing the audit in one round)
-            </label>
-            <label
-              class="bp3-control bp3-radio"
-            >
-              <input
-                name="sampleSize"
-                type="radio"
-                value="custom"
-              />
-              <span
-                class="bp3-control-indicator"
-              />
-              Enter your own sample size (not recommended)
-            </label>
+              Contest Name
+            </h4>
+            <div>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="asn"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                BRAVO Average Sample Number: 
+                46 samples
+                 (54% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.7"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                67 samples
+                 (70% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.5"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                88 samples
+                 (50% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.9"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                125 samples
+                 (90% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="custom"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Enter your own sample size (not recommended)
+              </label>
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/components/MultiJurisdictionAudit/Setup/Review/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Review/_mocks.ts
@@ -23,15 +23,29 @@ export const settingsMock = {
     /* istanbul ignore next */
     async () => true,
   ],
+  offline: [
+    {
+      state: 'AL',
+      electionName: 'Election Name',
+      online: false,
+      randomSeed: '12345',
+      riskLimit: 10,
+    },
+    // here for type completion but not used in this context
+    /* istanbul ignore next */
+    async () => true,
+  ],
 }
 
 export const sampleSizeMock = {
-  sampleSizes: [
-    { prob: 0.54, size: 46, type: 'ASN' },
-    { prob: 0.7, size: 67, type: null },
-    { prob: null, size: 88, type: null },
-    { prob: 0.9, size: 125, type: null },
-  ],
+  sampleSizes: {
+    'contest-id': [
+      { prob: 0.54, size: 46, key: 'asn' },
+      { prob: 0.7, size: 67, key: '0.7' },
+      { prob: 0.5, size: 88, key: '0.5' },
+      { prob: 0.9, size: 125, key: '0.9' },
+    ],
+  },
 }
 
 export default settingsMock

--- a/client/src/components/MultiJurisdictionAudit/Setup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Review/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { useParams, useHistory } from 'react-router-dom'
 import { H4, Callout, RadioGroup, Radio } from '@blueprintjs/core'
 import { toast } from 'react-toastify'
@@ -11,10 +11,9 @@ import useAuditSettings from '../../useAuditSettings'
 import useContests from '../../useContests'
 import { IContest, ISampleSizeOption } from '../../../../types'
 import useJurisdictions, { FileProcessingStatus } from '../../useJurisdictions'
-import { api, checkAndToast, testNumber } from '../../../utilities'
+import { testNumber } from '../../../utilities'
 import FormSection, {
   FormSectionDescription,
-  FormSectionLabel,
 } from '../../../Atoms/Form/FormSection'
 import ContestsTable from './ContestsTable'
 import SettingsTable from './SettingsTable'
@@ -22,15 +21,15 @@ import { isSetupComplete } from '../../StatusBox'
 import useJurisdictionFile from '../Participants/useJurisdictionFile'
 import ConfirmLaunch from './ConfirmLaunch'
 import FormField from '../../../Atoms/Form/FormField'
+import ElevatedCard from '../../../Atoms/SpacedCard'
+import useSampleSizes, { IStringSampleSizeOption } from './useSampleSizes'
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: 'percent',
 })
 
-interface IStringSampleSize {
-  size: string
-  type: string | null
-  prob: number | null
+interface IFormOptions {
+  [key: string]: IStringSampleSizeOption
 }
 
 interface IProps {
@@ -46,51 +45,27 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
   const jurisdictions = useJurisdictions(electionId)
   const [jurisdictionFile] = useJurisdictionFile(electionId)
   const [contests] = useContests(electionId)
-  const [sampleSizeOptions, setSampleSizeOptions] = useState<
-    IStringSampleSize[]
-  >([])
-  const [sampleSize, setSampleSize] = useState('')
+  const [sampleSizes, setSampleSizes] = useState<IFormOptions>({})
   const history = useHistory()
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false)
-
-  useEffect(() => {
-    ;(async () => {
-      try {
-        const { sampleSizes }: { sampleSizes: ISampleSizeOption[] } = await api(
-          `/election/${electionId}/sample-sizes`
-        )
-        setSampleSizeOptions(
-          sampleSizes.map(v => ({
-            ...v,
-            size: `${v.size}`,
-          }))
-        )
-      } catch (err) /* istanbul ignore next */ {
-        // TEST TODO
-        toast.error(err.message)
-      }
-    })()
-  }, [electionId])
+  const [sampleSizeOptions, uploadSampleSizes] = useSampleSizes(electionId)
 
   const submit = async () => {
     try {
-      const result = await api(`/election/${electionId}/round`, {
-        method: 'POST',
-        body: JSON.stringify({
-          sampleSize: Number(sampleSize),
-          roundNum: 1,
-        }),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
-      // checkAndToast left here for consistency and reference but not tested since it's vestigial
-      /* istanbul ignore next */
-      if (checkAndToast(result)) {
+      /* istanbul ignore else */
+      if (
+        await uploadSampleSizes(
+          Object.keys(sampleSizes).reduce((a, contestId) => {
+            return { ...a, [contestId]: sampleSizes[contestId].size }
+          }, {})
+        )
+      ) {
+        refresh()
+        history.push(`/election/${electionId}/progress`)
+      } else {
+        // TEST TODO when withMockFetch works with error handling
         return
       }
-      refresh()
-      history.push(`/election/${electionId}/progress`)
     } catch (err) /* istanbul ignore next */ {
       // TEST TODO
       toast.error(err.message)
@@ -126,6 +101,16 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
       j.ballotManifest.processing.status === FileProcessingStatus.PROCESSED
   ).length
 
+  const initialValues: IFormOptions = sampleSizeOptions
+    ? Object.keys(sampleSizeOptions).reduce(
+        (a, contestId) => ({
+          ...a,
+          [contestId]: sampleSizeOptions[contestId][0],
+        }),
+        {}
+      )
+    : {}
+
   return (
     <div>
       <H2Title>Review &amp; Launch</H2Title>
@@ -136,85 +121,83 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
       </Callout>
       <br />
       <H4>Audit Settings</H4>
-      <SettingsTable>
-        <tbody>
-          <tr>
-            <td>Election Name:</td>
-            <td>{electionName}</td>
-          </tr>
-          <tr>
-            <td>Risk Limit:</td>
-            <td>{riskLimit}</td>
-          </tr>
-          <tr>
-            <td>Random Seed:</td>
-            <td>{randomSeed}</td>
-          </tr>
-          <tr>
-            <td>Participating Jurisdictions:</td>
-            <td>
-              <a
-                href={`/api/election/${electionId}/jurisdiction/file/csv`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {jurisdictionFile && jurisdictionFile.file
-                  ? jurisdictionFile.file.name
-                  : ''}
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td>Audit Board Data Entry:</td>
-            <td>{online ? 'Online' : 'Offline'}</td>
-          </tr>
-        </tbody>
-      </SettingsTable>
-      <ContestsTable>
-        <thead>
-          <tr>
-            <th>Target Contests</th>
-            <th>Jurisdictions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {targetedContests.map((c: IContest) => (
-            <tr key={c.id}>
-              <td>{c.name}</td>
-              <td>{c.jurisdictionIds.join(', ')}</td>
+      <ElevatedCard>
+        <SettingsTable>
+          <tbody>
+            <tr>
+              <td>Election Name:</td>
+              <td>{electionName}</td>
             </tr>
-          ))}
-        </tbody>
-      </ContestsTable>
-      <ContestsTable>
-        <thead>
-          <tr>
-            <th>Opportunistic Contests</th>
-            <th>Jurisdictions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {opportunisticContests.map((c: IContest) => (
-            <tr key={c.id}>
-              <td>{c.name}</td>
-              <td>{c.jurisdictionIds.join(', ')}</td>
+            <tr>
+              <td>Risk Limit:</td>
+              <td>{riskLimit}</td>
             </tr>
-          ))}
-        </tbody>
-      </ContestsTable>
-      <H4>Sample Size Options</H4>
+            <tr>
+              <td>Random Seed:</td>
+              <td>{randomSeed}</td>
+            </tr>
+            <tr>
+              <td>Participating Jurisdictions:</td>
+              <td>
+                <a
+                  href={`/api/election/${electionId}/jurisdiction/file/csv`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {jurisdictionFile && jurisdictionFile.file
+                    ? jurisdictionFile.file.name
+                    : ''}
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td>Audit Board Data Entry:</td>
+              <td>{online ? 'Online' : 'Offline'}</td>
+            </tr>
+          </tbody>
+        </SettingsTable>
+        <ContestsTable>
+          <thead>
+            <tr>
+              <th>Target Contests</th>
+              <th>Jurisdictions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {targetedContests.map((c: IContest) => (
+              <tr key={c.id}>
+                <td>{c.name}</td>
+                <td>{c.jurisdictionIds.join(', ')}</td>
+              </tr>
+            ))}
+          </tbody>
+        </ContestsTable>
+        <ContestsTable>
+          <thead>
+            <tr>
+              <th>Opportunistic Contests</th>
+              <th>Jurisdictions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {opportunisticContests.map((c: IContest) => (
+              <tr key={c.id}>
+                <td>{c.name}</td>
+                <td>{c.jurisdictionIds.join(', ')}</td>
+              </tr>
+            ))}
+          </tbody>
+        </ContestsTable>
+      </ElevatedCard>
+      <br />
+      <H4>Sample Size</H4>
       <Formik
         initialValues={{
-          sampleSize: sampleSizeOptions.length ? sampleSizeOptions[0].size : '',
-          customSampleSize: '',
+          sampleSizes: initialValues,
         }}
         enableReinitialize
-        onSubmit={v => {
-          if (v.sampleSize === 'custom') {
-            setSampleSize(v.customSampleSize)
-          } else {
-            setSampleSize(v.sampleSize)
-          }
+        onSubmit={({ sampleSizes: sizes }) => {
+          setSampleSizes(sizes)
           setIsConfirmDialogOpen(true)
         }}
       >
@@ -222,53 +205,79 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
           values,
           handleSubmit,
           setFieldValue,
-        }: FormikProps<{ sampleSize: string }>) => (
+        }: FormikProps<{
+          sampleSizes: { [key: string]: IStringSampleSizeOption }
+        }>) => (
           <Form data-testid="sample-size-form">
-            {sampleSizeOptions.length && (
+            {sampleSizeOptions && (
               <FormSection>
-                <FormSectionLabel>Estimated Sample Size</FormSectionLabel>
                 <FormSectionDescription>
                   Choose the initial sample size for each contest you would like
                   to use for Round 1 of the audit from the options below.
                 </FormSectionDescription>
-                <FormSectionDescription>
-                  <RadioGroup
-                    name="sampleSize"
-                    onChange={e =>
-                      setFieldValue('sampleSize', e.currentTarget.value)
-                    }
-                    selectedValue={getIn(values, 'sampleSize')}
-                    disabled={locked}
-                  >
-                    {sampleSizeOptions.map((option: ISampleSizeOption) => {
-                      return (
-                        <Radio value={option.size} key={option.size}>
-                          {option.type ? 'BRAVO Average Sample Number: ' : ''}
-                          {`${option.size} samples`}
-                          {option.prob
-                            ? ` (${percentFormatter.format(
-                                option.prob
-                              )} chance of reaching risk limit and completing the audit in one round)`
-                            : ''}
-                        </Radio>
-                      )
-                    })}
-                    <Radio value="custom">
-                      Enter your own sample size (not recommended)
-                    </Radio>
-                    {getIn(values, 'sampleSize') === 'custom' && (
-                      <Field
-                        component={FormField}
-                        name="customSampleSize"
-                        type="text"
-                        validate={testNumber(
-                          Number(targetedContests[0].totalBallotsCast),
-                          'Must be less than or equal to the total number of ballots in targeted contests'
+                {targetedContests.map(contest => {
+                  const currentOption = getIn(
+                    values,
+                    `sampleSizes[${contest.id}]`
+                  )
+                  return (
+                    <ElevatedCard key={contest.id}>
+                      <FormSectionDescription>
+                        <H4>{contest.name}</H4>
+                        <RadioGroup
+                          name={`sampleSizes[${contest.id}]`}
+                          onChange={e => {
+                            const selectedOption = sampleSizeOptions[
+                              contest.id
+                            ].find(c => c.key === e.currentTarget.value)
+                            setFieldValue(
+                              `sampleSizes[${contest.id}]`,
+                              selectedOption
+                            )
+                          }}
+                          selectedValue={getIn(
+                            values,
+                            `sampleSizes[${contest.id}][key]`
+                          )}
+                          disabled={locked}
+                        >
+                          {sampleSizeOptions[contest.id].map(
+                            (option: ISampleSizeOption) => {
+                              return option.key === 'custom' ? (
+                                <Radio value="custom" key={option.key}>
+                                  Enter your own sample size (not recommended)
+                                </Radio>
+                              ) : (
+                                <Radio value={option.key} key={option.key}>
+                                  {option.key === 'asn'
+                                    ? 'BRAVO Average Sample Number: '
+                                    : ''}
+                                  {`${option.size} samples`}
+                                  {option.prob
+                                    ? ` (${percentFormatter.format(
+                                        option.prob
+                                      )} chance of reaching risk limit and completing the audit in one round)`
+                                    : ''}
+                                </Radio>
+                              )
+                            }
+                          )}
+                        </RadioGroup>
+                        {currentOption && currentOption.key === 'custom' && (
+                          <Field
+                            component={FormField}
+                            name={`sampleSizes[${contest.id}][size]`}
+                            type="text"
+                            validate={testNumber(
+                              Number(contest.totalBallotsCast),
+                              `Must be less than or equal to: ${contest.totalBallotsCast} (the total number of ballots in this targeted contest)`
+                            )}
+                          />
                         )}
-                      />
-                    )}
-                  </RadioGroup>
-                </FormSectionDescription>
+                      </FormSectionDescription>
+                    </ElevatedCard>
+                  )
+                })}
               </FormSection>
             )}
             <FormButtonBar>

--- a/client/src/components/MultiJurisdictionAudit/Setup/Review/useSampleSizes.ts
+++ b/client/src/components/MultiJurisdictionAudit/Setup/Review/useSampleSizes.ts
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'react-toastify'
+import { api } from '../../../utilities'
+import { ISampleSizeOption } from '../../../../types'
+
+export interface IStringSampleSizeOption {
+  size: string
+  key: string
+  prob: number | null
+}
+
+export interface IStringSampleSizeOptions {
+  [contestId: string]: IStringSampleSizeOption[]
+}
+
+export interface ISampleSizeOptions {
+  [contestId: string]: ISampleSizeOption[]
+}
+
+export interface IStringSampleSizes {
+  [contestId: string]: string
+}
+
+export interface ISampleSizes {
+  [contestId: string]: number
+}
+
+const loadSampleSizes = async (
+  electionId: string
+): Promise<IStringSampleSizeOptions | null> => {
+  try {
+    const {
+      sampleSizes: options,
+    }: { sampleSizes: ISampleSizeOptions } = await api(
+      `/election/${electionId}/sample-sizes`
+    )
+    return Object.keys(options).reduce(
+      (a, contestId) => ({
+        [contestId]: [
+          ...options[contestId].map(option => ({
+            ...option,
+            size: `${option.size}`,
+          })),
+          { key: 'custom', size: '', prob: null },
+        ],
+        ...a,
+      }),
+      {}
+    )
+  } catch (err) {
+    toast.error(err.message)
+    return null
+  }
+}
+
+const postRound = async (
+  electionId: string,
+  stringSampleSizes: IStringSampleSizes
+): Promise<boolean> => {
+  try {
+    const sampleSizes: ISampleSizes = {
+      // converts to number so it submits in the form: { [contestId: string]: number }
+      ...Object.keys(stringSampleSizes).reduce(
+        (a, v) => ({
+          ...a,
+          [v]: Number(stringSampleSizes[v]),
+        }),
+        {}
+      ),
+    }
+    await api(`/election/${electionId}/round`, {
+      method: 'POST',
+      body: JSON.stringify({
+        sampleSizes,
+        roundNum: 1,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    return true
+  } catch (err) /* istanbul ignore next */ {
+    // TEST TODO move toast handling to api
+    toast.error(err.message)
+    return false
+  }
+}
+
+const useSampleSizes = (
+  electionId: string
+): [
+  IStringSampleSizeOptions | null,
+  (sampleSizes: IStringSampleSizes) => Promise<boolean>
+] => {
+  const [
+    sampleSizeOptions,
+    setSampleSizeOptions,
+  ] = useState<IStringSampleSizeOptions | null>(null)
+
+  const uploadSampleSizes = async (
+    sizes: IStringSampleSizes
+  ): Promise<boolean> => {
+    // TODO poll for result of upload
+    /* istanbul ignore else */
+    if (await postRound(electionId, sizes)) {
+      return true
+    }
+    /* istanbul ignore next */
+    // TEST TODO included with above
+    return false
+  }
+
+  useEffect(() => {
+    ;(async () => {
+      setSampleSizeOptions(await loadSampleSizes(electionId))
+    })()
+  }, [electionId])
+
+  return [sampleSizeOptions, uploadSampleSizes]
+}
+
+export default useSampleSizes

--- a/client/src/components/MultiJurisdictionAudit/Setup/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/Setup/__snapshots__/index.test.tsx.snap
@@ -1776,100 +1776,104 @@ exports[`Setup renders Review & Launch stage 1`] = `
     >
       Audit Settings
     </h4>
-    <table
-      class="sc-jKJlTe bkTFhC"
+    <div
+      class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
     >
-      <tbody>
-        <tr>
-          <td>
-            Election Name:
-          </td>
-          <td>
-            Election Name
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Risk Limit:
-          </td>
-          <td>
-            10
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Random Seed:
-          </td>
-          <td>
-            12345
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Participating Jurisdictions:
-          </td>
-          <td>
-            <a
-              href="/api/election/1/jurisdiction/file/csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Audit Board Data Entry:
-          </td>
-          <td>
-            Online
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Target Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody />
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Opportunistic Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td />
-          <td />
-        </tr>
-      </tbody>
-    </table>
+      <table
+        class="sc-jKJlTe bkTFhC"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Election Name:
+            </td>
+            <td>
+              Election Name
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Risk Limit:
+            </td>
+            <td>
+              10
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Random Seed:
+            </td>
+            <td>
+              12345
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Participating Jurisdictions:
+            </td>
+            <td>
+              <a
+                href="/api/election/1/jurisdiction/file/csv"
+                rel="noopener noreferrer"
+                target="_blank"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Audit Board Data Entry:
+            </td>
+            <td>
+              Online
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Target Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Opportunistic Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td />
+            <td />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <br />
     <h4
       class="bp3-heading"
     >
-      Sample Size Options
+      Sample Size
     </h4>
     <form
       data-testid="sample-size-form"
     >
-      0
       <div
         class="sc-htpNat gtULUV"
       >
@@ -1939,100 +1943,104 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
     >
       Audit Settings
     </h4>
-    <table
-      class="sc-jKJlTe bkTFhC"
+    <div
+      class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
     >
-      <tbody>
-        <tr>
-          <td>
-            Election Name:
-          </td>
-          <td>
-            Election Name
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Risk Limit:
-          </td>
-          <td>
-            10
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Random Seed:
-          </td>
-          <td>
-            12345
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Participating Jurisdictions:
-          </td>
-          <td>
-            <a
-              href="/api/election/1/jurisdiction/file/csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Audit Board Data Entry:
-          </td>
-          <td>
-            Online
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Target Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody />
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Opportunistic Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td />
-          <td />
-        </tr>
-      </tbody>
-    </table>
+      <table
+        class="sc-jKJlTe bkTFhC"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Election Name:
+            </td>
+            <td>
+              Election Name
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Risk Limit:
+            </td>
+            <td>
+              10
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Random Seed:
+            </td>
+            <td>
+              12345
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Participating Jurisdictions:
+            </td>
+            <td>
+              <a
+                href="/api/election/1/jurisdiction/file/csv"
+                rel="noopener noreferrer"
+                target="_blank"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Audit Board Data Entry:
+            </td>
+            <td>
+              Online
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Target Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Opportunistic Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td />
+            <td />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <br />
     <h4
       class="bp3-heading"
     >
-      Sample Size Options
+      Sample Size
     </h4>
     <form
       data-testid="sample-size-form"
     >
-      0
       <div
         class="sc-htpNat gtULUV"
       >
@@ -2102,100 +2110,104 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
     >
       Audit Settings
     </h4>
-    <table
-      class="sc-jKJlTe bkTFhC"
+    <div
+      class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
     >
-      <tbody>
-        <tr>
-          <td>
-            Election Name:
-          </td>
-          <td>
-            Election Name
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Risk Limit:
-          </td>
-          <td>
-            10
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Random Seed:
-          </td>
-          <td>
-            12345
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Participating Jurisdictions:
-          </td>
-          <td>
-            <a
-              href="/api/election/1/jurisdiction/file/csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Audit Board Data Entry:
-          </td>
-          <td>
-            Online
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Target Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody />
-    </table>
-    <table
-      class="sc-ckVGcZ qPOwv"
-    >
-      <thead>
-        <tr>
-          <th>
-            Opportunistic Contests
-          </th>
-          <th>
-            Jurisdictions
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td />
-          <td />
-        </tr>
-      </tbody>
-    </table>
+      <table
+        class="sc-jKJlTe bkTFhC"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Election Name:
+            </td>
+            <td>
+              Election Name
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Risk Limit:
+            </td>
+            <td>
+              10
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Random Seed:
+            </td>
+            <td>
+              12345
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Participating Jurisdictions:
+            </td>
+            <td>
+              <a
+                href="/api/election/1/jurisdiction/file/csv"
+                rel="noopener noreferrer"
+                target="_blank"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Audit Board Data Entry:
+            </td>
+            <td>
+              Online
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Target Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Opportunistic Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td />
+            <td />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <br />
     <h4
       class="bp3-heading"
     >
-      Sample Size Options
+      Sample Size
     </h4>
     <form
       data-testid="sample-size-form"
     >
-      0
       <div
         class="sc-htpNat gtULUV"
       >

--- a/client/src/components/SingleJurisdictionAudit/SelectBallotsToAudit.tsx
+++ b/client/src/components/SingleJurisdictionAudit/SelectBallotsToAudit.tsx
@@ -29,7 +29,7 @@ import FormButtonBar from '../Atoms/Form/FormButtonBar'
 import {
   IJurisdiction,
   IAudit,
-  ISampleSizeOption,
+  IUnkeyedSampleSizeOption,
   IErrorResponse,
 } from '../../types'
 import { api, testNumber, checkAndToast, poll } from '../utilities'
@@ -56,7 +56,7 @@ export const AuditBoard = styled.div`
 `
 
 interface ISampleSizeOptionsByContest {
-  [key: string]: ISampleSizeOption[]
+  [contestId: string]: IUnkeyedSampleSizeOption[]
 }
 
 interface IProps {
@@ -73,10 +73,10 @@ interface ISelectBallotsToAuditValues {
   auditNames: string[]
   manifest: File | null
   sampleSize: {
-    [key: string]: string
+    [contestId: string]: string
   }
   customSampleSize: {
-    [key: string]: string
+    [contestId: string]: string
   }
 }
 
@@ -238,7 +238,7 @@ const SelectBallotsToAudit: React.FC<IProps> = ({
       ...sampleSizeOptionsByContest,
       [contest.id]:
         contest.sampleSizeOptions && contest.sampleSizeOptions.length
-          ? contest.sampleSizeOptions.reduce<ISampleSizeOption[]>(
+          ? contest.sampleSizeOptions.reduce<IUnkeyedSampleSizeOption[]>(
               (consolidatedSampleSizeOptions, option) => {
                 const duplicateOptionIndex: number = consolidatedSampleSizeOptions.findIndex(
                   v => Number(v.size) === option.size

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -28,12 +28,6 @@ export interface ICandidate {
   numVotes: number | string
 }
 
-export interface ISampleSizeOption {
-  size: number | string
-  prob: number | null
-  type: string | null
-}
-
 export interface IContest {
   id: string
   isTargeted: boolean
@@ -118,12 +112,24 @@ export interface IJurisdiction {
   batches?: IBatch[] // optional until I'm ready to update everything
 }
 
+export interface ISampleSizeOption {
+  size: number | string
+  prob: number | null
+  key: string
+}
+
+export interface IUnkeyedSampleSizeOption {
+  type: string | null
+  size: number | string
+  prob: number | null
+}
+
 export interface IRoundContest {
   id: string
   results: {
     [key: string]: number
   }
-  sampleSizeOptions: ISampleSizeOption[] | null
+  sampleSizeOptions: IUnkeyedSampleSizeOption[] | null
   sampleSize: number | null
   endMeasurements: {
     isComplete: null | boolean

--- a/server/api/audit_boards.py
+++ b/server/api/audit_boards.py
@@ -257,7 +257,7 @@ def set_audit_board_members(
 
 def calculate_risk_measurements(election: Election, round: Round):
     if not election.risk_limit:  # Shouldn't happen, we need this for typechecking
-        raise Exception("Risk limit not defined")
+        raise Exception("Risk limit not defined")  # pragma: no cover
     risk_limit: int = election.risk_limit
 
     for round_contest in round.round_contests:

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -119,20 +119,6 @@ def validate_contests(contests: List[JSONDict], election: Election):
                 f" ({total_votes} votes, {total_allowed_votes} allowed)"
             )
 
-    # Jointly targeted contests must all have the same contest universe and total ballots
-    targeted_contests = [contest for contest in contests if contest["isTargeted"]]
-    if any(
-        set(contest["jurisdictionIds"]) != set(contests[0]["jurisdictionIds"])
-        for contest in targeted_contests[1:]
-    ):
-        raise BadRequest("All targeted contests must have the same jurisdictions.")
-
-    if any(
-        contest["totalBallotsCast"] != contests[0]["totalBallotsCast"]
-        for contest in targeted_contests[1:]
-    ):
-        raise BadRequest("All targeted contests must have the same total ballots cast.")
-
 
 def round_status_by_contest(
     round: Optional[Round], contests: List[Contest]

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -243,9 +243,7 @@ def create_round(election: Election):
         json_round["sampleSizes"]
         if json_round["roundNum"] == 1
         else {
-            contest_id: next(
-                option["size"] for option in options if option["prob"] == 0.9
-            )
+            contest_id: options["0.9"]["size"]
             for contest_id, options in sample_size_options(election).items()
         }
     )

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, List
 from flask import jsonify
 from werkzeug.exceptions import BadRequest
 
@@ -17,14 +17,16 @@ def cumulative_contest_results(contest: Contest) -> Dict[str, int]:
     return results_by_choice
 
 
-def sample_size_options(election: Election, round_one=False) -> dict:
+def sample_size_options(
+    election: Election, round_one=False
+) -> Dict[str, List[bravo.SampleSizeOption]]:
     if not election.contests:
         raise BadRequest("Cannot compute sample sizes until contests are set")
     if not election.risk_limit:
         raise BadRequest("Cannot compute sample sizes until risk limit is set")
     risk_limit: int = election.risk_limit  # Need this to pass typechecking
 
-    def sample_sizes_for_contest(contest: Contest) -> dict:
+    def sample_sizes_for_contest(contest: Contest):
         # Because the /sample-sizes endpoint is only used for the audit setup flow,
         # we always want it to return the sample size options for the first round.
         # So we support a flag in this function to compute the sample sizes for
@@ -35,10 +37,12 @@ def sample_size_options(election: Election, round_one=False) -> dict:
             else cumulative_contest_results(contest)
         )
 
-        return bravo.get_sample_size(
-            float(risk_limit) / 100,
-            sampler_contest.from_db_contest(contest),
-            cumulative_results,
+        return list(
+            bravo.get_sample_size(
+                float(risk_limit) / 100,
+                sampler_contest.from_db_contest(contest),
+                cumulative_results,
+            ).values()
         )
 
     targeted_contests = Contest.query.filter_by(
@@ -49,23 +53,13 @@ def sample_size_options(election: Election, round_one=False) -> dict:
         if round_one
         else targeted_contests.join(RoundContest).filter_by(is_complete=False).all()
     )
-    samples_sizes_for_targeted_contests = [
-        sample_sizes_for_contest(contest)
+    return {
+        contest.id: sample_sizes_for_contest(contest)
         for contest in targeted_contests_that_havent_met_risk_limit
-    ]
-    # Choose the sample size options for the targted contest with the largest
-    # sample size, since that will cover the samples needed by the other
-    # targeted contests.
-    # TODO update this for independently targeted contests
-    return max(
-        samples_sizes_for_targeted_contests,
-        key=lambda sample_sizes: sample_sizes["asn"]["size"],
-    )
+    }
 
 
 @api.route("/election/<election_id>/sample-sizes", methods=["GET"])
 @with_election_access
 def get_sample_sizes(election: Election):
-    sample_sizes = sample_size_options(election, round_one=True)
-    json_sizes = list(sample_sizes.values())
-    return jsonify({"sampleSizes": json_sizes})
+    return jsonify({"sampleSizes": sample_size_options(election, round_one=True)})

--- a/server/audit_math/bravo.py
+++ b/server/audit_math/bravo.py
@@ -7,7 +7,8 @@ Note that this library works for one contest at a time, as if each contest being
 targeted is being audited completely independently.
 """
 import math
-from typing import Dict, Tuple, Union, Optional
+from typing import Dict, Tuple, Optional
+from typing_extensions import Literal, TypedDict
 from scipy import stats
 
 from .sampler_contest import Contest
@@ -269,9 +270,15 @@ def expected_prob(
     return round(float(stats.norm.cdf(-z)), 2)
 
 
+class SampleSizeOption(TypedDict):
+    type: Optional[Literal["ASN"]]
+    size: int
+    prob: Optional[float]
+
+
 def get_sample_size(
     risk_limit: float, contest: Contest, sample_results: Dict[str, int]
-) -> Dict[str, Dict[str, Optional[Union[float, int, str]]]]:
+) -> Dict[str, SampleSizeOption]:
     """
     Computes initial sample size parameterized by likelihood that the
     initial sample will confirm the election result, assuming no

--- a/server/tests/api/snapshots/snap_test_reports.py
+++ b/server/tests/api/snapshots/snap_test_reports.py
@@ -30,7 +30,7 @@ J1,Audit Board #2,Bubbikin Republican,Democrat,Joe Schmo,\r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
 1,Contest 1,Targeted,119,No,,DATETIME,,candidate 1: 0; candidate 2: 0\r
-1,Contest 2,Opportunistic,119,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
+1,Contest 2,Opportunistic,,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Batch Name,Ballot Position,Ticket Numbers,Audited?,Audit Result: Contest 1,Audit Result: Contest 2\r

--- a/server/tests/api/snapshots/snap_test_sample_sizes.py
+++ b/server/tests/api/snapshots/snap_test_sample_sizes.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots["test_sample_sizes_round_1 1"] = {
+    "Contest 1": [
+        {"key": "asn", "prob": 0.52, "size": 119},
+        {"key": "0.7", "prob": 0.7, "size": 184},
+        {"key": "0.8", "prob": 0.8, "size": 244},
+        {"key": "0.9", "prob": 0.9, "size": 351},
+    ]
+}
+
+snapshots["test_sample_sizes_round_2 1"] = {
+    "Contest 1": [
+        {"key": "asn", "prob": 0.52, "size": 119},
+        {"key": "0.7", "prob": 0.7, "size": 184},
+        {"key": "0.8", "prob": 0.8, "size": 244},
+        {"key": "0.9", "prob": 0.9, "size": 351},
+    ]
+}

--- a/server/tests/api/test_contests.py
+++ b/server/tests/api/test_contests.py
@@ -154,10 +154,15 @@ def test_contests_round_status(
     rv = put_json(client, f"/api/election/{election_id}/contest", json_contests)
     assert_ok(rv)
 
+    rv = client.get(f"/api/election/{election_id}/contest")
+    contests = json.loads(rv.data)["contests"]
+    for contest in contests:
+        assert contest["currentRoundStatus"] is None
+
     rv = post_json(
         client,
         f"/api/election/{election_id}/round",
-        {"roundNum": 1, "sampleSize": SAMPLE_SIZE_ROUND_1},
+        {"roundNum": 1, "sampleSizes": {contests[0]["id"]: SAMPLE_SIZE_ROUND_1}},
     )
     assert_ok(rv)
 

--- a/server/tests/api/test_jurisdictions.py
+++ b/server/tests/api/test_jurisdictions.py
@@ -312,7 +312,7 @@ def test_jurisdictions_round_status_offline(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],
-    contest_ids: List[str],  # pylint: disable=unused-argument
+    contest_ids: List[str],
     election_settings,  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
@@ -330,7 +330,7 @@ def test_jurisdictions_round_status_offline(
     rv = post_json(
         client,
         f"/api/election/{election_id}/round",
-        {"roundNum": 1, "sampleSize": SAMPLE_SIZE_ROUND_1},
+        {"roundNum": 1, "sampleSizes": {contest_ids[0]: SAMPLE_SIZE_ROUND_1}},
     )
     assert_ok(rv)
 

--- a/server/tests/api/test_sample_sizes.py
+++ b/server/tests/api/test_sample_sizes.py
@@ -1,4 +1,5 @@
 import json
+from typing import List
 from flask.testing import FlaskClient
 
 
@@ -18,7 +19,7 @@ def test_sample_sizes_without_contests(client: FlaskClient, election_id: str):
 def test_sample_sizes_without_risk_limit(
     client: FlaskClient,
     election_id: str,
-    contest_ids: str,  # pylint: disable=unused-argument
+    contest_ids: List[str],  # pylint: disable=unused-argument
 ):
     rv = client.get(f"/api/election/{election_id}/sample-sizes")
     assert rv.status_code == 400
@@ -35,34 +36,39 @@ def test_sample_sizes_without_risk_limit(
 def test_sample_sizes_round_1(
     client: FlaskClient,
     election_id: str,
-    contest_ids: str,  # pylint: disable=unused-argument
+    contest_ids: List[str],
     election_settings,  # pylint: disable=unused-argument
 ):
     rv = client.get(f"/api/election/{election_id}/sample-sizes")
     sample_sizes = json.loads(rv.data)
     assert sample_sizes == {
-        "sampleSizes": [
-            {"prob": 0.52, "size": 119, "type": "ASN"},
-            {"prob": 0.7, "size": 184, "type": None},
-            {"prob": 0.8, "size": 244, "type": None},
-            {"prob": 0.9, "size": 351, "type": None},
-        ]
+        "sampleSizes": {
+            contest_ids[0]: [
+                {"prob": 0.52, "size": 119, "type": "ASN"},
+                {"prob": 0.7, "size": 184, "type": None},
+                {"prob": 0.8, "size": 244, "type": None},
+                {"prob": 0.9, "size": 351, "type": None},
+            ]
+        }
     }
 
 
 def test_sample_sizes_round_2(
     client: FlaskClient,
     election_id: str,
+    contest_ids: List[str],
     round_2_id: str,  # pylint: disable=unused-argument
 ):
     rv = client.get(f"/api/election/{election_id}/sample-sizes")
     sample_sizes = json.loads(rv.data)
     # Should still return round 1 sample sizes
     assert sample_sizes == {
-        "sampleSizes": [
-            {"prob": 0.52, "size": 119, "type": "ASN"},
-            {"prob": 0.7, "size": 184, "type": None},
-            {"prob": 0.8, "size": 244, "type": None},
-            {"prob": 0.9, "size": 351, "type": None},
-        ]
+        "sampleSizes": {
+            contest_ids[0]: [
+                {"prob": 0.52, "size": 119, "type": "ASN"},
+                {"prob": 0.7, "size": 184, "type": None},
+                {"prob": 0.8, "size": 244, "type": None},
+                {"prob": 0.9, "size": 351, "type": None},
+            ]
+        }
     }

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -178,7 +178,7 @@ def round_1_id(
     rv = post_json(
         client,
         f"/api/election/{election_id}/round",
-        {"roundNum": 1, "sampleSize": SAMPLE_SIZE_ROUND_1},
+        {"roundNum": 1, "sampleSizes": {contest_ids[0]: SAMPLE_SIZE_ROUND_1}},
     )
     assert_ok(rv)
     rv = client.get(f"/api/election/{election_id}/round",)

--- a/server/tests/snapshots/snap_test_multiple_targeted_contests.py
+++ b/server/tests/snapshots/snap_test_multiple_targeted_contests.py
@@ -9,16 +9,16 @@ snapshots = Snapshot()
 
 snapshots["test_sample_size_round_1 1"] = {
     "Contest 1": [
-        {"prob": 0.71, "size": 191, "type": "ASN"},
-        {"prob": 0.7, "size": 295, "type": None},
-        {"prob": 0.8, "size": 391, "type": None},
-        {"prob": 0.9, "size": 562, "type": None},
+        {"key": "asn", "prob": 0.71, "size": 191},
+        {"key": "0.7", "prob": 0.7, "size": 295},
+        {"key": "0.8", "prob": 0.8, "size": 391},
+        {"key": "0.9", "prob": 0.9, "size": 562},
     ],
     "Contest 2": [
-        {"prob": 0.55, "size": 485, "type": "ASN"},
-        {"prob": 0.7, "size": 770, "type": None},
-        {"prob": 0.8, "size": 1018, "type": None},
-        {"prob": 0.9, "size": 1468, "type": None},
+        {"key": "asn", "prob": 0.55, "size": 485},
+        {"key": "0.7", "prob": 0.7, "size": 770},
+        {"key": "0.8", "prob": 0.8, "size": 1018},
+        {"key": "0.9", "prob": 0.9, "size": 1468},
     ],
 }
 

--- a/server/tests/snapshots/snap_test_multiple_targeted_contests.py
+++ b/server/tests/snapshots/snap_test_multiple_targeted_contests.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots["test_sample_size_round_1 1"] = {
+    "Contest 1": [
+        {"prob": 0.71, "size": 191, "type": "ASN"},
+        {"prob": 0.7, "size": 295, "type": None},
+        {"prob": 0.8, "size": 391, "type": None},
+        {"prob": 0.9, "size": 562, "type": None},
+    ],
+    "Contest 2": [
+        {"prob": 0.55, "size": 485, "type": "ASN"},
+        {"prob": 0.7, "size": 770, "type": None},
+        {"prob": 0.8, "size": 1018, "type": None},
+        {"prob": 0.9, "size": 1468, "type": None},
+    ],
+}
+
+snapshots["test_two_rounds 1"] = {
+    "Contest 1 - candidate 1": 132,
+    "Contest 1 - candidate 2": 59,
+    "Contest 2 - No": 0,
+    "Contest 2 - Yes": 0,
+    "Contest 3 - candidate 1": 0,
+    "Contest 3 - candidate 2": 0,
+    "Contest 3 - candidate 3": 0,
+}
+
+snapshots["test_two_rounds 2"] = 1468
+
+snapshots["test_two_rounds 3"] = {
+    "Contest 2 - No": 440,
+    "Contest 2 - Yes": 1028,
+    "Contest 3 - candidate 1": 0,
+    "Contest 3 - candidate 2": 0,
+    "Contest 3 - candidate 3": 0,
+}

--- a/server/tests/test_multiple_targeted_contests.py
+++ b/server/tests/test_multiple_targeted_contests.py
@@ -4,6 +4,7 @@ import pytest
 from flask.testing import FlaskClient
 
 from .helpers import *  # pylint: disable=wildcard-import
+from ..models import *  # pylint: disable=wildcard-import
 
 
 @pytest.fixture


### PR DESCRIPTION
Task: #622

Adds support for multiple independently targeted contests by drawing a separate sample for each targeted contest.

Removes support for jointly targeted contests because we decided we don't need to implement it right now.

Breaking changes to two APIs:
- GET /sample-sizes now returns a map from targeted contest ids to sample size options
- POST /round now requires a map from targeted contest id to sample size, rather than just one sample size

Also fixes an issue in the audit report where we were reporting a sample size for opportunistic contests. This doesn't make sense when there are multiple targeted contests, because the number of ballots we count for the opportunistic contests doesn't necessarily match the sample size. Instead, we don't report a sample size for opportunistic contests.