### PR TITLE
Batch audit guards

### DIFF
--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -26,6 +26,7 @@ def process_batch_tallies_file(
     def process():
         # We only support one contest for batch audits, so we can just take the
         # first contest from the jurisdiction's universe.
+        assert len(jurisdiction.contests) == 1
         contest = jurisdiction.contests[0]
 
         columns = [CSVColumnType(BATCH_NAME, CSVValueType.TEXT, unique=True)] + [

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -135,7 +135,8 @@ def validate_batch_results(
     if set(batch_results.keys()) != {batch.id for batch in batches}:
         raise BadRequest("Invalid batch ids")
 
-    # For now, we only support one contest for batch audits
+    # We only support one contest for batch audits
+    assert len(list(jurisdiction.contests)) == 1
     contest = list(jurisdiction.contests)[0]
     contest_choice_ids = {choice.id for choice in contest.choices}
 

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -114,6 +114,12 @@ def validate_contests(contests: List[JSONDict], election: Election):
 
     validate(contests, {"type": "array", "items": CONTEST_SCHEMA})
 
+    if not any(contest["isTargeted"] for contest in contests):
+        raise BadRequest("Must have at least one targeted contest")
+
+    if election.audit_type == AuditType.BATCH_COMPARISON and len(contests) > 1:
+        raise BadRequest("Batch comparison audits may only have one contest.")
+
     for contest in contests:
         total_votes = sum(c["numVotes"] for c in contest["choices"])
         total_allowed_votes = contest["totalBallotsCast"] * contest["votesAllowed"]

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -321,7 +321,9 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
 
     round_id_to_num = {round.id: round.round_num for round in election.rounds}
 
-    contest = list(election.contests)[0]  # We only support one contest for batch audits
+    # We only support one contest for batch audits
+    assert len(list(election.contests)) == 1
+    contest = list(election.contests)[0]
     rows.append(
         [
             "Jurisdiction Name",

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -1,6 +1,6 @@
 import uuid
 from collections import defaultdict
-from typing import Optional, NamedTuple, List, Tuple, Dict
+from typing import Optional, NamedTuple, List, Tuple, Dict, cast as typing_cast
 from datetime import datetime
 from flask import jsonify, request
 from jsonschema import validate
@@ -122,13 +122,36 @@ def cumulative_contest_results(contest: Contest) -> Dict[str, int]:
 BatchTallies = Dict[Tuple[str, str], Dict[str, Dict[str, int]]]
 
 
-def batch_tallies(election: Election,) -> BatchTallies:
+def batch_tallies(election: Election) -> BatchTallies:
+    # We only support one contest for batch audits
+    contest = list(election.contests)[0]
+
+    # Validate the batch tallies files. We can't do this validation when they
+    # are uploaded because we need all of the jurisdictions' files.
+    total_votes_by_choice: Dict[str, int] = defaultdict(int)
+    for jurisdiction in contest.jurisdictions:
+        batch_tallies = typing_cast(BatchTallies, jurisdiction.batch_tallies)
+        if batch_tallies is None:
+            raise Conflict(
+                "Some jurisdictions haven't uploaded their batch tallies files yet."
+            )
+        for tally in batch_tallies.values():
+            for choice_id, votes in tally[contest.id].items():
+                total_votes_by_choice[choice_id] += votes
+
+    for choice in contest.choices:
+        if total_votes_by_choice[choice.id] > choice.num_votes:
+            raise Conflict(
+                f"Total votes in batch tallies files for contest choice {choice.name}"
+                f" ({total_votes_by_choice[choice.id]}) is greater than the"
+                f" reported number of votes for that choice ({choice.num_votes})."
+            )
+
     # Key each batch by jurisdiction name and batch name since batch names
     # are only guaranteed unique within a jurisdiction
     return {
         (jurisdiction.name, batch_name): tally
-        for jurisdiction in election.jurisdictions
-        if jurisdiction.batch_tallies
+        for jurisdiction in contest.jurisdictions
         for batch_name, tally in jurisdiction.batch_tallies.items()  # type: ignore
     }
 

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -124,6 +124,7 @@ BatchTallies = Dict[Tuple[str, str], Dict[str, Dict[str, int]]]
 
 def batch_tallies(election: Election) -> BatchTallies:
     # We only support one contest for batch audits
+    assert len(list(election.contests)) == 1
     contest = list(election.contests)[0]
 
     # Validate the batch tallies files. We can't do this validation when they
@@ -183,6 +184,7 @@ def cumulative_batch_results(election: Election) -> BatchTallies:
         key=lambda result: (result[0], result[1]),  # (jurisdiction_name, batch_name)
     )
     # We only support one contest for batch audits
+    assert len(list(election.contests)) == 1
     contest_id = list(election.contests)[0].id
     return {
         batch_key: {
@@ -453,7 +455,8 @@ def sample_batches(
     contests: List[Contest],
     sample_sizes: Dict[str, int],
 ):
-    # We currently only support one contest for batch audits
+    # We only support one contest for batch audits
+    assert len(contests) == 1
     contest = contests[0]
 
     num_previously_sampled = (

--- a/server/tests/api/test_contests.py
+++ b/server/tests/api/test_contests.py
@@ -222,7 +222,22 @@ def test_update_contests_after_audit_starts(
     }
 
 
-def test_contests_missing_field(
+def test_update_contests_no_targeted(
+    client: FlaskClient, election_id: str, json_contests: List[JSONDict]
+):
+    rv = put_json(client, f"/api/election/{election_id}/contest", [json_contests[1]])
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Bad Request",
+                "message": "Must have at least one targeted contest",
+            }
+        ]
+    }
+
+
+def test_update_contests_missing_field(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
     contest: JSONDict = {

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -1,9 +1,11 @@
+import io
 from typing import List
 from flask.testing import FlaskClient
 
 from ...models import *  # pylint: disable=wildcard-import
 from ..helpers import *  # pylint: disable=wildcard-import
 from ...util.group_by import group_by
+from ...bgcompute import bgcompute_update_batch_tallies_file
 
 
 def test_batch_comparison_sample_size(
@@ -21,6 +23,82 @@ def test_batch_comparison_sample_size(
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     assert len(sample_size_options) == 1
     snapshot.assert_match(sample_size_options[contest_id])
+
+
+def test_batch_comparison_without_all_batch_tallies(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+    contest_id: str,
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+):
+    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Conflict",
+                "message": "Some jurisdictions haven't uploaded their batch tallies files yet.",
+            }
+        ]
+    }
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {"roundNum": 1, "sampleSizes": {contest_id: 1}},
+    )
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Conflict",
+                "message": "Some jurisdictions haven't uploaded their batch tallies files yet.",
+            }
+        ]
+    }
+
+
+def test_batch_comparison_too_many_votes(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+    contest_id: str,
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    batch_tallies,  # pylint: disable=unused-argument
+):
+    batch_tallies_file = (
+        b"Batch Name,candidate 1,candidate 2,candidate 3\n"
+        b"Batch 1,1000,0,0\n"  # Too many votes for candidate 1
+        b"Batch 2,500,250,250\n"
+        b"Batch 3,500,250,250\n"
+        b"Batch 4,500,250,250\n"
+        b"Batch 5,100,50,50\n"
+        b"Batch 6,100,50,50\n"
+    )
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/batch-tallies",
+        data={"batchTallies": (io.BytesIO(batch_tallies_file), "batchTallies.csv",)},
+    )
+    assert_ok(rv)
+    bgcompute_update_batch_tallies_file()
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {"roundNum": 1, "sampleSizes": {contest_id: 1}},
+    )
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Conflict",
+                "message": "Total votes in batch tallies files for contest choice candidate 1 (5200) is greater than the reported number of votes for that choice (5000).",
+            }
+        ]
+    }
 
 
 def test_batch_comparison_round_1(


### PR DESCRIPTION
Task: #684 

- Validate batch tallies files
  - Check that all jurisdictions have uploaded a file before computing
sample sizes/starting a round
  - Check that the total tallies for each choice don't exceed the
reported vote count for that choice
- Only allow one contest