### PR TITLE
Batch offline data entry

### DIFF
--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`App renders properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-cmTdod ftrAGQ"
+    class="sc-btzYZH dFjlDG"
   >
     <div
       class="bp3-navbar sc-EHOje gMcVig"

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.tsx
@@ -31,6 +31,7 @@ interface IProps {
   nextStage: ISidebarMenuItem
   prevStage: ISidebarMenuItem
   locked: boolean
+  isBatch?: boolean
 }
 
 const Contests: React.FC<IProps> = ({
@@ -38,6 +39,7 @@ const Contests: React.FC<IProps> = ({
   nextStage,
   prevStage,
   locked,
+  isBatch,
 }) => {
   const contestValues: IContest[] = [
     {
@@ -255,17 +257,19 @@ const Contests: React.FC<IProps> = ({
                       </Card>
                     )
                   })}
-                  <FormButtonBar>
-                    <FormButton
-                      type="button"
-                      onClick={() =>
-                        contestsArrayHelpers.push({ ...contestValues[0] })
-                      }
-                    >
-                      Add another {isTargeted ? 'targeted' : 'opportunistic'}{' '}
-                      contest
-                    </FormButton>
-                  </FormButtonBar>
+                  {!isBatch && ( // TODO support multiple contests in batch comparison audits
+                    <FormButtonBar>
+                      <FormButton
+                        type="button"
+                        onClick={() =>
+                          contestsArrayHelpers.push({ ...contestValues[0] })
+                        }
+                      >
+                        Add another {isTargeted ? 'targeted' : 'opportunistic'}{' '}
+                        contest
+                      </FormButton>
+                    </FormButtonBar>
+                  )}
                 </>
               )}
             />

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.tsx
@@ -71,6 +71,7 @@ const Contests: React.FC<IProps> = ({
   if (!contests) return null // Still loading
   const filteredContests = contests.filter(c => c.isTargeted === isTargeted)
 
+  /* istanbul ignore next */
   if (isBatch && !isTargeted && nextStage.activate) nextStage.activate() // skip to next stage if on opportunistic contests screen and during a batch audit (until batch audits support multiple contests)
 
   const submit = async (values: { contests: IContest[] }) => {

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.tsx
@@ -71,6 +71,8 @@ const Contests: React.FC<IProps> = ({
   if (!contests) return null // Still loading
   const filteredContests = contests.filter(c => c.isTargeted === isTargeted)
 
+  if (isBatch && !isTargeted && nextStage.activate) nextStage.activate() // skip to next stage if on opportunistic contests screen and during a batch audit (until batch audits support multiple contests)
+
   const submit = async (values: { contests: IContest[] }) => {
     const response = await updateContests(values.contests)
     // TEST TODO

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
@@ -1012,6 +1012,280 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
 </div>
 `;
 
+exports[`Audit Setup > Review & Launch renders full state with batch comparison 1`] = `
+<div>
+  <div>
+    <h2
+      class="bp3-heading sc-bdVaJa ibVpPq"
+    >
+      Review & Launch
+    </h2>
+    <div
+      class="bp3-callout bp3-intent-warning bp3-callout-icon"
+    >
+      <span
+        class="bp3-icon bp3-icon-warning-sign"
+        icon="warning-sign"
+      >
+        <svg
+          data-icon="warning-sign"
+          height="20"
+          viewBox="0 0 20 20"
+          width="20"
+        >
+          <desc>
+            warning-sign
+          </desc>
+          <path
+            d="M19.86 17.52l.01-.01-9-16-.01.01C10.69 1.21 10.37 1 10 1s-.69.21-.86.52l-.01-.01-9 16 .01.01c-.08.14-.14.3-.14.48 0 .55.45 1 1 1h18c.55 0 1-.45 1-1 0-.18-.06-.34-.14-.48zM11 17H9v-2h2v2zm0-3H9V6h2v8z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      Once the audit is started, the audit definition will no longer be editable. Please make sure this data is correct before launching the audit.
+    </div>
+    <br />
+    <h4
+      class="bp3-heading"
+    >
+      Audit Settings
+    </h4>
+    <div
+      class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
+    >
+      <table
+        class="sc-jKJlTe bkTFhC"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Election Name:
+            </td>
+            <td>
+              Election Name
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Audit Type:
+            </td>
+            <td>
+              Batch Comparison
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Risk Limit:
+            </td>
+            <td>
+              10
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Random Seed:
+            </td>
+            <td>
+              12345
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Participating Jurisdictions:
+            </td>
+            <td>
+              <a
+                href="/api/election/1/jurisdiction/file/csv"
+                rel="noopener noreferrer"
+                target="_blank"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Audit Board Data Entry:
+            </td>
+            <td>
+              Offline
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Target Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              Contest Name
+            </td>
+            <td>
+              Jurisdiction 1, Jurisdiction 2
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table
+        class="sc-ckVGcZ qPOwv"
+      >
+        <thead>
+          <tr>
+            <th>
+              Opportunistic Contests
+            </th>
+            <th>
+              Jurisdictions
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+    <br />
+    <h4
+      class="bp3-heading"
+    >
+      Sample Size
+    </h4>
+    <form
+      data-testid="sample-size-form"
+    >
+      <div
+        class="sc-gzVnrw coBAaV"
+      >
+        <div
+          class="sc-htoDjs GlcDy"
+        >
+          Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
+        </div>
+        <div
+          class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
+        >
+          <div
+            class="sc-htoDjs GlcDy"
+          >
+            <h4
+              class="bp3-heading"
+            >
+              Contest Name
+            </h4>
+            <div>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="asn"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                BRAVO Average Sample Number: 
+                46 samples
+                 (54% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.7"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                67 samples
+                 (70% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.5"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                88 samples
+                 (50% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.9"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                125 samples
+                 (90% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="custom"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Enter your own sample size (not recommended)
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-htpNat gtULUV"
+      >
+        <button
+          class="bp3-button sc-EHOje gmpgQN"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Back
+          </span>
+        </button>
+        <button
+          class="bp3-button bp3-intent-primary sc-EHOje gmpgQN"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Launch Audit
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+`;
+
 exports[`Audit Setup > Review & Launch renders full state with jurisdictions on opportunistic contest 1`] = `
 <div>
   <div>

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/_mocks.ts
@@ -38,6 +38,19 @@ export const settingsMock = {
     /* istanbul ignore next */
     async () => true,
   ],
+  batch: [
+    {
+      state: 'AL',
+      electionName: 'Election Name',
+      online: false,
+      randomSeed: '12345',
+      riskLimit: 10,
+      auditType: 'BATCH_COMPARISON',
+    },
+    // here for type completion but not used in this context
+    /* istanbul ignore next */
+    async () => true,
+  ],
 }
 
 export const sampleSizeMock = {

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
@@ -141,6 +141,23 @@ describe('Audit Setup > Review & Launch', () => {
     })
   })
 
+  it('renders full state with batch comparison', async () => {
+    auditSettingsMock.mockReturnValue(settingsMock.batch)
+    const expectedCalls = [
+      apiCalls.getJurisdictions({
+        jurisdictions: jurisdictionMocks.allManifests,
+      }),
+      apiCalls.getJurisdictionFile,
+      apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getSampleSizeOptions,
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderView()
+      await screen.findByText('Batch Comparison')
+      expect(container).toMatchSnapshot()
+    })
+  })
+
   it('renders full state with jurisdictions on opportunistic contest', async () => {
     auditSettingsMock.mockReturnValue(settingsMock.full)
     const expectedCalls = [

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Settings/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Settings/index.tsx
@@ -46,7 +46,7 @@ const Settings: React.FC<IProps> = ({
     randomSeed: randomSeed === null ? '' : randomSeed,
     riskLimit: riskLimit === null ? 10 : riskLimit,
     online:
-      auditType === 'BATCH_COMPARISON'
+      auditType === 'BATCH_COMPARISON' // batch comparison audits are always offline
         ? false
         : online === null
         ? true

--- a/client/src/components/MultiJurisdictionAudit/AASetup/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/index.tsx
@@ -19,9 +19,10 @@ interface IProps {
   stage: ElementType<typeof setupStages>
   menuItems: ISidebarMenuItem[]
   refresh: () => void
+  isBatch?: boolean
 }
 
-const AASetup: React.FC<IProps> = ({ stage, menuItems, refresh }) => {
+const AASetup: React.FC<IProps> = ({ stage, menuItems, refresh, isBatch }) => {
   const activeStage = menuItems.find(m => m.title === stage)
   const nextStage: ISidebarMenuItem | undefined =
     menuItems[menuItems.indexOf(activeStage!) + 1]
@@ -44,10 +45,11 @@ const AASetup: React.FC<IProps> = ({ stage, menuItems, refresh }) => {
           nextStage={nextStage!}
           prevStage={prevStage!}
           locked={activeStage!.state === 'locked'}
+          isBatch={isBatch}
         />
       )
     case 'Opportunistic Contests':
-      return (
+      return isBatch ? null : ( // TODO support multiple contests in batch comparison audits
         <Contests
           isTargeted={false}
           key="opportunistic"

--- a/client/src/components/MultiJurisdictionAudit/AASetup/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/index.tsx
@@ -19,7 +19,7 @@ interface IProps {
   stage: ElementType<typeof setupStages>
   menuItems: ISidebarMenuItem[]
   refresh: () => void
-  isBatch?: boolean
+  isBatch?: boolean // TODO support multiple contests in batch comparison audits
 }
 
 const AASetup: React.FC<IProps> = ({ stage, menuItems, refresh, isBatch }) => {
@@ -49,13 +49,14 @@ const AASetup: React.FC<IProps> = ({ stage, menuItems, refresh, isBatch }) => {
         />
       )
     case 'Opportunistic Contests':
-      return isBatch ? null : ( // TODO support multiple contests in batch comparison audits
+      return (
         <Contests
           isTargeted={false}
           key="opportunistic"
           nextStage={nextStage!}
           prevStage={prevStage!}
           locked={activeStage!.state === 'locked'}
+          isBatch={isBatch}
         />
       )
     case 'Audit Settings':

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import { screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useParams } from 'react-router-dom'
+import BatchRoundDataEntry from './BatchRoundDataEntry'
+import { roundMocks, contestMocks } from '../useSetupMenuItems/_mocks'
+import { batchesMocks, batchResultsMocks, INullResultValues } from './_mocks'
+import { renderWithRouter, withMockFetch } from '../../testUtilities'
+import { IContest } from '../../../types'
+import { IBatch } from './useBatchResults'
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
+  useRouteMatch: jest.fn(),
+  useParams: jest.fn(),
+}))
+const paramsMock = useParams as jest.Mock
+paramsMock.mockReturnValue({
+  electionId: '1',
+  jurisdictionId: '1',
+})
+
+const apiCalls = {
+  getJAContests: (response: { contests: IContest[] }) => ({
+    url: `/api/election/1/jurisdiction/1/contest`,
+    response,
+  }),
+  getBatches: (response: { batches: IBatch[] }) => ({
+    url: '/api/election/1/jurisdiction/1/round/round-1/batches',
+    response,
+  }),
+  putResults: (results: INullResultValues) => ({
+    url: '/api/election/1/jurisdiction/1/round/round-1/batches/results',
+    options: {
+      method: 'PUT',
+      body: JSON.stringify(results),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+    response: { status: 'ok' },
+  }),
+}
+
+describe('offline round data entry', () => {
+  it('renders', async () => {
+    const expectedCalls = [
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getBatches(batchesMocks.emptyInitial),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderWithRouter(
+        <BatchRoundDataEntry round={roundMocks.singleIncomplete[0]} />,
+        {
+          route: '/election/1/jurisdiction/1',
+        }
+      )
+      await screen.findByText('Round 1 Data Entry')
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  it('submits', async () => {
+    const expectedCalls = [
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getBatches(batchesMocks.emptyInitial),
+      apiCalls.putResults(batchResultsMocks.complete),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderWithRouter(
+        <BatchRoundDataEntry round={roundMocks.singleIncomplete[0]} />,
+        {
+          route: '/election/1/jurisdiction/1',
+        }
+      )
+      await screen.findByText('Round 1 Data Entry')
+      ;[0, 1, 2].forEach(batch => {
+        fireEvent.change(
+          screen.getAllByLabelText('Votes for Choice One:')[batch],
+          {
+            target: { value: '1' },
+          }
+        )
+        fireEvent.change(
+          screen.getAllByLabelText('Votes for Choice Two:')[batch],
+          {
+            target: { value: '2' },
+          }
+        )
+      })
+      userEvent.click(screen.getByText('Submit Data for Round 1'))
+      await screen.findByText('Already Submitted Data for Round 1')
+      expect(container).toMatchSnapshot()
+    })
+  })
+})

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.test.tsx
@@ -60,6 +60,23 @@ describe('offline round data entry', () => {
     })
   })
 
+  it('renders after submission', async () => {
+    const expectedCalls = [
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getBatches(batchesMocks.complete),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderWithRouter(
+        <BatchRoundDataEntry round={roundMocks.singleIncomplete[0]} />,
+        {
+          route: '/election/1/jurisdiction/1',
+        }
+      )
+      await screen.findByText('Round 1 Data Entry')
+      expect(container).toMatchSnapshot()
+    })
+  })
+
   it('submits', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.test.tsx
@@ -29,6 +29,10 @@ const apiCalls = {
     url: '/api/election/1/jurisdiction/1/round/round-1/batches',
     response,
   }),
+  getResults: (response: INullResultValues) => ({
+    url: '/api/election/1/jurisdiction/1/round/round-1/batches/results',
+    response,
+  }),
   putResults: (results: INullResultValues) => ({
     url: '/api/election/1/jurisdiction/1/round/round-1/batches/results',
     options: {
@@ -47,6 +51,7 @@ describe('offline round data entry', () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
       apiCalls.getBatches(batchesMocks.emptyInitial),
+      apiCalls.getResults(batchResultsMocks.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
@@ -64,6 +69,7 @@ describe('offline round data entry', () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
       apiCalls.getBatches(batchesMocks.complete),
+      apiCalls.getResults(batchResultsMocks.complete),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
@@ -81,6 +87,7 @@ describe('offline round data entry', () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
       apiCalls.getBatches(batchesMocks.emptyInitial),
+      apiCalls.getResults(batchResultsMocks.empty),
       apiCalls.putResults(batchResultsMocks.complete),
     ]
     await withMockFetch(expectedCalls, async () => {

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.tsx
@@ -10,7 +10,7 @@ import Card from '../../Atoms/SpacedCard'
 import FormField from '../../Atoms/Form/FormField'
 import FormButton from '../../Atoms/Form/FormButton'
 import { testNumber } from '../../utilities'
-import useResults, { IResultValues } from './useResults'
+import useBatchResults, { IResultValues } from './useBatchResults'
 
 const BottomButton = styled(FormButton)`
   margin: 30px 0;
@@ -29,19 +29,22 @@ interface IValues {
   results: IResultValues
 }
 
-const RoundDataEntry = ({ round }: IProps) => {
+const BatchRoundDataEntry = ({ round }: IProps) => {
   const { electionId, jurisdictionId } = useParams<{
     electionId: string
     jurisdictionId: string
   }>()
-  const contests = useContestsJurisdictionAdmin(electionId, jurisdictionId)
-  const [results, updateResults] = useResults(
+  const allContests = useContestsJurisdictionAdmin(electionId, jurisdictionId)
+  const [results, batches, updateResults] = useBatchResults(
     electionId,
     jurisdictionId,
     round.id
   )
 
-  if (!results || !contests) return null
+  if (!results || !allContests || !batches) return null
+
+  // batch comparison audits only support a single contest for now
+  const contest = allContests.filter(c => c.isTargeted)[0]
 
   const alreadySubmittedResults = Object.values(results).some(a =>
     Object.values(a).some(b => b)
@@ -61,21 +64,21 @@ const RoundDataEntry = ({ round }: IProps) => {
             number of votes recorded for each candidate/choice from the audited
             ballots.
           </p>
-          {contests.map(contest => (
-            <Card key={contest.id}>
-              <H5>{contest.name}</H5>
+          {batches.map(batch => (
+            <Card key={batch.id}>
+              <H5>{`Batch: ${batch.name}, Contest: ${contest.name}`}</H5>
               {contest.choices.map(choice => (
                 <BlockLabel
                   key={choice.id}
-                  htmlFor={`results[${contest.id}][${choice.id}]`}
+                  htmlFor={`results[${batch.id}][${choice.id}]`}
                 >
                   Votes for {choice.name}:
                   {alreadySubmittedResults ? (
-                    results[contest.id][choice.id]
+                    results[batch.id][choice.id]
                   ) : (
                     <Field
-                      id={`results[${contest.id}][${choice.id}]`}
-                      name={`results[${contest.id}][${choice.id}]`}
+                      id={`results[${batch.id}][${choice.id}]`}
+                      name={`results[${batch.id}][${choice.id}]`}
                       disabled={alreadySubmittedResults}
                       validate={testNumber()}
                       component={FormField}
@@ -101,4 +104,4 @@ const RoundDataEntry = ({ round }: IProps) => {
   )
 }
 
-export default RoundDataEntry
+export default BatchRoundDataEntry

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.tsx
@@ -44,7 +44,7 @@ const BatchRoundDataEntry = ({ round }: IProps) => {
   if (!results || !allContests || !batches) return null
 
   // batch comparison audits only support a single contest for now
-  const contest = allContests.filter(c => c.isTargeted)[0]
+  const contest = allContests[0]
 
   const alreadySubmittedResults = Object.values(results).some(a =>
     Object.values(a).some(b => b)

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/BatchRoundDataEntry.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/BatchRoundDataEntry.test.tsx.snap
@@ -1,0 +1,303 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`offline round data entry renders 1`] = `
+<div>
+  <form>
+    <h2
+      class="bp3-heading sc-bdVaJa ibVpPq"
+    >
+      Round 
+      1
+       Data Entry
+    </h2>
+    <p>
+      When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
+    </p>
+    <div
+      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+    >
+      <h5
+        class="bp3-heading"
+      >
+        Batch: Batch One, Contest: Contest 1
+      </h5>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-1][choice-id-1]"
+      >
+        Votes for 
+        Choice One
+        :
+        <div
+          class="sc-htpNat gdpVCF"
+        >
+          <div
+            class="bp3-input-group sc-bxivhb eSUmfF"
+          >
+            <input
+              class="bp3-input"
+              id="results[batch-1][choice-id-1]"
+              name="results[batch-1][choice-id-1]"
+              style="padding-right: 10px;"
+              value=""
+            />
+          </div>
+        </div>
+      </label>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-1][choice-id-2]"
+      >
+        Votes for 
+        Choice Two
+        :
+        <div
+          class="sc-htpNat gdpVCF"
+        >
+          <div
+            class="bp3-input-group sc-bxivhb eSUmfF"
+          >
+            <input
+              class="bp3-input"
+              id="results[batch-1][choice-id-2]"
+              name="results[batch-1][choice-id-2]"
+              style="padding-right: 10px;"
+              value=""
+            />
+          </div>
+        </div>
+      </label>
+    </div>
+    <div
+      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+    >
+      <h5
+        class="bp3-heading"
+      >
+        Batch: Batch Two, Contest: Contest 1
+      </h5>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-2][choice-id-1]"
+      >
+        Votes for 
+        Choice One
+        :
+        <div
+          class="sc-htpNat gdpVCF"
+        >
+          <div
+            class="bp3-input-group sc-bxivhb eSUmfF"
+          >
+            <input
+              class="bp3-input"
+              id="results[batch-2][choice-id-1]"
+              name="results[batch-2][choice-id-1]"
+              style="padding-right: 10px;"
+              value=""
+            />
+          </div>
+        </div>
+      </label>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-2][choice-id-2]"
+      >
+        Votes for 
+        Choice Two
+        :
+        <div
+          class="sc-htpNat gdpVCF"
+        >
+          <div
+            class="bp3-input-group sc-bxivhb eSUmfF"
+          >
+            <input
+              class="bp3-input"
+              id="results[batch-2][choice-id-2]"
+              name="results[batch-2][choice-id-2]"
+              style="padding-right: 10px;"
+              value=""
+            />
+          </div>
+        </div>
+      </label>
+    </div>
+    <div
+      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+    >
+      <h5
+        class="bp3-heading"
+      >
+        Batch: Batch Three, Contest: Contest 1
+      </h5>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-3][choice-id-1]"
+      >
+        Votes for 
+        Choice One
+        :
+        <div
+          class="sc-htpNat gdpVCF"
+        >
+          <div
+            class="bp3-input-group sc-bxivhb eSUmfF"
+          >
+            <input
+              class="bp3-input"
+              id="results[batch-3][choice-id-1]"
+              name="results[batch-3][choice-id-1]"
+              style="padding-right: 10px;"
+              value=""
+            />
+          </div>
+        </div>
+      </label>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-3][choice-id-2]"
+      >
+        Votes for 
+        Choice Two
+        :
+        <div
+          class="sc-htpNat gdpVCF"
+        >
+          <div
+            class="bp3-input-group sc-bxivhb eSUmfF"
+          >
+            <input
+              class="bp3-input"
+              id="results[batch-3][choice-id-2]"
+              name="results[batch-3][choice-id-2]"
+              style="padding-right: 10px;"
+              value=""
+            />
+          </div>
+        </div>
+      </label>
+    </div>
+    <button
+      class="bp3-button bp3-intent-primary sc-dnqmqq bytmcb sc-htoDjs dESvso"
+      type="submit"
+    >
+      <span
+        class="bp3-button-text"
+      >
+        Submit Data for Round 1
+      </span>
+    </button>
+  </form>
+</div>
+`;
+
+exports[`offline round data entry submits 1`] = `
+<div>
+  <form>
+    <h2
+      class="bp3-heading sc-bdVaJa ibVpPq"
+    >
+      Round 
+      1
+       Data Entry
+    </h2>
+    <p>
+      When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
+    </p>
+    <div
+      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+    >
+      <h5
+        class="bp3-heading"
+      >
+        Batch: Batch One, Contest: Contest 1
+      </h5>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-1][choice-id-1]"
+      >
+        Votes for 
+        Choice One
+        :
+        1
+      </label>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-1][choice-id-2]"
+      >
+        Votes for 
+        Choice Two
+        :
+        2
+      </label>
+    </div>
+    <div
+      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+    >
+      <h5
+        class="bp3-heading"
+      >
+        Batch: Batch Two, Contest: Contest 1
+      </h5>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-2][choice-id-1]"
+      >
+        Votes for 
+        Choice One
+        :
+        1
+      </label>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-2][choice-id-2]"
+      >
+        Votes for 
+        Choice Two
+        :
+        2
+      </label>
+    </div>
+    <div
+      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+    >
+      <h5
+        class="bp3-heading"
+      >
+        Batch: Batch Three, Contest: Contest 1
+      </h5>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-3][choice-id-1]"
+      >
+        Votes for 
+        Choice One
+        :
+        1
+      </label>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-3][choice-id-2]"
+      >
+        Votes for 
+        Choice Two
+        :
+        2
+      </label>
+    </div>
+    <button
+      class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq bytmcb sc-htoDjs dESvso"
+      disabled=""
+      tabindex="-1"
+      type="submit"
+    >
+      <span
+        class="bp3-button-text"
+      >
+        Already Submitted Data for Round 1
+      </span>
+    </button>
+  </form>
+</div>
+`;

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/BatchRoundDataEntry.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/BatchRoundDataEntry.test.tsx.snap
@@ -192,6 +192,116 @@ exports[`offline round data entry renders 1`] = `
 </div>
 `;
 
+exports[`offline round data entry renders after submission 1`] = `
+<div>
+  <form>
+    <h2
+      class="bp3-heading sc-bdVaJa ibVpPq"
+    >
+      Round 
+      1
+       Data Entry
+    </h2>
+    <p>
+      When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
+    </p>
+    <div
+      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+    >
+      <h5
+        class="bp3-heading"
+      >
+        Batch: Batch One, Contest: Contest 1
+      </h5>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-1][choice-id-1]"
+      >
+        Votes for 
+        Choice One
+        :
+        1
+      </label>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-1][choice-id-2]"
+      >
+        Votes for 
+        Choice Two
+        :
+        2
+      </label>
+    </div>
+    <div
+      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+    >
+      <h5
+        class="bp3-heading"
+      >
+        Batch: Batch Two, Contest: Contest 1
+      </h5>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-2][choice-id-1]"
+      >
+        Votes for 
+        Choice One
+        :
+        1
+      </label>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-2][choice-id-2]"
+      >
+        Votes for 
+        Choice Two
+        :
+        2
+      </label>
+    </div>
+    <div
+      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+    >
+      <h5
+        class="bp3-heading"
+      >
+        Batch: Batch Three, Contest: Contest 1
+      </h5>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-3][choice-id-1]"
+      >
+        Votes for 
+        Choice One
+        :
+        1
+      </label>
+      <label
+        class="sc-iwsKbI gesrUq"
+        for="results[batch-3][choice-id-2]"
+      >
+        Votes for 
+        Choice Two
+        :
+        2
+      </label>
+    </div>
+    <button
+      class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq bytmcb sc-htoDjs dESvso"
+      disabled=""
+      tabindex="-1"
+      type="submit"
+    >
+      <span
+        class="bp3-button-text"
+      >
+        Already Submitted Data for Round 1
+      </span>
+    </button>
+  </form>
+</div>
+`;
+
 exports[`offline round data entry submits 1`] = `
 <div>
   <form>

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
@@ -32,8 +32,22 @@ export const resultsMocks: {
 }
 
 export const batchResultsMocks: {
-  [key in 'complete']: INullResultValues
+  [key in 'empty' | 'complete']: INullResultValues
 } = {
+  empty: {
+    'batch-1': {
+      'choice-id-1': null,
+      'choice-id-2': null,
+    },
+    'batch-2': {
+      'choice-id-1': null,
+      'choice-id-2': null,
+    },
+    'batch-3': {
+      'choice-id-1': null,
+      'choice-id-2': null,
+    },
+  },
   complete: {
     'batch-1': {
       'choice-id-1': 1,
@@ -60,21 +74,18 @@ export const batchesMocks: {
         name: 'Batch One',
         numBallots: 100,
         auditBoard: null,
-        results: null,
       },
       {
         id: 'batch-2',
         name: 'Batch Two',
         numBallots: 100,
         auditBoard: null,
-        results: null,
       },
       {
         id: 'batch-3',
         name: 'Batch Three',
         numBallots: 100,
         auditBoard: null,
-        results: null,
       },
     ],
   },
@@ -88,10 +99,6 @@ export const batchesMocks: {
           id: 'ab-1',
           name: 'Audit Board One',
         },
-        results: {
-          'choice-id-1': 1,
-          'choice-id-2': 2,
-        },
       },
       {
         id: 'batch-2',
@@ -101,10 +108,6 @@ export const batchesMocks: {
           id: 'ab-1',
           name: 'Audit Board One',
         },
-        results: {
-          'choice-id-1': 1,
-          'choice-id-2': 2,
-        },
       },
       {
         id: 'batch-3',
@@ -113,10 +116,6 @@ export const batchesMocks: {
         auditBoard: {
           id: 'ab-1',
           name: 'Audit Board One',
-        },
-        results: {
-          'choice-id-1': 1,
-          'choice-id-2': 2,
         },
       },
     ],

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
@@ -84,22 +84,40 @@ export const batchesMocks: {
         id: 'batch-1',
         name: 'Batch One',
         numBallots: 100,
-        auditBoard: null,
-        results: null,
+        auditBoard: {
+          id: 'ab-1',
+          name: 'Audit Board One',
+        },
+        results: {
+          'choice-id-1': 1,
+          'choice-id-2': 2,
+        },
       },
       {
         id: 'batch-2',
         name: 'Batch Two',
         numBallots: 100,
-        auditBoard: null,
-        results: null,
+        auditBoard: {
+          id: 'ab-1',
+          name: 'Audit Board One',
+        },
+        results: {
+          'choice-id-1': 1,
+          'choice-id-2': 2,
+        },
       },
       {
         id: 'batch-3',
         name: 'Batch Three',
         numBallots: 100,
-        auditBoard: null,
-        results: null,
+        auditBoard: {
+          id: 'ab-1',
+          name: 'Audit Board One',
+        },
+        results: {
+          'choice-id-1': 1,
+          'choice-id-2': 2,
+        },
       },
     ],
   },

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
@@ -1,3 +1,5 @@
+import { IBatch } from './useBatchResults'
+
 export interface INullResultValues {
   [contestId: string]: {
     [choiceId: string]: null | string | number
@@ -26,6 +28,80 @@ export const resultsMocks: {
       'choice-id-3': 1,
       'choice-id-4': 2,
     },
+  },
+}
+
+export const batchResultsMocks: {
+  [key in 'complete']: INullResultValues
+} = {
+  complete: {
+    'batch-1': {
+      'choice-id-1': 1,
+      'choice-id-2': 2,
+    },
+    'batch-2': {
+      'choice-id-1': 1,
+      'choice-id-2': 2,
+    },
+    'batch-3': {
+      'choice-id-1': 1,
+      'choice-id-2': 2,
+    },
+  },
+}
+
+export const batchesMocks: {
+  [key in 'emptyInitial' | 'complete']: { batches: IBatch[] }
+} = {
+  emptyInitial: {
+    batches: [
+      {
+        id: 'batch-1',
+        name: 'Batch One',
+        numBallots: 100,
+        auditBoard: null,
+        results: null,
+      },
+      {
+        id: 'batch-2',
+        name: 'Batch Two',
+        numBallots: 100,
+        auditBoard: null,
+        results: null,
+      },
+      {
+        id: 'batch-3',
+        name: 'Batch Three',
+        numBallots: 100,
+        auditBoard: null,
+        results: null,
+      },
+    ],
+  },
+  complete: {
+    batches: [
+      {
+        id: 'batch-1',
+        name: 'Batch One',
+        numBallots: 100,
+        auditBoard: null,
+        results: null,
+      },
+      {
+        id: 'batch-2',
+        name: 'Batch Two',
+        numBallots: 100,
+        auditBoard: null,
+        results: null,
+      },
+      {
+        id: 'batch-3',
+        name: 'Batch Three',
+        numBallots: 100,
+        auditBoard: null,
+        results: null,
+      },
+    ],
   },
 }
 

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
@@ -19,6 +19,7 @@ import { IAuditBoard } from '../useAuditBoards'
 import QRs from './QRs'
 import RoundDataEntry from './RoundDataEntry'
 import useAuditSettingsJurisdictionAdmin from './useAuditSettingsJurisdictionAdmin'
+import BatchRoundDataEntry from './BatchRoundDataEntry'
 
 const PaddedWrapper = styled(Wrapper)`
   padding: 30px 0;
@@ -61,7 +62,7 @@ const RoundManagement = ({ round, auditBoards, createAuditBoards }: IProps) => {
     auditBoards,
   ])
 
-  const { online } = useAuditSettingsJurisdictionAdmin(
+  const { online, auditType } = useAuditSettingsJurisdictionAdmin(
     electionId,
     jurisdictionId
   )
@@ -88,11 +89,15 @@ const RoundManagement = ({ round, auditBoards, createAuditBoards }: IProps) => {
               verticalSpaced
               onClick={() =>
                 apiDownload(
-                  `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${round.id}/ballots/retrieval-list`
+                  `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${
+                    round.id
+                  }/${
+                    auditType === 'BALLOT_POLLING' ? 'ballots' : 'batches'
+                  }/retrieval-list`
                 )
               }
             >
-              Download Aggregated Ballot Retrival List for Round {roundNum}
+              Download Aggregated Ballot Retrieval List for Round {roundNum}
             </FormButton>
             <FormButton
               verticalSpaced
@@ -117,6 +122,8 @@ const RoundManagement = ({ round, auditBoards, createAuditBoards }: IProps) => {
                 <QRs passphrases={auditBoards.map(b => b.passphrase)} />
                 <RoundProgress auditBoards={auditBoards} round={round} />
               </>
+            ) : auditType === 'BATCH_COMPARISON' ? (
+              <BatchRoundDataEntry round={round} />
             ) : (
               <RoundDataEntry round={round} />
             )}

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
@@ -97,7 +97,9 @@ const RoundManagement = ({ round, auditBoards, createAuditBoards }: IProps) => {
                 )
               }
             >
-              Download Aggregated Ballot Retrieval List for Round {roundNum}
+              Download Aggregated{' '}
+              {auditType === 'BALLOT_POLLING' ? 'Ballot' : 'Batch'} Retrieval
+              List for Round {roundNum}
             </FormButton>
             <FormButton
               verticalSpaced

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
@@ -124,7 +124,7 @@ const RoundManagement = ({ round, auditBoards, createAuditBoards }: IProps) => {
                 <QRs passphrases={auditBoards.map(b => b.passphrase)} />
                 <RoundProgress auditBoards={auditBoards} round={round} />
               </>
-            ) : auditType === 'BATCH_COMPARISON' ? (
+            ) : auditType === 'BATCH_COMPARISON' ? ( // batch comparison audits are always offline
               <BatchRoundDataEntry round={round} />
             ) : (
               <RoundDataEntry round={round} />

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useBatchResults.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useBatchResults.ts
@@ -58,7 +58,7 @@ const getBatches = async (
         (a, batch) =>
           batch.results
             ? reformatResults({ ...a, [batch.id]: batch.results }, false)
-            : { ...a },
+            : { ...a, [batch.id]: {} },
         {}
       ),
     ]
@@ -82,6 +82,7 @@ const useBatchResults = (
   const [batches, setBatches] = useState<IBatch[] | null>(null)
 
   const updateResults = async (newResults: IResultValues): Promise<boolean> => {
+    /* istanbul ignore next */
     if (!results) return false
     try {
       await api(

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useBatchResults.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useBatchResults.ts
@@ -87,8 +87,6 @@ const useBatchResults = (
   const [batches, setBatches] = useState<IBatch[] | null>(null)
 
   const updateResults = async (newResults: IResultValues): Promise<boolean> => {
-    /* istanbul ignore next */
-    if (!results) return false
     try {
       await api(
         `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/batches/results`,

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useBatchResults.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useBatchResults.ts
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'react-toastify'
+import { api } from '../../utilities'
+
+export interface IResultValues {
+  [batchId: string]: {
+    [choiceId: string]: number | string
+  }
+}
+
+export interface IBatch {
+  id: string
+  name: string
+  numBallots: number
+  auditBoard: null | {
+    id: string
+    name: string
+  }
+  results: {
+    [choiceId: string]: number
+  } | null
+}
+
+const stringifyPossibleNull = (v: string | number | null) => (v ? `${v}` : '')
+
+const reformatResults = (r: IResultValues, numberify = true): IResultValues => {
+  return Object.keys(r).reduce(
+    (a, batchId) => ({
+      ...a,
+      [batchId]: Object.keys(r[batchId]).reduce(
+        (b, choiceId) => ({
+          ...b,
+          [choiceId]: numberify
+            ? Number(r[batchId][choiceId])
+            : stringifyPossibleNull(r[batchId][choiceId]),
+        }),
+        {}
+      ),
+    }),
+    {}
+  )
+}
+
+const numberifyResults = (r: IResultValues): IResultValues => reformatResults(r)
+
+const getBatches = async (
+  electionId: string,
+  jurisdictionId: string,
+  roundId: string
+): Promise<[IBatch[] | null, IResultValues | null]> => {
+  try {
+    const { batches }: { batches: IBatch[] } = await api(
+      `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/batches`
+    )
+    return [
+      batches,
+      batches.reduce(
+        (a, batch) =>
+          batch.results
+            ? reformatResults({ ...a, [batch.id]: batch.results }, false)
+            : { ...a },
+        {}
+      ),
+    ]
+  } catch (err) /* istanbul ignore next */ {
+    // TODO move toasting into api
+    toast.error(err.message)
+    return [null, null]
+  }
+}
+
+const useBatchResults = (
+  electionId: string,
+  jurisdictionId: string,
+  roundId: string
+): [
+  IResultValues | null,
+  IBatch[] | null,
+  (arg0: IResultValues) => Promise<boolean>
+] => {
+  const [results, setResults] = useState<IResultValues | null>(null)
+  const [batches, setBatches] = useState<IBatch[] | null>(null)
+
+  const updateResults = async (newResults: IResultValues): Promise<boolean> => {
+    if (!results) return false
+    try {
+      await api(
+        `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/batches/results`,
+        {
+          method: 'PUT',
+          // stringify and numberify the contests (all number values are handled as strings clientside, but are required as numbers serverside)
+          body: JSON.stringify(numberifyResults(newResults)),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+    } catch (err) /* istanbul ignore next */ {
+      // TODO move toasting into api
+      toast.error(err.message)
+      return false
+    }
+    setResults(newResults)
+    return true
+  }
+
+  useEffect(() => {
+    ;(async () => {
+      const [newBatches, newResults] = await getBatches(
+        electionId,
+        jurisdictionId,
+        roundId
+      )
+      setBatches(newBatches)
+      setResults(newResults)
+    })()
+  }, [electionId, jurisdictionId, roundId])
+  return [results, batches, updateResults]
+}
+
+export default useBatchResults

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useResults.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useResults.ts
@@ -55,8 +55,6 @@ const useResults = (
   const [results, setResults] = useState<IResultValues | null>(null)
 
   const updateResults = async (newResults: IResultValues): Promise<boolean> => {
-    /* istanbul ignore next */
-    if (!results) return false
     try {
       await api(
         `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results`,

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useResults.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useResults.ts
@@ -55,6 +55,7 @@ const useResults = (
   const [results, setResults] = useState<IResultValues | null>(null)
 
   const updateResults = async (newResults: IResultValues): Promise<boolean> => {
+    /* istanbul ignore next */
     if (!results) return false
     try {
       await api(

--- a/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
@@ -1534,7 +1534,7 @@ exports[`JA setup renders initial state 1`] = `
       </div>
     </div>
     <div
-      class="sc-bwzfXH sc-Rmtcm itcnIC"
+      class="sc-bwzfXH sc-hzDkRC kJxuMx"
     >
       <h2
         class="bp3-heading sc-htpNat fysvnw"
@@ -1702,7 +1702,7 @@ exports[`JA setup submits ballot manifest 1`] = `
       </div>
     </div>
     <div
-      class="sc-bwzfXH sc-Rmtcm itcnIC"
+      class="sc-bwzfXH sc-hzDkRC kJxuMx"
     >
       <h2
         class="bp3-heading sc-htpNat fysvnw"
@@ -1870,7 +1870,7 @@ exports[`JA setup submits batch tallies 1`] = `
       </div>
     </div>
     <div
-      class="sc-bwzfXH sc-Rmtcm itcnIC"
+      class="sc-bwzfXH sc-hzDkRC kJxuMx"
     >
       <h2
         class="bp3-heading sc-htpNat fysvnw"

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -54,6 +54,12 @@ export const AuditAdminView: React.FC = () => {
     refresh()
   }, [refresh])
 
+  // TODO support multiple contests in batch comparison audits
+  const isBatch = auditSettings.auditType === 'BATCH_COMPARISON'
+  const singleContestMenuItems = menuItems.filter(
+    i => i.title !== 'Opportunistic Contests'
+  )
+
   if (!contests || !rounds) return null // Still loading
 
   switch (view) {
@@ -67,8 +73,16 @@ export const AuditAdminView: React.FC = () => {
             auditSettings={auditSettings}
           />
           <Inner>
-            <Sidebar title="Audit Setup" menuItems={menuItems} />
-            <Setup stage={stage} refresh={refresh} menuItems={menuItems} />
+            <Sidebar
+              title="Audit Setup"
+              menuItems={isBatch ? singleContestMenuItems : menuItems}
+            />
+            <Setup
+              stage={stage}
+              refresh={refresh}
+              menuItems={menuItems}
+              isBatch={isBatch}
+            />
           </Inner>
         </Wrapper>
       )


### PR DESCRIPTION
**Description**

- Adding a new component and hook for batch data entry.

**Testing**

- Duplicated the tests from the regular data entry, and added a couple more to both to help with the coverage cause.

**Progress**

- This seems to work just fine with the first round, but the second round is displaying some really weird behavior. But I think that's from the backend.
- There's a react warning because the source of truth for the results (the batches endpoint) returns null instead of the expected structure of batch ids and choice ids with null values, which means the form is switching from uncontrolled to controlled components when we first interact with the fields. Ideally, the results object would contain the expected structure instead of null, and this would clean up the FE code quite a bit.

- Also noting that this doesn't support multiple contests, and this is not reflected during the AA setup process yet. We should add constraints there if it's a batch comparison audit to prevent unexpected surprises.
