### PR TITLE
Wrapping passphrase url if too long

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/generateSheets.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/generateSheets.ts
@@ -107,7 +107,10 @@ export const downloadDataEntry = (auditBoards: IAuditBoard[]): string => {
         120
       )
       auditBoardCreds.text(
-        `${window.location.origin}/auditboard/${board.passphrase}`,
+        auditBoardCreds.splitTextToSize(
+          `${window.location.origin}/auditboard/${board.passphrase}`,
+          180
+        ),
         20,
         140
       )


### PR DESCRIPTION
**Description**

- Enclosed the addition of the url to the pdf in the same wrapping function as the instructions.

**Testing**

- Doesn't change current tests, tested manually though and it works.

**Progress**

- All done!
