### PR TITLE
Clear data instead of dropping tables when seeding data for Cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,4 +178,4 @@ To run tests while developing, you can use these commands to make things more in
 
 - Server tests: `pipenv run pytest` (you can add flags - e.g. `-k <pattern>` only runs tests that match the pattern, `-n auto` to run the tests in parallel)
 - Client tests: `yarn --cwd client test` (runs interactive test CLI)
-- End-to-end tests: first run `FLASK_ENV=test ./run-dev.sh` to run the server, then, in a separate shell, run `yarn --cwd client cy:open` (opens the Cypress test app for interactive test running/debugging)
+- End-to-end tests: first run `FLASK_ENV=test ./run-dev.sh` to run the server, then, in a separate shell, run `yarn --cwd client run cypress open` (opens the Cypress test app for interactive test running/debugging)

--- a/client/cypress/end-to-end/ballot-polling-basic.spec.js
+++ b/client/cypress/end-to-end/ballot-polling-basic.spec.js
@@ -1,3 +1,5 @@
+before(() => cy.exec('./cypress/seed-test-db.sh'))
+
 describe('Basic ballot polling audit', () => {
   it('runs', () => {
     cy.visit('/')

--- a/client/cypress/seed-test-db.sh
+++ b/client/cypress/seed-test-db.sh
@@ -4,6 +4,6 @@ export FLASK_ENV=test
 trap 'kill 0' SIGINT SIGHUP
 cd "$(dirname "${BASH_SOURCE[0]}")"
 cd ../..
-pipenv run python -m scripts.resetdb --skip-db-creation
+pipenv run python -m scripts.cleardb
 ORG_ID=`pipenv run python -m scripts.create-org "Cypress Test Org"`
 pipenv run python -m scripts.create-admin $ORG_ID "audit-admin-cypress@example.com"

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "scripts": {
     "build": "react-scripts build",
-    "cy:open": "./cypress/seed-test-db.sh && cypress open",
     "lint": "eslint --ext ts --ext tsx src",
     "lint:fix": "yarn lint --fix",
     "start": "react-scripts start",

--- a/scripts/cleardb.py
+++ b/scripts/cleardb.py
@@ -1,0 +1,7 @@
+from server.database import engine, clear_db
+
+if __name__ == "__main__":
+    print(f"database: {engine.url}")
+
+    print("clearing data from all tables…")
+    clear_db()

--- a/server/database.py
+++ b/server/database.py
@@ -44,3 +44,11 @@ def reset_db():
 
     Base.metadata.drop_all(bind=engine)
     init_db()
+
+
+def clear_db():
+    # pylint: disable=wildcard-import,import-outside-toplevel,unused-import
+    import server.models
+
+    for table in reversed(Base.metadata.sorted_tables):
+        engine.execute(table.delete())


### PR DESCRIPTION
Previously, we used the existing `resetdb` script to prepare the db for
seed data in Cypress tests. The problem with this approach is that it
hangs when a Flask app is already running, since that app has an open db
session, so SQLAlchemy gets blocked trying to drop the tables.

Instead, we add a new script `cleardb` that iterates over the tables and
deletes all the data from them. This does not block if the Flask app is
already running.

With this block removed, we can move the seeding of data into the actual
Cypress test spec so that it runs every time we run the tests, instead
of trying to run it via bash scripts for test running (much simpler and
less error-prone).