### PR TITLE
Log exceptions in bgcompute

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -221,7 +221,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=Base.metadata,db_session.(commit|add|rollback|delete|merge|execute)
+generated-members=Base.metadata,db_session.(commit|add|rollback|delete|merge|execute),app.logger.(info|warning|error|critical|debug|exception)
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/server/bgcompute.py
+++ b/server/bgcompute.py
@@ -1,6 +1,7 @@
 import time
 from sqlalchemy import update
 
+from server.app import app
 from server.database import db_session
 from server.models import *  # pylint: disable=wildcard-import
 from server.api.routes import compute_sample_sizes
@@ -29,7 +30,7 @@ def bgcompute_compute_round_contests_sample_sizes():
 
     for round_contest in round_contests:
         try:
-            print(
+            app.logger.info(
                 "computing sample size options for round {:d} of election ID {:s}".format(
                     round_contest.round.round_num, round_contest.round.election_id
                 )
@@ -52,7 +53,7 @@ def bgcompute_compute_round_contests_sample_sizes():
 
             compute_sample_sizes(round_contest)
 
-            print(
+            app.logger.info(
                 "done computing sample size options for round {:d} of election ID {:s}: {:s}".format(
                     round_contest.round.round_num,
                     round_contest.round.election_id,
@@ -60,7 +61,9 @@ def bgcompute_compute_round_contests_sample_sizes():
                 )
             )
         except Exception:
-            print("ERROR while computing sample size options, continuing to next one.")
+            app.logger.exception(
+                "ERROR while computing sample size options, continuing to next one."
+            )
 
 
 def bgcompute_update_election_jurisdictions_file() -> int:
@@ -73,11 +76,24 @@ def bgcompute_update_election_jurisdictions_file() -> int:
     for file in files:
         try:
             election = Election.query.filter_by(jurisdictions_file_id=file.id).one()
-            print(f"updating jurisdictions file for election ID {election.id}")
+
+            # Save election_id in a variable so we can log it even if some
+            # error happens and the election object is borked
+            election_id = election.id
+
+            app.logger.info(
+                f"START updating jurisdictions file. election_id: {election_id}"
+            )
+
             process_jurisdictions_file(db_session, election, file)
-            print(f"done updating jurisdictions file for election ID {election.id}")
+
+            app.logger.info(
+                f"DONE updating jurisdictions file. election_id: {election_id}"
+            )
         except Exception:
-            print("ERROR while updating jurisdictions file")
+            app.logger.exception(
+                f"ERROR updating jurisdictions file. election_id: {election_id}"
+            )
 
     return len(files)
 
@@ -92,9 +108,25 @@ def bgcompute_update_ballot_manifest_file() -> int:
     for file in files:
         try:
             jurisdiction = Jurisdiction.query.filter_by(manifest_file_id=file.id).one()
+
+            # Save ids in variables so we can log them even if some
+            # error happens and the ORM objects are borked
+            election_id = jurisdiction.election_id
+            jurisdiction_id = jurisdiction.id
+
+            app.logger.info(
+                f"START updating ballot manifest file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
+            )
+
             process_ballot_manifest_file(db_session, jurisdiction, file)
+
+            app.logger.info(
+                f"DONE updating ballot manifest file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
+            )
         except Exception:
-            print("ERROR updating ballot manifest file")
+            app.logger.exception(
+                f"ERROR updating ballot manifest file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
+            )
 
     return len(files)
 
@@ -111,9 +143,25 @@ def bgcompute_update_batch_tallies_file() -> int:
             jurisdiction = Jurisdiction.query.filter_by(
                 batch_tallies_file_id=file.id
             ).one()
+
+            # Save ids in variables so we can log them even if some
+            # error happens and the ORM objects are borked
+            election_id = jurisdiction.election_id
+            jurisdiction_id = jurisdiction.id
+
+            app.logger.info(
+                f"START updating batch tallies file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
+            )
+
             process_batch_tallies_file(db_session, jurisdiction, file)
+
+            app.logger.info(
+                f"DONE updating batch tallies file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
+            )
         except Exception:
-            print("ERROR updating batch tallies file")
+            app.logger.exception(
+                f"ERROR updating batch tallies file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
+            )
 
     return len(files)
 

--- a/server/tests/test_errors.py
+++ b/server/tests/test_errors.py
@@ -1,6 +1,7 @@
 import io
 import json
 import logging
+from typing import Optional
 from flask.testing import FlaskClient
 
 from ..app import app
@@ -38,6 +39,17 @@ def test_internal_error_500(client: FlaskClient):
     )
 
 
+def find_log(caplog, level: int, message: str) -> Optional[logging.LogRecord]:
+    return next(
+        (
+            record
+            for record in caplog.records
+            if record.levelno == level and record.message == message
+        ),
+        None,
+    )
+
+
 def test_bgcompute_jurisdictions_file_errors(
     client: FlaskClient, election_id: str, caplog, monkeypatch
 ):
@@ -52,23 +64,27 @@ def test_bgcompute_jurisdictions_file_errors(
     )
     assert_ok(rv)
 
-    def raise_exception():
-        raise Exception("mock error")
+    mock_exception = Exception("mock error")
+
+    def raise_exception(*args):
+        raise mock_exception
 
     monkeypatch.setattr(bgcompute, "process_jurisdictions_file", raise_exception)
 
     bgcompute_update_election_jurisdictions_file()
 
-    assert (
-        "server.app",
+    assert find_log(
+        caplog,
         logging.INFO,
         f"START updating jurisdictions file. election_id: {election_id}",
-    ) in caplog.record_tuples
-    assert (
-        "server.app",
+    )
+    err_log = find_log(
+        caplog,
         logging.ERROR,
         f"ERROR updating jurisdictions file. election_id: {election_id}",
-    ) in caplog.record_tuples
+    )
+    assert err_log
+    assert err_log.exc_info[1] == mock_exception  # type: ignore
 
 
 def test_bgcompute_ballot_manifest_errors(
@@ -90,23 +106,27 @@ def test_bgcompute_ballot_manifest_errors(
     )
     assert_ok(rv)
 
-    def raise_exception():
-        raise Exception("mock error")
+    mock_exception = Exception("mock error")
+
+    def raise_exception(*args):
+        raise mock_exception
 
     monkeypatch.setattr(bgcompute, "process_ballot_manifest_file", raise_exception)
 
     bgcompute_update_ballot_manifest_file()
 
-    assert (
-        "server.app",
+    assert find_log(
+        caplog,
         logging.INFO,
         f"START updating ballot manifest file. election_id: {election_id}, jurisdiction_id: {jurisdiction_ids[0]}",
-    ) in caplog.record_tuples
-    assert (
-        "server.app",
+    )
+    err_log = find_log(
+        caplog,
         logging.ERROR,
         f"ERROR updating ballot manifest file. election_id: {election_id}, jurisdiction_id: {jurisdiction_ids[0]}",
-    ) in caplog.record_tuples
+    )
+    assert err_log
+    assert err_log.exc_info[1] == mock_exception  # type: ignore
 
 
 def test_bgcompute_batch_tallies_errors(
@@ -136,20 +156,24 @@ def test_bgcompute_batch_tallies_errors(
     )
     assert_ok(rv)
 
-    def raise_exception():
-        raise Exception("mock error")
+    mock_exception = Exception("mock error")
+
+    def raise_exception(*args):
+        raise mock_exception
 
     monkeypatch.setattr(bgcompute, "process_batch_tallies_file", raise_exception)
 
     bgcompute_update_batch_tallies_file()
 
-    assert (
-        "server.app",
+    assert find_log(
+        caplog,
         logging.INFO,
         f"START updating batch tallies file. election_id: {election_id}, jurisdiction_id: {jurisdiction_ids[0]}",
-    ) in caplog.record_tuples
-    assert (
-        "server.app",
+    )
+    err_log = find_log(
+        caplog,
         logging.ERROR,
         f"ERROR updating batch tallies file. election_id: {election_id}, jurisdiction_id: {jurisdiction_ids[0]}",
-    ) in caplog.record_tuples
+    )
+    assert err_log
+    assert err_log.exc_info[1] == mock_exception  # type: ignore

--- a/server/tests/test_errors.py
+++ b/server/tests/test_errors.py
@@ -1,7 +1,16 @@
+import io
 import json
+import threading
+import logging
 from flask.testing import FlaskClient
 
 from ..app import app
+from ..bgcompute import (
+    bgcompute_update_election_jurisdictions_file,
+    bgcompute_update_ballot_manifest_file,
+    bgcompute_update_batch_tallies_file,
+)
+from .helpers import *  # pylint: disable=wildcard-import
 
 
 def test_uncaught_exception_500(client: FlaskClient):
@@ -27,3 +36,166 @@ def test_internal_error_500(client: FlaskClient):
         rv.data
         == b'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n<title>500 Internal Server Error</title>\n<h1>Internal Server Error</h1>\n<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.</p>\n'
     )
+
+
+def test_bgcompute_jurisdictions_file_errors(
+    client: FlaskClient, election_id: str, caplog
+):
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/file",
+        data={
+            "jurisdictions": (
+                io.BytesIO(
+                    (
+                        "Jurisdiction,Admin Email\n"
+                        + "\n".join(f"J{i},ja{i}@example.com" for i in range(100))
+                    ).encode()
+                ),
+                "jurisdictions.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+
+    # We'll delete the election out from under bgcompute to cause it to error
+    def delete_election():
+        election = Election.query.get(election_id)
+        db_session.delete(election)
+        db_session.commit()
+
+    thread1 = threading.Thread(target=bgcompute_update_election_jurisdictions_file)
+    thread2 = threading.Thread(target=delete_election)
+
+    thread1.start()
+    thread2.start()
+    thread1.join()
+    thread2.join()
+
+    assert (
+        "server.app",
+        logging.INFO,
+        f"START updating jurisdictions file. election_id: {election_id}",
+    ) in caplog.record_tuples
+    assert (
+        "server.app",
+        logging.ERROR,
+        f"ERROR updating jurisdictions file. election_id: {election_id}",
+    ) in caplog.record_tuples
+
+
+def test_bgcompute_ballot_manifest_errors(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str], caplog
+):
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, user_key=DEFAULT_JA_EMAIL)
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
+        data={
+            "manifest": (
+                io.BytesIO(
+                    (
+                        "Batch Name,Number of Ballots\n"
+                        + "\n".join(f"B{i},{i}" for i in range(100))
+                    ).encode()
+                ),
+                "manifest.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+
+    # We'll delete the election out from under bgcompute to cause it to error
+    def delete_election():
+        election = Election.query.get(election_id)
+        db_session.delete(election)
+        db_session.commit()
+
+    thread1 = threading.Thread(target=bgcompute_update_ballot_manifest_file)
+    thread2 = threading.Thread(target=delete_election)
+
+    thread1.start()
+    thread2.start()
+    thread1.join()
+    thread2.join()
+
+    assert (
+        "server.app",
+        logging.INFO,
+        f"START updating ballot manifest file. election_id: {election_id}, jurisdiction_id: {jurisdiction_ids[0]}",
+    ) in caplog.record_tuples
+    assert (
+        "server.app",
+        logging.ERROR,
+        f"ERROR updating ballot manifest file. election_id: {election_id}, jurisdiction_id: {jurisdiction_ids[0]}",
+    ) in caplog.record_tuples
+
+
+def test_bgcompute_batch_tallies_errors(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_ids: List[str],
+    caplog,
+):
+    election = Election.query.get(election_id)
+    election.audit_type = AuditType.BATCH_COMPARISON
+    contest_2 = Contest.query.get(contest_ids[1])
+    db_session.delete(contest_2)
+    db_session.commit()
+
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, user_key=DEFAULT_JA_EMAIL)
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
+        data={
+            "manifest": (
+                io.BytesIO(
+                    (
+                        "Batch Name,Number of Ballots\n"
+                        + "\n".join(f"B{i},{i}" for i in range(100))
+                    ).encode()
+                ),
+                "manifest.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+    bgcompute_update_ballot_manifest_file()
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
+        data={
+            "batchTallies": (
+                io.BytesIO(
+                    (
+                        "Batch Name,candidate 1,candidate 2\n"
+                        + "\n".join(f"B{i},0,0" for i in range(100))
+                    ).encode()
+                ),
+                "batchTallies.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+
+    # We'll delete the jurisdiction out from under bgcompute to cause it to error
+    def delete_jurisdiction():
+        jurisdiction = Jurisdiction.query.get(jurisdiction_ids[0])
+        db_session.delete(jurisdiction)
+        db_session.commit()
+
+    thread1 = threading.Thread(target=bgcompute_update_batch_tallies_file)
+    thread2 = threading.Thread(target=delete_jurisdiction)
+
+    thread1.start()
+    thread2.start()
+    thread1.join()
+    thread2.join()
+
+    assert (
+        "server.app",
+        logging.INFO,
+        f"START updating batch tallies file. election_id: {election_id}, jurisdiction_id: {jurisdiction_ids[0]}",
+    ) in caplog.record_tuples
+    assert (
+        "server.app",
+        logging.ERROR,
+        f"ERROR updating batch tallies file. election_id: {election_id}, jurisdiction_id: {jurisdiction_ids[0]}",
+    ) in caplog.record_tuples


### PR DESCRIPTION
Task: #708 

Use the Flask application logger to log info and exceptions in
bgcompute.

Open question: where else could we benefit from beefing up our error logging before the next live audits?
