### PR TITLE
Multiple user types per route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ format-server:
 	pipenv run black .
 
 lint-server:
-	pipenv run pylint -j 0 server scripts
+	pipenv run pylint server scripts
 
 test-client:
 	yarn --cwd client lint

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ format-server:
 	pipenv run black .
 
 lint-server:
-	pipenv run pylint server scripts
+	pipenv run pylint -j 0 server scripts
 
 test-client:
 	yarn --cwd client lint

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     ],
     "*.py": [
       "pipenv run black",
-      "pipenv run pylint"
+      "pipenv run pylint -j 0"
     ],
     "package.json": [
       "sort-package-json"

--- a/server/api/audit_boards.py
+++ b/server/api/audit_boards.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import contains_eager
 from . import api
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
-from ..auth import with_jurisdiction_access, with_audit_board_access
+from ..auth import restrict_access, UserType
 from .rounds import get_current_round, is_round_complete, end_round
 from ..util.jsonschema import validate, JSONDict
 from ..util.binpacking import BalancedBucketList, Bucket
@@ -104,7 +104,7 @@ def assign_sampled_batches(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board",
     methods=["POST"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def create_audit_boards(election: Election, jurisdiction: Jurisdiction, round_id: str):
     json_audit_boards = request.get_json()
     round = get_or_404(Round, round_id)
@@ -190,7 +190,7 @@ def serialize_members(audit_board):
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board",
     methods=["GET"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def list_audit_boards(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
@@ -252,7 +252,7 @@ def validate_members(members: List[JSONDict]):
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board/<audit_board_id>/members",
     methods=["PUT"],
 )
-@with_audit_board_access
+@restrict_access([UserType.AUDIT_BOARD])
 def set_audit_board_members(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
@@ -305,7 +305,7 @@ def validate_sign_off(sign_off_request: JSONDict, audit_board: AuditBoard):
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board/<audit_board_id>/sign-off",
     methods=["POST"],
 )
-@with_audit_board_access
+@restrict_access([UserType.AUDIT_BOARD])
 def sign_off_audit_board(
     election: Election,
     jurisdiction: Jurisdiction,  # pylint: disable=unused-argument

--- a/server/api/audit_boards.py
+++ b/server/api/audit_boards.py
@@ -105,9 +105,8 @@ def assign_sampled_batches(
     methods=["POST"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def create_audit_boards(election: Election, jurisdiction: Jurisdiction, round_id: str):
+def create_audit_boards(election: Election, jurisdiction: Jurisdiction, round: Round):
     json_audit_boards = request.get_json()
-    round = get_or_404(Round, round_id)
     validate_audit_boards(json_audit_boards, election, jurisdiction, round)
 
     audit_boards = [
@@ -194,15 +193,14 @@ def serialize_members(audit_board):
 def list_audit_boards(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
-    round_id: str,
+    round: Round,
 ):
-    get_or_404(Round, round_id)
     audit_boards = (
-        AuditBoard.query.filter_by(jurisdiction_id=jurisdiction.id, round_id=round_id)
+        AuditBoard.query.filter_by(jurisdiction_id=jurisdiction.id, round_id=round.id)
         .order_by(AuditBoard.name)
         .all()
     )
-    round_status = round_status_by_audit_board(jurisdiction.id, round_id)
+    round_status = round_status_by_audit_board(jurisdiction.id, round.id)
     json_audit_boards = [
         serialize_audit_board(ab, round_status[ab.id]) for ab in audit_boards
     ]

--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -135,12 +135,9 @@ def get_ballot_manifest(
 )
 @restrict_access([UserType.AUDIT_ADMIN])
 def download_ballot_manifest_file(
-    election: Election, jurisdiction_id: str,  # pylint: disable=unused-argument
+    election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):
-    jurisdiction = Jurisdiction.query.filter_by(
-        election_id=election.id, id=jurisdiction_id
-    ).first()
-    if not jurisdiction or not jurisdiction.manifest_file:
+    if not jurisdiction.manifest_file:
         return NotFound()
 
     return csv_response(

--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -7,7 +7,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 from . import api
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
-from ..auth import with_jurisdiction_access, with_election_access
+from ..auth import restrict_access, UserType
 from ..util.process_file import (
     process_file,
     serialize_file,
@@ -104,7 +104,7 @@ def clear_ballot_manifest_file(jurisdiction: Jurisdiction):
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/ballot-manifest",
     methods=["PUT"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def upload_ballot_manifest(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):
@@ -119,7 +119,7 @@ def upload_ballot_manifest(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/ballot-manifest",
     methods=["GET"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def get_ballot_manifest(
     election: Election, jurisdiction: Jurisdiction  # pylint: disable=unused-argument
 ):
@@ -133,7 +133,7 @@ def get_ballot_manifest(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/ballot-manifest/csv",
     methods=["GET"],
 )
-@with_election_access
+@restrict_access([UserType.AUDIT_ADMIN])
 def download_ballot_manifest_file(
     election: Election, jurisdiction_id: str,  # pylint: disable=unused-argument
 ):
@@ -152,7 +152,7 @@ def download_ballot_manifest_file(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/ballot-manifest",
     methods=["DELETE"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def clear_ballot_manifest(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):

--- a/server/api/ballots.py
+++ b/server/api/ballots.py
@@ -90,8 +90,7 @@ def ballot_retrieval_list(jurisdiction: Jurisdiction, round: Round) -> str:
     methods=["GET"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def get_retrieval_list(election: Election, jurisdiction: Jurisdiction, round_id: str):
-    round = get_or_404(Round, round_id)
+def get_retrieval_list(election: Election, jurisdiction: Jurisdiction, round: Round):
     retrieval_list_csv = ballot_retrieval_list(jurisdiction, round)
     return csv_response(
         retrieval_list_csv,
@@ -148,14 +147,13 @@ def serialize_ballot(ballot: SampledBallot) -> JSONDict:
 def list_ballots_for_jurisdiction(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
-    round_id: str,
+    round: Round,
 ):
-    get_or_404(Round, round_id)
     ballots = (
         SampledBallot.query.join(Batch)
         .filter_by(jurisdiction_id=jurisdiction.id)
         .join(SampledBallotDraw)
-        .filter_by(round_id=round_id)
+        .filter_by(round_id=round.id)
         .outerjoin(SampledBallot.audit_board)
         .order_by(AuditBoard.name, Batch.name, SampledBallot.ballot_position)
         .options(

--- a/server/api/ballots.py
+++ b/server/api/ballots.py
@@ -6,7 +6,7 @@ from flask import jsonify, request
 from werkzeug.exceptions import BadRequest, NotFound
 
 from . import api
-from ..auth import with_jurisdiction_access, with_audit_board_access
+from ..auth import restrict_access, UserType
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from ..util.csv_download import csv_response, jurisdiction_timestamp_name
@@ -89,7 +89,7 @@ def ballot_retrieval_list(jurisdiction: Jurisdiction, round: Round) -> str:
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/ballots/retrieval-list",
     methods=["GET"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def get_retrieval_list(election: Election, jurisdiction: Jurisdiction, round_id: str):
     round = get_or_404(Round, round_id)
     retrieval_list_csv = ballot_retrieval_list(jurisdiction, round)
@@ -144,7 +144,7 @@ def serialize_ballot(ballot: SampledBallot) -> JSONDict:
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/ballots",
     methods=["GET"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def list_ballots_for_jurisdiction(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
@@ -172,7 +172,7 @@ def list_ballots_for_jurisdiction(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board/<audit_board_id>/ballots",
     methods=["GET"],
 )
-@with_audit_board_access
+@restrict_access([UserType.AUDIT_BOARD])
 def list_ballots_for_audit_board(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
@@ -266,7 +266,7 @@ def validate_audit_ballot(ballot_audit: JSONDict):
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board/<audit_board_id>/ballots/<ballot_id>",
     methods=["PUT"],
 )
-@with_audit_board_access
+@restrict_access([UserType.AUDIT_BOARD])
 def audit_ballot(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,  # pylint: disable=unused-argument

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -7,7 +7,7 @@ from werkzeug.exceptions import BadRequest, NotFound, Conflict
 from . import api
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
-from ..auth import with_jurisdiction_access, with_election_access
+from ..auth import restrict_access, UserType
 from ..util.process_file import (
     process_file,
     serialize_file,
@@ -119,7 +119,7 @@ def clear_batch_tallies_file(jurisdiction: Jurisdiction):
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/batch-tallies",
     methods=["PUT"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def upload_batch_tallies(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):
@@ -144,7 +144,7 @@ def upload_batch_tallies(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/batch-tallies",
     methods=["GET"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def get_batch_tallies(
     election: Election, jurisdiction: Jurisdiction  # pylint: disable=unused-argument
 ):
@@ -158,7 +158,7 @@ def get_batch_tallies(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/batch-tallies/csv",
     methods=["GET"],
 )
-@with_election_access
+@restrict_access([UserType.AUDIT_ADMIN])
 def download_batch_tallies_file(
     election: Election, jurisdiction_id: str,  # pylint: disable=unused-argument
 ):
@@ -177,7 +177,7 @@ def download_batch_tallies_file(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/batch-tallies",
     methods=["DELETE"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def clear_batch_tallies(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -160,12 +160,9 @@ def get_batch_tallies(
 )
 @restrict_access([UserType.AUDIT_ADMIN])
 def download_batch_tallies_file(
-    election: Election, jurisdiction_id: str,  # pylint: disable=unused-argument
+    election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):
-    jurisdiction = Jurisdiction.query.filter_by(
-        election_id=election.id, id=jurisdiction_id
-    ).first()
-    if not jurisdiction or not jurisdiction.batch_tallies_file:
+    if not jurisdiction.batch_tallies_file:
         return NotFound()
 
     return csv_response(

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -4,7 +4,7 @@ from werkzeug.exceptions import BadRequest, Conflict
 from sqlalchemy.orm import Query
 
 from . import api
-from ..auth import with_jurisdiction_access
+from ..auth import restrict_access, UserType
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from .rounds import is_round_complete, end_round, get_current_round
@@ -29,7 +29,7 @@ def already_audited_batches(jurisdiction: Jurisdiction, round: Round) -> Query:
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/batches/retrieval-list",
     methods=["GET"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def get_batch_retrieval_list(
     election: Election, jurisdiction: Jurisdiction, round_id: str
 ):
@@ -73,7 +73,7 @@ def serialize_batch(batch: Batch) -> JSONDict:
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/batches",
     methods=["GET"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def list_batches_for_jurisdiction(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
@@ -158,7 +158,7 @@ def validate_batch_results(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/batches/results",
     methods=["PUT"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def record_batch_results(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
@@ -191,7 +191,7 @@ def record_batch_results(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/batches/results",
     methods=["GET"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def get_batch_results(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -31,14 +31,12 @@ def already_audited_batches(jurisdiction: Jurisdiction, round: Round) -> Query:
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
 def get_batch_retrieval_list(
-    election: Election, jurisdiction: Jurisdiction, round_id: str
+    election: Election, jurisdiction: Jurisdiction, round: Round
 ):
-    round = get_or_404(Round, round_id)
-
     batches = (
         Batch.query.filter_by(jurisdiction_id=jurisdiction.id)
         .join(SampledBatchDraw)
-        .filter_by(round_id=round_id)
+        .filter_by(round_id=round.id)
         .filter(Batch.id.notin_(already_audited_batches(jurisdiction, round)))
         .join(AuditBoard)
         .group_by(AuditBoard.id, Batch.id)
@@ -77,14 +75,12 @@ def serialize_batch(batch: Batch) -> JSONDict:
 def list_batches_for_jurisdiction(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
-    round_id: str,
+    round: Round,
 ):
-    round = get_or_404(Round, round_id)
-
     batches = (
         Batch.query.filter_by(jurisdiction_id=jurisdiction.id)
         .join(SampledBatchDraw)
-        .filter_by(round_id=round_id)
+        .filter_by(round_id=round.id)
         .filter(Batch.id.notin_(already_audited_batches(jurisdiction, round)))
         .outerjoin(AuditBoard)
         .order_by(AuditBoard.name, Batch.name)
@@ -162,10 +158,8 @@ def validate_batch_results(
 def record_batch_results(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
-    round_id: str,
+    round: Round,
 ):
-    round = get_or_404(Round, round_id)
-
     batch_results = request.get_json()
     validate_batch_results(election, jurisdiction, round, batch_results)
 
@@ -195,14 +189,12 @@ def record_batch_results(
 def get_batch_results(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
-    round_id: str,
+    round: Round,
 ):
-    round = get_or_404(Round, round_id)
-
     results = list(
         Batch.query.filter_by(jurisdiction_id=jurisdiction.id)
         .join(SampledBatchDraw)
-        .filter_by(round_id=round_id)
+        .filter_by(round_id=round.id)
         .filter(Batch.id.notin_(already_audited_batches(jurisdiction, round)))
         .join(Jurisdiction)
         .join(Jurisdiction.contests)

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -4,11 +4,7 @@ from werkzeug.exceptions import BadRequest, Conflict
 from sqlalchemy import func
 
 from . import api
-from ..auth import (
-    with_election_access,
-    with_audit_board_access,
-    with_jurisdiction_access,
-)
+from ..auth import restrict_access, UserType
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from .rounds import get_current_round
@@ -165,7 +161,7 @@ def round_status_by_contest(
 
 
 @api.route("/election/<election_id>/contest", methods=["PUT"])
-@with_election_access
+@restrict_access([UserType.AUDIT_ADMIN])
 def create_or_update_all_contests(election: Election):
     json_contests = request.get_json()
     validate_contests(json_contests, election)
@@ -182,7 +178,7 @@ def create_or_update_all_contests(election: Election):
 
 
 @api.route("/election/<election_id>/contest", methods=["GET"])
-@with_election_access
+@restrict_access([UserType.AUDIT_ADMIN])
 def list_contests(election: Election):
     current_round = get_current_round(election)
     round_status = round_status_by_contest(current_round, list(election.contests))
@@ -196,7 +192,7 @@ def list_contests(election: Election):
 @api.route(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/contest", methods=["GET"]
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def list_jurisdictions_contests(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):
@@ -208,7 +204,7 @@ def list_jurisdictions_contests(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/audit-board/<audit_board_id>/contest",
     methods=["GET"],
 )
-@with_audit_board_access
+@restrict_access([UserType.AUDIT_BOARD])
 def list_audit_board_contests(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,

--- a/server/api/election_settings.py
+++ b/server/api/election_settings.py
@@ -2,7 +2,7 @@ from flask import jsonify, request
 from werkzeug.exceptions import Conflict
 
 from . import api
-from ..auth import with_election_access, with_jurisdiction_access
+from ..auth import restrict_access, UserType
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from ..util.jsonschema import validate, JSONDict
@@ -48,7 +48,7 @@ def serialize_election_settings(election: Election) -> JSONDict:
 
 
 @api.route("/election/<election_id>/settings", methods=["GET"])
-@with_election_access
+@restrict_access([UserType.AUDIT_ADMIN])
 def get_election_settings(election: Election):
     return jsonify(serialize_election_settings(election))
 
@@ -56,7 +56,7 @@ def get_election_settings(election: Election):
 @api.route(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/settings", methods=["GET"]
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def get_jurisdiction_election_settings(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):
@@ -71,7 +71,7 @@ def validate_election_settings(settings: JSONDict, election: Election):
 
 
 @api.route("/election/<election_id>/settings", methods=["PUT"])
-@with_election_access
+@restrict_access([UserType.AUDIT_ADMIN])
 def put_election_settings(election: Election):
     settings = request.get_json()
     validate_election_settings(settings, election)

--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -5,7 +5,7 @@ from sqlalchemy import func
 
 from . import api
 from ..models import *  # pylint: disable=wildcard-import
-from ..auth import with_election_access
+from ..auth import restrict_access, UserType
 from .rounds import get_current_round
 from ..util.process_file import serialize_file, serialize_file_processing
 from ..util.jsonschema import JSONDict
@@ -275,7 +275,7 @@ def batch_comparison_round_status(
 
 
 @api.route("/election/<election_id>/jurisdiction", methods=["GET"])
-@with_election_access
+@restrict_access([UserType.AUDIT_ADMIN])
 def list_jurisdictions(election: Election):
     current_round = get_current_round(election)
     round_status = round_status_by_jurisdiction(election, current_round)

--- a/server/api/offline_results.py
+++ b/server/api/offline_results.py
@@ -6,7 +6,7 @@ from . import api
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from .rounds import is_round_complete, end_round, get_current_round
-from ..auth import with_jurisdiction_access
+from ..auth import restrict_access, UserType
 from ..util.jsonschema import JSONDict, validate
 
 OFFLINE_RESULTS_SCHEMA = {
@@ -84,7 +84,7 @@ def validate_offline_results(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results",
     methods=["PUT"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def record_offline_results(
     election: Election,
     jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
@@ -147,7 +147,7 @@ def serialize_results(round: Round, results: List[JurisdictionResult]) -> JSONDi
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results",
     methods=["GET"],
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def get_offline_results(
     election: Election,
     jurisdiction: Jurisdiction,  # pylint: disable=unused-argument

--- a/server/api/offline_results.py
+++ b/server/api/offline_results.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 from flask import jsonify, request
-from werkzeug.exceptions import BadRequest, NotFound, Conflict
+from werkzeug.exceptions import BadRequest, Conflict
 
 from . import api
 from ..database import db_session
@@ -86,14 +86,8 @@ def validate_offline_results(
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
 def record_offline_results(
-    election: Election,
-    jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
-    round_id: str,
+    election: Election, jurisdiction: Jurisdiction, round: Round,
 ):
-    round = Round.query.filter_by(id=round_id, election_id=election.id).first()
-    if round is None:
-        raise NotFound()
-
     results = request.get_json()
     validate_offline_results(election, jurisdiction, round, results)
 
@@ -149,14 +143,10 @@ def serialize_results(round: Round, results: List[JurisdictionResult]) -> JSONDi
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
 def get_offline_results(
-    election: Election,
-    jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
-    round_id: str,
+    election: Election,  # pylint: disable=unused-argument
+    jurisdiction: Jurisdiction,
+    round: Round,
 ):
-    round = Round.query.filter_by(id=round_id, election_id=election.id).first()
-    if round is None:
-        raise NotFound()
-
     results = JurisdictionResult.query.filter_by(
         jurisdiction_id=jurisdiction.id, round_id=round.id
     ).all()

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 
 from . import api
 from ..models import *  # pylint: disable=wildcard-import
-from ..auth import with_election_access, with_jurisdiction_access
+from ..auth import restrict_access, UserType
 from ..util.csv_download import (
     csv_response,
     election_timestamp_name,
@@ -351,7 +351,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
 
 
 @api.route("/election/<election_id>/report", methods=["GET"])
-@with_election_access
+@restrict_access([UserType.AUDIT_ADMIN])
 def audit_admin_audit_report(election: Election):
     row_sets = [
         election_info_rows(election),
@@ -382,7 +382,7 @@ def audit_admin_audit_report(election: Election):
 @api.route(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/report", methods=["GET"]
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def jursdiction_admin_audit_report(election: Election, jurisdiction: Jurisdiction):
     csv_io = io.StringIO()
     report = csv.writer(csv_io)

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -10,7 +10,7 @@ from sqlalchemy import and_
 from . import api
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
-from ..auth import with_election_access, with_jurisdiction_access
+from ..auth import restrict_access, UserType
 from . import sample_sizes as sample_sizes_module
 from ..util.isoformat import isoformat
 from ..util.group_by import group_by
@@ -529,7 +529,7 @@ def validate_round(round: dict, election: Election):
 
 
 @api.route("/election/<election_id>/round", methods=["POST"])
-@with_election_access
+@restrict_access([UserType.AUDIT_ADMIN])
 def create_round(election: Election):
     json_round = request.get_json()
     validate_round(json_round, election)
@@ -574,7 +574,7 @@ def serialize_round(round: Round) -> dict:
 
 
 @api.route("/election/<election_id>/round", methods=["GET"])
-@with_election_access
+@restrict_access([UserType.AUDIT_ADMIN])
 def list_rounds_audit_admin(election: Election):
     return jsonify({"rounds": [serialize_round(r) for r in election.rounds]})
 
@@ -586,7 +586,7 @@ def list_rounds_audit_admin(election: Election):
 @api.route(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round", methods=["GET"]
 )
-@with_jurisdiction_access
+@restrict_access([UserType.JURISDICTION_ADMIN])
 def list_rounds_jurisdiction_admin(
     election: Election, jurisdiction: Jurisdiction  # pylint: disable=unused-argument
 ):

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -4,7 +4,7 @@ from werkzeug.exceptions import BadRequest
 
 from . import api
 from ..models import *  # pylint: disable=wildcard-import
-from ..auth import with_election_access
+from ..auth import restrict_access, UserType
 from ..audit_math import bravo, macro, sampler_contest
 from . import rounds  # pylint: disable=cyclic-import
 
@@ -73,7 +73,7 @@ def sample_size_options(
 
 
 @api.route("/election/<election_id>/sample-sizes", methods=["GET"])
-@with_election_access
+@restrict_access([UserType.AUDIT_ADMIN])
 def get_sample_sizes(election: Election):
     sample_sizes = {
         contest_id: list(options.values())

--- a/server/auth/lib.py
+++ b/server/auth/lib.py
@@ -73,7 +73,6 @@ def check_access(
     user_types: List[UserType],
     election: Election,
     jurisdiction: Jurisdiction = None,
-    round: Round = None,
     audit_board: AuditBoard = None,
 ):
     # Bypass for single-jurisdiction flow - no auth check
@@ -99,6 +98,7 @@ def check_access(
             )
 
     elif user_type == UserType.JURISDICTION_ADMIN:
+        assert jurisdiction
         user = User.query.filter_by(email=user_key).one()
         if not any(j for j in user.jurisdictions if j.id == jurisdiction.id):
             raise Forbidden(
@@ -107,6 +107,7 @@ def check_access(
 
     else:
         assert user_type == UserType.AUDIT_BOARD
+        assert audit_board
         if audit_board.id != user_key:
             raise Forbidden(
                 description=f"User does not have access to audit board {audit_board.id}"
@@ -155,7 +156,7 @@ def restrict_access(user_types: List[UserType]):
                 )
                 kwargs["audit_board"] = audit_board
 
-            check_access(user_types, election, jurisdiction, round, audit_board)
+            check_access(user_types, election, jurisdiction, audit_board)
 
             return route(*args, **kwargs)
 

--- a/server/auth/lib.py
+++ b/server/auth/lib.py
@@ -122,6 +122,19 @@ def restrict_access(user_types: List[UserType]):
     def restrict_access_decorator(route: Callable):
         @functools.wraps(route)
         def wrapper(*args, **kwargs):
+            if "jurisdiction_id" in kwargs and "election_id" not in kwargs:
+                # pragma: no cover
+                raise Exception("election_id required in route params")
+            if "round_id" in kwargs and "election_id" not in kwargs:
+                # pragma: no cover
+                raise Exception("election_id required in route params")
+            if "audit_board_id" in kwargs and "jurisdiction_id" not in kwargs:
+                # pragma: no cover
+                raise Exception("jurisdiction_id required in route params")
+            if "audit_board_id" in kwargs and "round_id" not in kwargs:
+                # pragma: no cover
+                raise Exception("round_id required in route params")
+
             # Substitute route params for their corresponding resources
             if "election_id" in kwargs:
                 election = get_or_404(Election, kwargs.pop("election_id"))

--- a/server/superadmin.py
+++ b/server/superadmin.py
@@ -5,7 +5,7 @@ from .models import *  # pylint: disable=wildcard-import
 from .database import db_session
 from .auth import (
     UserType,
-    with_superadmin_access,
+    restrict_access_superadmin,
     set_loggedin_user,
 )
 from .config import FLASK_ENV
@@ -16,7 +16,7 @@ superadmin = Blueprint("superadmin", __name__)
 @superadmin.route(
     "/superadmin/", methods=["GET"],
 )
-@with_superadmin_access
+@restrict_access_superadmin
 def superadmin_organizations():
     organizations = Organization.query.all()
     return render_template("superadmin/organizations.html", organizations=organizations)
@@ -25,7 +25,7 @@ def superadmin_organizations():
 @superadmin.route(
     "/superadmin/jurisdictions", methods=["GET"],
 )
-@with_superadmin_access
+@restrict_access_superadmin
 def superadmin_jurisdictions():
     election_id = request.args["election_id"]
     election = Election.query.filter_by(id=election_id).one()
@@ -35,7 +35,7 @@ def superadmin_jurisdictions():
 @superadmin.route(
     "/superadmin/auditadmin-login", methods=["POST"],
 )
-@with_superadmin_access
+@restrict_access_superadmin
 def superadmin_auditadmin_login():
     user_email = request.form["email"]
     set_loggedin_user(UserType.AUDIT_ADMIN, user_email)
@@ -45,7 +45,7 @@ def superadmin_auditadmin_login():
 @superadmin.route(
     "/superadmin/jurisdictionadmin-login", methods=["POST"],
 )
-@with_superadmin_access
+@restrict_access_superadmin
 def superadmin_jurisdictionadmin_login():
     user_email = request.form["email"]
     set_loggedin_user(UserType.JURISDICTION_ADMIN, user_email)
@@ -53,7 +53,7 @@ def superadmin_jurisdictionadmin_login():
 
 
 @superadmin.route("/superadmin/delete-election/<election_id>", methods=["POST"])
-@with_superadmin_access
+@restrict_access_superadmin
 def superadmin_delete_election(election_id: str):
     if FLASK_ENV == "production":  # pragma: no cover
         raise Forbidden("Can't delete audits in production")

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -111,7 +111,6 @@ def test_ballot_manifest_replace(
 
     bgcompute_update_ballot_manifest_file()
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={

--- a/server/tests/api/test_contests.py
+++ b/server/tests/api/test_contests.py
@@ -145,6 +145,7 @@ def test_contests_round_status(
     election_settings,  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = put_json(client, f"/api/election/{election_id}/contest", json_contests)
     assert_ok(rv)
 
@@ -394,6 +395,7 @@ def test_audit_board_contests_list(
     round_1_id: str,
     audit_board_round_1_ids: List[str],
 ):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/contest")
     expected_contests = json.loads(rv.data)["contests"]
 

--- a/server/tests/api/test_jurisdictions.py
+++ b/server/tests/api/test_jurisdictions.py
@@ -76,6 +76,7 @@ def test_jurisdictions_list_with_manifest(
     assert_ok(rv)
     bgcompute_update_ballot_manifest_file()
 
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)
     expected = {
@@ -151,6 +152,7 @@ def test_duplicate_batch_name(client, election_id, jurisdiction_ids):
 
     bgcompute_update_ballot_manifest_file()
 
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)
     expected = {
@@ -232,6 +234,7 @@ def test_jurisdictions_status_round_1_no_audit_boards(
 def test_jurisdictions_status_round_1_with_audit_boards(
     client: FlaskClient, election_id: str, audit_board_round_1_ids: List[str],
 ):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)["jurisdictions"]
 
@@ -302,6 +305,7 @@ def test_jurisdictions_status_round_1_with_audit_boards_without_ballots(
     SampledBallot.query.filter_by(audit_board_id=audit_board_round_1_ids[0]).delete()
     db_session.commit()
 
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/jurisdiction")
     jurisdictions = json.loads(rv.data)["jurisdictions"]
     assert jurisdictions[0]["currentRoundStatus"]["status"] == "IN_PROGRESS"
@@ -326,6 +330,7 @@ def test_jurisdictions_round_status_offline(
     election_settings,  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     # Change the settings to offline
     settings = {
         "electionName": "Test Election",

--- a/server/tests/api/test_reports.py
+++ b/server/tests/api/test_reports.py
@@ -24,6 +24,7 @@ def test_audit_admin_report(
             contest_ids[0],
             audit_board_id,
         )
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/report")
     assert (
         scrub_datetime(rv.headers["Content-Disposition"])

--- a/server/tests/api/test_rounds.py
+++ b/server/tests/api/test_rounds.py
@@ -29,6 +29,7 @@ def test_rounds_create_one(
     contest_ids: List[str],
     manifests,  # pylint: disable=unused-argument
 ):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = post_json(
         client,
         f"/api/election/{election_id}/round",

--- a/server/tests/batch_comparison/conftest.py
+++ b/server/tests/batch_comparison/conftest.py
@@ -11,11 +11,13 @@ from ...util.process_file import ProcessingStatus
 
 
 @pytest.fixture
-def election_id(client: FlaskClient, request):
+def election_id(client: FlaskClient, org_id: str, request):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     return create_election(
         client,
         audit_name=f"Test Audit {request.node.name}",
         audit_type=AuditType.BATCH_COMPARISON,
+        organization_id=org_id,
     )
 
 
@@ -145,6 +147,7 @@ def round_1_id(
     manifests,  # pylint: disable=unused-argument
     batch_tallies,  # pylint: disable=unused-argument
 ):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/sample-sizes")
     assert rv.status_code == 200
     sample_size_options = json.loads(rv.data)["sampleSizes"]

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -53,12 +53,16 @@ def client() -> FlaskClient:
 
 
 @pytest.fixture
-def election_id(client: FlaskClient, request) -> str:
-    org = create_organization(f"Test Org {request.node.name}")
-    assign_admin_to_org(org.id, DEFAULT_AA_EMAIL)
+def org_id(client: FlaskClient, request) -> str:  # pylint: disable=unused-argument
+    org_id, _ = create_org_and_admin(f"Test Org {request.node.name}", DEFAULT_AA_EMAIL)
+    return org_id
+
+
+@pytest.fixture
+def election_id(client: FlaskClient, org_id: str, request) -> str:
     set_logged_in_user(client, UserType.AUDIT_ADMIN, user_key=DEFAULT_AA_EMAIL)
     return create_election(
-        client, audit_name=f"Test Audit {request.node.name}", organization_id=org.id
+        client, audit_name=f"Test Audit {request.node.name}", organization_id=org_id
     )
 
 
@@ -132,6 +136,7 @@ def contest_ids(
 
 @pytest.fixture
 def election_settings(client: FlaskClient, election_id: str):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     settings = {
         "electionName": "Test Election",
         "online": True,

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -278,7 +278,7 @@ def auth_decorator_test_routes():
         return jsonify(election.id)
 
     @app.route("/api/election/<election_id>/jurisdiction/<jurisdiction_id>/test_auth")
-    @restrict_access([UserType.JURISDICTION_ADMIN])
+    @restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
     def fake_jurisdiction_route(
         election: Election, jurisdiction: Jurisdiction
     ):  # pylint: disable=unused-variable

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -97,6 +97,13 @@ def create_org_and_admin(
     return org.id, audit_admin.id
 
 
+def assign_admin_to_org(org_id: str, user_email: str):
+    user = User.query.filter_by(email=user_email).first()
+    admin = AuditAdministration(organization_id=org.id, user_id=user.id)
+    db_session.add(admin)
+    db_session.commit()
+
+
 def create_jurisdiction_admin(
     jurisdiction_id: str, user_email: str = DEFAULT_JA_EMAIL
 ) -> str:
@@ -150,7 +157,7 @@ def create_election(
     )
     result = json.loads(rv.data)
     if "electionId" not in result:
-        raise Exception(f"No electionID in response: {rv.data}")
+        raise Exception(f"No electionId in response: {rv.data}")
     return str(result["electionId"])
 
 

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -97,13 +97,6 @@ def create_org_and_admin(
     return org.id, audit_admin.id
 
 
-def assign_admin_to_org(org_id: str, user_email: str):
-    user = User.query.filter_by(email=user_email).first()
-    admin = AuditAdministration(organization_id=org.id, user_id=user.id)
-    db_session.add(admin)
-    db_session.commit()
-
-
 def create_jurisdiction_admin(
     jurisdiction_id: str, user_email: str = DEFAULT_JA_EMAIL
 ) -> str:

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -500,15 +500,8 @@ def test_restrict_access_jurisdiction_admin_with_audit_admin(
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/test_auth"
     )
-    assert rv.status_code == 403
-    assert json.loads(rv.data) == {
-        "errors": [
-            {
-                "errorType": "Forbidden",
-                "message": "Access forbidden for user type audit_admin",
-            }
-        ]
-    }
+    assert rv.status_code == 200
+    assert json.loads(rv.data) == [election_id, jurisdiction_id]
 
 
 def test_restrict_access_jurisdiction_admin_with_audit_board_user(

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -351,7 +351,10 @@ def test_restrict_access_audit_admin_not_found(
 
 
 def test_restrict_access_audit_admin_with_jurisdiction_admin(
-    client: FlaskClient, org_id: str, election_id: str, ja_email: str,
+    client: FlaskClient,
+    org_id: str,  # pylint: disable=unused-argument
+    election_id: str,
+    ja_email: str,
 ):
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, ja_email)
     rv = client.get(f"/api/election/{election_id}/test_auth")
@@ -367,7 +370,10 @@ def test_restrict_access_audit_admin_with_jurisdiction_admin(
 
 
 def test_restrict_access_audit_admin_audit_board_user(
-    client: FlaskClient, org_id: str, election_id: str, audit_board_id: str,
+    client: FlaskClient,
+    org_id: str,  # pylint: disable=unused-argument
+    election_id: str,
+    audit_board_id: str,
 ):
     set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
 
@@ -384,7 +390,9 @@ def test_restrict_access_audit_admin_audit_board_user(
 
 
 def test_restrict_access_audit_admin_anonymous_user(
-    client: FlaskClient, org_id: str, election_id: str
+    client: FlaskClient,
+    org_id: str,  # pylint: disable=unused-argument
+    election_id: str,
 ):
     clear_logged_in_user(client)
     rv = client.get(f"/api/election/{election_id}/test_auth")

--- a/server/tests/test_multiple_targeted_contests.py
+++ b/server/tests/test_multiple_targeted_contests.py
@@ -65,6 +65,7 @@ def test_sample_size_round_1(
     election_settings,  # pylint: disable=unused-argument
     snapshot,
 ):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/sample-sizes")
     sample_sizes = json.loads(rv.data)["sampleSizes"]
     contest_id_to_name = dict(Contest.query.values(Contest.id, Contest.name))
@@ -82,6 +83,7 @@ def test_two_rounds(
     manifests,  # pylint: disable=unused-argument
     snapshot,
 ):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/sample-sizes")
     sample_sizes = json.loads(rv.data)["sampleSizes"]
     selected_sample_sizes = {


### PR DESCRIPTION
Reworks the Flask route decorators that control permissions to allow multiple user types per route. This will be useful since we want to start letting AAs access more of the JA routes.

Also updates a ton of tests, which were lazily using an election that wasn't tied to an organization to circumvent the need to have the correct AA user logged in.
