### PR TITLE
Adding jurisdiction names to header for JA views

### DIFF
--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`App renders properly 1`] = `
     class="sc-cmTdod ftrAGQ"
   >
     <div
-      class="bp3-navbar sc-EHOje kGnsSl"
+      class="bp3-navbar sc-EHOje gMcVig"
     >
       <div
         class="sc-bxivhb sc-bZQynM ftKVqf"

--- a/client/src/components/Header.test.tsx
+++ b/client/src/components/Header.test.tsx
@@ -96,30 +96,6 @@ describe('Header', () => {
     })
   })
 
-  it('shows the jurisdictions when authenticated as ja on the home page', async () => {
-    apiMock.mockImplementation(async () => ({
-      type: 'jurisdiction_admin',
-      name: 'Joe',
-      email: 'test@email.org',
-      jurisdictions: [
-        {
-          id: 'jurisdiction-id-1',
-          name: 'Jurisdiction One',
-        },
-        {
-          id: 'jurisdiction-id-2',
-          name: 'Jurisdiction Two',
-        },
-      ],
-      organizations: [],
-    }))
-    renderHeader('/')
-
-    await screen.findByText('Jurisdictions: Jurisdiction One, Jurisdiction Two')
-    expect(apiMock).toHaveBeenCalledTimes(1)
-    expect(apiMock).toHaveBeenCalledWith('/me')
-  })
-
   it('shows the active jurisdiction name when authenticated as ja', async () => {
     apiMock.mockImplementation(async () => ({
       type: 'jurisdiction_admin',

--- a/client/src/components/Header.test.tsx
+++ b/client/src/components/Header.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { render, waitFor } from '@testing-library/react'
-import { BrowserRouter as Router } from 'react-router-dom'
+import { waitFor, screen } from '@testing-library/react'
 import Header from './Header'
 import * as utilities from './utilities'
 import AuthDataProvider from './UserContext'
+import { renderWithRouter } from './testUtilities'
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
@@ -14,15 +14,13 @@ const checkAndToastMock: jest.SpyInstance<
   Parameters<typeof utilities.checkAndToast>
 > = jest.spyOn(utilities, 'checkAndToast').mockReturnValue(false)
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
-  useRouteMatch: () => ({
-    url: '/election/1',
-    params: {
-      electionId: '1',
-    },
-  }),
-}))
+const renderHeader = (route: string) =>
+  renderWithRouter(
+    <AuthDataProvider>
+      <Header />
+    </AuthDataProvider>,
+    { route }
+  )
 
 checkAndToastMock.mockReturnValue(false)
 
@@ -32,12 +30,10 @@ afterEach(() => {
 })
 
 describe('Header', () => {
-  it('renders correctly', () => {
-    const { container } = render(
-      <Router>
-        <Header />
-      </Router>
-    )
+  it('renders correctly', async () => {
+    apiMock.mockRejectedValue(async () => ({}))
+    const { container } = renderHeader('/election/1')
+    await screen.findAllByAltText('Arlo, by VotingWorks')
     expect(container).toMatchSnapshot()
   })
 
@@ -49,30 +45,18 @@ describe('Header', () => {
       jurisdictions: [],
       organizations: [],
     }))
-    const { findByText } = render(
-      <Router>
-        <AuthDataProvider>
-          <Header />
-        </AuthDataProvider>
-      </Router>
-    )
+    renderHeader('/election/1')
 
-    await findByText('Log out')
+    await screen.findByText('Log out')
     expect(apiMock).toHaveBeenCalledTimes(1)
     expect(apiMock).toHaveBeenCalledWith('/me')
   })
 
   it('does not show logout button if not authenticated', async () => {
     apiMock.mockRejectedValue(async () => ({}))
-    const { queryByText } = render(
-      <Router>
-        <AuthDataProvider>
-          <Header />
-        </AuthDataProvider>
-      </Router>
-    )
+    renderHeader('/election/1')
 
-    const loginButton = queryByText('Log out')
+    const loginButton = screen.queryByText('Log out')
     await waitFor(() => {
       expect(apiMock).toHaveBeenCalledTimes(1)
       expect(apiMock).toHaveBeenCalledWith('/me')
@@ -83,15 +67,9 @@ describe('Header', () => {
   it('does not show logout button if the authentication verification has a server error', async () => {
     checkAndToastMock.mockReturnValue(true)
     apiMock.mockRejectedValue(async () => ({}))
-    const { queryByText } = render(
-      <Router>
-        <AuthDataProvider>
-          <Header />
-        </AuthDataProvider>
-      </Router>
-    )
+    renderHeader('/election/1')
 
-    const loginButton = queryByText('Log out')
+    const loginButton = screen.queryByText('Log out')
     await waitFor(() => {
       expect(apiMock).toHaveBeenCalledTimes(1)
       expect(apiMock).toHaveBeenCalledWith('/me')
@@ -108,19 +86,61 @@ describe('Header', () => {
       jurisdictions: [],
       organizations: [],
     }))
-    const { container, getByText } = render(
-      <Router>
-        <AuthDataProvider>
-          <Header />
-        </AuthDataProvider>
-      </Router>
-    )
+    const { container } = renderHeader('/election/1')
     await waitFor(() => {
-      expect(getByText('Audit Setup')).toBeTruthy()
-      expect(getByText('Audit Progress')).toBeTruthy()
-      expect(getByText('View Audits')).toBeTruthy()
-      expect(getByText('New Audit')).toBeTruthy()
+      expect(screen.getByText('Audit Setup')).toBeTruthy()
+      expect(screen.getByText('Audit Progress')).toBeTruthy()
+      expect(screen.getByText('View Audits')).toBeTruthy()
+      expect(screen.getByText('New Audit')).toBeTruthy()
       expect(container).toMatchSnapshot()
     })
+  })
+
+  it('shows the jurisdictions when authenticated as ja on the home page', async () => {
+    apiMock.mockImplementation(async () => ({
+      type: 'jurisdiction_admin',
+      name: 'Joe',
+      email: 'test@email.org',
+      jurisdictions: [
+        {
+          id: 'jurisdiction-id-1',
+          name: 'Jurisdiction One',
+        },
+        {
+          id: 'jurisdiction-id-2',
+          name: 'Jurisdiction Two',
+        },
+      ],
+      organizations: [],
+    }))
+    renderHeader('/')
+
+    await screen.findByText('Jurisdictions: Jurisdiction One, Jurisdiction Two')
+    expect(apiMock).toHaveBeenCalledTimes(1)
+    expect(apiMock).toHaveBeenCalledWith('/me')
+  })
+
+  it('shows the active jurisdiction name when authenticated as ja', async () => {
+    apiMock.mockImplementation(async () => ({
+      type: 'jurisdiction_admin',
+      name: 'Joe',
+      email: 'test@email.org',
+      jurisdictions: [
+        {
+          id: 'jurisdiction-id-1',
+          name: 'Jurisdiction One',
+        },
+        {
+          id: 'jurisdiction-id-2',
+          name: 'Jurisdiction Two',
+        },
+      ],
+      organizations: [],
+    }))
+    renderHeader('/election/1/jurisdiction/jurisdiction-id-1')
+
+    await screen.findByText('Jurisdiction: Jurisdiction One')
+    expect(apiMock).toHaveBeenCalledTimes(1)
+    expect(apiMock).toHaveBeenCalledWith('/me')
   })
 })

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -23,7 +23,7 @@ const Nav = styled(Navbar)`
 
   .bp3-navbar-heading img {
     height: 35px;
-    padding-top: 8px;
+    padding-top: 5px;
   }
 
   .bp3-navbar-divider {
@@ -55,6 +55,11 @@ const Header: React.FC<{}> = () => {
               <img src="/arlo.png" alt="Arlo, by VotingWorks" />
             </Link>
           </NavbarHeading>
+          {isAuthenticated && meta!.type === 'jurisdiction_admin' && (
+            <NavbarHeading>
+              Jurisdictions: {meta!.jurisdictions.map(j => j.name).join(', ')}
+            </NavbarHeading>
+          )}
         </NavbarGroup>
         <NavbarGroup align={Alignment.RIGHT}>
           {isAuthenticated && electionId && meta!.type === 'audit_admin' && (

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -60,14 +60,11 @@ const Header: React.FC<{}> = () => {
           </NavbarHeading>
           {isAuthenticated && meta!.type === 'jurisdiction_admin' && (
             <NavbarHeading>
-              {jurisdictionId
-                ? `Jurisdiction: ${
-                    meta!.jurisdictions.filter(j => j.id === jurisdictionId)[0]
-                      .name
-                  }`
-                : `Jurisdictions: ${meta!.jurisdictions
-                    .map(j => j.name)
-                    .join(', ')}`}
+              {jurisdictionId &&
+                `Jurisdiction: ${
+                  meta!.jurisdictions.filter(j => j.id === jurisdictionId)[0]
+                    .name
+                }`}
             </NavbarHeading>
           )}
         </NavbarGroup>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -38,13 +38,16 @@ const InnerBar = styled(Inner)`
 
 interface TParams {
   electionId: string
+  jurisdiction?: string
+  jurisdictionId?: string
 }
 
 const Header: React.FC<{}> = () => {
   const match: RouteComponentProps<TParams>['match'] | null = useRouteMatch(
-    '/election/:electionId'
+    '/election/:electionId/:jurisdiction?/:jurisdictionId?'
   )
   const electionId = match ? match.params.electionId : undefined
+  const jurisdictionId = match ? match.params.jurisdictionId : undefined
   const { isAuthenticated, meta } = useAuthDataContext()
   return (
     <Nav>
@@ -57,7 +60,14 @@ const Header: React.FC<{}> = () => {
           </NavbarHeading>
           {isAuthenticated && meta!.type === 'jurisdiction_admin' && (
             <NavbarHeading>
-              Jurisdictions: {meta!.jurisdictions.map(j => j.name).join(', ')}
+              {jurisdictionId
+                ? `Jurisdiction: ${
+                    meta!.jurisdictions.filter(j => j.id === jurisdictionId)[0]
+                      .name
+                  }`
+                : `Jurisdictions: ${meta!.jurisdictions
+                    .map(j => j.name)
+                    .join(', ')}`}
             </NavbarHeading>
           )}
         </NavbarGroup>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -38,17 +38,26 @@ const InnerBar = styled(Inner)`
 
 interface TParams {
   electionId: string
-  jurisdiction?: string
   jurisdictionId?: string
 }
 
 const Header: React.FC<{}> = () => {
-  const match: RouteComponentProps<TParams>['match'] | null = useRouteMatch(
-    '/election/:electionId/:jurisdiction?/:jurisdictionId?'
+  const electionMatch:
+    | RouteComponentProps<TParams>['match']
+    | null = useRouteMatch('/election/:electionId')
+  const jurisdictionMatch:
+    | RouteComponentProps<TParams>['match']
+    | null = useRouteMatch(
+    '/election/:electionId/jurisdiction/:jurisdictionId?'
   )
-  const electionId = match ? match.params.electionId : undefined
-  const jurisdictionId = match ? match.params.jurisdictionId : undefined
   const { isAuthenticated, meta } = useAuthDataContext()
+  const electionId = electionMatch ? electionMatch.params.electionId : undefined
+  const jurisdiction =
+    jurisdictionMatch && meta
+      ? meta.jurisdictions.find(
+          j => j.id === jurisdictionMatch.params.jurisdictionId
+        )
+      : undefined
   return (
     <Nav>
       <InnerBar>
@@ -60,11 +69,7 @@ const Header: React.FC<{}> = () => {
           </NavbarHeading>
           {isAuthenticated && meta!.type === 'jurisdiction_admin' && (
             <NavbarHeading>
-              {jurisdictionId &&
-                `Jurisdiction: ${
-                  meta!.jurisdictions.filter(j => j.id === jurisdictionId)[0]
-                    .name
-                }`}
+              {jurisdiction && `Jurisdiction: ${jurisdiction.name}`}
             </NavbarHeading>
           )}
         </NavbarGroup>

--- a/client/src/components/__snapshots__/Header.test.tsx.snap
+++ b/client/src/components/__snapshots__/Header.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Header renders correctly 1`] = `
 <div>
   <div
-    class="bp3-navbar sc-EHOje kGnsSl"
+    class="bp3-navbar sc-EHOje gMcVig"
   >
     <div
       class="sc-bxivhb sc-bZQynM ftKVqf"
@@ -40,7 +40,7 @@ exports[`Header renders correctly 1`] = `
 exports[`Header shows the nav bar when authenticated and there is an electionId 1`] = `
 <div>
   <div
-    class="bp3-navbar sc-EHOje kGnsSl"
+    class="bp3-navbar sc-EHOje gMcVig"
   >
     <div
       class="sc-bxivhb sc-bZQynM ftKVqf"


### PR DESCRIPTION
**Description**

Closes #693 

@mcchilders It looks like we currently support multiple jurisdictions under the same login, so I made it so that it will display all the jurisdiction names associated with the current login.

**Testing**

- Updated snapshots

**Progress**

- LGTM
- I think this part of the code might be covered in my wip coverage PR, so instead of redoing it all over here, I'd rather merge this then update that PR to reflect this relatively simple change.
