### PR TITLE
Update batch results

### DIFF
--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -126,6 +126,7 @@ def validate_batch_results(
         Batch.query.filter_by(jurisdiction_id=jurisdiction.id)
         .join(SampledBatchDraw)
         .filter_by(round_id=round.id)
+        .filter(Batch.id.notin_(already_audited_batch_ids(jurisdiction, round)))
         .order_by(Batch.name)
         .all()
     )

--- a/server/tests/batch_comparison/conftest.py
+++ b/server/tests/batch_comparison/conftest.py
@@ -27,11 +27,11 @@ def contest_ids(client: FlaskClient, election_id: str, jurisdiction_ids: List[st
             "name": "Contest 1",
             "isTargeted": True,
             "choices": [
-                {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 600},
-                {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 400},
-                {"id": str(uuid.uuid4()), "name": "candidate 3", "numVotes": 500},
+                {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 5000},
+                {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 2500},
+                {"id": str(uuid.uuid4()), "name": "candidate 3", "numVotes": 2500},
             ],
-            "totalBallotsCast": 1500,
+            "totalBallotsCast": 5000,
             "numWinners": 1,
             "votesAllowed": 2,
             "jurisdictionIds": jurisdiction_ids[:2],
@@ -57,9 +57,15 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
             "manifest": (
                 io.BytesIO(
                     b"Batch Name,Number of Ballots\n"
-                    b"Batch 1,200\n"
-                    b"Batch 2,300\n"
-                    b"Batch 3,400\n"
+                    b"Batch 1,500\n"
+                    b"Batch 2,500\n"
+                    b"Batch 3,500\n"
+                    b"Batch 4,500\n"
+                    b"Batch 5,100\n"
+                    b"Batch 6,100\n"
+                    b"Batch 7,100\n"
+                    b"Batch 8,100\n"
+                    b"Batch 9,100\n"
                 ),
                 "manifest.csv",
             )
@@ -71,7 +77,13 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         data={
             "manifest": (
                 io.BytesIO(
-                    b"Batch Name,Number of Ballots\n" b"Batch 1,300\n" b"Batch 2,400\n"
+                    b"Batch Name,Number of Ballots\n"
+                    b"Batch 1,500\n"
+                    b"Batch 2,500\n"
+                    b"Batch 3,500\n"
+                    b"Batch 4,500\n"
+                    b"Batch 5,250\n"
+                    b"Batch 6,250\n"
                 ),
                 "manifest.csv",
             )
@@ -92,9 +104,15 @@ def batch_tallies(
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
     batch_tallies_file = (
         b"Batch Name,candidate 1,candidate 2,candidate 3\n"
-        b"Batch 1,1,10,100\n"
-        b"Batch 2,2,20,200\n"
-        b"Batch 3,3,30,300\n"
+        b"Batch 1,500,250,250\n"
+        b"Batch 2,500,250,250\n"
+        b"Batch 3,500,250,250\n"
+        b"Batch 4,500,250,250\n"
+        b"Batch 5,100,50,50\n"
+        b"Batch 6,100,50,50\n"
+        b"Batch 7,100,50,50\n"
+        b"Batch 8,100,50,50\n"
+        b"Batch 9,100,50,50\n"
     )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
@@ -102,8 +120,12 @@ def batch_tallies(
     )
     batch_tallies_file = (
         b"Batch Name,candidate 1,candidate 2,candidate 3\n"
-        b"Batch 1,1,10,100\n"
-        b"Batch 2,2,20,200\n"
+        b"Batch 1,500,250,250\n"
+        b"Batch 2,500,250,250\n"
+        b"Batch 3,500,250,250\n"
+        b"Batch 4,500,250,250\n"
+        b"Batch 5,100,50,50\n"
+        b"Batch 6,100,50,50\n"
     )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/batch-tallies",

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -8,13 +8,13 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots["test_batch_comparison_sample_size 1"] = [
-    {"key": "macro", "prob": None, "size": 18}
+    {"key": "macro", "prob": None, "size": 6}
 ]
 
 snapshots[
     "test_batch_comparison_sample_batches_round_2 1"
 ] = """Batch Name,Storage Location,Tabulator,Already Audited,Audit Board
-Batch 1,,,Yes,Audit Board #1
-Batch 3,,,Yes,Audit Board #1
-Batch 2,,,Yes,Audit Board #2
+Batch 2,,,No,Audit Board #1
+Batch 4,,,No,Audit Board #1
+Batch 3,,,Yes,Audit Board #2
 """

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -13,8 +13,7 @@ snapshots["test_batch_comparison_sample_size 1"] = [
 
 snapshots[
     "test_batch_comparison_sample_batches_round_2 1"
-] = """Batch Name,Storage Location,Tabulator,Already Audited,Audit Board
-Batch 2,,,No,Audit Board #1
-Batch 4,,,No,Audit Board #1
-Batch 3,,,Yes,Audit Board #2
+] = """Batch Name,Storage Location,Tabulator,Audit Board
+Batch 2,,,Audit Board #1
+Batch 4,,,Audit Board #1
 """

--- a/server/tests/batch_comparison/snapshots/snap_test_batches.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batches.py
@@ -11,12 +11,11 @@ snapshots[
     "test_batch_retrieval_list_round_1 1"
 ] = """Batch Name,Storage Location,Tabulator,Already Audited,Audit Board
 Batch 1,,,No,Audit Board #1
-Batch 3,,,No,Audit Board #1
-Batch 2,,,No,Audit Board #2
+Batch 3,,,No,Audit Board #2
 """
 
 snapshots["test_record_batch_results 1"] = {
-    "Contest 1 - candidate 1": 589,
-    "Contest 1 - candidate 2": 318,
-    "Contest 1 - candidate 3": 466,
+    "Contest 1 - candidate 1": 2400,
+    "Contest 1 - candidate 2": 300,
+    "Contest 1 - candidate 3": 240,
 }

--- a/server/tests/batch_comparison/snapshots/snap_test_batches.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batches.py
@@ -9,9 +9,9 @@ snapshots = Snapshot()
 
 snapshots[
     "test_batch_retrieval_list_round_1 1"
-] = """Batch Name,Storage Location,Tabulator,Already Audited,Audit Board
-Batch 1,,,No,Audit Board #1
-Batch 3,,,No,Audit Board #2
+] = """Batch Name,Storage Location,Tabulator,Audit Board
+Batch 1,,,Audit Board #1
+Batch 3,,,Audit Board #2
 """
 
 snapshots["test_record_batch_results 1"] = {

--- a/server/tests/batch_comparison/test_batches.py
+++ b/server/tests/batch_comparison/test_batches.py
@@ -90,10 +90,7 @@ def test_batch_retrieval_list_round_1(
     assert ".csv" in rv.headers["Content-Disposition"]
 
     retrieval_list = rv.data.decode("utf-8").replace("\r\n", "\n")
-    assert (
-        retrieval_list
-        == "Batch Name,Storage Location,Tabulator,Already Audited,Audit Board\n"
-    )
+    assert retrieval_list == "Batch Name,Storage Location,Tabulator,Audit Board\n"
 
     rv = post_json(
         client,


### PR DESCRIPTION
- Add a separate endpoint to get batch results
- When no results are recorded, return full results object (with choice
ids) instead of null
- Filter out batches that were sampled in previous rounds in batches and
results endpoints