### PR TITLE
Save table state on refresh

### DIFF
--- a/client/src/components/Atoms/Table.tsx
+++ b/client/src/components/Atoms/Table.tsx
@@ -64,6 +64,7 @@ export const Table = <T extends object>({ data, columns }: ITableProps<T>) => {
     {
       data: React.useMemo(() => data, [data]),
       columns: React.useMemo(() => columns, [columns]),
+      autoResetSortBy: false,
     },
     useSortBy
   )

--- a/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`AA setup flow renders sidebar when authenticated on /progress 1`] = `
             0 of 2 jurisdictions have completed file uploads.
           </p>
           <span
-            class="bp3-tag sc-fBuWsC fcYpqz"
+            class="bp3-tag sc-fBuWsC exjrNq"
           >
             <span
               class="bp3-text-overflow-ellipsis bp3-fill"
@@ -366,7 +366,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
             0 of 2 jurisdictions have completed file uploads.
           </p>
           <span
-            class="bp3-tag sc-fBuWsC fcYpqz"
+            class="bp3-tag sc-fBuWsC exjrNq"
           >
             <span
               class="bp3-text-overflow-ellipsis bp3-fill"
@@ -909,7 +909,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 2`] = `
             0 of 2 jurisdictions have completed file uploads.
           </p>
           <span
-            class="bp3-tag sc-fBuWsC fcYpqz"
+            class="bp3-tag sc-fBuWsC exjrNq"
           >
             <span
               class="bp3-text-overflow-ellipsis bp3-fill"

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -26,22 +26,8 @@ import H2Title from '../Atoms/H2Title'
 import CSVFile from './CSVForm'
 import { useInterval } from '../utilities'
 
-export const prettifyRefreshStatus = (refreshTime: number) => {
-  if (refreshTime < 240000)
-    return `Will refresh in ${5 - Math.floor(refreshTime / 60000)} minutes`
-  if (refreshTime < 250000) return `Will refresh in 1 minute`
-  return `Will refresh in ${Math.ceil((300000 - refreshTime) / 10000) *
-    10} seconds`
-}
-
 const VerticalInner = styled(Inner)`
   flex-direction: column;
-`
-
-const RefreshStatusTag = styled(Tag)`
-  margin-top: 20px;
-  width: 20em;
-  text-align: center;
 `
 
 interface IParams {
@@ -66,20 +52,6 @@ export const AuditAdminView: React.FC = () => {
   const [contests] = useContests(electionId, refreshId)
   const [auditSettings] = useAuditSettings(electionId, refreshId)
 
-  const [lastRefreshTime, setLastRefreshTime] = useState(Date.now())
-  const [time, setTime] = useState(Date.now())
-
-  // poll the apis every 5 minutes
-  useInterval(() => {
-    const now = Date.now()
-    if (now - lastRefreshTime >= 1000 * 60 * 5) {
-      setLastRefreshTime(now)
-      refresh()
-    }
-    setTime(now)
-  }, 1000)
-  const refreshStatus = prettifyRefreshStatus(time - lastRefreshTime)
-
   // TODO support multiple contests in batch comparison audits
   const isBatch = auditSettings.auditType === 'BATCH_COMPARISON'
   const singleContestMenuItems = menuItems.filter(
@@ -98,7 +70,7 @@ export const AuditAdminView: React.FC = () => {
             contests={contests}
             auditSettings={auditSettings}
           >
-            <RefreshStatusTag>{refreshStatus}</RefreshStatusTag>
+            <RefreshTag refresh={refresh} />
           </AuditAdminStatusBox>
           <Inner>
             <Sidebar
@@ -123,7 +95,7 @@ export const AuditAdminView: React.FC = () => {
             contests={contests}
             auditSettings={auditSettings}
           >
-            <RefreshStatusTag>{refreshStatus}</RefreshStatusTag>
+            <RefreshTag refresh={refresh} />
           </AuditAdminStatusBox>
           <Inner>
             <Sidebar
@@ -240,5 +212,40 @@ export const JurisdictionAdminView: React.FC = () => {
         />
       </Inner>
     </Wrapper>
+  )
+}
+
+const RefreshStatusTag = styled(Tag)`
+  margin-top: 20px;
+  width: 14em;
+  text-align: center;
+`
+
+export const prettifyRefreshStatus = (refreshTime: number) => {
+  if (refreshTime < 240000)
+    return `Will refresh in ${5 - Math.floor(refreshTime / 60000)} minutes`
+  if (refreshTime < 250000) return `Will refresh in 1 minute`
+  return `Will refresh in ${Math.ceil((300000 - refreshTime) / 10000) *
+    10} seconds`
+}
+
+const RefreshTag = ({ refresh }: { refresh: () => void }) => {
+  const [lastRefreshTime, setLastRefreshTime] = useState(Date.now())
+  const [time, setTime] = useState(Date.now())
+
+  // poll the apis every 5 minutes
+  useInterval(() => {
+    const now = Date.now()
+    if (now - lastRefreshTime >= 1000 * 60 * 5) {
+      setLastRefreshTime(now)
+      refresh()
+    }
+    setTime(now)
+  }, 1000)
+
+  return (
+    <RefreshStatusTag>
+      {prettifyRefreshStatus(time - lastRefreshTime)}
+    </RefreshStatusTag>
   )
 }


### PR DESCRIPTION
Two problems were happening:

1. Every time the useInterval that checks if it's time to refresh
ticked, the whole Progress component (including the table) was getting
re-rendered. (The React DevTools profiler is amazing and highlights each
component as it renders, so it was easy to figure out). I solved this by
isolating the state for the refresh tag in its own component.

2. When the Progress component re-rendered, the Table reset its sort
state. This was originally happening every second, but after fixing the
above problem, was still happening when the data actually refreshed
every 5 minutes. I fixed this by passing `autoResetSortBy: false` to the
Table config.

