### PR TITLE
Update and clarify README.md and auth0.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,9 @@ dev-environment: deps initdevdb install-development resetdb
 typecheck-server:
 	pipenv run mypy server scripts
 
+# Note that this reformats ALL the Python files in the given directories, in-place
 format-server:
-	pipenv run black .
+	pipenv run black server scripts
 
 lint-server:
 	pipenv run pylint server scripts

--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ Before submitting a pull request, please review our [Contribution Guidelines](./
 
 ### Configuration
 
-[Auth0](https://auth0.com/) is used for authentication, as documented at [Auth0](docs/auth0.md).
-
 Arlo is configured mostly through environment variables:
 
 - `FLASK_ENV`: [environment](https://flask.palletsprojects.com/en/1.1.x/config/#environment-and-debug-features) for the Flask server
@@ -107,11 +105,17 @@ Arlo is configured mostly through environment variables:
 
 ### Creating Organizations and Administrators
 
-Organizations are, for example, the State of
+Arlo identifies and authenticates three classes of end-user:
+organization administrators, jurisdiction adminstrators,
+and audit boards.
+
+Organizations identify administrators and jurisdictions for whom they
+administrate audits. Jurisdictions identify their own administrators,
+as well as audit boards. Audit boards enter ballot-by-ballot auditing data.
+
+Thus, organizations are, for example, the State of
 Massachusetts. Administrators are individual users that administer
-audits for an organization. All authentication is done via auth0 with
-email addresses, so users in the Arlo database also need to be
-mirrored in the appropriate auth0 tenant user database.
+audits for an organization.
 
 To create an organization in the database:
 
@@ -124,6 +128,26 @@ Then, to create an administrator for the organization:
 `pipenv run python -m scripts.create-admin <org_id> <admin_email>`
 
 which returns the `user_id`.
+
+This can be be automated via:
+
+    org=$(python -m scripts.create-org MyOrg)
+    python -m scripts.create-admin $org my_administrator@example.org
+
+The email addresses authorized to administer jurisdictions are identified
+via the `filesheet.csv` file uploaded by the organization administrator.
+
+After the jurisdiction admin creates audit boards for each audit,
+they download the `Audit Board Credentials for Data Entry.pdf` files.
+Each one contains a URL for an audit board, with an embedded
+authentication token.
+
+All authentication is done using OAuth 2.0
+(e.g. via [Auth0](https://auth0.com/), with
+email addresses, so users in the Arlo database also should typically be
+configured in the appropriate auth0 tenant user database.
+
+For design details, see [Arlo's use of Auth0](docs/auth0.md).
 
 ### Resetting the Database When Upgrading Arlo
 
@@ -153,6 +177,7 @@ We recommend Ubuntu 18.0.4.
 
 #### Troubleshooting
 
+- Beware: if you run make format-server, it will run black in a way which changes all files under the current directory without providing a backup
 - Postgres is best installed by grabbing `postgresql-server-dev-10` and `postgresql-client-10`.
 - `psychopg2` has known issues depending on your install (see, e.g., [here](https://github.com/psycopg/psycopg2/issues/674)). If you run into issues, switch `psychopg2` to `psychopg2-binary` in the Pipfile
 - `pipenv install` can hang attempting to get [a lock on the packages it's installing](https://github.com/pypa/pipenv/issues/3827). To get around this, add the `--skip-lock` flag in the Makefile (the first line should be `pipenv install --skip-lock`).

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ organization administrators, jurisdiction adminstrators,
 and audit boards.
 
 Organizations identify administrators and jurisdictions for whom they
-administrate audits. Jurisdictions identify their own administrators,
+administer audits. Jurisdictions identify their own administrators,
 as well as audit boards. Audit boards enter ballot-by-ballot auditing data.
 
 Thus, organizations are, for example, the State of
@@ -142,8 +142,8 @@ they download the `Audit Board Credentials for Data Entry.pdf` files.
 Each one contains a URL for an audit board, with an embedded
 authentication token.
 
-All authentication is done using OAuth 2.0
-(e.g. via [Auth0](https://auth0.com/), with
+Administrator authentication is done using OAuth 2.0
+(e.g. via [Auth0](https://auth0.com/)), with
 email addresses, so users in the Arlo database also should typically be
 configured in the appropriate auth0 tenant user database.
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ We recommend Ubuntu 18.0.4.
 
 #### Troubleshooting
 
-- Beware: if you run make format-server, it will run black in a way which changes all files under the current directory without providing a backup
 - Postgres is best installed by grabbing `postgresql-server-dev-10` and `postgresql-client-10`.
 - `psychopg2` has known issues depending on your install (see, e.g., [here](https://github.com/psycopg/psycopg2/issues/674)). If you run into issues, switch `psychopg2` to `psychopg2-binary` in the Pipfile
 - `pipenv install` can hang attempting to get [a lock on the packages it's installing](https://github.com/pypa/pipenv/issues/3827). To get around this, add the `--skip-lock` flag in the Makefile (the first line should be `pipenv install --skip-lock`).

--- a/docs/auth0.md
+++ b/docs/auth0.md
@@ -12,13 +12,13 @@ Auth0 is used for authentication. Key things to keep in mind:
 - we use two separate Auth0 tenants, one for audit administrators, one
   for jurisdiction administrators, each with its own single
   application, so we can use completely different login screens for
-  both, specifically 2FA for audit administrators and passwordless for
-  jurisdiction administrators.
+  both, specifically 2FA for audit administrators, and both 2FA
+  and passwordless for jurisdiction administrators / audit boards.
 
 - setting up auth0 passwordless requires either creating users via the
   Management API, or letting anyone sign in and filtering on our
-  end. We'll start with the latter, we may do the former at some
-  point.
+  end. We'll start with the latter, creating URLs for audit boards on
+  the fly, but we may do the former at some point.
 
 - right now we're using "Universal Login", where Auth0 controls the
   login page. It's not clear that's the right way forward for Arlo, as


### PR DESCRIPTION
**Description**

As noted in #657, documentation is lacking for the new authentication and authorization approach
in Arlo, which now relies on OAuth 2 and/or Auth0.

This is my attempt to clarify what seems to work at this point. It should be reviewed by someone who can confirm these changes.

**Testing**

Only documentation is changed.

**Progress**

It would probably make sense to put the Organizations section before the Configuration section, to introduce the use of administrators and Auth0.

This PR should be helpful and self-contained, but before the issue can be closed, more detail on how to configure Auth0 should be added.