### PR TITLE
Run db migrations on deploy

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,12 +14,12 @@ pylint = "*"
 # for now (or enable pre-releases for all packages, which we don't want)
 black = "==19.10b0"
 snapshottest = "*"
-alembic = "*"
 pytest-alembic = "*"
 pytest-xdist = "*"
 filelock = "*"
 
 [packages]
+alembic = "*"
 authlib = "*"
 chardet = "*"
 consistent_sampler = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9e8d8b80a084f4e40ee6ddef491eb93b3c5405770a24fb622285bb932caede47"
+            "sha256": "d95f173a049469c59c3d1b0b468fd49cac4f9904237efeefc95620b6d8be61fe"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "alembic": {
+            "hashes": [
+                "sha256:035ab00497217628bf5d0be82d664d8713ab13d37b630084da8e1f98facf4dbf"
+            ],
+            "index": "pypi",
+            "version": "==1.4.2"
+        },
         "attrs": {
             "hashes": [
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
@@ -195,6 +202,13 @@
             "index": "pypi",
             "version": "==3.2.0"
         },
+        "mako": {
+            "hashes": [
+                "sha256:8195c8c1400ceb53496064314c6736719c6f25e7479cd24c77be3d9361cddc27",
+                "sha256:93729a258e4ff0747c876bd9e20df1b9758028946e976324ccd2d68245c7b6a9"
+            ],
+            "version": "==1.1.3"
+        },
         "markupsafe": {
             "hashes": [
                 "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
@@ -313,6 +327,21 @@
                 "sha256:28669905fe725965daa16184933676547c5bb40a5153055a8dee2a4bd7933ad3"
             ],
             "version": "==0.16.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
+        },
+        "python-editor": {
+            "hashes": [
+                "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d",
+                "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b",
+                "sha256:5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8"
+            ],
+            "version": "==1.0.4"
         },
         "requests": {
             "hashes": [

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
+release: alembic upgrade head
 web: python -m server.main
 worker: python -m server.bgcompute


### PR DESCRIPTION
Adds a Heroku Release Phase task to migrate to the current db state
before deploying a new build. See https://devcenter.heroku.com/articles/release-phase
