### PR TITLE
Check db queries filter by election

### DIFF
--- a/server/api/routes.py
+++ b/server/api/routes.py
@@ -242,7 +242,9 @@ def validate_new_election(election: JSONDict, organization_id: str):
         organization_id
         and Election.query.filter_by(
             audit_name=election["auditName"], organization_id=organization_id
-        ).first()
+        )
+        .execution_options(query_across_elections=True)
+        .first()
     ):
         raise Conflict(
             f"An audit with name '{election['auditName']}' already exists within your organization"

--- a/server/app.py
+++ b/server/app.py
@@ -51,6 +51,9 @@ app.register_blueprint(superadmin)
 from . import static
 from . import errors
 
+if FLASK_ENV in DEVELOPMENT_ENVS:
+    from . import check_query_scope
+
 
 @app.teardown_appcontext
 def shutdown_session(exception=None):  # pylint: disable=unused-argument

--- a/server/bgcompute.py
+++ b/server/bgcompute.py
@@ -49,6 +49,7 @@ def bgcompute_update_election_jurisdictions_file() -> int:
     files = (
         File.query.join(Election, File.id == Election.jurisdictions_file_id)
         .filter(File.processing_started_at.is_(None))
+        .execution_options(query_across_elections=True)
         .all()
     )
 
@@ -68,6 +69,7 @@ def bgcompute_update_ballot_manifest_file() -> int:
     files = (
         File.query.join(Jurisdiction, File.id == Jurisdiction.manifest_file_id)
         .filter(File.processing_started_at.is_(None))
+        .execution_options(query_across_elections=True)
         .all()
     )
 

--- a/server/check_query_scope.py
+++ b/server/check_query_scope.py
@@ -1,0 +1,139 @@
+from typing import Dict
+from sqlalchemy import event, sql
+from sqlalchemy.orm import Query
+from . import models
+from .models import *  # pylint: disable=wildcard-import
+
+# Every database query the app makes should be scoped to the audit for the
+# logged-in user. This module registers an event listener with SQLAlchemy to
+# check every database query to ensure that it is properly scoped.
+#
+# It checks that each query filters by either:
+# - a primary key
+# - election_id
+# - a foreign key to a model that is related to Election
+#
+# In order to opt out of this check, a query can specify:
+# .execution_options(query_across_elections=True)
+
+# This dict defines which columns satisfy the requirement for each model. Note
+# that primary keys do not need to be included - those are checked separately.
+model_to_election_columns: Dict[Type[models.BaseModel], list] = {
+    Election: [Election.organization_id, Election.jurisdictions_file_id],
+    Organization: [],
+    Jurisdiction: [Jurisdiction.election_id, Jurisdiction.manifest_file_id],
+    Batch: [Batch.jurisdiction_id],
+    Contest: [Contest.election_id],
+    ContestChoice: [ContestChoice.contest_id],
+    AuditBoard: [
+        AuditBoard.jurisdiction_id,
+        AuditBoard.round_id,
+        AuditBoard.passphrase,
+    ],
+    Round: [Round.election_id],
+    SampledBallot: [SampledBallot.batch_id, SampledBallot.audit_board_id],
+    SampledBallotDraw: [
+        SampledBallotDraw.ballot_id,
+        SampledBallotDraw.round_id,
+        SampledBallotDraw.contest_id,
+    ],
+    BallotInterpretation: [
+        BallotInterpretation.ballot_id,
+        BallotInterpretation.contest_id,
+    ],
+    RoundContest: [RoundContest.round_id, RoundContest.contest_id],
+    RoundContestResult: [
+        RoundContestResult.round_id,
+        RoundContestResult.contest_id,
+        RoundContestResult.contest_choice_id,
+    ],
+    File: [File.id],
+    JurisdictionAdministration: [],
+    AuditAdministration: [],
+    User: [User.email],
+}
+all_models = {
+    export
+    for export in models.__dict__.values()
+    if isinstance(export, type)
+    and issubclass(export, models.BaseModel)
+    and export != models.BaseModel
+}
+checked_models = set(model_to_election_columns.keys())
+if checked_models != all_models:
+    # pylint: disable=invalid-name
+    missing_models = ",".join(m.__name__ for m in all_models - checked_models)
+    raise Exception(f"Missing models from check_query_scope: {missing_models}")
+
+# Basic global variable lock - Python's threading locks don't seem to work
+# easily here. We need to make sure only one event handler can operate at a
+# time because when we try to print query.statement, it triggers the handler
+# again, leading to an infinite loop.
+check_query_scope_lock = False  # pylint: disable=invalid-name
+
+# pylint: disable=protected-access
+@event.listens_for(Query, "before_compile")
+def check_query_scope(query: Query):
+    def criterion_contains_column(column):
+        def side_equals_column(side):
+            return (
+                side.key == column.key
+                and side.table.name == column.class_.__tablename__
+            )
+
+        return lambda criterion: side_equals_column(
+            criterion.left
+        ) or side_equals_column(criterion.right)
+
+    def criterion_contains_primary_key(criterion):
+        return criterion.left.primary_key or criterion.right.primary_key
+
+    def check_criterion(criterion, check_fn):
+        if criterion is None:
+            return False
+        if isinstance(criterion, sql.elements.BinaryExpression):
+            return check_fn(criterion)
+        return any(
+            check_criterion(subcriterion, check_fn) for subcriterion in criterion
+        )
+
+    def query_filters_on_primary_key_or_election(query, model):
+        return check_criterion(query._criterion, criterion_contains_primary_key) or any(
+            check_criterion(query._criterion, criterion_contains_column(column))
+            for column in model_to_election_columns[model]
+        )
+
+    # Allow a flag to bypass this check
+    if query._execution_options.get("query_across_elections", False):  # type: ignore
+        return
+
+    # When you call .count(), SQLAlchemy turns your query into a subquery and
+    # adds a "SELECT count(*) FROM subquery" around it. Both the subquery and
+    # the wrapped query get passed to this event handler individually, but the
+    # wrapped query doesn't have the data we need to analyze it. So we skip the
+    # wrapped count query and just check the subquery.
+    if isinstance(query.column_descriptions[0]["expr"], sql.functions.count):
+        return
+
+    global check_query_scope_lock  # pylint: disable=global-statement,invalid-name
+    if not check_query_scope_lock:
+        check_query_scope_lock = True
+
+        queried_models = [c["entity"] for c in query.column_descriptions if c["entity"]]
+        joined_models = [e.class_ for e in query._join_entities]  # type: ignore
+        models = set(queried_models + joined_models)
+
+        if models and not any(
+            query_filters_on_primary_key_or_election(query, model) for model in models
+        ):
+            raise Exception(
+                "Query must filter on primary key or one of the following columns:\n"
+                + "\n".join(
+                    ", ".join(str(m) for m in model_to_election_columns[model])
+                    for model in models
+                )
+                + "\n\n"
+                + str(query.statement)
+            )
+
+        check_query_scope_lock = False

--- a/server/models.py
+++ b/server/models.py
@@ -1,10 +1,9 @@
-import enum, sys
+import enum
 from typing import Type
 from datetime import datetime as dt
 from werkzeug.exceptions import NotFound
 from sqlalchemy import *  # pylint: disable=wildcard-import
-from sqlalchemy import event, sql
-from sqlalchemy.orm import relationship, backref, validates, Query
+from sqlalchemy.orm import relationship, backref, validates
 from .database import Base  # pylint: disable=cyclic-import
 
 
@@ -585,93 +584,3 @@ def get_or_404(model: Type[Base], primary_key: str):
     if instance:
         return instance
     raise NotFound(f"{model.__class__.__name__} {primary_key} not found")
-
-
-@event.listens_for(Query, "before_compile")
-def check_query_scope(query: Query):
-    def side_equals_column(side, column):
-        return side.key == column.key and side.table.name == column.class_.__tablename__
-
-    def criterion_contains_column(criterion, column):
-        return side_equals_column(criterion.left, column) or side_equals_column(
-            criterion.right, column
-        )
-
-    def criterion_contains_primary_key(criterion):
-        return criterion.left.primary_key or criterion.right.primary_key
-
-    def criterion_filters_on_column(criterion, column):
-        if criterion is None:
-            return False
-        if isinstance(criterion, sql.elements.BinaryExpression):
-            return criterion_contains_column(
-                criterion, column
-            ) or criterion_contains_primary_key(criterion)
-        return any(
-            criterion_filters_on_column(criterion, column) for criterion in criterion
-        )
-
-    def check_query_for_columns(query, columns):
-        if not any(
-            criterion_filters_on_column(query._criterion, column) for column in columns
-        ):
-            print(
-                f"Query must filter on one of the following columns: {', '.join(str(c) for c in columns)}"
-            )
-            sys.exit(1)
-
-    queried_models = [c["entity"] for c in query.column_descriptions]
-    for model in queried_models:
-        if model == Jurisdiction:
-            check_query_for_columns(
-                query, [Jurisdiction.election_id, Jurisdiction.manifest_file_id]
-            )
-        if model == Batch:
-            check_query_for_columns(query, [Batch.jurisdiction_id])
-        if model == Contest:
-            check_query_for_columns(query, [Contest.election_id])
-        if model == ContestChoice:
-            check_query_for_columns(query, [ContestChoice.contest_id])
-        if model == AuditBoard:
-            check_query_for_columns(
-                query,
-                [
-                    AuditBoard.jurisdiction_id,
-                    AuditBoard.round_id,
-                    AuditBoard.passphrase,
-                ],
-            )
-        if model == Round:
-            check_query_for_columns(query, [Round.election_id])
-        if model == SampledBallot:
-            check_query_for_columns(
-                query, [SampledBallot.batch_id, SampledBallot.audit_board_id]
-            )
-        if model == SampledBallotDraw:
-            check_query_for_columns(
-                query,
-                [
-                    SampledBallotDraw.ballot_id,
-                    SampledBallotDraw.round_id,
-                    SampledBallotDraw.contest_id,
-                ],
-            )
-        if model == BallotInterpretation:
-            check_query_for_columns(
-                query,
-                [BallotInterpretation.ballot_id, BallotInterpretation.contest_id],
-            )
-        if model == RoundContest:
-            check_query_for_columns(
-                query, [RoundContest.round_id, RoundContest.contest_id],
-            )
-        if model == RoundContestResult:
-            check_query_for_columns(
-                query,
-                [
-                    RoundContestResult.round_id,
-                    RoundContestResult.contest_id,
-                    RoundContestResult.contest_choice_id,
-                ],
-            )
-

--- a/server/superadmin.py
+++ b/server/superadmin.py
@@ -15,7 +15,9 @@ superadmin = Blueprint("superadmin", __name__)
 )
 @with_superadmin_access
 def superadmin_organizations():
-    organizations = Organization.query.all()
+    organizations = Organization.query.execution_options(
+        query_across_elections=True
+    ).all()
     return render_template("superadmin/organizations.html", organizations=organizations)
 
 

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -107,7 +107,8 @@ def test_ballot_manifest_replace(
     )
     assert_ok(rv)
 
-    num_files = File.query.count()
+    file_id = Jurisdiction.query.get(jurisdiction_ids[0]).manifest_file_id
+    assert file_id
 
     bgcompute_update_ballot_manifest_file()
 
@@ -128,7 +129,7 @@ def test_ballot_manifest_replace(
     assert_ok(rv)
 
     # The old file should have been deleted
-    assert File.query.count() == num_files
+    assert File.query.get(file_id) is None
 
     bgcompute_update_ballot_manifest_file()
 

--- a/server/tests/api/test_contests.py
+++ b/server/tests/api/test_contests.py
@@ -332,7 +332,7 @@ def test_audit_board_contests_list_empty(
     round_1_id: str,
     audit_board_round_1_ids: List[str],
 ):
-    contests = Contest.query.all()
+    contests = Contest.query.filter_by(election_id=election_id).all()
     for contest in contests:
         contest.jurisdictions = []
     db_session.commit()
@@ -376,7 +376,11 @@ def test_audit_board_contests_list_order(
     round_1_id: str,
     audit_board_round_1_ids: List[str],
 ):
-    db_contests = Contest.query.order_by(Contest.created_at).all()
+    db_contests = (
+        Contest.query.filter_by(election_id=election_id)
+        .order_by(Contest.created_at)
+        .all()
+    )
     db_contests[0].name = "ZZZ Contest"
     db_contests[1].name = "AAA Contest"
     db_choices = sorted(db_contests[0].choices, key=lambda c: c.created_at)
@@ -392,7 +396,11 @@ def test_audit_board_contests_list_order(
     )
     contests = json.loads(rv.data)["contests"]
 
-    db_contests = Contest.query.order_by(Contest.created_at).all()
+    db_contests = (
+        Contest.query.filter_by(election_id=election_id)
+        .order_by(Contest.created_at)
+        .all()
+    )
     db_choices = sorted(db_contests[0].choices, key=lambda c: c.created_at)
 
     assert contests[0]["name"] == db_contests[0].name

--- a/server/tests/test_jointly_targeted_contests.py
+++ b/server/tests/test_jointly_targeted_contests.py
@@ -97,7 +97,7 @@ def test_two_rounds(
         {"roundNum": 1, "sampleSize": JOINT_SAMPLE_SIZE_ROUND_1},
     )
     assert_ok(rv)
-    round_1 = Round.query.first()
+    round_1 = Round.query.filter_by(election_id=election_id).first()
 
     # Audit all the ballots for Contest 1 and meet the risk limit, but don't
     # audit any for Contest 2, which should still trigger a second round.
@@ -122,7 +122,7 @@ def test_two_rounds(
 
     # Check that the ballots got sampled
     # We expect both contests to use the same sample size
-    ballot_draws = SampledBallotDraw.query.all()
+    ballot_draws = SampledBallotDraw.query.filter_by(round_id=round_1.id).all()
     assert len(ballot_draws) == JOINT_SAMPLE_SIZE_ROUND_1 * 2
 
     # Check that the same ballots were sampled for both contests

--- a/server/tests/util/test_jurisdiction_bulk_update.py
+++ b/server/tests/util/test_jurisdiction_bulk_update.py
@@ -37,7 +37,7 @@ def test_first_update(session):
     ]
 
     assert User.query.count() == 1
-    assert Jurisdiction.query.count() == 1
+    assert Jurisdiction.query.filter_by(election_id=election.id).count() == 1
     assert JurisdictionAdministration.query.count() == 1
 
 
@@ -57,7 +57,7 @@ def test_idempotent(session):
     session.commit()
 
     user = User.query.one()
-    jurisdiction = Jurisdiction.query.one()
+    jurisdiction = Jurisdiction.query.filter_by(election_id=election.id).one()
 
     # Do the same thing again.
     bulk_update_jurisdictions(
@@ -65,7 +65,7 @@ def test_idempotent(session):
     )
 
     assert User.query.one() == user
-    assert Jurisdiction.query.one() == jurisdiction
+    assert Jurisdiction.query.filter_by(election_id=election.id).one() == jurisdiction
 
 
 def test_remove_outdated_jurisdictions(session):
@@ -88,5 +88,5 @@ def test_remove_outdated_jurisdictions(session):
 
     assert new_admins == []
     assert User.query.count() == 1  # keep the user
-    assert Jurisdiction.query.count() == 0
+    assert Jurisdiction.query.filter_by(election_id=election.id).count() == 0
     assert JurisdictionAdministration.query.count() == 0

--- a/server/util/jurisdiction_bulk_update.py
+++ b/server/util/jurisdiction_bulk_update.py
@@ -43,7 +43,9 @@ def bulk_update_jurisdictions(
     with session.begin_nested():
         # Clear existing admins.
         session.query(JurisdictionAdministration).filter(
-            Jurisdiction.election == election
+            JurisdictionAdministration.jurisdiction_id.in_(
+                [j.id for j in election.jurisdictions]
+            )
         ).delete(synchronize_session="fetch")
         new_admins: List[JurisdictionAdministration] = []
 


### PR DESCRIPTION
Task: #631 

Here's a first attempt at ensuring that all db queries filter by election. We use a SQLAlchemy event hook that runs every time a query is going to be compiled to check that the query has either:
- a filter on a primary key
- a filter on election id
- a filter on some foreign key to another object that is scoped to an election

This solution feels brittle for a few reasons:
- it relies heavily on SQLAlchemy internals that I don't understand well
- I ran into a few edge cases with the queries we have already, which makes me think we'll have to come back and address more edge cases in the future
- we have half a permissions scheme already in place with the route decorators that check and populate election/jurisdiction/audit board objects based on the user's permissions - this outsources the rest of the permission checking (that we correctly use those objects in the rest of the code) to a totally unrelated piece of code. it seems like something might slip through the cracks

In summary, I think this could work, but the process of implementing it has made me realize that really this is a piece of a larger permissions problem, and there is probably a more robust solution. I'm thinking about creating an abstraction layer on top of the database that provides a "view" into the database from a particular user's perspective, offering some interface similar to SQLAlchemy models that enforces proper scoping in its design.

