### PR TITLE
scripts.create-admin: support existing audit admins

### DIFF
--- a/scripts/create-admin.py
+++ b/scripts/create-admin.py
@@ -10,13 +10,15 @@ if __name__ == "__main__":
         sys.exit(1)
 
     org_id, email = sys.argv[1:]  # pylint: disable=unbalanced-tuple-unpacking
-    u = User(id=str(uuid.uuid4()), email=email, external_id=email)
-    audit_admin = AuditAdministration(user_id=u.id, organization_id=org_id)
-    db_session.add(u)
+    user = User.query.filter_by(email=email).first()
+    if not user:
+        user = User(id=str(uuid.uuid4()), email=email, external_id=email)
+        db_session.add(user)
+    audit_admin = AuditAdministration(user_id=user.id, organization_id=org_id)
     db_session.add(audit_admin)
     db_session.commit()
 
-    print(u.id)
+    print(user.id)
     print("Now add the user to auth0: https://manage.auth0.com/")
     print("For staging users, user the arlo-aa-staging tenant.")
     print("For prod users, use the arlo-aa tenant.")


### PR DESCRIPTION
Sometimes we want users to be able to be audit admins for multiple orgs,
so we modify the create-admin script to find or create the user, then
make them an admin for the org.