### PR TITLE
Add jurisdiction name to filenames

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/generateSheets.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/generateSheets.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`generateSheets downloadDataEntry generates data entry sheets 1`] = `
+exports[`generateSheets downloadAuditBoardCredentials generates audit board credentials sheets 1`] = `
 "%PDF-1.3
 %ºß¬à
 3 0 obj
@@ -2860,7 +2860,7 @@ startxref
 %%EOF"
 `;
 
-exports[`generateSheets downloadDataEntry generates data entry sheets with ballotless audit board 1`] = `
+exports[`generateSheets downloadAuditBoardCredentials generates audit board credentials sheets with ballotless audit board 1`] = `
 "%PDF-1.3
 %ºß¬à
 3 0 obj

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/generateSheets.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/generateSheets.ts
@@ -1,10 +1,11 @@
 import jsPDF from 'jspdf'
-import { IBallot } from '../../../types'
+import { IBallot, IJurisdictionMeta } from '../../../types'
 import { IAuditBoard } from '../useAuditBoards'
 
 export const downloadLabels = async (
   roundNum: number,
-  ballots: IBallot[]
+  ballots: IBallot[],
+  jurisdiction: IJurisdictionMeta
 ): Promise<string> => {
   /* istanbul ignore else */
   if (ballots.length) {
@@ -38,7 +39,9 @@ export const downloadLabels = async (
       labels.text(`Ballot Number: ${ballot.position}`, x, y[2])
     })
     labels.autoPrint()
-    labels.save(`Round ${roundNum} Labels.pdf`)
+    labels.save(
+      `Round ${roundNum} Labels - ${jurisdiction.name} - ${jurisdiction.election.auditName}.pdf`
+    )
     return labels.output() // returned for test snapshots
   }
   return ''
@@ -46,7 +49,8 @@ export const downloadLabels = async (
 
 export const downloadPlaceholders = async (
   roundNum: number,
-  ballots: IBallot[]
+  ballots: IBallot[],
+  jurisdiction: IJurisdictionMeta
 ): Promise<string> => {
   /* istanbul ignore else */
   if (ballots.length) {
@@ -69,13 +73,18 @@ export const downloadPlaceholders = async (
       pageCount += 1
     })
     placeholders.autoPrint()
-    placeholders.save(`Round ${roundNum} Placeholders.pdf`)
+    placeholders.save(
+      `Round ${roundNum} Placeholders - ${jurisdiction.name} - ${jurisdiction.election.auditName}.pdf`
+    )
     return placeholders.output() // returned for test snapshots
   }
   return ''
 }
 
-export const downloadDataEntry = (auditBoards: IAuditBoard[]): string => {
+export const downloadAuditBoardCredentials = (
+  auditBoards: IAuditBoard[],
+  jurisdiction: IJurisdictionMeta
+): string => {
   const auditBoardsWithoutBallots: string[] = []
   const auditBoardCreds = new jsPDF({ format: 'letter' })
   auditBoards.forEach((board, i) => {
@@ -125,6 +134,8 @@ export const downloadDataEntry = (auditBoards: IAuditBoard[]): string => {
     })
   }
   auditBoardCreds.autoPrint()
-  auditBoardCreds.save(`Audit Boards Credentials for Data Entry.pdf`)
+  auditBoardCreds.save(
+    `Audit Board Credentials - ${jurisdiction.name} - ${jurisdiction.election.auditName}.pdf`
+  )
   return auditBoardCreds.output() // returned for test snapshots
 }

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
@@ -17,12 +17,18 @@ import {
 } from '../useSetupMenuItems/_mocks'
 import { IAuditSettings, IContest } from '../../../types'
 import { IBatch } from './useBatchResults'
+import { jaApiCalls } from '../_mocks'
+import AuthDataProvider from '../../UserContext'
 
 const renderView = (props: IRoundManagementProps) =>
   renderWithRouter(
     <Route
       path="/election/:electionId/jurisdiction/:jurisdictionId"
-      render={routeProps => <RoundManagement {...routeProps} {...props} />}
+      render={routeProps => (
+        <AuthDataProvider>
+          <RoundManagement {...routeProps} {...props} />
+        </AuthDataProvider>
+      )}
     />,
     {
       route: '/election/1/jurisdiction/jurisdiction-id-1',
@@ -62,6 +68,7 @@ describe('RoundManagement', () => {
     const expectedCalls = [
       apiCalls.getBallots,
       apiCalls.getSettings(auditSettings.blank),
+      jaApiCalls.getUser,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView({
@@ -78,6 +85,7 @@ describe('RoundManagement', () => {
     const expectedCalls = [
       apiCalls.getBallots,
       apiCalls.getSettings(auditSettings.batchComparisonAll),
+      jaApiCalls.getUser,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView({
@@ -94,6 +102,7 @@ describe('RoundManagement', () => {
     const expectedCalls = [
       apiCalls.getBallots,
       apiCalls.getSettings(auditSettings.all),
+      jaApiCalls.getUser,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView({
@@ -110,6 +119,7 @@ describe('RoundManagement', () => {
     const expectedCalls = [
       apiCalls.getBallots,
       apiCalls.getSettings(auditSettings.all),
+      jaApiCalls.getUser,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView({
@@ -128,6 +138,7 @@ describe('RoundManagement', () => {
     const expectedCalls = [
       apiCalls.getBallots,
       apiCalls.getSettings(auditSettings.all),
+      jaApiCalls.getUser,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView({
@@ -146,6 +157,7 @@ describe('RoundManagement', () => {
     const expectedCalls = [
       apiCalls.getBallots,
       apiCalls.getSettings(auditSettings.offlineAll),
+      jaApiCalls.getUser,
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
       apiCalls.getResults(batchResultsMocks.empty),
     ]
@@ -166,6 +178,7 @@ describe('RoundManagement', () => {
     const expectedCalls = [
       apiCalls.getBallots,
       apiCalls.getSettings(auditSettings.batchComparisonAll),
+      jaApiCalls.getUser,
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
       apiCalls.getBatches(batchesMocks.emptyInitial),
       apiCalls.getBatchResults(batchResultsMocks.empty),

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
@@ -13,13 +13,14 @@ import FormButton from '../../Atoms/Form/FormButton'
 import {
   downloadPlaceholders,
   downloadLabels,
-  downloadDataEntry,
+  downloadAuditBoardCredentials,
 } from './generateSheets'
 import { IAuditBoard } from '../useAuditBoards'
 import QRs from './QRs'
 import RoundDataEntry from './RoundDataEntry'
 import useAuditSettingsJurisdictionAdmin from './useAuditSettingsJurisdictionAdmin'
 import BatchRoundDataEntry from './BatchRoundDataEntry'
+import { useAuthDataContext } from '../../UserContext'
 
 const PaddedWrapper = styled(Wrapper)`
   padding: 30px 0;
@@ -40,6 +41,7 @@ const RoundManagement = ({
     electionId: string
     jurisdictionId: string
   }>()
+  const { meta } = useAuthDataContext()
 
   const [ballots, setBallots] = useState<IBallot[] | null>(null)
   useEffect(() => {
@@ -64,12 +66,14 @@ const RoundManagement = ({
     jurisdictionId
   )
 
-  if (!ballots || online === null)
+  if (!meta || !ballots || online === null)
     return (
       <p>
         Loading... <Spinner size={Spinner.SIZE_SMALL} tagName="span" />
       </p>
     )
+
+  const jurisdiction = meta.jurisdictions.find(j => j.id === jurisdictionId)!
 
   if (!round.isAuditComplete) {
     const { roundNum } = round
@@ -109,7 +113,7 @@ const RoundManagement = ({
               verticalSpaced
               onClick={
                 /* istanbul ignore next */ // tested in generateSheets.test.tsx
-                () => downloadPlaceholders(roundNum, ballots)
+                () => downloadPlaceholders(roundNum, ballots, jurisdiction)
               }
             >
               Download Placeholder Sheets for Round {roundNum}
@@ -118,7 +122,7 @@ const RoundManagement = ({
               verticalSpaced
               onClick={
                 /* istanbul ignore next */ // tested in generateSheets.test.tsx
-                () => downloadLabels(roundNum, ballots)
+                () => downloadLabels(roundNum, ballots, jurisdiction)
               }
             >
               Download Ballot Labels for Round {roundNum}
@@ -129,7 +133,8 @@ const RoundManagement = ({
                   verticalSpaced
                   onClick={
                     /* istanbul ignore next */ // tested in generateSheets.test.tsx
-                    () => downloadDataEntry(auditBoards)
+                    () =>
+                      downloadAuditBoardCredentials(auditBoards, jurisdiction)
                   }
                 >
                   Download Audit Board Credentials for Data Entry

--- a/server/api/ballots.py
+++ b/server/api/ballots.py
@@ -9,7 +9,7 @@ from . import api
 from ..auth import with_jurisdiction_access, with_audit_board_access
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
-from ..util.csv_download import csv_response, election_timestamp_name
+from ..util.csv_download import csv_response, jurisdiction_timestamp_name
 from ..util.jsonschema import JSONDict, validate
 
 
@@ -95,7 +95,7 @@ def get_retrieval_list(election: Election, jurisdiction: Jurisdiction, round_id:
     retrieval_list_csv = ballot_retrieval_list(jurisdiction, round)
     return csv_response(
         retrieval_list_csv,
-        filename=f"ballot-retrieval-{election_timestamp_name(election)}.csv",
+        filename=f"ballot-retrieval-{jurisdiction_timestamp_name(election, jurisdiction)}.csv",
     )
 
 

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -8,7 +8,7 @@ from ..auth import with_jurisdiction_access
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from .rounds import is_round_complete, end_round, get_current_round
-from ..util.csv_download import csv_response, election_timestamp_name
+from ..util.csv_download import csv_response, jurisdiction_timestamp_name
 from ..util.jsonschema import JSONDict, validate
 from ..util.group_by import group_by
 
@@ -55,7 +55,7 @@ def get_batch_retrieval_list(
 
     return csv_response(
         csv_io.getvalue(),
-        filename=f"batch-retrieval-{election_timestamp_name(election)}.csv",
+        filename=f"batch-retrieval-{jurisdiction_timestamp_name(election, jurisdiction)}.csv",
     )
 
 

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -4,7 +4,11 @@ from typing import Dict, List, Optional
 from . import api
 from ..models import *  # pylint: disable=wildcard-import
 from ..auth import with_election_access, with_jurisdiction_access
-from ..util.csv_download import csv_response, election_timestamp_name
+from ..util.csv_download import (
+    csv_response,
+    election_timestamp_name,
+    jurisdiction_timestamp_name,
+)
 from ..util.isoformat import isoformat
 from ..util.group_by import group_by
 
@@ -391,5 +395,5 @@ def jursdiction_admin_audit_report(election: Election, jurisdiction: Jurisdictio
 
     return csv_response(
         csv_io.getvalue(),
-        filename=f"audit-report-{election_timestamp_name(election)}.csv",
+        filename=f"audit-report-{jurisdiction_timestamp_name(election, jurisdiction)}.csv",
     )

--- a/server/tests/api/test_ballots.py
+++ b/server/tests/api/test_ballots.py
@@ -2,19 +2,7 @@ from typing import List
 import json
 from flask.testing import FlaskClient
 
-from ..helpers import (
-    set_logged_in_user,
-    DEFAULT_JA_EMAIL,
-    assert_is_id,
-    compare_json,
-    put_json,
-    assert_ok,
-    J1_BALLOTS_ROUND_1,
-    J1_BALLOTS_ROUND_2,
-    AB1_BALLOTS_ROUND_1,
-    AB2_BALLOTS_ROUND_1,
-    AB1_BALLOTS_ROUND_2,
-)
+from ..helpers import *  # pylint: disable=wildcard-import
 from ...auth import UserType
 from ...models import *  # pylint: disable=wildcard-import
 from ...util.jsonschema import JSONDict
@@ -779,8 +767,10 @@ def test_ja_ballot_retrieval_list_round_1(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/ballots/retrieval-list"
     )
     assert rv.status_code == 200
-    assert "attachment; filename=" in rv.headers["Content-Disposition"]
-    assert ".csv" in rv.headers["Content-Disposition"]
+    assert (
+        scrub_datetime(rv.headers["Content-Disposition"])
+        == 'attachment; filename="ballot-retrieval-J1-Test-Audit-test-ja-ballot-retrieval-list-round-1-DATETIME.csv"'
+    )
 
     retrieval_list = rv.data.decode("utf-8").replace("\r\n", "\n")
     assert len(retrieval_list.splitlines()) == J1_BALLOTS_ROUND_1 + 1
@@ -800,7 +790,10 @@ def test_ja_ballot_retrieval_list_round_2(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/ballots/retrieval-list"
     )
     assert rv.status_code == 200
-    assert "attachment; filename=" in rv.headers["Content-Disposition"]
+    assert (
+        scrub_datetime(rv.headers["Content-Disposition"])
+        == 'attachment; filename="ballot-retrieval-J1-Test-Audit-test-ja-ballot-retrieval-list-round-2-DATETIME.csv"'
+    )
 
     retrieval_list = rv.data.decode("utf-8").replace("\r\n", "\n")
     assert len(retrieval_list.splitlines()) == J1_BALLOTS_ROUND_2 + 1

--- a/server/tests/api/test_reports.py
+++ b/server/tests/api/test_reports.py
@@ -2,12 +2,10 @@ from typing import List
 from flask.testing import FlaskClient
 from .test_audit_boards import set_up_audit_board
 from ...models import *  # pylint: disable=wildcard-import
-from ..helpers import set_logged_in_user, DEFAULT_JA_EMAIL, assert_match_report
+from ..helpers import *  # pylint: disable=wildcard-import
 from ...auth import UserType
 
 
-# TODO This is just a basic snapshot test. We still need to implement more
-# comprehensive testing.
 def test_audit_admin_report(
     client: FlaskClient,
     election_id: str,
@@ -27,6 +25,10 @@ def test_audit_admin_report(
             audit_board_id,
         )
     rv = client.get(f"/api/election/{election_id}/report")
+    assert (
+        scrub_datetime(rv.headers["Content-Disposition"])
+        == 'attachment; filename="audit-report-Test-Audit-test-audit-admin-report-DATETIME.csv"'
+    )
     assert_match_report(rv.data, snapshot)
 
 
@@ -51,5 +53,9 @@ def test_jurisdiction_admin_report(
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/report"
+    )
+    assert (
+        scrub_datetime(rv.headers["Content-Disposition"])
+        == 'attachment; filename="audit-report-J1-Test-Audit-test-jurisdiction-admin-report-DATETIME.csv"'
     )
     assert_match_report(rv.data, snapshot)

--- a/server/tests/batch_comparison/test_batches.py
+++ b/server/tests/batch_comparison/test_batches.py
@@ -86,8 +86,10 @@ def test_batch_retrieval_list_round_1(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches/retrieval-list"
     )
     assert rv.status_code == 200
-    assert "attachment; filename=" in rv.headers["Content-Disposition"]
-    assert ".csv" in rv.headers["Content-Disposition"]
+    assert (
+        scrub_datetime(rv.headers["Content-Disposition"])
+        == 'attachment; filename="batch-retrieval-J1-Test-Audit-test-batch-retrieval-list-round-1-DATETIME.csv"'
+    )
 
     retrieval_list = rv.data.decode("utf-8").replace("\r\n", "\n")
     assert retrieval_list == "Batch Name,Storage Location,Tabulator,Audit Board\n"

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -204,13 +204,16 @@ def run_audit_round(round_id: str, contest_id: str, vote_ratio: float):
     db_session.commit()
 
 
-DATETIME_REGEX = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}")
+DATETIME_REGEX = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}.\d{6})?")
+
+
+def scrub_datetime(string: str) -> str:
+    return re.sub(DATETIME_REGEX, "DATETIME", string)
 
 
 def assert_match_report(report_bytes: bytes, snapshot):
     report = report_bytes.decode("utf-8")
-    report = re.sub(DATETIME_REGEX, "DATETIME", report)
-    snapshot.assert_match(report)
+    snapshot.assert_match(scrub_datetime(report))
 
 
 def assert_is_id(value):

--- a/server/util/csv_download.py
+++ b/server/util/csv_download.py
@@ -4,11 +4,20 @@ from flask import Response
 
 from ..models import *  # pylint: disable=wildcard-import
 
+clean_name_re = re.compile(r"[^a-zA-Z0-9]+")
+
 
 def election_timestamp_name(election: Election) -> str:
-    clean_election_name = re.sub(r"[^a-zA-Z0-9]+", r"-", str(election.election_name))
+    election_name = re.sub(clean_name_re, "-", str(election.audit_name))
     now = datetime.utcnow().isoformat(timespec="minutes")
-    return f"{clean_election_name}-{now}"
+    return f"{election_name}-{now}"
+
+
+def jurisdiction_timestamp_name(election: Election, jurisdiction: Jurisdiction) -> str:
+    election_name = re.sub(clean_name_re, "-", str(election.audit_name))
+    jurisdiction_name = re.sub(clean_name_re, "-", str(jurisdiction.name))
+    now = datetime.utcnow().isoformat(timespec="minutes")
+    return f"{jurisdiction_name}-{election_name}-{now}"
 
 
 def csv_response(csv_text: str, filename: str) -> Response:


### PR DESCRIPTION
Task: #692 
- Backend: add jurisdiction name to retrieval list/audit report filename (also switched election name to audit name)
- Frontend: add jurisdiction name and audit name to labels/placeholders/audit board creds filenames