### PR TITLE
Note auth0.md in README, but need more doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Before submitting a pull request, please review our [Contribution Guidelines](./
 
 ### Configuration
 
+[Auth0](https://auth0.com/) is used for authentication, as documented at [Auth0](docs/auth0.md).
+
 Arlo is configured mostly through environment variables:
 
 - `FLASK_ENV`: [environment](https://flask.palletsprojects.com/en/1.1.x/config/#environment-and-debug-features) for the Flask server


### PR DESCRIPTION
**Description**

There was no link to `docs/auth0.md` in the project, so this PR adds a link to it from the README.

**Testing**

- [x] Check the relative links in GitHub from the README and the repo landing page.

**Progress**

Note that neither the README nor auth0.md have very much to say about the practicalities of the relatively complex matter of setting up auth0, which is now the only way to log in and run Arlo.
So please augment the documentation.
But merging this doesn't have to wait on that.