### PR TITLE
scripts.resetdb: stamp db with latest migration revision

### DIFF
--- a/scripts/resetdb.py
+++ b/scripts/resetdb.py
@@ -1,5 +1,7 @@
-import sys
+import sys, os
 from sqlalchemy_utils import database_exists, create_database, drop_database
+from alembic.config import Config
+from alembic import command
 from server.database import engine, reset_db
 
 if __name__ == "__main__":
@@ -20,3 +22,9 @@ if __name__ == "__main__":
 
     print("resetting tables…")
     reset_db()
+
+    print("stamping latest migration revision...")
+    # Following recipe: https://alembic.sqlalchemy.org/en/latest/cookbook.html#building-an-up-to-date-database-from-scratch
+    alembic_cfg = Config(os.path.join(os.path.dirname(__file__), "../alembic.ini"))
+    alembic_cfg.set_main_option("sqlalchemy.url", str(engine.url))
+    command.stamp(alembic_cfg, "head")

--- a/server/migrations/README.md
+++ b/server/migrations/README.md
@@ -11,7 +11,6 @@ First, make sure the database is in the existing, unmigrated state. Two options:
 - Check out the last commit, then run:
 
       make resetdb
-      pipenv run alembic stamp head
 
 - Restore from a database backup
 


### PR DESCRIPTION
Whenever we reset the database schema, we need to mark in the database
the version of the schema we're using in order for Alembic to be able to
tell where to start from when running migrations on the database. I'd
been doing this ad hoc whenever I encountered a db without a revision
stamp, but I realized that would be less likely to happen if we stamp
every time we reset (or create) a database.