### PR TITLE
Restyle/refactor JA RoundManagement screen

### DIFF
--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`App / renders aa logged in properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-lhVmIH daMHBT"
+    class="sc-elJkPf jKMEUh"
   >
     <div
       class="bp3-navbar sc-EHOje gMcVig"
@@ -51,7 +51,7 @@ exports[`App / renders aa logged in properly 1`] = `
       </div>
     </div>
     <div
-      class="sc-htpNat GipZb"
+      class="sc-htpNat eniUlo"
     >
       <div
         class="sc-bxivhb ddQihQ"
@@ -60,7 +60,7 @@ exports[`App / renders aa logged in properly 1`] = `
           style="width: 50%;"
         >
           <div
-            class="sc-cIShpX dKrnmF"
+            class="sc-feJyhm jMxHdo"
           >
             <div>
               <h2>
@@ -78,7 +78,7 @@ exports[`App / renders aa logged in properly 1`] = `
           style="width: 50%;"
         >
           <div
-            class="sc-feJyhm kPqGV"
+            class="sc-cmTdod ijJZYA"
           >
             <h2>
               New Audit
@@ -96,7 +96,7 @@ exports[`App / renders aa logged in properly 1`] = `
                   Audit name
                 </p>
                 <div
-                  class="sc-iELTvK dsVrZo sc-cSHVUG gyNSie"
+                  class="sc-jwKygS iCLILr sc-cSHVUG gyNSie"
                 >
                   <div
                     class="bp3-input-group sc-kAzzGY fpNxNJ"
@@ -177,7 +177,7 @@ exports[`App / renders ja logged in properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-lhVmIH daMHBT"
+    class="sc-elJkPf jKMEUh"
   >
     <div
       class="bp3-navbar sc-EHOje gMcVig"
@@ -225,7 +225,7 @@ exports[`App / renders ja logged in properly 1`] = `
       </div>
     </div>
     <div
-      class="sc-htpNat GipZb"
+      class="sc-htpNat eniUlo"
     >
       <div
         class="sc-bxivhb ddQihQ"
@@ -234,7 +234,7 @@ exports[`App / renders ja logged in properly 1`] = `
           style="width: 50%;"
         >
           <div
-            class="sc-cIShpX dKrnmF"
+            class="sc-feJyhm jMxHdo"
           >
             <div>
               <h2>
@@ -242,7 +242,7 @@ exports[`App / renders ja logged in properly 1`] = `
                 audit one
               </h2>
               <button
-                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-kafWEX bllqpN"
+                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-iELTvK foWIVl"
                 href="/election/1/jurisdiction/jurisdiction-id-1"
                 type="button"
               >
@@ -253,7 +253,7 @@ exports[`App / renders ja logged in properly 1`] = `
                 </span>
               </button>
               <button
-                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-kafWEX bllqpN"
+                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-iELTvK foWIVl"
                 href="/election/1/jurisdiction/jurisdiction-id-3"
                 type="button"
               >
@@ -270,7 +270,7 @@ exports[`App / renders ja logged in properly 1`] = `
                 audit two
               </h2>
               <button
-                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-kafWEX bllqpN"
+                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-iELTvK foWIVl"
                 href="/election/2/jurisdiction/jurisdiction-id-2"
                 type="button"
               >
@@ -295,7 +295,7 @@ exports[`App / renders unauthenticated properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-lhVmIH daMHBT"
+    class="sc-elJkPf jKMEUh"
   >
     <div
       class="bp3-navbar sc-EHOje gMcVig"
@@ -330,7 +330,7 @@ exports[`App / renders unauthenticated properly 1`] = `
       </div>
     </div>
     <div
-      class="sc-ktHwxA kFGeCR"
+      class="sc-kafWEX gOIPeA"
     >
       <img
         alt="Arlo, by VotingWorks"
@@ -379,7 +379,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders aa logged i
     class="Toastify"
   />
   <div
-    class="sc-lhVmIH daMHBT"
+    class="sc-elJkPf jKMEUh"
   >
     <div
       class="bp3-navbar sc-EHOje gMcVig"
@@ -424,7 +424,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders aa logged i
       </div>
     </div>
     <div
-      class="sc-htpNat GipZb"
+      class="sc-htpNat eniUlo"
     >
       <div
         class="sc-bxivhb ddQihQ"
@@ -433,7 +433,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders aa logged i
           style="width: 50%;"
         >
           <div
-            class="sc-cIShpX dKrnmF"
+            class="sc-feJyhm jMxHdo"
           >
             <div>
               <h2>
@@ -451,7 +451,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders aa logged i
           style="width: 50%;"
         >
           <div
-            class="sc-feJyhm kPqGV"
+            class="sc-cmTdod ijJZYA"
           >
             <h2>
               New Audit
@@ -469,7 +469,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders aa logged i
                   Audit name
                 </p>
                 <div
-                  class="sc-iELTvK dsVrZo sc-cSHVUG gyNSie"
+                  class="sc-jwKygS iCLILr sc-cSHVUG gyNSie"
                 >
                   <div
                     class="bp3-input-group sc-kAzzGY fpNxNJ"
@@ -552,7 +552,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ja logged i
     class="Toastify"
   />
   <div
-    class="sc-lhVmIH daMHBT"
+    class="sc-elJkPf jKMEUh"
   >
     <div
       class="bp3-navbar sc-EHOje gMcVig"
@@ -600,7 +600,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ja logged i
       </div>
     </div>
     <div
-      class="sc-htpNat GipZb"
+      class="sc-htpNat eniUlo"
     >
       <div
         class="sc-bxivhb ddQihQ"
@@ -609,7 +609,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ja logged i
           style="width: 50%;"
         >
           <div
-            class="sc-cIShpX dKrnmF"
+            class="sc-feJyhm jMxHdo"
           >
             <div>
               <h2>
@@ -617,7 +617,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ja logged i
                 audit one
               </h2>
               <button
-                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-kafWEX bllqpN"
+                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-iELTvK foWIVl"
                 href="/election/1/jurisdiction/jurisdiction-id-1"
                 type="button"
               >
@@ -628,7 +628,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ja logged i
                 </span>
               </button>
               <button
-                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-kafWEX bllqpN"
+                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-iELTvK foWIVl"
                 href="/election/1/jurisdiction/jurisdiction-id-3"
                 type="button"
               >
@@ -645,7 +645,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ja logged i
                 audit two
               </h2>
               <button
-                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-kafWEX bllqpN"
+                class="bp3-button bp3-fill bp3-large bp3-intent-primary sc-iELTvK foWIVl"
                 href="/election/2/jurisdiction/jurisdiction-id-2"
                 type="button"
               >
@@ -697,7 +697,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders unauthentic
     </div>
   </div>
   <div
-    class="sc-lhVmIH daMHBT"
+    class="sc-elJkPf jKMEUh"
   >
     <div
       class="bp3-navbar sc-EHOje gMcVig"
@@ -732,7 +732,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders unauthentic
       </div>
     </div>
     <div
-      class="sc-ktHwxA kFGeCR"
+      class="sc-kafWEX gOIPeA"
     >
       <img
         alt="Arlo, by VotingWorks"
@@ -781,7 +781,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders aa logge
     class="Toastify"
   />
   <div
-    class="sc-lhVmIH daMHBT"
+    class="sc-elJkPf jKMEUh"
   >
     <div
       class="bp3-navbar sc-EHOje gMcVig"
@@ -826,7 +826,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders aa logge
       </div>
     </div>
     <div
-      class="sc-htpNat GipZb"
+      class="sc-htpNat eniUlo"
     >
       <div
         class="sc-bxivhb ddQihQ"
@@ -835,7 +835,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders aa logge
           style="width: 50%;"
         >
           <div
-            class="sc-cIShpX dKrnmF"
+            class="sc-feJyhm jMxHdo"
           >
             <div>
               <h2>
@@ -853,7 +853,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders aa logge
           style="width: 50%;"
         >
           <div
-            class="sc-feJyhm kPqGV"
+            class="sc-cmTdod ijJZYA"
           >
             <h2>
               New Audit
@@ -871,7 +871,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders aa logge
                   Audit name
                 </p>
                 <div
-                  class="sc-iELTvK dsVrZo sc-cSHVUG gyNSie"
+                  class="sc-jwKygS iCLILr sc-cSHVUG gyNSie"
                 >
                   <div
                     class="bp3-input-group sc-kAzzGY fpNxNJ"
@@ -952,7 +952,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders ja logge
     class="Toastify"
   />
   <div
-    class="sc-lhVmIH daMHBT"
+    class="sc-elJkPf jKMEUh"
   >
     <div
       class="bp3-navbar sc-EHOje gMcVig"
@@ -1002,7 +1002,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders ja logge
       </div>
     </div>
     <div
-      class="sc-htpNat GipZb"
+      class="sc-htpNat eniUlo"
     >
       <div
         class="bp3-callout sc-eHgmQL gudjM"
@@ -1025,7 +1025,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders ja logge
         </div>
       </div>
       <div
-        class="sc-bxivhb sc-fMiknA grfJwm"
+        class="sc-bxivhb sc-dVhcbM jpYGJw"
       >
         <h2
           class="bp3-heading sc-gzVnrw hQaoin"
@@ -1198,7 +1198,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders unauthen
     </div>
   </div>
   <div
-    class="sc-lhVmIH daMHBT"
+    class="sc-elJkPf jKMEUh"
   >
     <div
       class="bp3-navbar sc-EHOje gMcVig"
@@ -1233,7 +1233,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders unauthen
       </div>
     </div>
     <div
-      class="sc-ktHwxA kFGeCR"
+      class="sc-kafWEX gOIPeA"
     >
       <img
         alt="Arlo, by VotingWorks"

--- a/client/src/components/Atoms/Wrapper.tsx
+++ b/client/src/components/Atoms/Wrapper.tsx
@@ -4,14 +4,6 @@ export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-
-  &.single-page {
-    flex-direction: column;
-    align-items: center;
-    &.left {
-      align-items: flex-start;
-    }
-  }
 `
 
 export const Inner = styled.div`

--- a/client/src/components/DataEntry/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/DataEntry/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DataEntry ballot interaction renders ballot route 1`] = `
 <div>
   <div
-    class="sc-eNQAEJ hubqqz"
+    class="sc-eNQAEJ enNqmj"
   >
     <div
       class="sc-hMqMXs sc-kEYyzF jYziDw"
@@ -366,7 +366,7 @@ exports[`DataEntry ballot interaction renders ballot route 1`] = `
 exports[`DataEntry ballot interaction renders board table with ballots 1`] = `
 <div>
   <div
-    class="sc-eNQAEJ hubqqz"
+    class="sc-eNQAEJ enNqmj"
   >
     <div
       class="sc-hMqMXs sc-kEYyzF jYziDw"
@@ -966,7 +966,7 @@ exports[`DataEntry ballot interaction renders board table with ballots 1`] = `
 exports[`DataEntry ballot interaction renders board table with large container size 1`] = `
 <div>
   <div
-    class="sc-eNQAEJ hubqqz"
+    class="sc-eNQAEJ enNqmj"
   >
     <div
       class="sc-hMqMXs sc-kEYyzF jYziDw"
@@ -1566,7 +1566,7 @@ exports[`DataEntry ballot interaction renders board table with large container s
 exports[`DataEntry ballot interaction renders board table with no ballots 1`] = `
 <div>
   <div
-    class="sc-eNQAEJ hubqqz"
+    class="sc-eNQAEJ enNqmj"
   >
     <div
       class="sc-hMqMXs sc-kEYyzF jYziDw"
@@ -1981,7 +1981,7 @@ exports[`DataEntry ballot interaction renders board table with no ballots 1`] = 
 exports[`DataEntry member form submits and goes to ballot table 1`] = `
 <div>
   <div
-    class="sc-eNQAEJ hubqqz"
+    class="sc-eNQAEJ enNqmj"
   >
     <div
       class="sc-hMqMXs sc-kEYyzF jYziDw"

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.test.tsx
@@ -60,7 +60,7 @@ describe('offline round data entry', () => {
           route: '/election/1/jurisdiction/1',
         }
       )
-      await screen.findByText('Round 1 Data Entry')
+      await screen.findByText('Batch: Batch One, Contest: Contest 1')
       expect(container).toMatchSnapshot()
     })
   })
@@ -78,7 +78,7 @@ describe('offline round data entry', () => {
           route: '/election/1/jurisdiction/1',
         }
       )
-      await screen.findByText('Round 1 Data Entry')
+      await screen.findByText('Batch: Batch One, Contest: Contest 1')
       expect(container).toMatchSnapshot()
     })
   })
@@ -97,7 +97,7 @@ describe('offline round data entry', () => {
           route: '/election/1/jurisdiction/1',
         }
       )
-      await screen.findByText('Round 1 Data Entry')
+      await screen.findByText('Batch: Batch One, Contest: Contest 1')
       ;[0, 1, 2].forEach(batch => {
         fireEvent.change(
           screen.getAllByLabelText('Votes for Choice One:')[batch],

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/BatchRoundDataEntry.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'react-router-dom'
 import { H5 } from '@blueprintjs/core'
 import { Field, Formik, Form, FormikProps } from 'formik'
 import styled from 'styled-components'
-import H2Title from '../../Atoms/H2Title'
 import useContestsJurisdictionAdmin from './useContestsJurisdictionAdmin'
 import { IRound } from '../useRoundsJurisdictionAdmin'
 import Card from '../../Atoms/SpacedCard'
@@ -58,7 +57,6 @@ const BatchRoundDataEntry = ({ round }: IProps) => {
     <Formik initialValues={{ results }} enableReinitialize onSubmit={submit}>
       {({ handleSubmit }: FormikProps<IValues>) => (
         <Form>
-          <H2Title>Round {round.roundNum} Data Entry</H2Title>
           <p>
             When you have examined all the ballots assigned to you, enter the
             number of votes recorded for each candidate/choice from the audited

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/CreateAuditBoards.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/CreateAuditBoards.test.tsx
@@ -5,12 +5,7 @@ import CreateAuditBoards from './CreateAuditBoards'
 test('names audit boards numerically', async () => {
   const createAuditBoards = jest.fn()
   const { getByText, getByTestId } = render(
-    <CreateAuditBoards
-      auditBoards={[]}
-      numBallots={10}
-      roundNum={1}
-      createAuditBoards={createAuditBoards}
-    />
+    <CreateAuditBoards createAuditBoards={createAuditBoards} />
   )
 
   fireEvent.change(getByTestId('numAuditBoards'), { target: { value: '3' } })
@@ -28,12 +23,7 @@ test('names audit boards numerically', async () => {
 test('names audit boards such that the names sort sensibly', async () => {
   const createAuditBoards = jest.fn()
   const { getByText, getByTestId } = render(
-    <CreateAuditBoards
-      auditBoards={[]}
-      numBallots={10}
-      roundNum={1}
-      createAuditBoards={createAuditBoards}
-    />
+    <CreateAuditBoards createAuditBoards={createAuditBoards} />
   )
 
   fireEvent.change(getByTestId('numAuditBoards'), { target: { value: '10' } })

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/CreateAuditBoards.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/CreateAuditBoards.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { H4 } from '@blueprintjs/core'
 import { Formik, Field } from 'formik'
 import styled from 'styled-components'
 import { generateOptions } from '../../Atoms/Form/_helpers'
 import FormButton from '../../Atoms/Form/FormButton'
 import Select from '../../Atoms/Form/Select'
-import { IAuditBoard } from '../useAuditBoards'
+import FormSection from '../../Atoms/Form/FormSection'
 
 const Wrapper = styled.div`
   margin: 20px 0;
@@ -15,29 +15,17 @@ const AuditBoardsInput = styled(Field)`
   margin-left: 0;
   width: 100px;
 `
-
-const BallotsToAudit = styled.p`
-  margin: 15px 0;
-  font-weight: 500;
-`
-
 interface IValues {
   numAuditBoards: number
 }
 
 interface IProps {
   createAuditBoards: (auditBoards: { name: string }[]) => Promise<boolean>
-  auditBoards: IAuditBoard[]
-  numBallots: number
-  roundNum: number
 }
 
-const CreateAuditBoards = ({
-  createAuditBoards,
-  auditBoards,
-  numBallots,
-  roundNum,
-}: IProps) => {
+const CreateAuditBoards = ({ createAuditBoards }: IProps) => {
+  const [submitting, setSubmitting] = useState(false)
+
   const submit = async ({ numAuditBoards }: IValues) => {
     const maxAuditBoardsIndexLength = numAuditBoards.toString().length
     const boards = [...Array(numAuditBoards).keys()].map(i => ({
@@ -45,10 +33,9 @@ const CreateAuditBoards = ({
         .toString()
         .padStart(maxAuditBoardsIndexLength, '0')}`,
     }))
-    createAuditBoards(boards)
+    await createAuditBoards(boards)
+    setSubmitting(false)
   }
-
-  const disabled = auditBoards.length > 0
 
   return (
     <Wrapper>
@@ -60,31 +47,30 @@ const CreateAuditBoards = ({
         number of audit boards before the next round of the audit, if another
         round is required.
       </p>
-      <Formik
-        enableReinitialize
-        initialValues={{ numAuditBoards: auditBoards.length || 1 }}
-        onSubmit={submit}
-      >
+      <Formik initialValues={{ numAuditBoards: 1 }} onSubmit={submit}>
         {({ handleSubmit, setFieldValue }) => (
           <>
-            <AuditBoardsInput
-              component={Select}
-              id="numAuditBoards"
-              data-testid="numAuditBoards"
-              name="numAuditBoards"
-              onChange={(e: React.FormEvent<HTMLSelectElement>) =>
-                setFieldValue('numAuditBoards', Number(e.currentTarget.value))
-              }
-              disabled={disabled}
+            <FormSection>
+              <AuditBoardsInput
+                component={Select}
+                id="numAuditBoards"
+                data-testid="numAuditBoards"
+                name="numAuditBoards"
+                onChange={(e: React.FormEvent<HTMLSelectElement>) =>
+                  setFieldValue('numAuditBoards', Number(e.currentTarget.value))
+                }
+                disabled={submitting}
+              >
+                {generateOptions(15)}
+              </AuditBoardsInput>
+            </FormSection>
+            <FormButton
+              intent="primary"
+              onClick={handleSubmit}
+              loading={submitting}
             >
-              {generateOptions(15)}
-            </AuditBoardsInput>
-            <BallotsToAudit>
-              {numBallots} Ballots to Audit in Round {roundNum}
-            </BallotsToAudit>
-            {!disabled && (
-              <FormButton onClick={handleSubmit}>Save &amp; Next</FormButton>
-            )}
+              Save &amp; Next
+            </FormButton>
           </>
         )}
       </Formik>

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundDataEntry.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundDataEntry.test.tsx
@@ -54,7 +54,7 @@ describe('offline round data entry', () => {
           route: '/election/1/jurisdiction/1',
         }
       )
-      await screen.findByText('Round 1 Data Entry')
+      await screen.findByText('Votes for Choice One:')
       expect(container).toMatchSnapshot()
     })
   })
@@ -72,7 +72,7 @@ describe('offline round data entry', () => {
           route: '/election/1/jurisdiction/1',
         }
       )
-      await screen.findByText('Round 1 Data Entry')
+      await screen.findByText('Votes for Choice One:')
       fireEvent.change(screen.getByLabelText('Votes for Choice One:'), {
         target: { value: '1' },
       })

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundDataEntry.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'react-router-dom'
 import { H5 } from '@blueprintjs/core'
 import { Field, Formik, Form, FormikProps } from 'formik'
 import styled from 'styled-components'
-import H2Title from '../../Atoms/H2Title'
 import useContestsJurisdictionAdmin from './useContestsJurisdictionAdmin'
 import { IRound } from '../useRoundsJurisdictionAdmin'
 import Card from '../../Atoms/SpacedCard'
@@ -55,7 +54,6 @@ const RoundDataEntry = ({ round }: IProps) => {
     <Formik initialValues={{ results }} enableReinitialize onSubmit={submit}>
       {({ handleSubmit }: FormikProps<IValues>) => (
         <Form>
-          <H2Title>Round {round.roundNum} Data Entry</H2Title>
           <p>
             When you have examined all the ballots assigned to you, enter the
             number of votes recorded for each candidate/choice from the audited
@@ -70,17 +68,13 @@ const RoundDataEntry = ({ round }: IProps) => {
                   htmlFor={`results[${contest.id}][${choice.id}]`}
                 >
                   Votes for {choice.name}:
-                  {alreadySubmittedResults ? (
-                    results[contest.id][choice.id]
-                  ) : (
-                    <Field
-                      id={`results[${contest.id}][${choice.id}]`}
-                      name={`results[${contest.id}][${choice.id}]`}
-                      disabled={alreadySubmittedResults}
-                      validate={testNumber()}
-                      component={FormField}
-                    />
-                  )}
+                  <Field
+                    id={`results[${contest.id}][${choice.id}]`}
+                    name={`results[${contest.id}][${choice.id}]`}
+                    disabled={alreadySubmittedResults}
+                    validate={testNumber()}
+                    component={FormField}
+                  />
                 </BlockLabel>
               ))}
             </Card>

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.test.tsx
@@ -1,65 +1,47 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import RoundProgress from './RoundProgress'
-import { roundMocks, auditBoardMocks } from '../useSetupMenuItems/_mocks'
+import { auditBoardMocks } from '../useSetupMenuItems/_mocks'
 
 describe('RoundProgress', () => {
   it('renders incomplete round with no audit boards', () => {
     const { container } = render(
-      <RoundProgress
-        round={roundMocks.singleIncomplete[0]}
-        auditBoards={auditBoardMocks.empty}
-      />
+      <RoundProgress auditBoards={auditBoardMocks.empty} />
     )
     expect(container).toMatchSnapshot()
   })
 
   it('renders incomplete round with an audit board', () => {
     const { container } = render(
-      <RoundProgress
-        round={roundMocks.singleIncomplete[0]}
-        auditBoards={auditBoardMocks.single}
-      />
+      <RoundProgress auditBoards={auditBoardMocks.single} />
     )
     expect(container).toMatchSnapshot()
   })
 
   it('renders incomplete round with two audit boards', () => {
     const { container } = render(
-      <RoundProgress
-        round={roundMocks.singleIncomplete[0]}
-        auditBoards={auditBoardMocks.double}
-      />
+      <RoundProgress auditBoards={auditBoardMocks.double} />
     )
     expect(container).toMatchSnapshot()
   })
 
   it('renders incomplete round with auditing in progress', () => {
     const { container } = render(
-      <RoundProgress
-        round={roundMocks.singleIncomplete[0]}
-        auditBoards={auditBoardMocks.started}
-      />
+      <RoundProgress auditBoards={auditBoardMocks.started} />
     )
     expect(container).toMatchSnapshot()
   })
 
   it('renders incomplete round with an audit board with no ballots sampled', () => {
     const { container } = render(
-      <RoundProgress
-        round={roundMocks.singleIncomplete[0]}
-        auditBoards={auditBoardMocks.noBallots}
-      />
+      <RoundProgress auditBoards={auditBoardMocks.noBallots} />
     )
     expect(container).toMatchSnapshot()
   })
 
   it('renders complete round', () => {
     const { container } = render(
-      <RoundProgress
-        round={roundMocks.singleComplete[0]}
-        auditBoards={auditBoardMocks.signedOff}
-      />
+      <RoundProgress auditBoards={auditBoardMocks.signedOff} />
     )
     expect(container).toMatchSnapshot()
   })

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
-import { ProgressBar } from '@blueprintjs/core'
+import { ProgressBar, H4 } from '@blueprintjs/core'
 import styled from 'styled-components'
-import H2Title from '../../Atoms/H2Title'
-import { IRound } from '../useRoundsJurisdictionAdmin'
 import { IAuditBoard } from '../useAuditBoards'
 
 const MainBarWrapper = styled.div`
@@ -16,13 +14,7 @@ const SmallBarWrapper = styled.div`
   width: 400px;
 `
 
-const RoundProgress = ({
-  auditBoards,
-  round,
-}: {
-  auditBoards: IAuditBoard[]
-  round: IRound
-}) => {
+const RoundProgress = ({ auditBoards }: { auditBoards: IAuditBoard[] }) => {
   if (!auditBoards.length) return null
   const sum = (ns: number[]) => ns.reduce((a, b) => a + b)
   const auditedBallots = sum(
@@ -33,8 +25,8 @@ const RoundProgress = ({
   )
   return (
     <>
-      <H2Title>Round {round.roundNum} Progress</H2Title>
       <MainBarWrapper>
+        <H4>Audit Board Progress</H4>
         <span>
           {auditedBallots} of {sampledBallots} ballots audited{' '}
         </span>

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/BatchRoundDataEntry.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/BatchRoundDataEntry.test.tsx.snap
@@ -3,18 +3,11 @@
 exports[`offline round data entry renders 1`] = `
 <div>
   <form>
-    <h2
-      class="bp3-heading sc-bdVaJa ibVpPq"
-    >
-      Round 
-      1
-       Data Entry
-    </h2>
     <p>
       When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
     </p>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -22,17 +15,17 @@ exports[`offline round data entry renders 1`] = `
         Batch: Batch One, Contest: Contest 1
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-1][choice-id-1]"
       >
         Votes for 
         Choice One
         :
         <div
-          class="sc-htpNat gdpVCF"
+          class="sc-bwzfXH jsIzlm"
         >
           <div
-            class="bp3-input-group sc-bxivhb eSUmfF"
+            class="bp3-input-group sc-htpNat iapfBj"
           >
             <input
               class="bp3-input"
@@ -45,17 +38,17 @@ exports[`offline round data entry renders 1`] = `
         </div>
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-1][choice-id-2]"
       >
         Votes for 
         Choice Two
         :
         <div
-          class="sc-htpNat gdpVCF"
+          class="sc-bwzfXH jsIzlm"
         >
           <div
-            class="bp3-input-group sc-bxivhb eSUmfF"
+            class="bp3-input-group sc-htpNat iapfBj"
           >
             <input
               class="bp3-input"
@@ -69,7 +62,7 @@ exports[`offline round data entry renders 1`] = `
       </label>
     </div>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -77,17 +70,17 @@ exports[`offline round data entry renders 1`] = `
         Batch: Batch Two, Contest: Contest 1
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-2][choice-id-1]"
       >
         Votes for 
         Choice One
         :
         <div
-          class="sc-htpNat gdpVCF"
+          class="sc-bwzfXH jsIzlm"
         >
           <div
-            class="bp3-input-group sc-bxivhb eSUmfF"
+            class="bp3-input-group sc-htpNat iapfBj"
           >
             <input
               class="bp3-input"
@@ -100,17 +93,17 @@ exports[`offline round data entry renders 1`] = `
         </div>
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-2][choice-id-2]"
       >
         Votes for 
         Choice Two
         :
         <div
-          class="sc-htpNat gdpVCF"
+          class="sc-bwzfXH jsIzlm"
         >
           <div
-            class="bp3-input-group sc-bxivhb eSUmfF"
+            class="bp3-input-group sc-htpNat iapfBj"
           >
             <input
               class="bp3-input"
@@ -124,7 +117,7 @@ exports[`offline round data entry renders 1`] = `
       </label>
     </div>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -132,17 +125,17 @@ exports[`offline round data entry renders 1`] = `
         Batch: Batch Three, Contest: Contest 1
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-3][choice-id-1]"
       >
         Votes for 
         Choice One
         :
         <div
-          class="sc-htpNat gdpVCF"
+          class="sc-bwzfXH jsIzlm"
         >
           <div
-            class="bp3-input-group sc-bxivhb eSUmfF"
+            class="bp3-input-group sc-htpNat iapfBj"
           >
             <input
               class="bp3-input"
@@ -155,17 +148,17 @@ exports[`offline round data entry renders 1`] = `
         </div>
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-3][choice-id-2]"
       >
         Votes for 
         Choice Two
         :
         <div
-          class="sc-htpNat gdpVCF"
+          class="sc-bwzfXH jsIzlm"
         >
           <div
-            class="bp3-input-group sc-bxivhb eSUmfF"
+            class="bp3-input-group sc-htpNat iapfBj"
           >
             <input
               class="bp3-input"
@@ -179,7 +172,7 @@ exports[`offline round data entry renders 1`] = `
       </label>
     </div>
     <button
-      class="bp3-button bp3-intent-primary sc-dnqmqq bytmcb sc-htoDjs dESvso"
+      class="bp3-button bp3-intent-primary sc-htoDjs hNDkTe sc-gzVnrw kdzzfK"
       type="submit"
     >
       <span
@@ -195,18 +188,11 @@ exports[`offline round data entry renders 1`] = `
 exports[`offline round data entry renders after submission 1`] = `
 <div>
   <form>
-    <h2
-      class="bp3-heading sc-bdVaJa ibVpPq"
-    >
-      Round 
-      1
-       Data Entry
-    </h2>
     <p>
       When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
     </p>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -214,7 +200,7 @@ exports[`offline round data entry renders after submission 1`] = `
         Batch: Batch One, Contest: Contest 1
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-1][choice-id-1]"
       >
         Votes for 
@@ -223,7 +209,7 @@ exports[`offline round data entry renders after submission 1`] = `
         1
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-1][choice-id-2]"
       >
         Votes for 
@@ -233,7 +219,7 @@ exports[`offline round data entry renders after submission 1`] = `
       </label>
     </div>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -241,7 +227,7 @@ exports[`offline round data entry renders after submission 1`] = `
         Batch: Batch Two, Contest: Contest 1
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-2][choice-id-1]"
       >
         Votes for 
@@ -250,7 +236,7 @@ exports[`offline round data entry renders after submission 1`] = `
         1
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-2][choice-id-2]"
       >
         Votes for 
@@ -260,7 +246,7 @@ exports[`offline round data entry renders after submission 1`] = `
       </label>
     </div>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -268,7 +254,7 @@ exports[`offline round data entry renders after submission 1`] = `
         Batch: Batch Three, Contest: Contest 1
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-3][choice-id-1]"
       >
         Votes for 
@@ -277,7 +263,7 @@ exports[`offline round data entry renders after submission 1`] = `
         1
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-3][choice-id-2]"
       >
         Votes for 
@@ -287,7 +273,7 @@ exports[`offline round data entry renders after submission 1`] = `
       </label>
     </div>
     <button
-      class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq bytmcb sc-htoDjs dESvso"
+      class="bp3-button bp3-disabled bp3-intent-primary sc-htoDjs hNDkTe sc-gzVnrw kdzzfK"
       disabled=""
       tabindex="-1"
       type="submit"
@@ -305,18 +291,11 @@ exports[`offline round data entry renders after submission 1`] = `
 exports[`offline round data entry submits 1`] = `
 <div>
   <form>
-    <h2
-      class="bp3-heading sc-bdVaJa ibVpPq"
-    >
-      Round 
-      1
-       Data Entry
-    </h2>
     <p>
       When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
     </p>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -324,7 +303,7 @@ exports[`offline round data entry submits 1`] = `
         Batch: Batch One, Contest: Contest 1
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-1][choice-id-1]"
       >
         Votes for 
@@ -333,7 +312,7 @@ exports[`offline round data entry submits 1`] = `
         1
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-1][choice-id-2]"
       >
         Votes for 
@@ -343,7 +322,7 @@ exports[`offline round data entry submits 1`] = `
       </label>
     </div>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -351,7 +330,7 @@ exports[`offline round data entry submits 1`] = `
         Batch: Batch Two, Contest: Contest 1
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-2][choice-id-1]"
       >
         Votes for 
@@ -360,7 +339,7 @@ exports[`offline round data entry submits 1`] = `
         1
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-2][choice-id-2]"
       >
         Votes for 
@@ -370,7 +349,7 @@ exports[`offline round data entry submits 1`] = `
       </label>
     </div>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -378,7 +357,7 @@ exports[`offline round data entry submits 1`] = `
         Batch: Batch Three, Contest: Contest 1
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-3][choice-id-1]"
       >
         Votes for 
@@ -387,7 +366,7 @@ exports[`offline round data entry submits 1`] = `
         1
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[batch-3][choice-id-2]"
       >
         Votes for 
@@ -397,7 +376,7 @@ exports[`offline round data entry submits 1`] = `
       </label>
     </div>
     <button
-      class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq bytmcb sc-htoDjs dESvso"
+      class="bp3-button bp3-disabled bp3-intent-primary sc-htoDjs hNDkTe sc-gzVnrw kdzzfK"
       disabled=""
       tabindex="-1"
       type="submit"

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/RoundDataEntry.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/RoundDataEntry.test.tsx.snap
@@ -3,18 +3,11 @@
 exports[`offline round data entry renders 1`] = `
 <div>
   <form>
-    <h2
-      class="bp3-heading sc-bdVaJa ibVpPq"
-    >
-      Round 
-      1
-       Data Entry
-    </h2>
     <p>
       When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
     </p>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -22,17 +15,17 @@ exports[`offline round data entry renders 1`] = `
         Contest 1
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[contest-id-1][choice-id-1]"
       >
         Votes for 
         Choice One
         :
         <div
-          class="sc-htpNat gdpVCF"
+          class="sc-bwzfXH jsIzlm"
         >
           <div
-            class="bp3-input-group sc-bxivhb eSUmfF"
+            class="bp3-input-group sc-htpNat iapfBj"
           >
             <input
               class="bp3-input"
@@ -45,17 +38,17 @@ exports[`offline round data entry renders 1`] = `
         </div>
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[contest-id-1][choice-id-2]"
       >
         Votes for 
         Choice Two
         :
         <div
-          class="sc-htpNat gdpVCF"
+          class="sc-bwzfXH jsIzlm"
         >
           <div
-            class="bp3-input-group sc-bxivhb eSUmfF"
+            class="bp3-input-group sc-htpNat iapfBj"
           >
             <input
               class="bp3-input"
@@ -69,7 +62,7 @@ exports[`offline round data entry renders 1`] = `
       </label>
     </div>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -77,17 +70,17 @@ exports[`offline round data entry renders 1`] = `
         Contest 2
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[contest-id-2][choice-id-3]"
       >
         Votes for 
         Choice Three
         :
         <div
-          class="sc-htpNat gdpVCF"
+          class="sc-bwzfXH jsIzlm"
         >
           <div
-            class="bp3-input-group sc-bxivhb eSUmfF"
+            class="bp3-input-group sc-htpNat iapfBj"
           >
             <input
               class="bp3-input"
@@ -100,17 +93,17 @@ exports[`offline round data entry renders 1`] = `
         </div>
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[contest-id-2][choice-id-4]"
       >
         Votes for 
         Choice Four
         :
         <div
-          class="sc-htpNat gdpVCF"
+          class="sc-bwzfXH jsIzlm"
         >
           <div
-            class="bp3-input-group sc-bxivhb eSUmfF"
+            class="bp3-input-group sc-htpNat iapfBj"
           >
             <input
               class="bp3-input"
@@ -124,7 +117,7 @@ exports[`offline round data entry renders 1`] = `
       </label>
     </div>
     <button
-      class="bp3-button bp3-intent-primary sc-dnqmqq bytmcb sc-htoDjs dESvso"
+      class="bp3-button bp3-intent-primary sc-htoDjs hNDkTe sc-gzVnrw kdzzfK"
       type="submit"
     >
       <span
@@ -140,18 +133,11 @@ exports[`offline round data entry renders 1`] = `
 exports[`offline round data entry submits 1`] = `
 <div>
   <form>
-    <h2
-      class="bp3-heading sc-bdVaJa ibVpPq"
-    >
-      Round 
-      1
-       Data Entry
-    </h2>
     <p>
       When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
     </p>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -159,26 +145,56 @@ exports[`offline round data entry submits 1`] = `
         Contest 1
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[contest-id-1][choice-id-1]"
       >
         Votes for 
         Choice One
         :
-        1
+        <div
+          class="sc-bwzfXH jsIzlm"
+        >
+          <div
+            class="bp3-input-group bp3-disabled sc-htpNat iapfBj"
+          >
+            <input
+              class="bp3-input"
+              disabled=""
+              id="results[contest-id-1][choice-id-1]"
+              name="results[contest-id-1][choice-id-1]"
+              style="padding-right: 10px;"
+              value="1"
+            />
+          </div>
+        </div>
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[contest-id-1][choice-id-2]"
       >
         Votes for 
         Choice Two
         :
-        2
+        <div
+          class="sc-bwzfXH jsIzlm"
+        >
+          <div
+            class="bp3-input-group bp3-disabled sc-htpNat iapfBj"
+          >
+            <input
+              class="bp3-input"
+              disabled=""
+              id="results[contest-id-1][choice-id-2]"
+              name="results[contest-id-1][choice-id-2]"
+              style="padding-right: 10px;"
+              value="2"
+            />
+          </div>
+        </div>
       </label>
     </div>
     <div
-      class="bp3-card bp3-elevation-2 sc-bwzfXH hrCotL"
+      class="bp3-card bp3-elevation-2 sc-bdVaJa hxCaJY"
     >
       <h5
         class="bp3-heading"
@@ -186,26 +202,56 @@ exports[`offline round data entry submits 1`] = `
         Contest 2
       </h5>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[contest-id-2][choice-id-3]"
       >
         Votes for 
         Choice Three
         :
-        1
+        <div
+          class="sc-bwzfXH jsIzlm"
+        >
+          <div
+            class="bp3-input-group bp3-disabled sc-htpNat iapfBj"
+          >
+            <input
+              class="bp3-input"
+              disabled=""
+              id="results[contest-id-2][choice-id-3]"
+              name="results[contest-id-2][choice-id-3]"
+              style="padding-right: 10px;"
+              value="1"
+            />
+          </div>
+        </div>
       </label>
       <label
-        class="sc-iwsKbI gesrUq"
+        class="sc-dnqmqq cUrdEb"
         for="results[contest-id-2][choice-id-4]"
       >
         Votes for 
         Choice Four
         :
-        2
+        <div
+          class="sc-bwzfXH jsIzlm"
+        >
+          <div
+            class="bp3-input-group bp3-disabled sc-htpNat iapfBj"
+          >
+            <input
+              class="bp3-input"
+              disabled=""
+              id="results[contest-id-2][choice-id-4]"
+              name="results[contest-id-2][choice-id-4]"
+              style="padding-right: 10px;"
+              value="2"
+            />
+          </div>
+        </div>
       </label>
     </div>
     <button
-      class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq bytmcb sc-htoDjs dESvso"
+      class="bp3-button bp3-disabled bp3-intent-primary sc-htoDjs hNDkTe sc-gzVnrw kdzzfK"
       disabled=""
       tabindex="-1"
       type="submit"

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/RoundProgress.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/RoundProgress.test.tsx.snap
@@ -2,16 +2,14 @@
 
 exports[`RoundProgress renders complete round 1`] = `
 <div>
-  <h2
-    class="bp3-heading sc-bdVaJa ibVpPq"
-  >
-    Round 
-    1
-     Progress
-  </h2>
   <div
-    class="sc-bwzfXH eeIcAa"
+    class="sc-bdVaJa dXfzyv"
   >
+    <h4
+      class="bp3-heading"
+    >
+      Audit Board Progress
+    </h4>
     <span>
       30
        of 
@@ -29,7 +27,7 @@ exports[`RoundProgress renders complete round 1`] = `
     </div>
   </div>
   <div
-    class="sc-htpNat jxYgaV"
+    class="sc-bwzfXH jGjlAC"
   >
     <span>
       Audit Board #01: 30 of 30 ballots audited 
@@ -48,16 +46,14 @@ exports[`RoundProgress renders complete round 1`] = `
 
 exports[`RoundProgress renders incomplete round with an audit board 1`] = `
 <div>
-  <h2
-    class="bp3-heading sc-bdVaJa ibVpPq"
-  >
-    Round 
-    1
-     Progress
-  </h2>
   <div
-    class="sc-bwzfXH eeIcAa"
+    class="sc-bdVaJa dXfzyv"
   >
+    <h4
+      class="bp3-heading"
+    >
+      Audit Board Progress
+    </h4>
     <span>
       0
        of 
@@ -75,7 +71,7 @@ exports[`RoundProgress renders incomplete round with an audit board 1`] = `
     </div>
   </div>
   <div
-    class="sc-htpNat jxYgaV"
+    class="sc-bwzfXH jGjlAC"
   >
     <span>
       Audit Board #01: 0 of 30 ballots audited 
@@ -94,16 +90,14 @@ exports[`RoundProgress renders incomplete round with an audit board 1`] = `
 
 exports[`RoundProgress renders incomplete round with an audit board with no ballots sampled 1`] = `
 <div>
-  <h2
-    class="bp3-heading sc-bdVaJa ibVpPq"
-  >
-    Round 
-    1
-     Progress
-  </h2>
   <div
-    class="sc-bwzfXH eeIcAa"
+    class="sc-bdVaJa dXfzyv"
   >
+    <h4
+      class="bp3-heading"
+    >
+      Audit Board Progress
+    </h4>
     <span>
       0
        of 
@@ -121,7 +115,7 @@ exports[`RoundProgress renders incomplete round with an audit board with no ball
     </div>
   </div>
   <div
-    class="sc-htpNat jxYgaV"
+    class="sc-bwzfXH jGjlAC"
   >
     <span>
       Audit Board #01
@@ -129,7 +123,7 @@ exports[`RoundProgress renders incomplete round with an audit board with no ball
     </span>
   </div>
   <div
-    class="sc-htpNat jxYgaV"
+    class="sc-bwzfXH jGjlAC"
   >
     <span>
       Audit Board #02: 0 of 30 ballots audited 
@@ -148,16 +142,14 @@ exports[`RoundProgress renders incomplete round with an audit board with no ball
 
 exports[`RoundProgress renders incomplete round with auditing in progress 1`] = `
 <div>
-  <h2
-    class="bp3-heading sc-bdVaJa ibVpPq"
-  >
-    Round 
-    1
-     Progress
-  </h2>
   <div
-    class="sc-bwzfXH eeIcAa"
+    class="sc-bdVaJa dXfzyv"
   >
+    <h4
+      class="bp3-heading"
+    >
+      Audit Board Progress
+    </h4>
     <span>
       15
        of 
@@ -175,7 +167,7 @@ exports[`RoundProgress renders incomplete round with auditing in progress 1`] = 
     </div>
   </div>
   <div
-    class="sc-htpNat jxYgaV"
+    class="sc-bwzfXH jGjlAC"
   >
     <span>
       Audit Board #01: 15 of 30 ballots audited 
@@ -196,16 +188,14 @@ exports[`RoundProgress renders incomplete round with no audit boards 1`] = `<div
 
 exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
 <div>
-  <h2
-    class="bp3-heading sc-bdVaJa ibVpPq"
-  >
-    Round 
-    1
-     Progress
-  </h2>
   <div
-    class="sc-bwzfXH eeIcAa"
+    class="sc-bdVaJa dXfzyv"
   >
+    <h4
+      class="bp3-heading"
+    >
+      Audit Board Progress
+    </h4>
     <span>
       0
        of 
@@ -223,7 +213,7 @@ exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
     </div>
   </div>
   <div
-    class="sc-htpNat jxYgaV"
+    class="sc-bwzfXH jGjlAC"
   >
     <span>
       Audit Board #01: 0 of 30 ballots audited 
@@ -238,7 +228,7 @@ exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
     </div>
   </div>
   <div
-    class="sc-htpNat jxYgaV"
+    class="sc-bwzfXH jGjlAC"
   >
     <span>
       Audit Board #02: 0 of 30 ballots audited 

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
@@ -3,17 +3,24 @@
 exports[`RoundManagement renders audit setup with ballot audit 1`] = `
 <div>
   <div
-    class="sc-bdVaJa single-page left sc-dxgOiQ hFvvYA"
+    class="sc-bdVaJa sc-ckVGcZ eyWwvb"
   >
-    <h2
-      class="bp3-heading sc-htpNat fysvnw"
+    <h3
+      class="bp3-heading"
     >
       Round 
       1
        Audit Board Setup
-    </h2>
+    </h3>
+    <p
+      class="sc-eNQAEJ iwowog"
+    >
+      40
+       ballots to audit in Round 
+      1
+    </p>
     <div
-      class="sc-gzVnrw dTrzyS"
+      class="sc-dnqmqq jnbCEU"
     >
       <h4
         class="bp3-heading"
@@ -24,89 +31,86 @@ exports[`RoundManagement renders audit setup with ballot audit 1`] = `
         Select the appropriate number of audit boards based upon the personnel available and the number of ballots assigned to your jurisdiction for this round of the audit. You will have the opportunity to adjust the number of audit boards before the next round of the audit, if another round is required.
       </p>
       <div
-        class="bp3-html-select sc-htoDjs hCYfMu sc-bZQynM dFcXvN"
+        class="sc-bZQynM ibvdum"
       >
-        <select
-          data-testid="numAuditBoards"
-          field="[object Object]"
-          form="[object Object]"
-          id="numAuditBoards"
+        <div
+          class="bp3-html-select sc-iwsKbI iSMuWx sc-EHOje lcjkJq"
         >
-          <option>
-            1
-          </option>
-          <option>
-            2
-          </option>
-          <option>
-            3
-          </option>
-          <option>
-            4
-          </option>
-          <option>
-            5
-          </option>
-          <option>
-            6
-          </option>
-          <option>
-            7
-          </option>
-          <option>
-            8
-          </option>
-          <option>
-            9
-          </option>
-          <option>
-            10
-          </option>
-          <option>
-            11
-          </option>
-          <option>
-            12
-          </option>
-          <option>
-            13
-          </option>
-          <option>
-            14
-          </option>
-          <option>
-            15
-          </option>
-        </select>
-        <span
-          class="bp3-icon bp3-icon-double-caret-vertical"
-          icon="double-caret-vertical"
-        >
-          <svg
-            data-icon="double-caret-vertical"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
+          <select
+            data-testid="numAuditBoards"
+            field="[object Object]"
+            form="[object Object]"
+            id="numAuditBoards"
           >
-            <desc>
-              double-caret-vertical
-            </desc>
-            <path
-              d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </span>
+            <option>
+              1
+            </option>
+            <option>
+              2
+            </option>
+            <option>
+              3
+            </option>
+            <option>
+              4
+            </option>
+            <option>
+              5
+            </option>
+            <option>
+              6
+            </option>
+            <option>
+              7
+            </option>
+            <option>
+              8
+            </option>
+            <option>
+              9
+            </option>
+            <option>
+              10
+            </option>
+            <option>
+              11
+            </option>
+            <option>
+              12
+            </option>
+            <option>
+              13
+            </option>
+            <option>
+              14
+            </option>
+            <option>
+              15
+            </option>
+          </select>
+          <span
+            class="bp3-icon bp3-icon-double-caret-vertical"
+            icon="double-caret-vertical"
+          >
+            <svg
+              data-icon="double-caret-vertical"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                double-caret-vertical
+              </desc>
+              <path
+                d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
-      <p
-        class="sc-dnqmqq cMacxD"
-      >
-        40
-         Ballots to Audit in Round 
-        1
-      </p>
       <button
-        class="bp3-button sc-EHOje gmpgQN"
+        class="bp3-button bp3-intent-primary sc-ifAKCX zdCNs"
         type="button"
       >
         <span
@@ -123,17 +127,24 @@ exports[`RoundManagement renders audit setup with ballot audit 1`] = `
 exports[`RoundManagement renders audit setup with batch audit 1`] = `
 <div>
   <div
-    class="sc-bdVaJa single-page left sc-dxgOiQ hFvvYA"
+    class="sc-bdVaJa sc-ckVGcZ eyWwvb"
   >
-    <h2
-      class="bp3-heading sc-htpNat fysvnw"
+    <h3
+      class="bp3-heading"
     >
       Round 
       1
        Audit Board Setup
-    </h2>
+    </h3>
+    <p
+      class="sc-eNQAEJ iwowog"
+    >
+      40
+       ballots to audit in Round 
+      1
+    </p>
     <div
-      class="sc-gzVnrw dTrzyS"
+      class="sc-dnqmqq jnbCEU"
     >
       <h4
         class="bp3-heading"
@@ -144,89 +155,86 @@ exports[`RoundManagement renders audit setup with batch audit 1`] = `
         Select the appropriate number of audit boards based upon the personnel available and the number of ballots assigned to your jurisdiction for this round of the audit. You will have the opportunity to adjust the number of audit boards before the next round of the audit, if another round is required.
       </p>
       <div
-        class="bp3-html-select sc-htoDjs hCYfMu sc-bZQynM dFcXvN"
+        class="sc-bZQynM ibvdum"
       >
-        <select
-          data-testid="numAuditBoards"
-          field="[object Object]"
-          form="[object Object]"
-          id="numAuditBoards"
+        <div
+          class="bp3-html-select sc-iwsKbI iSMuWx sc-EHOje lcjkJq"
         >
-          <option>
-            1
-          </option>
-          <option>
-            2
-          </option>
-          <option>
-            3
-          </option>
-          <option>
-            4
-          </option>
-          <option>
-            5
-          </option>
-          <option>
-            6
-          </option>
-          <option>
-            7
-          </option>
-          <option>
-            8
-          </option>
-          <option>
-            9
-          </option>
-          <option>
-            10
-          </option>
-          <option>
-            11
-          </option>
-          <option>
-            12
-          </option>
-          <option>
-            13
-          </option>
-          <option>
-            14
-          </option>
-          <option>
-            15
-          </option>
-        </select>
-        <span
-          class="bp3-icon bp3-icon-double-caret-vertical"
-          icon="double-caret-vertical"
-        >
-          <svg
-            data-icon="double-caret-vertical"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
+          <select
+            data-testid="numAuditBoards"
+            field="[object Object]"
+            form="[object Object]"
+            id="numAuditBoards"
           >
-            <desc>
-              double-caret-vertical
-            </desc>
-            <path
-              d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </span>
+            <option>
+              1
+            </option>
+            <option>
+              2
+            </option>
+            <option>
+              3
+            </option>
+            <option>
+              4
+            </option>
+            <option>
+              5
+            </option>
+            <option>
+              6
+            </option>
+            <option>
+              7
+            </option>
+            <option>
+              8
+            </option>
+            <option>
+              9
+            </option>
+            <option>
+              10
+            </option>
+            <option>
+              11
+            </option>
+            <option>
+              12
+            </option>
+            <option>
+              13
+            </option>
+            <option>
+              14
+            </option>
+            <option>
+              15
+            </option>
+          </select>
+          <span
+            class="bp3-icon bp3-icon-double-caret-vertical"
+            icon="double-caret-vertical"
+          >
+            <svg
+              data-icon="double-caret-vertical"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                double-caret-vertical
+              </desc>
+              <path
+                d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
-      <p
-        class="sc-dnqmqq cMacxD"
-      >
-        40
-         Ballots to Audit in Round 
-        1
-      </p>
       <button
-        class="bp3-button sc-EHOje gmpgQN"
+        class="bp3-button bp3-intent-primary sc-ifAKCX zdCNs"
         type="button"
       >
         <span
@@ -243,10 +251,10 @@ exports[`RoundManagement renders audit setup with batch audit 1`] = `
 exports[`RoundManagement renders complete view 1`] = `
 <div>
   <div
-    class="sc-bdVaJa single-page sc-dxgOiQ hFvvYA"
+    class="sc-bdVaJa sc-ckVGcZ eyWwvb"
   >
     <h2
-      class="bp3-heading sc-htpNat fysvnw"
+      class="bp3-heading"
     >
       Congratulations! Your Risk-Limiting Audit is now complete.
     </h2>
@@ -257,231 +265,305 @@ exports[`RoundManagement renders complete view 1`] = `
 exports[`RoundManagement renders links & data entry with batch audit 1`] = `
 <div>
   <div
-    class="sc-bdVaJa single-page left sc-dxgOiQ hFvvYA"
+    class="sc-bdVaJa sc-ckVGcZ eyWwvb"
   >
-    <button
-      class="bp3-button sc-ifAKCX kKfkZO"
-      type="button"
+    <h3
+      class="bp3-heading"
     >
-      <span
-        class="bp3-button-text"
-      >
-        Download Aggregated
-         
-        Batch
-         Retrieval List for Round 
-        1
-      </span>
-    </button>
-    <button
-      class="bp3-button sc-ifAKCX kKfkZO"
-      type="button"
+      Round 
+      1
+       Data Entry
+    </h3>
+    <div
+      class="sc-jKJlTe lcqeCu"
     >
-      <span
-        class="bp3-button-text"
+      <p
+        class="sc-eNQAEJ iwowog"
       >
-        Download Placeholder Sheets for Round 
+        40
+         ballots to audit in Round 
         1
-      </span>
-    </button>
-    <button
-      class="bp3-button sc-ifAKCX kKfkZO"
-      type="button"
-    >
-      <span
-        class="bp3-button-text"
-      >
-        Download Ballot Labels for Round 
-        1
-      </span>
-    </button>
-    <form>
-      <h2
-        class="bp3-heading sc-htpNat fysvnw"
-      >
-        Round 
-        1
-         Data Entry
-      </h2>
-      <p>
-        When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
       </p>
       <div
-        class="bp3-card bp3-elevation-2 sc-VigVT bXvjOC"
+        class="bp3-button-group bp3-vertical bp3-align-left"
       >
-        <h5
-          class="bp3-heading"
+        <button
+          class="bp3-button"
+          type="button"
         >
-          Batch: Batch One, Contest: Contest 1
-        </h5>
-        <label
-          class="sc-kpOJdX fZDKze"
-          for="results[batch-1][choice-id-1]"
-        >
-          Votes for 
-          Choice One
-          :
-          <div
-            class="sc-jTzLTM gTHUJn"
+          <span
+            class="bp3-icon bp3-icon-th"
+            icon="th"
           >
-            <div
-              class="bp3-input-group sc-fjdhpX dmEgAR"
+            <svg
+              data-icon="th"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
             >
-              <input
-                class="bp3-input"
-                id="results[batch-1][choice-id-1]"
-                name="results[batch-1][choice-id-1]"
-                style="padding-right: 10px;"
-                value=""
+              <desc>
+                th
+              </desc>
+              <path
+                d="M15 1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h14c.6 0 1-.4 1-1V2c0-.5-.4-1-1-1zM6 13H2v-2h4v2zm0-3H2V8h4v2zm0-3H2V5h4v2zm8 6H7v-2h7v2zm0-3H7V8h7v2zm0-3H7V5h7v2z"
+                fill-rule="evenodd"
               />
-            </div>
-          </div>
-        </label>
-        <label
-          class="sc-kpOJdX fZDKze"
-          for="results[batch-1][choice-id-2]"
-        >
-          Votes for 
-          Choice Two
-          :
-          <div
-            class="sc-jTzLTM gTHUJn"
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
           >
-            <div
-              class="bp3-input-group sc-fjdhpX dmEgAR"
+            Download Aggregated
+             
+            Batch
+             
+            Retrieval List
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-document"
+            icon="document"
+          >
+            <svg
+              data-icon="document"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
             >
-              <input
-                class="bp3-input"
-                id="results[batch-1][choice-id-2]"
-                name="results[batch-1][choice-id-2]"
-                style="padding-right: 10px;"
-                value=""
+              <desc>
+                document
+              </desc>
+              <path
+                d="M9 0H3c-.55 0-1 .45-1 1v14c0 .55.45 1 1 1h10c.55 0 1-.45 1-1V5L9 0zm3 14H4V2h4v4h4v8z"
+                fill-rule="evenodd"
               />
-            </div>
-          </div>
-        </label>
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Download Placeholder Sheets
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-label"
+            icon="label"
+          >
+            <svg
+              data-icon="label"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                label
+              </desc>
+              <path
+                d="M11 2H1c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h14c.55 0 1-.45 1-1V7l-5-5zm3 10H2V4h8v2H3v1h7v1h4v4zm-3-5V4l3 3h-3zm-8 3h10V9H3v1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Download Ballot Labels
+          </span>
+        </button>
       </div>
-      <div
-        class="bp3-card bp3-elevation-2 sc-VigVT bXvjOC"
-      >
-        <h5
-          class="bp3-heading"
+    </div>
+    <div
+      class="sc-jKJlTe lcqeCu"
+    >
+      <form>
+        <p>
+          When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
+        </p>
+        <div
+          class="bp3-card bp3-elevation-2 sc-jTzLTM kZeJjn"
         >
-          Batch: Batch Two, Contest: Contest 1
-        </h5>
-        <label
-          class="sc-kpOJdX fZDKze"
-          for="results[batch-2][choice-id-1]"
-        >
-          Votes for 
-          Choice One
-          :
-          <div
-            class="sc-jTzLTM gTHUJn"
+          <h5
+            class="bp3-heading"
           >
-            <div
-              class="bp3-input-group sc-fjdhpX dmEgAR"
-            >
-              <input
-                class="bp3-input"
-                id="results[batch-2][choice-id-1]"
-                name="results[batch-2][choice-id-1]"
-                style="padding-right: 10px;"
-                value=""
-              />
-            </div>
-          </div>
-        </label>
-        <label
-          class="sc-kpOJdX fZDKze"
-          for="results[batch-2][choice-id-2]"
-        >
-          Votes for 
-          Choice Two
-          :
-          <div
-            class="sc-jTzLTM gTHUJn"
+            Batch: Batch One, Contest: Contest 1
+          </h5>
+          <label
+            class="sc-dxgOiQ hkjLkh"
+            for="results[batch-1][choice-id-1]"
           >
+            Votes for 
+            Choice One
+            :
             <div
-              class="bp3-input-group sc-fjdhpX dmEgAR"
+              class="sc-fjdhpX hpEPln"
             >
-              <input
-                class="bp3-input"
-                id="results[batch-2][choice-id-2]"
-                name="results[batch-2][choice-id-2]"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <div
+                class="bp3-input-group sc-jzJRlG lpfNbV"
+              >
+                <input
+                  class="bp3-input"
+                  id="results[batch-1][choice-id-1]"
+                  name="results[batch-1][choice-id-1]"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <div
-        class="bp3-card bp3-elevation-2 sc-VigVT bXvjOC"
-      >
-        <h5
-          class="bp3-heading"
-        >
-          Batch: Batch Three, Contest: Contest 1
-        </h5>
-        <label
-          class="sc-kpOJdX fZDKze"
-          for="results[batch-3][choice-id-1]"
-        >
-          Votes for 
-          Choice One
-          :
-          <div
-            class="sc-jTzLTM gTHUJn"
+          </label>
+          <label
+            class="sc-dxgOiQ hkjLkh"
+            for="results[batch-1][choice-id-2]"
           >
+            Votes for 
+            Choice Two
+            :
             <div
-              class="bp3-input-group sc-fjdhpX dmEgAR"
+              class="sc-fjdhpX hpEPln"
             >
-              <input
-                class="bp3-input"
-                id="results[batch-3][choice-id-1]"
-                name="results[batch-3][choice-id-1]"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <div
+                class="bp3-input-group sc-jzJRlG lpfNbV"
+              >
+                <input
+                  class="bp3-input"
+                  id="results[batch-1][choice-id-2]"
+                  name="results[batch-1][choice-id-2]"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-        <label
-          class="sc-kpOJdX fZDKze"
-          for="results[batch-3][choice-id-2]"
+          </label>
+        </div>
+        <div
+          class="bp3-card bp3-elevation-2 sc-jTzLTM kZeJjn"
         >
-          Votes for 
-          Choice Two
-          :
-          <div
-            class="sc-jTzLTM gTHUJn"
+          <h5
+            class="bp3-heading"
           >
+            Batch: Batch Two, Contest: Contest 1
+          </h5>
+          <label
+            class="sc-dxgOiQ hkjLkh"
+            for="results[batch-2][choice-id-1]"
+          >
+            Votes for 
+            Choice One
+            :
             <div
-              class="bp3-input-group sc-fjdhpX dmEgAR"
+              class="sc-fjdhpX hpEPln"
             >
-              <input
-                class="bp3-input"
-                id="results[batch-3][choice-id-2]"
-                name="results[batch-3][choice-id-2]"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <div
+                class="bp3-input-group sc-jzJRlG lpfNbV"
+              >
+                <input
+                  class="bp3-input"
+                  id="results[batch-2][choice-id-1]"
+                  name="results[batch-2][choice-id-1]"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <button
-        class="bp3-button bp3-intent-primary sc-kGXeez fuuyeD sc-EHOje gmpgQN"
-        type="submit"
-      >
-        <span
-          class="bp3-button-text"
+          </label>
+          <label
+            class="sc-dxgOiQ hkjLkh"
+            for="results[batch-2][choice-id-2]"
+          >
+            Votes for 
+            Choice Two
+            :
+            <div
+              class="sc-fjdhpX hpEPln"
+            >
+              <div
+                class="bp3-input-group sc-jzJRlG lpfNbV"
+              >
+                <input
+                  class="bp3-input"
+                  id="results[batch-2][choice-id-2]"
+                  name="results[batch-2][choice-id-2]"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="bp3-card bp3-elevation-2 sc-jTzLTM kZeJjn"
         >
-          Submit Data for Round 1
-        </span>
-      </button>
-    </form>
+          <h5
+            class="bp3-heading"
+          >
+            Batch: Batch Three, Contest: Contest 1
+          </h5>
+          <label
+            class="sc-dxgOiQ hkjLkh"
+            for="results[batch-3][choice-id-1]"
+          >
+            Votes for 
+            Choice One
+            :
+            <div
+              class="sc-fjdhpX hpEPln"
+            >
+              <div
+                class="bp3-input-group sc-jzJRlG lpfNbV"
+              >
+                <input
+                  class="bp3-input"
+                  id="results[batch-3][choice-id-1]"
+                  name="results[batch-3][choice-id-1]"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+          <label
+            class="sc-dxgOiQ hkjLkh"
+            for="results[batch-3][choice-id-2]"
+          >
+            Votes for 
+            Choice Two
+            :
+            <div
+              class="sc-fjdhpX hpEPln"
+            >
+              <div
+                class="bp3-input-group sc-jzJRlG lpfNbV"
+              >
+                <input
+                  class="bp3-input"
+                  id="results[batch-3][choice-id-2]"
+                  name="results[batch-3][choice-id-2]"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <button
+          class="bp3-button bp3-intent-primary sc-kpOJdX glAiLs sc-ifAKCX zdCNs"
+          type="submit"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Submit Data for Round 1
+          </span>
+        </button>
+      </form>
+    </div>
   </div>
 </div>
 `;
@@ -489,176 +571,250 @@ exports[`RoundManagement renders links & data entry with batch audit 1`] = `
 exports[`RoundManagement renders links & data entry with offline ballot audit 1`] = `
 <div>
   <div
-    class="sc-bdVaJa single-page left sc-dxgOiQ hFvvYA"
+    class="sc-bdVaJa sc-ckVGcZ eyWwvb"
   >
-    <button
-      class="bp3-button sc-ifAKCX kKfkZO"
-      type="button"
+    <h3
+      class="bp3-heading"
     >
-      <span
-        class="bp3-button-text"
-      >
-        Download Aggregated
-         
-        Ballot
-         Retrieval List for Round 
-        1
-      </span>
-    </button>
-    <button
-      class="bp3-button sc-ifAKCX kKfkZO"
-      type="button"
+      Round 
+      1
+       Data Entry
+    </h3>
+    <div
+      class="sc-jKJlTe lcqeCu"
     >
-      <span
-        class="bp3-button-text"
+      <p
+        class="sc-eNQAEJ iwowog"
       >
-        Download Placeholder Sheets for Round 
+        40
+         ballots to audit in Round 
         1
-      </span>
-    </button>
-    <button
-      class="bp3-button sc-ifAKCX kKfkZO"
-      type="button"
-    >
-      <span
-        class="bp3-button-text"
-      >
-        Download Ballot Labels for Round 
-        1
-      </span>
-    </button>
-    <form>
-      <h2
-        class="bp3-heading sc-htpNat fysvnw"
-      >
-        Round 
-        1
-         Data Entry
-      </h2>
-      <p>
-        When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
       </p>
       <div
-        class="bp3-card bp3-elevation-2 sc-VigVT bXvjOC"
+        class="bp3-button-group bp3-vertical bp3-align-left"
       >
-        <h5
-          class="bp3-heading"
+        <button
+          class="bp3-button"
+          type="button"
         >
-          Contest 1
-        </h5>
-        <label
-          class="sc-kgoBCf hiauKL"
-          for="results[contest-id-1][choice-id-1]"
-        >
-          Votes for 
-          Choice One
-          :
-          <div
-            class="sc-jTzLTM gTHUJn"
+          <span
+            class="bp3-icon bp3-icon-th"
+            icon="th"
           >
-            <div
-              class="bp3-input-group sc-fjdhpX dmEgAR"
+            <svg
+              data-icon="th"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
             >
-              <input
-                class="bp3-input"
-                id="results[contest-id-1][choice-id-1]"
-                name="results[contest-id-1][choice-id-1]"
-                style="padding-right: 10px;"
-                value=""
+              <desc>
+                th
+              </desc>
+              <path
+                d="M15 1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h14c.6 0 1-.4 1-1V2c0-.5-.4-1-1-1zM6 13H2v-2h4v2zm0-3H2V8h4v2zm0-3H2V5h4v2zm8 6H7v-2h7v2zm0-3H7V8h7v2zm0-3H7V5h7v2z"
+                fill-rule="evenodd"
               />
-            </div>
-          </div>
-        </label>
-        <label
-          class="sc-kgoBCf hiauKL"
-          for="results[contest-id-1][choice-id-2]"
-        >
-          Votes for 
-          Choice Two
-          :
-          <div
-            class="sc-jTzLTM gTHUJn"
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
           >
-            <div
-              class="bp3-input-group sc-fjdhpX dmEgAR"
+            Download Aggregated
+             
+            Ballot
+             
+            Retrieval List
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-document"
+            icon="document"
+          >
+            <svg
+              data-icon="document"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
             >
-              <input
-                class="bp3-input"
-                id="results[contest-id-1][choice-id-2]"
-                name="results[contest-id-1][choice-id-2]"
-                style="padding-right: 10px;"
-                value=""
+              <desc>
+                document
+              </desc>
+              <path
+                d="M9 0H3c-.55 0-1 .45-1 1v14c0 .55.45 1 1 1h10c.55 0 1-.45 1-1V5L9 0zm3 14H4V2h4v4h4v8z"
+                fill-rule="evenodd"
               />
-            </div>
-          </div>
-        </label>
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Download Placeholder Sheets
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-label"
+            icon="label"
+          >
+            <svg
+              data-icon="label"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                label
+              </desc>
+              <path
+                d="M11 2H1c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h14c.55 0 1-.45 1-1V7l-5-5zm3 10H2V4h8v2H3v1h7v1h4v4zm-3-5V4l3 3h-3zm-8 3h10V9H3v1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Download Ballot Labels
+          </span>
+        </button>
       </div>
-      <div
-        class="bp3-card bp3-elevation-2 sc-VigVT bXvjOC"
-      >
-        <h5
-          class="bp3-heading"
+    </div>
+    <div
+      class="sc-jKJlTe lcqeCu"
+    >
+      <form>
+        <p>
+          When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice from the audited ballots.
+        </p>
+        <div
+          class="bp3-card bp3-elevation-2 sc-jTzLTM kZeJjn"
         >
-          Contest 2
-        </h5>
-        <label
-          class="sc-kgoBCf hiauKL"
-          for="results[contest-id-2][choice-id-3]"
-        >
-          Votes for 
-          Choice Three
-          :
-          <div
-            class="sc-jTzLTM gTHUJn"
+          <h5
+            class="bp3-heading"
           >
-            <div
-              class="bp3-input-group sc-fjdhpX dmEgAR"
-            >
-              <input
-                class="bp3-input"
-                id="results[contest-id-2][choice-id-3]"
-                name="results[contest-id-2][choice-id-3]"
-                style="padding-right: 10px;"
-                value=""
-              />
-            </div>
-          </div>
-        </label>
-        <label
-          class="sc-kgoBCf hiauKL"
-          for="results[contest-id-2][choice-id-4]"
-        >
-          Votes for 
-          Choice Four
-          :
-          <div
-            class="sc-jTzLTM gTHUJn"
+            Contest 1
+          </h5>
+          <label
+            class="sc-kGXeez htRkSS"
+            for="results[contest-id-1][choice-id-1]"
           >
+            Votes for 
+            Choice One
+            :
             <div
-              class="bp3-input-group sc-fjdhpX dmEgAR"
+              class="sc-fjdhpX hpEPln"
             >
-              <input
-                class="bp3-input"
-                id="results[contest-id-2][choice-id-4]"
-                name="results[contest-id-2][choice-id-4]"
-                style="padding-right: 10px;"
-                value=""
-              />
+              <div
+                class="bp3-input-group sc-jzJRlG lpfNbV"
+              >
+                <input
+                  class="bp3-input"
+                  id="results[contest-id-1][choice-id-1]"
+                  name="results[contest-id-1][choice-id-1]"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
             </div>
-          </div>
-        </label>
-      </div>
-      <button
-        class="bp3-button bp3-intent-primary sc-chPdSV ikUOhS sc-EHOje gmpgQN"
-        type="submit"
-      >
-        <span
-          class="bp3-button-text"
+          </label>
+          <label
+            class="sc-kGXeez htRkSS"
+            for="results[contest-id-1][choice-id-2]"
+          >
+            Votes for 
+            Choice Two
+            :
+            <div
+              class="sc-fjdhpX hpEPln"
+            >
+              <div
+                class="bp3-input-group sc-jzJRlG lpfNbV"
+              >
+                <input
+                  class="bp3-input"
+                  id="results[contest-id-1][choice-id-2]"
+                  name="results[contest-id-1][choice-id-2]"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <div
+          class="bp3-card bp3-elevation-2 sc-jTzLTM kZeJjn"
         >
-          Submit Data for Round 1
-        </span>
-      </button>
-    </form>
+          <h5
+            class="bp3-heading"
+          >
+            Contest 2
+          </h5>
+          <label
+            class="sc-kGXeez htRkSS"
+            for="results[contest-id-2][choice-id-3]"
+          >
+            Votes for 
+            Choice Three
+            :
+            <div
+              class="sc-fjdhpX hpEPln"
+            >
+              <div
+                class="bp3-input-group sc-jzJRlG lpfNbV"
+              >
+                <input
+                  class="bp3-input"
+                  id="results[contest-id-2][choice-id-3]"
+                  name="results[contest-id-2][choice-id-3]"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+          <label
+            class="sc-kGXeez htRkSS"
+            for="results[contest-id-2][choice-id-4]"
+          >
+            Votes for 
+            Choice Four
+            :
+            <div
+              class="sc-fjdhpX hpEPln"
+            >
+              <div
+                class="bp3-input-group sc-jzJRlG lpfNbV"
+              >
+                <input
+                  class="bp3-input"
+                  id="results[contest-id-2][choice-id-4]"
+                  name="results[contest-id-2][choice-id-4]"
+                  style="padding-right: 10px;"
+                  value=""
+                />
+              </div>
+            </div>
+          </label>
+        </div>
+        <button
+          class="bp3-button bp3-intent-primary sc-kgoBCf oMZJm sc-ifAKCX zdCNs"
+          type="submit"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Submit Data for Round 1
+          </span>
+        </button>
+      </form>
+    </div>
   </div>
 </div>
 `;
@@ -666,143 +822,207 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
 exports[`RoundManagement renders links & progress with online ballot audit 1`] = `
 <div>
   <div
-    class="sc-bdVaJa single-page left sc-dxgOiQ hFvvYA"
+    class="sc-bdVaJa sc-ckVGcZ eyWwvb"
   >
-    <button
-      class="bp3-button sc-ifAKCX kKfkZO"
-      type="button"
-    >
-      <span
-        class="bp3-button-text"
-      >
-        Download Aggregated
-         
-        Ballot
-         Retrieval List for Round 
-        1
-      </span>
-    </button>
-    <button
-      class="bp3-button sc-ifAKCX kKfkZO"
-      type="button"
-    >
-      <span
-        class="bp3-button-text"
-      >
-        Download Placeholder Sheets for Round 
-        1
-      </span>
-    </button>
-    <button
-      class="bp3-button sc-ifAKCX kKfkZO"
-      type="button"
-    >
-      <span
-        class="bp3-button-text"
-      >
-        Download Ballot Labels for Round 
-        1
-      </span>
-    </button>
-    <button
-      class="bp3-button sc-ifAKCX kKfkZO"
-      type="button"
-    >
-      <span
-        class="bp3-button-text"
-      >
-        Download Audit Board Credentials for Data Entry
-      </span>
-    </button>
-    <div
-      class="sc-gqjmRU bfUpFK"
-      id="qr-root"
-    >
-      <span
-        id="qr-happy-rebel-base"
-      >
-        <canvas
-          height="200"
-          style="height: 200px; width: 200px;"
-          width="200"
-        />
-      </span>
-    </div>
-    <h2
-      class="bp3-heading sc-htpNat fysvnw"
+    <h3
+      class="bp3-heading"
     >
       Round 
       1
-       Progress
-    </h2>
+       Data Entry
+    </h3>
     <div
-      class="sc-iwsKbI fpOYtu"
+      class="sc-jKJlTe lcqeCu"
     >
-      <span>
-        0
-         of 
-        30
-         ballots audited
-         
-      </span>
-      <div
-        class="bp3-progress-bar bp3-intent-primary"
+      <p
+        class="sc-eNQAEJ iwowog"
       >
+        40
+         ballots to audit in Round 
+        1
+      </p>
+      <div
+        class="bp3-button-group bp3-vertical bp3-align-left"
+      >
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-th"
+            icon="th"
+          >
+            <svg
+              data-icon="th"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                th
+              </desc>
+              <path
+                d="M15 1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h14c.6 0 1-.4 1-1V2c0-.5-.4-1-1-1zM6 13H2v-2h4v2zm0-3H2V8h4v2zm0-3H2V5h4v2zm8 6H7v-2h7v2zm0-3H7V8h7v2zm0-3H7V5h7v2z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Download Aggregated
+             
+            Ballot
+             
+            Retrieval List
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-document"
+            icon="document"
+          >
+            <svg
+              data-icon="document"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                document
+              </desc>
+              <path
+                d="M9 0H3c-.55 0-1 .45-1 1v14c0 .55.45 1 1 1h10c.55 0 1-.45 1-1V5L9 0zm3 14H4V2h4v4h4v8z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Download Placeholder Sheets
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-label"
+            icon="label"
+          >
+            <svg
+              data-icon="label"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                label
+              </desc>
+              <path
+                d="M11 2H1c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h14c.55 0 1-.45 1-1V7l-5-5zm3 10H2V4h8v2H3v1h7v1h4v4zm-3-5V4l3 3h-3zm-8 3h10V9H3v1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Download Ballot Labels
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-key"
+            icon="key"
+          >
+            <svg
+              data-icon="key"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                key
+              </desc>
+              <path
+                d="M11 0C8.24 0 6 2.24 6 5c0 1.02.31 1.96.83 2.75L.29 14.29a1.003 1.003 0 001.42 1.42L3 14.41l1.29 1.29c.18.19.43.3.71.3s.53-.11.71-.29l2-2c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71L6.41 11l1.83-1.83c.8.52 1.74.83 2.76.83 2.76 0 5-2.24 5-5s-2.24-5-5-5zm0 8c-.23 0-.45-.03-.66-.08-.01 0-.02-.01-.03-.01-.21-.05-.41-.12-.6-.21a3.014 3.014 0 01-1.62-2c0-.01-.01-.02-.01-.03C8.03 5.45 8 5.23 8 5c0-1.66 1.34-3 3-3s3 1.34 3 3-1.34 3-3 3z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Download Audit Board Credentials
+          </span>
+        </button>
         <div
-          class="bp3-progress-meter"
-          style="width: 0%;"
-        />
+          class="sc-VigVT iyEYjY"
+          id="qr-root"
+        >
+          <span
+            id="qr-happy-rebel-base"
+          >
+            <canvas
+              height="200"
+              style="height: 200px; width: 200px;"
+              width="200"
+            />
+          </span>
+        </div>
       </div>
     </div>
     <div
-      class="sc-gZMcBi dmwxst"
+      class="sc-jKJlTe lcqeCu"
     >
-      <span>
-        Audit Board #01: 0 of 30 ballots audited 
-      </span>
       <div
-        class="bp3-progress-bar bp3-intent-primary"
+        class="sc-gZMcBi hUnsTv"
       >
+        <h4
+          class="bp3-heading"
+        >
+          Audit Board Progress
+        </h4>
+        <span>
+          0
+           of 
+          30
+           ballots audited
+           
+        </span>
         <div
-          class="bp3-progress-meter"
-          style="width: 0%;"
-        />
+          class="bp3-progress-bar bp3-intent-primary"
+        >
+          <div
+            class="bp3-progress-meter"
+            style="width: 0%;"
+          />
+        </div>
+      </div>
+      <div
+        class="sc-gqjmRU fWgawt"
+      >
+        <span>
+          Audit Board #01: 0 of 30 ballots audited 
+        </span>
+        <div
+          class="bp3-progress-bar bp3-intent-primary"
+        >
+          <div
+            class="bp3-progress-meter"
+            style="width: 0%;"
+          />
+        </div>
       </div>
     </div>
   </div>
-</div>
-`;
-
-exports[`RoundManagement renders null when still loading 1`] = `
-<div>
-  <p>
-    Loading... 
-    <span
-      class="bp3-spinner"
-    >
-      <span
-        class="bp3-spinner-animation"
-      >
-        <svg
-          height="20"
-          stroke-width="16.00"
-          viewBox="-3.00 -3.00 106.00 106.00"
-          width="20"
-        >
-          <path
-            class="bp3-spinner-track"
-            d="M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90"
-          />
-          <path
-            class="bp3-spinner-head"
-            d="M 50,50 m 0,-45 a 45,45 0 1 1 0,90 a 45,45 0 1 1 0,-90"
-            pathLength="280"
-            stroke-dasharray="280 280"
-            stroke-dashoffset="210"
-          />
-        </svg>
-      </span>
-    </span>
-  </p>
 </div>
 `;

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
@@ -64,23 +64,6 @@ const apiCalls = {
 }
 
 describe('RoundManagement', () => {
-  it('renders null when still loading', async () => {
-    const expectedCalls = [
-      apiCalls.getBallots,
-      apiCalls.getSettings(auditSettings.blank),
-      jaApiCalls.getUser,
-    ]
-    await withMockFetch(expectedCalls, async () => {
-      const { container } = renderView({
-        round: roundMocks.incomplete,
-        auditBoards: [],
-        createAuditBoards: jest.fn(),
-      })
-      expect(container).toMatchSnapshot()
-      await screen.findByText('Loading...')
-    })
-  })
-
   it('renders audit setup with batch audit', async () => {
     const expectedCalls = [
       apiCalls.getBallots,
@@ -146,9 +129,7 @@ describe('RoundManagement', () => {
         auditBoards: auditBoardMocks.unfinished,
         createAuditBoards: jest.fn(),
       })
-      await screen.findByText(
-        'Download Aggregated Ballot Retrieval List for Round 1'
-      )
+      await screen.findByText('Download Aggregated Ballot Retrieval List')
       expect(container).toMatchSnapshot()
     })
   })
@@ -167,9 +148,7 @@ describe('RoundManagement', () => {
         auditBoards: auditBoardMocks.unfinished,
         createAuditBoards: jest.fn(),
       })
-      await screen.findByText(
-        'Download Aggregated Ballot Retrieval List for Round 1'
-      )
+      await screen.findByText('Download Aggregated Ballot Retrieval List')
       expect(container).toMatchSnapshot()
     })
   })
@@ -189,9 +168,7 @@ describe('RoundManagement', () => {
         auditBoards: auditBoardMocks.unfinished,
         createAuditBoards: jest.fn(),
       })
-      await screen.findByText(
-        'Download Aggregated Batch Retrieval List for Round 1'
-      )
+      await screen.findByText('Download Aggregated Batch Retrieval List')
       expect(container).toMatchSnapshot()
     })
   })

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useAuditSettingsJurisdictionAdmin.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useAuditSettingsJurisdictionAdmin.ts
@@ -2,36 +2,23 @@ import { useEffect, useState } from 'react'
 import { api } from '../../utilities'
 import { IAuditSettings } from '../../../types'
 
-const defaultValues: IAuditSettings = {
-  state: null,
-  electionName: null,
-  online: null,
-  randomSeed: null,
-  riskLimit: null,
-  auditType: 'BALLOT_POLLING',
-}
-
 const getSettings = async (
   electionId: string,
   jurisdictionId: string
 ): Promise<IAuditSettings | null> => {
-  const response = await api<IAuditSettings>(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/settings`
-  )
-  if (!response) return null
-  return response
+  return api(`/election/${electionId}/jurisdiction/${jurisdictionId}/settings`)
 }
 
 const useAuditSettingsJurisdictionAdmin = (
   electionId: string,
   jurisdictionId: string
-): IAuditSettings => {
-  const [settings, setSettings] = useState<IAuditSettings>(defaultValues)
+): IAuditSettings | null => {
+  const [settings, setSettings] = useState<IAuditSettings | null>(null)
 
   useEffect(() => {
     ;(async () => {
       const newSettings = await getSettings(electionId, jurisdictionId)
-      setSettings(newSettings || defaultValues)
+      setSettings(newSettings)
     })()
   }, [electionId, jurisdictionId])
 

--- a/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
 <div>
   <div
-    class="sc-bdVaJa AANBu"
+    class="sc-bdVaJa bsPuXO"
   >
     <div
       class="bp3-callout sc-kkGfuU jfrnYf"
@@ -26,7 +26,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
             0 of 2 jurisdictions have completed file uploads.
           </p>
           <span
-            class="bp3-tag sc-jhAzac bQjcXi"
+            class="bp3-tag sc-fBuWsC fcYpqz"
           >
             <span
               class="bp3-text-overflow-ellipsis bp3-fill"
@@ -343,7 +343,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
 exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
 <div>
   <div
-    class="sc-bdVaJa AANBu"
+    class="sc-bdVaJa bsPuXO"
   >
     <div
       class="bp3-callout sc-kkGfuU jfrnYf"
@@ -366,7 +366,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
             0 of 2 jurisdictions have completed file uploads.
           </p>
           <span
-            class="bp3-tag sc-jhAzac bQjcXi"
+            class="bp3-tag sc-fBuWsC fcYpqz"
           >
             <span
               class="bp3-text-overflow-ellipsis bp3-fill"
@@ -886,7 +886,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
 exports[`AA setup flow renders sidebar when authenticated on /setup 2`] = `
 <div>
   <div
-    class="sc-bdVaJa AANBu"
+    class="sc-bdVaJa bsPuXO"
   >
     <div
       class="bp3-callout sc-kkGfuU jfrnYf"
@@ -909,7 +909,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 2`] = `
             0 of 2 jurisdictions have completed file uploads.
           </p>
           <span
-            class="bp3-tag sc-jhAzac bQjcXi"
+            class="bp3-tag sc-fBuWsC fcYpqz"
           >
             <span
               class="bp3-text-overflow-ellipsis bp3-fill"
@@ -1429,7 +1429,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 2`] = `
 exports[`JA setup renders initial state 1`] = `
 <div>
   <div
-    class="sc-bdVaJa AANBu"
+    class="sc-bdVaJa bsPuXO"
   >
     <div
       class="bp3-callout sc-kkGfuU jfrnYf"
@@ -1452,7 +1452,7 @@ exports[`JA setup renders initial state 1`] = `
       </div>
     </div>
     <div
-      class="sc-bwzfXH sc-hzDkRC kJxuMx"
+      class="sc-bwzfXH sc-jhAzac dWgAMN"
     >
       <h2
         class="bp3-heading sc-htpNat fysvnw"
@@ -1594,7 +1594,7 @@ exports[`JA setup renders initial state 1`] = `
 exports[`JA setup submits ballot manifest 1`] = `
 <div>
   <div
-    class="sc-bdVaJa AANBu"
+    class="sc-bdVaJa bsPuXO"
   >
     <div
       class="bp3-callout sc-kkGfuU jfrnYf"
@@ -1620,7 +1620,7 @@ exports[`JA setup submits ballot manifest 1`] = `
       </div>
     </div>
     <div
-      class="sc-bwzfXH sc-hzDkRC kJxuMx"
+      class="sc-bwzfXH sc-jhAzac dWgAMN"
     >
       <h2
         class="bp3-heading sc-htpNat fysvnw"
@@ -1762,7 +1762,7 @@ exports[`JA setup submits ballot manifest 1`] = `
 exports[`JA setup submits batch tallies 1`] = `
 <div>
   <div
-    class="sc-bdVaJa AANBu"
+    class="sc-bdVaJa bsPuXO"
   >
     <div
       class="bp3-callout sc-kkGfuU jfrnYf"
@@ -1788,7 +1788,7 @@ exports[`JA setup submits batch tallies 1`] = `
       </div>
     </div>
     <div
-      class="sc-bwzfXH sc-hzDkRC kJxuMx"
+      class="sc-bwzfXH sc-jhAzac dWgAMN"
     >
       <h2
         class="bp3-heading sc-htpNat fysvnw"

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -162,7 +162,7 @@ export const JurisdictionAdminView: React.FC = () => {
     jurisdictionId: string
   }>()
 
-  const { auditType } = useAuditSettingsJurisdictionAdmin(
+  const auditSettings = useAuditSettingsJurisdictionAdmin(
     electionId,
     jurisdictionId
   )
@@ -183,7 +183,14 @@ export const JurisdictionAdminView: React.FC = () => {
     rounds
   )
 
-  if (!rounds || !ballotManifest || !batchTallies || !auditBoards) return null // Still loading
+  if (
+    !auditSettings ||
+    !rounds ||
+    !ballotManifest ||
+    !batchTallies ||
+    !auditBoards
+  )
+    return null // Still loading
   if (!rounds.length) {
     return (
       <Wrapper>
@@ -201,7 +208,7 @@ export const JurisdictionAdminView: React.FC = () => {
             filePurpose="ballot-manifest"
             enabled
           />
-          {auditType === 'BATCH_COMPARISON' && (
+          {auditSettings.auditType === 'BATCH_COMPARISON' && (
             <CSVFile
               csvFile={batchTallies}
               enabled={

--- a/client/src/components/SingleJurisdictionAudit/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/SingleJurisdictionAudit/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when audit.jurisdictions has length but audit.rounds does not 1`] = `
 <div>
   <div
-    class="single-page sc-kEYyzF eUtHUm"
+    class="sc-kEYyzF sc-iAyFgw gBUvOf"
   >
     <form
       data-testid="form-one"
@@ -706,7 +706,7 @@ exports[`RiskLimitingAuditForm does not render CalculateRiskMeasurement when aud
 exports[`RiskLimitingAuditForm does not render SelectBallotsToAudit when /audit/status is processing samplesizes 1`] = `
 <div>
   <div
-    class="single-page sc-kEYyzF eUtHUm"
+    class="sc-kEYyzF sc-iAyFgw gBUvOf"
   >
     <form
       data-testid="form-one"
@@ -1170,7 +1170,7 @@ exports[`RiskLimitingAuditForm does not render SelectBallotsToAudit when /audit/
 exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
 <div>
   <div
-    class="single-page sc-kEYyzF eUtHUm"
+    class="sc-kEYyzF sc-iAyFgw gBUvOf"
   >
     <form
       data-testid="form-one"
@@ -1640,7 +1640,7 @@ exports[`RiskLimitingAuditForm fetches initial state from api 1`] = `
 exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/status returns round data 1`] = `
 <div>
   <div
-    class="single-page sc-kEYyzF eUtHUm"
+    class="sc-kEYyzF sc-iAyFgw gBUvOf"
   >
     <form
       data-testid="form-one"
@@ -2496,7 +2496,7 @@ exports[`RiskLimitingAuditForm renders CalculateRiskMeasurement when /audit/stat
 exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status returns contest data 1`] = `
 <div>
   <div
-    class="single-page sc-kEYyzF eUtHUm"
+    class="sc-kEYyzF sc-iAyFgw gBUvOf"
   >
     <form
       data-testid="form-one"
@@ -3199,7 +3199,7 @@ exports[`RiskLimitingAuditForm renders SelectBallotsToAudit when /audit/status r
 exports[`RiskLimitingAuditForm renders correctly with initialData 1`] = `
 <div>
   <div
-    class="single-page sc-kEYyzF eUtHUm"
+    class="sc-kEYyzF sc-iAyFgw gBUvOf"
   >
     <form
       data-testid="form-one"
@@ -3669,7 +3669,7 @@ exports[`RiskLimitingAuditForm renders correctly with initialData 1`] = `
 exports[`RiskLimitingAuditForm still renders if there is a server error 1`] = `
 <div>
   <div
-    class="single-page sc-kEYyzF eUtHUm"
+    class="sc-kEYyzF sc-iAyFgw gBUvOf"
   >
     <form
       data-testid="form-one"

--- a/client/src/components/SingleJurisdictionAudit/index.tsx
+++ b/client/src/components/SingleJurisdictionAudit/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { Redirect, useParams } from 'react-router-dom'
+import styled from 'styled-components'
 import EstimateSampleSize from './EstimateSampleSize'
 import SelectBallotsToAudit from './SelectBallotsToAudit'
 import CalculateRiskMeasurement from './CalculateRiskMeasurement'
@@ -7,6 +8,11 @@ import { api } from '../utilities'
 import { IAudit } from '../../types'
 import ResetButton from '../ResetButton'
 import { Wrapper } from '../Atoms/Wrapper'
+
+const SinglePageWrapper = styled(Wrapper)`
+  flex-direction: column;
+  align-items: center;
+`
 
 interface IParams {
   electionId: string
@@ -58,7 +64,7 @@ const SingleJurisdictionAudit: React.FC = () => {
     !!audit.rounds.length && audit.rounds[0].contests.every(c => !!c.sampleSize)
 
   return (
-    <Wrapper className="single-page">
+    <SinglePageWrapper>
       <ResetButton
         electionId={electionId}
         disabled={!audit.contests.length || isLoading}
@@ -92,7 +98,7 @@ const SingleJurisdictionAudit: React.FC = () => {
           electionId={electionId}
         />
       )}
-    </Wrapper>
+    </SinglePageWrapper>
   )
 }
 


### PR DESCRIPTION
- Ensure there's always a heading at the top of the page
- Pull the num ballots message out of the CreateAuditBoards component so that
it still shows during data entry
- Remove unnecessary props from CreateAuditBoards
- Put the buttons in a ButtonGroup and add icons so they look nice (this
will be useful when we reuse those buttons in the AA Audit Progress
view)
- Shrink the page width so that lines of text aren't super long
- Remove the special-case styles from the Wrapper class, since they are
only used in this page and the single-jurisdiction flow

I separated out the snapshot updates into a separate commit because there were so many of them.

<img width="1038" alt="Screen Shot 2020-09-22 at 11 22 32 AM" src="https://user-images.githubusercontent.com/530106/93941098-945aab80-fce2-11ea-9142-2731cc0c249b.png">
<img width="1067" alt="Screen Shot 2020-09-22 at 11 23 22 AM" src="https://user-images.githubusercontent.com/530106/93941106-96246f00-fce2-11ea-98a2-bdc5027b92af.png">
<img width="1038" alt="Screen Shot 2020-09-22 at 11 29 06 AM" src="https://user-images.githubusercontent.com/530106/93941109-97559c00-fce2-11ea-9591-20b5aba6a2b6.png">
