### PR TITLE
Standardized contests file

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -11,6 +11,7 @@ from . import routes
 from . import election_settings
 from . import contests
 from . import jurisdictions
+from . import standardized_contests
 from . import rounds
 from . import sample_sizes
 from . import ballot_manifest

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -1,0 +1,102 @@
+import uuid
+from datetime import datetime
+from flask import request, jsonify
+from sqlalchemy.orm.session import Session
+from werkzeug.exceptions import BadRequest
+
+from . import api
+from ..auth import restrict_access, UserType
+from ..database import db_session
+from ..models import *  # pylint: disable=wildcard-import
+from ..util.csv_parse import decode_csv_file, parse_csv, CSVColumnType, CSVValueType
+from ..util.process_file import (
+    process_file,
+    UserError,
+    serialize_file,
+    serialize_file_processing,
+)
+
+CONTEST_NAME = "Contest Name"
+JURISDICTIONS = "Jurisdictions"
+
+STANDARDIZED_CONTEST_COLUMNS = [
+    CSVColumnType(CONTEST_NAME, CSVValueType.TEXT, unique=True),
+    CSVColumnType(JURISDICTIONS, CSVValueType.TEXT),
+]
+
+
+def process_standardized_contests_file(
+    session: Session, election: Election, file: File
+):
+    def process():
+        standardized_contests_csv = parse_csv(
+            file.contents, STANDARDIZED_CONTEST_COLUMNS
+        )
+
+        standardized_contests = []
+        for row in standardized_contests_csv:
+            if row[JURISDICTIONS].strip() == "all":
+                jurisdictions = election.jurisdictions
+            else:
+                jurisdiction_names = {
+                    name.strip() for name in row[JURISDICTIONS].split(",")
+                }
+                jurisdictions = (
+                    Jurisdiction.query.filter_by(election_id=election.id)
+                    .filter(Jurisdiction.name.in_(jurisdiction_names))
+                    .order_by(Jurisdiction.name)
+                    .all()
+                )
+
+                if len(jurisdictions) < len(jurisdiction_names):
+                    invalid_jurisdictions = jurisdiction_names - {
+                        jurisdiction.name for jurisdiction in jurisdictions
+                    }
+                    raise UserError(
+                        f"Invalid jurisdictions for contest {row[CONTEST_NAME]}: {', '.join(sorted(invalid_jurisdictions))}"
+                    )
+
+            standardized_contests.append(
+                dict(
+                    name=row[CONTEST_NAME],
+                    jurisdictionIds=[jurisdiction.id for jurisdiction in jurisdictions],
+                )
+            )
+
+        election.standardized_contests = standardized_contests
+
+    process_file(session, file, process)
+
+
+@api.route("/election/<election_id>/standardized-contests/file", methods=["PUT"])
+@restrict_access([UserType.AUDIT_ADMIN])
+def upload_standardized_contests_file(election: Election):
+    file = request.files.get("standardized-contests")
+    if not file:
+        raise BadRequest("Missing required file parameter 'standardized-contests'")
+
+    file_string = decode_csv_file(file.read())
+    election.standardized_contests_file = File(
+        id=str(uuid.uuid4()),
+        name=file.filename,
+        contents=file_string,
+        uploaded_at=datetime.utcnow(),
+    )
+    db_session.commit()
+
+    return jsonify(status="ok")
+
+
+@api.route("/election/<election_id>/standardized-contests/file", methods=["GET"])
+@restrict_access([UserType.AUDIT_ADMIN])
+def get_standardized_contests_file(election: Election):
+    return jsonify(
+        file=serialize_file(election.standardized_contests_file),
+        processing=serialize_file_processing(election.standardized_contests_file),
+    )
+
+
+@api.route("/election/<election_id>/standardized-contests", methods=["GET"])
+@restrict_access([UserType.AUDIT_ADMIN])
+def get_standardized_contests(election: Election):
+    return jsonify(election.standardized_contests)

--- a/server/migrations/versions/5acbd2f95b9f_standardized_contests_file.py
+++ b/server/migrations/versions/5acbd2f95b9f_standardized_contests_file.py
@@ -1,0 +1,48 @@
+# pylint: disable=invalid-name
+"""Standardized contests file
+
+Revision ID: 5acbd2f95b9f
+Revises: 7f86511c05e0
+Create Date: 2020-09-30 22:38:19.350287+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "5acbd2f95b9f"
+down_revision = "7f86511c05e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("contest", "num_winners", existing_type=sa.INTEGER(), nullable=True)
+    op.alter_column(
+        "contest", "total_ballots_cast", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.alter_column(
+        "contest", "votes_allowed", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.add_column(
+        "election", sa.Column("standardized_contests", sa.JSON(), nullable=True)
+    )
+    op.add_column(
+        "election",
+        sa.Column(
+            "standardized_contests_file_id", sa.String(length=200), nullable=True
+        ),
+    )
+    op.create_foreign_key(
+        op.f("election_standardized_contests_file_id_fkey"),
+        "election",
+        "file",
+        ["standardized_contests_file_id"],
+        ["id"],
+        ondelete="set null",
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -81,10 +81,25 @@ class Election(BaseModel):
         order_by="Round.round_num",
     )
 
+    # The jurisdictions file contains a list of jurisdictions participating in
+    # the audit and emails for the admins of each jurisdiction. We use this to
+    # create Jurisdictions and JAs.
     jurisdictions_file_id = Column(
         String(200), ForeignKey("file.id", ondelete="set null")
     )
-    jurisdictions_file = relationship("File")
+    jurisdictions_file = relationship("File", foreign_keys=[jurisdictions_file_id])
+
+    # The standardized contests file (only used in ballot comparison audits)
+    # contains a list of all possible contests and the corresponding list of
+    # jurisdictions for those contests. The AA will select some of these
+    # contests to target in the audit.
+    standardized_contests_file_id = Column(
+        String(200), ForeignKey("file.id", ondelete="set null")
+    )
+    standardized_contests_file = relationship(
+        "File", foreign_keys=[standardized_contests_file_id]
+    )
+    standardized_contests = Column(JSON)
 
     __table_args__ = (UniqueConstraint("organization_id", "audit_name"),)
 
@@ -249,9 +264,10 @@ class Contest(BaseModel):
     name = Column(String(200), nullable=False)
     # is_targeted = True for targeted contests, False for opportunistic contests
     is_targeted = Column(Boolean, nullable=False)
-    total_ballots_cast = Column(Integer, nullable=False)
-    num_winners = Column(Integer, nullable=False)
-    votes_allowed = Column(Integer, nullable=False)
+
+    total_ballots_cast = Column(Integer)
+    num_winners = Column(Integer)
+    votes_allowed = Column(Integer)
 
     choices = relationship(
         "ContestChoice",

--- a/server/tests/ballot_comparison/conftest.py
+++ b/server/tests/ballot_comparison/conftest.py
@@ -1,0 +1,60 @@
+import io
+import pytest
+from flask.testing import FlaskClient
+
+from ...models import *  # pylint: disable=wildcard-import
+from ..helpers import *  # pylint: disable=wildcard-import
+from ...bgcompute import (
+    bgcompute_update_ballot_manifest_file,
+    bgcompute_update_cvr_file,
+)
+from .test_cvrs import TEST_CVRS
+
+
+@pytest.fixture
+def election_id(client: FlaskClient, org_id: str, request):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    return create_election(
+        client,
+        audit_name=f"Test Audit {request.node.name}",
+        audit_type=AuditType.BALLOT_COMPARISON,
+        organization_id=org_id,
+    )
+
+
+@pytest.fixture
+def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]):
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
+        data={
+            "manifest": (
+                io.BytesIO(
+                    b"Batch Name,Number of Ballots\n"
+                    b"1 - 1,23\n"
+                    b"1 - 2,101\n"
+                    b"2 - 1,122\n"
+                    b"2 - 2,400"
+                ),
+                "manifest.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+    bgcompute_update_ballot_manifest_file()
+
+
+@pytest.fixture
+def cvrs(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    manifests,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
+        data={"cvrs": (io.BytesIO(TEST_CVRS.encode()), "cvrs.csv",)},
+    )
+    assert_ok(rv)
+    bgcompute_update_cvr_file()

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -15,6 +15,8 @@ def test_ballot_comparison_round_1(
     manifests,  # pylint: disable=unused-argument
     cvrs,  # pylint: disable=unused-argument
 ):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+
     # AA uploads standardized contests file
     rv = client.put(
         f"/api/election/{election_id}/standardized-contests/file",

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -1,0 +1,57 @@
+import io
+import json
+from flask.testing import FlaskClient
+
+from ...models import *  # pylint: disable=wildcard-import
+from ..helpers import *  # pylint: disable=wildcard-import
+from ...bgcompute import bgcompute_update_standardized_contests_file
+
+
+def test_ballot_comparison_round_1(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    cvrs,  # pylint: disable=unused-argument
+):
+    # AA uploads standardized contests file
+    rv = client.put(
+        f"/api/election/{election_id}/standardized-contests/file",
+        data={
+            "standardized-contests": (
+                io.BytesIO(
+                    b"Contest Name,Jurisdictions\n"
+                    b"Contest 1,all\n"
+                    b'Contest 2,"J1,J3"\n'
+                    b"Contest 3,J2\n"
+                ),
+                "standardized-contests.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+
+    bgcompute_update_standardized_contests_file()
+
+    # AA selects a contest to target from the standardized contest list
+    rv = client.get(f"/api/election/{election_id}/standardized-contests")
+    standardized_contests = json.loads(rv.data)
+
+    target_contest = standardized_contests[0]
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/contest",
+        [
+            {
+                "id": str(uuid.uuid4()),
+                "name": target_contest["name"],
+                "jurisdictionIds": target_contest["jurisdictionIds"],
+                "isTargeted": True,
+            }
+        ],
+    )
+    assert_ok(rv)
+
+    # AA selects a sample size and launches the audit
+    # TODO

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -1,0 +1,118 @@
+import io
+import json
+from flask.testing import FlaskClient
+
+from ...models import *  # pylint: disable=wildcard-import
+from ..helpers import *  # pylint: disable=wildcard-import
+from ...bgcompute import bgcompute_update_standardized_contests_file
+
+
+def test_upload_standardized_contests(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
+    rv = client.put(
+        f"/api/election/{election_id}/standardized-contests/file",
+        data={
+            "standardized-contests": (
+                io.BytesIO(
+                    b"Contest Name,Jurisdictions\n"
+                    b"Contest 1,all\n"
+                    b'Contest 2,"J1, J3"\n'
+                    b"Contest 3,J2 \n"
+                ),
+                "standardized-contests.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
+    compare_json(
+        json.loads(rv.data),
+        {
+            "file": {
+                "name": "standardized-contests.csv",
+                "uploadedAt": assert_is_date,
+            },
+            "processing": {
+                "status": ProcessingStatus.READY_TO_PROCESS,
+                "startedAt": None,
+                "completedAt": None,
+                "error": None,
+            },
+        },
+    )
+
+    bgcompute_update_standardized_contests_file()
+
+    rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
+    compare_json(
+        json.loads(rv.data),
+        {
+            "file": {
+                "name": "standardized-contests.csv",
+                "uploadedAt": assert_is_date,
+            },
+            "processing": {
+                "status": ProcessingStatus.PROCESSED,
+                "startedAt": assert_is_date,
+                "completedAt": assert_is_date,
+                "error": None,
+            },
+        },
+    )
+
+    rv = client.get(f"/api/election/{election_id}/standardized-contests")
+    assert json.loads(rv.data) == [
+        {"name": "Contest 1", "jurisdictionIds": jurisdiction_ids},
+        {
+            "name": "Contest 2",
+            "jurisdictionIds": [jurisdiction_ids[0], jurisdiction_ids[2]],
+        },
+        {"name": "Contest 3", "jurisdictionIds": [jurisdiction_ids[1]]},
+    ]
+
+
+def test_standardized_contests_bad_jurisdiction(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+):
+    rv = client.put(
+        f"/api/election/{election_id}/standardized-contests/file",
+        data={
+            "standardized-contests": (
+                io.BytesIO(
+                    b"Contest Name,Jurisdictions\n"
+                    b'Contest 1,"J1,not a real jurisdiction,another bad one"\n"'
+                ),
+                "standardized-contests.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+
+    bgcompute_update_standardized_contests_file()
+
+    rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
+    compare_json(
+        json.loads(rv.data),
+        {
+            "file": {
+                "name": "standardized-contests.csv",
+                "uploadedAt": assert_is_date,
+            },
+            "processing": {
+                "status": ProcessingStatus.ERRORED,
+                "startedAt": assert_is_date,
+                "completedAt": assert_is_date,
+                "error": "Invalid jurisdictions for contest Contest 1: another bad one, not a real jurisdiction",
+            },
+        },
+    )
+
+    rv = client.get(f"/api/election/{election_id}/standardized-contests")
+    assert json.loads(rv.data) is None
+
+
+# TODO - test more invalid cases


### PR DESCRIPTION
Task: #766 

For ballot comparison audits, the AA uploads a standardized contests
file and then selects the target/opportunistic contests based on the
options in that file.

This change:
- Adds new endpoints for uploading the standardized contests file,
parsing it, storing it in Election.standardized_contests, and returning
the parsed data to the AA
- Modifies the endpoint for creating contests to allow creating contests
without metadata (since the standardized contests file doesn't include
that data - we parse it later from the CVRs)