### PR TITLE
Ballot comparison sample size

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -41,7 +41,7 @@ def process_cvr_file(session: Session, jurisdiction: Jurisdiction, file: File):
         for contest_header in contest_headers:
             match = re.match(r"^(.+) \(Vote For=(\d+)\)$", contest_header)
             contest_names.append(match[1])
-            contest_votes_allowed.append(match[2])
+            contest_votes_allowed.append(int(match[2]))
 
         interpretation_headers = list(
             zip(contest_names, contest_votes_allowed, contest_choices)
@@ -53,7 +53,7 @@ def process_cvr_file(session: Session, jurisdiction: Jurisdiction, file: File):
         for column, (contest_name, votes_allowed, contest_choice) in enumerate(
             interpretation_headers
         ):
-            contests_metadata[contest_name]["votes_allowed"] = int(votes_allowed)
+            contests_metadata[contest_name]["votes_allowed"] = votes_allowed
             contests_metadata[contest_name]["choices"][contest_choice] = dict(
                 # Store the column index of this contest choice so we can parse
                 # interpretations later

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -53,7 +53,7 @@ def process_cvr_file(session: Session, jurisdiction: Jurisdiction, file: File):
         for column, (contest_name, votes_allowed, contest_choice) in enumerate(
             interpretation_headers
         ):
-            contests_metadata[contest_name]["votes_allowed"] = votes_allowed
+            contests_metadata[contest_name]["votes_allowed"] = int(votes_allowed)
             contests_metadata[contest_name]["choices"][contest_choice] = dict(
                 # Store the column index of this contest choice so we can parse
                 # interpretations later

--- a/server/tests/ballot_comparison/conftest.py
+++ b/server/tests/ballot_comparison/conftest.py
@@ -41,6 +41,22 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         },
     )
     assert_ok(rv)
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/ballot-manifest",
+        data={
+            "manifest": (
+                io.BytesIO(
+                    b"Batch Name,Number of Ballots\n"
+                    b"1 - 1,23\n"
+                    b"1 - 2,101\n"
+                    b"2 - 1,122\n"
+                    b"2 - 2,400"
+                ),
+                "manifest.csv",
+            )
+        },
+    )
+    assert_ok(rv)
     bgcompute_update_ballot_manifest_file()
 
 
@@ -54,6 +70,11 @@ def cvrs(
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
+        data={"cvrs": (io.BytesIO(TEST_CVRS.encode()), "cvrs.csv",)},
+    )
+    assert_ok(rv)
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/cvrs",
         data={"cvrs": (io.BytesIO(TEST_CVRS.encode()), "cvrs.csv",)},
     )
     assert_ok(rv)

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots["test_ballot_comparison_round_1 1"] = [
+    {"key": "supersimple", "prob": None, "size": 24}
+]
+
+snapshots["test_set_contest_metadata_from_cvrs 1"] = {
+    "choices": [
+        {"name": "Choice 2-1", "num_votes": 30},
+        {"name": "Choice 2-2", "num_votes": 14},
+        {"name": "Choice 2-3", "num_votes": 16},
+    ],
+    "num_winners": 1,
+    "total_ballots_cast": 30,
+    "votes_allowed": 2,
+}

--- a/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
@@ -107,7 +107,7 @@ snapshots["test_cvr_upload 2"] = {
             "Choice 1-2": {"column": 1, "num_votes": 6},
         },
         "total_ballots_cast": 12,
-        "votes_allowed": "1",
+        "votes_allowed": 1,
     },
     "Contest 2": {
         "choices": {
@@ -116,6 +116,6 @@ snapshots["test_cvr_upload 2"] = {
             "Choice 2-3": {"column": 4, "num_votes": 8},
         },
         "total_ballots_cast": 15,
-        "votes_allowed": "2",
+        "votes_allowed": 2,
     },
 }

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -5,6 +5,52 @@ from flask.testing import FlaskClient
 from ...models import *  # pylint: disable=wildcard-import
 from ..helpers import *  # pylint: disable=wildcard-import
 from ...bgcompute import bgcompute_update_standardized_contests_file
+from ...api.sample_sizes import set_contest_metadata_from_cvrs
+
+
+def test_set_contest_metadata_from_cvrs(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    cvrs,  # pylint: disable=unused-argument
+    snapshot,
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    contest_id = str(uuid.uuid4())
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/contest",
+        [
+            {
+                "id": contest_id,
+                "name": "Contest 2",
+                "jurisdictionIds": jurisdiction_ids[:2],
+                "isTargeted": True,
+            }
+        ],
+    )
+    assert_ok(rv)
+
+    contest = Contest.query.get(contest_id)
+    assert contest.total_ballots_cast is None
+    assert contest.votes_allowed is None
+    assert contest.num_winners is None
+    assert contest.choices == []
+
+    set_contest_metadata_from_cvrs(contest)
+
+    snapshot.assert_match(
+        dict(
+            total_ballots_cast=contest.total_ballots_cast,
+            votes_allowed=contest.votes_allowed,
+            num_winners=contest.num_winners,
+            choices=[
+                dict(name=choice.name, num_votes=choice.num_votes,)
+                for choice in contest.choices
+            ],
+        )
+    )
 
 
 def test_ballot_comparison_round_1(
@@ -14,6 +60,7 @@ def test_ballot_comparison_round_1(
     election_settings,  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
     cvrs,  # pylint: disable=unused-argument
+    snapshot,
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
 
@@ -24,8 +71,8 @@ def test_ballot_comparison_round_1(
             "standardized-contests": (
                 io.BytesIO(
                     b"Contest Name,Jurisdictions\n"
-                    b"Contest 1,all\n"
-                    b'Contest 2,"J1,J3"\n'
+                    b'Contest 1,"J1,J2"\n'
+                    b"Contest 2,all\n"
                     b"Contest 3,J2\n"
                 ),
                 "standardized-contests.csv",
@@ -56,4 +103,11 @@ def test_ballot_comparison_round_1(
     assert_ok(rv)
 
     # AA selects a sample size and launches the audit
-    # TODO
+    rv = client.get(f"/api/election/{election_id}/contest")
+    contest = json.loads(rv.data)["contests"][0]
+
+    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    assert len(sample_size_options) == 1
+    sample_size = sample_size_options[contest["id"]]
+    snapshot.assert_match(sample_size)


### PR DESCRIPTION
- Parse the contest metadata out of Jurisdiction.cvr_contests_metadata
where we stashed it
- Use that contest metadata to call supersimple.get_sample_sizes to get
the estimated sample sizes for ballot comparison audits

Still todo in a future PR: come back and compute the sample results for
previous rounds so we can draw samples for later rounds.