### PR TITLE
Fix Election.audit_type migration to set value for existing audits

### DIFF
--- a/server/migrations/versions/9ed660c31c0a_election_audit_type.py
+++ b/server/migrations/versions/9ed660c31c0a_election_audit_type.py
@@ -27,8 +27,15 @@ def upgrade():
     )
     audit_type_enum.create(op.get_bind())
     op.add_column(
-        "election", sa.Column("audit_type", audit_type_enum, nullable=False,),
+        "election", sa.Column("audit_type", audit_type_enum),
     )
+    op.execute(
+        """
+        UPDATE election
+        SET audit_type = 'BALLOT_POLLING'
+        """
+    )
+    op.alter_column("election", "audit_type", nullable=False)
 
 
 def downgrade():  # pragma: no cover


### PR DESCRIPTION
This was failing on staging because it required the `Election.audit_type` field to have a value but didn't set any value for existing audits in the database.

