### PR TITLE
Add contests and settings endpoints for jurisdiction admins

### DIFF
--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -4,7 +4,11 @@ from werkzeug.exceptions import BadRequest, Conflict
 from sqlalchemy import func
 
 from . import api
-from ..auth import with_election_access, with_audit_board_access
+from ..auth import (
+    with_election_access,
+    with_audit_board_access,
+    with_jurisdiction_access,
+)
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from .rounds import get_current_round
@@ -180,6 +184,17 @@ def list_contests(election: Election):
     json_contests = [
         serialize_contest(c, round_status[c.id]) for c in election.contests
     ]
+    return jsonify({"contests": json_contests})
+
+
+@api.route(
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/contest", methods=["GET"]
+)
+@with_jurisdiction_access
+def list_jurisdictions_contests(
+    election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
+):
+    json_contests = [serialize_contest(c) for c in jurisdiction.contests]
     return jsonify({"contests": json_contests})
 
 

--- a/server/api/election_settings.py
+++ b/server/api/election_settings.py
@@ -2,7 +2,7 @@ from flask import jsonify, request
 from werkzeug.exceptions import Conflict
 
 from . import api
-from ..auth import with_election_access
+from ..auth import with_election_access, with_jurisdiction_access
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from ..util.jsonschema import validate, JSONDict
@@ -35,6 +35,24 @@ ELECTION_SETTINGS_SCHEMA = {
 @api.route("/election/<election_id>/settings", methods=["GET"])
 @with_election_access
 def get_election_settings(election: Election):
+    return jsonify(
+        {
+            "electionName": election.election_name,
+            "online": election.online,
+            "randomSeed": election.random_seed,
+            "riskLimit": election.risk_limit,
+            "state": election.state,
+        }
+    )
+
+
+@api.route(
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/settings", methods=["GET"]
+)
+@with_jurisdiction_access
+def get_jurisdiction_election_settings(
+    election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
+):
     return jsonify(
         {
             "electionName": election.election_name,


### PR DESCRIPTION
In offline data entry audits, the jurisdiction admin needs to enter results for each contest. So JAs need to be able to load the election settings (to see if the audit is online/offline) and load the contests (to know which contests/choices to enter results for).

This adds two new endpoints to support those use cases:
- /election/<election_id>/jurisdiction/<jurisdiction_id>/contest
- /election/<election_id>/jurisdiction/<jurisdiction_id>/settings

The contests returned are scoped to the jurisdiction's contest universe.