### PR TITLE
Implements more intelligent subsequent round MACRO sample size computation

### DIFF
--- a/server/audit_math/sampler.py
+++ b/server/audit_math/sampler.py
@@ -104,7 +104,7 @@ def draw_ppeb_sample(
 
     assert batch_results, "Must have batch-level results to use MACRO"
 
-    U = macro.compute_U(batch_results, contest)
+    U = macro.compute_U(batch_results, {}, contest)
 
     # Map each batch to its weighted probability of being picked
     batch_to_prob = {}

--- a/server/tests/audit_math/test_macro.py
+++ b/server/tests/audit_math/test_macro.py
@@ -136,6 +136,76 @@ def test_max_error(contests, batches):
             )
 
 
+def test_get_sample_sizes(contests, batches):
+    expected_first_round = {
+        "Contest A": 29,
+        "Contest B": 15,
+        "Contest C": 10,
+    }
+
+    sample = {}
+    for contest in contests:
+        computed = macro.get_sample_sizes(
+            RISK_LIMIT, contests[contest], batches, sample
+        )
+
+        assert (
+            expected_first_round[contest] == computed
+        ), "First round sample expected {}, got {}".format(
+            expected_first_round[contest], computed
+        )
+
+    # Add 31 batches to the sample that is correct
+    for i in range(31):
+        sample["Batch {}".format(i)] = {
+            "Contest A": {"winner": 200, "loser": 180,},
+            "Contest B": {"winner": 200, "loser": 160,},
+            "Contest C": {"winner": 200, "loser": 140,},
+        }
+
+    expected_second_round = {
+        "Contest A": 26,
+        "Contest B": 12,
+        "Contest C": 7,
+    }
+
+    for contest in contests:
+        computed = macro.get_sample_sizes(
+            RISK_LIMIT, contests[contest], batches, sample
+        )
+
+        assert (
+            expected_second_round[contest] == computed
+        ), "Second round sample expected {}, got {}".format(
+            expected_second_round[contest], computed
+        )
+
+    # Now add in some errors
+    # draws with taint of 0.04047619
+    for i in range(100, 106):
+        sample["Batch {}".format(i)] = {
+            "Contest A": {"winner": 190, "loser": 190,},
+            "Contest C": {"winner": 200, "loser": 140,},
+        }
+
+    expected_third_round = {
+        "Contest A": 25,
+        "Contest B": 12,
+        "Contest C": 6,
+    }
+
+    for contest in contests:
+        computed = macro.get_sample_sizes(
+            RISK_LIMIT, contests[contest], batches, sample
+        )
+
+        assert (
+            expected_third_round[contest] == computed
+        ), "Third round sample expected {}, got {}".format(
+            expected_third_round[contest], computed
+        )
+
+
 def test_compute_risk(contests, batches):
 
     sample = {}
@@ -152,7 +222,6 @@ def test_compute_risk(contests, batches):
     for i in range(100, 106):
         sample["Batch {}".format(i)] = {
             "Contest A": {"winner": 190, "loser": 190,},
-            "Contest B": {"winner": 200, "loser": 160,},
             "Contest C": {"winner": 200, "loser": 140,},
         }
 

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -60,10 +60,10 @@ snapshots["test_batch_comparison_round_2 4"] = {
 }
 
 snapshots["test_batch_comparison_round_2 5"] = {
-    "numSamples": 4,
-    "numSamplesAudited": 2,
-    "numUnique": 3,
-    "numUniqueAudited": 1,
+    "numSamples": 2,
+    "numSamplesAudited": 0,
+    "numUnique": 2,
+    "numUniqueAudited": 0,
     "status": "NOT_STARTED",
 }
 
@@ -79,7 +79,7 @@ snapshots[
     "test_batch_comparison_round_2 7"
 ] = """Batch Name,Storage Location,Tabulator,Audit Board
 Batch 2,,,Audit Board #1
-Batch 4,,,Audit Board #1
+Batch 4,,,Audit Board #2
 """
 
 snapshots[
@@ -99,12 +99,12 @@ Test Audit test_batch_comparison_round_2,BATCH_COMPARISON,10%,1234567890,Yes\r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
 1,Contest 1,Targeted,6,No,0.189590948,DATETIME,DATETIME,candidate 1: 2400; candidate 2: 300; candidate 3: 240\r
-2,Contest 1,Targeted,6,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
+2,Contest 1,Targeted,4,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
 \r
 ######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Result\r
 J1,Batch 1,Round 1: 0.025053745,Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40\r
-J1,Batch 3,"Round 1: 0.023650366, 0.122600189, 0.150810694, Round 2: 0.216697081, 0.236539754",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40\r
+J1,Batch 3,"Round 1: 0.023650366, 0.122600189, 0.150810694",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40\r
 J2,Batch 1,Round 1: 0.128219632,Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40\r
 J2,Batch 5,"Round 1: 0.121751602, Round 2: 0.172408497",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40\r
 J1,Batch 2,Round 2: 0.203857756,No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
@@ -117,7 +117,7 @@ snapshots[
 ] = """######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Result\r
 J1,Batch 1,Round 1: 0.025053745,Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40\r
-J1,Batch 3,"Round 1: 0.023650366, 0.122600189, 0.150810694, Round 2: 0.216697081, 0.236539754",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40\r
+J1,Batch 3,"Round 1: 0.023650366, 0.122600189, 0.150810694",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40\r
 J1,Batch 2,Round 2: 0.203857756,No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
 J1,Batch 4,Round 2: 0.169018243,No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
 """

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -368,7 +368,7 @@ def test_batch_comparison_round_2(
 
     # Check that we automatically select the sample size
     batch_draws = SampledBatchDraw.query.filter_by(round_id=rounds[1]["id"]).all()
-    assert len(batch_draws) == 6
+    assert len(batch_draws) == 4
 
     # Check that we're sampling batches from the jurisdiction that uploaded manifests
     sampled_jurisdictions = {draw.batch.jurisdiction_id for draw in batch_draws}


### PR DESCRIPTION
Opening a new PR because github is bugging out.

Description

Modifies the MACRO math to make more informed sample size estimates based on previously drawn samples. Notably, this doesn't change the conservative nature of the statistics, since the new computation will always require sampling at least one batch. Leaves the conservative math up to p-value computations.

Testing

Adds test for get_sample_sizes which we really should have had anyways.

Progress

Ready to go.