### PR TITLE
Exposes discrepancies from math code. 

### DIFF
--- a/server/audit_math/supersimple.py
+++ b/server/audit_math/supersimple.py
@@ -1,6 +1,6 @@
 # pylint: disable=invalid-name
 import math
-from typing import Dict, Tuple, Union
+from typing import Dict, Tuple, Union, TypedDict
 
 from .sampler_contest import Contest
 
@@ -14,6 +14,17 @@ u1: float = 0.001
 # This sets the expected two-vote misstatements at 1 in 10000
 o2: float = 0.0001
 u2: float = 0.0001
+
+# { ballot_id: { contest_id: { choice_id: 0 | 1 }}}
+CVRS = Dict[str, Dict[str, Dict[str, int]]]
+CVR = Dict[str, Dict[str, int]]
+
+
+class Discrepancy(TypedDict):
+    counted_as: int
+    weighted_error: float
+    cvr: CVR
+    sample_cvr: CVR
 
 
 def nMin(
@@ -38,6 +49,82 @@ def nMin(
             / contest.diluted_margin
         ),
     )
+
+
+def find_discrepancies(
+    contest: Contest, cvrs: CVRS, sample_cvr: CVRS,
+) -> Dict[str, Discrepancy]:
+    """
+    Iterates through a given sample and returns the discrepancies found.
+
+    Inputs:
+        contests       - the contests and results being audited
+        cvrs           - mapping of ballot_id to votes:
+                {
+                    'ballot_id': {
+                        'contest': {
+                            'candidate1': 1,
+                            'candidate2': 0,
+                            ...
+                        }
+                    ...
+                }
+
+        sample_cvr - the CVR of the audited ballots
+                {
+                    'ballot_id': {
+                        'contest': {
+                            'candidate1': 1,
+                            'candidate2': 0,
+                            ...
+                        }
+                    ...
+                }
+
+    Outputs:
+        discrepancies   - A mapping of ballot ids to their discrepancies. This
+                          includes entries for all ballots in the sample, even those without
+                          discrepancies.
+                {
+                    'ballot_id': {
+                        'counted_as': -1, # The maximum value for a discrepancy
+                        'weighted_error': -0.0033 # Weighted error used for p-value calculation
+                        'cvr': <CVR for this ballot>,
+                        'sample_cvr': <Sample CVR for this ballot>
+                    }
+    """
+
+    discrepancies: Dict[str, Discrepancy] = {}
+    for ballot in sample_cvr:
+        e_r = 0.0
+        e_int = 0
+
+        if contest.name not in sample_cvr[ballot]:
+            continue
+        for winner in contest.winners:
+            for loser in contest.losers:
+                v_w = cvrs[ballot][contest.name][winner]
+                a_w = sample_cvr[ballot][contest.name][winner]
+
+                v_l = cvrs[ballot][contest.name][loser]
+                a_l = sample_cvr[ballot][contest.name][loser]
+
+                V_wl = contest.candidates[winner] - contest.candidates[loser]
+
+                e = (v_w - a_w) - (v_l - a_l)
+                e_weighted = e / V_wl
+                if e_weighted > e_r:
+                    e_r = e_weighted
+                    e_int = e
+
+        discrepancies[ballot] = Discrepancy(
+            counted_as=e_int,
+            weighted_error=e_weighted,
+            cvr=cvrs[ballot],
+            sample_cvr=sample_cvr[ballot],
+        )
+
+    return discrepancies
 
 
 def get_sample_sizes(
@@ -101,10 +188,6 @@ def get_sample_sizes(
     return nMin(risk_limit, contest, r1, r2, s1, s2)
 
 
-# { ballot_id: { contest_id: { choice_id: 0 | 1 }}}
-CVRS = Dict[str, Dict[str, Dict[str, int]]]
-
-
 def compute_risk(
     risk_limit: float, contest: Contest, cvrs: CVRS, sample_cvr: CVRS,
 ) -> Tuple[float, bool]:
@@ -147,24 +230,11 @@ def compute_risk(
     U = 2 * gamma / contest.diluted_margin
 
     result = False
-    for ballot in sample_cvr:
-        e_r = 0.0
 
-        if contest.name not in sample_cvr[ballot]:
-            continue
-        for winner in contest.winners:
-            for loser in contest.losers:
-                v_w = cvrs[ballot][contest.name][winner]
-                a_w = sample_cvr[ballot][contest.name][winner]
+    discrepancies = find_discrepancies(contest, cvrs, sample_cvr)
 
-                v_l = cvrs[ballot][contest.name][loser]
-                a_l = sample_cvr[ballot][contest.name][loser]
-
-                V_wl = contest.candidates[winner] - contest.candidates[loser]
-
-                e = ((v_w - a_w) - (v_l - a_l)) / V_wl
-                if e > e_r:
-                    e_r = e
+    for ballot in discrepancies:
+        e_r = discrepancies[ballot]["weighted_error"]
 
         denom = (2 * gamma) / V
         p_b = (1 - 1 / U) / (1 - (e_r / denom))

--- a/server/audit_math/supersimple.py
+++ b/server/audit_math/supersimple.py
@@ -51,7 +51,7 @@ def nMin(
     )
 
 
-def find_discrepancies(
+def compute_discrepancies(
     contest: Contest, cvrs: CVRS, sample_cvr: CVRS,
 ) -> Dict[str, Discrepancy]:
     """
@@ -231,7 +231,7 @@ def compute_risk(
 
     result = False
 
-    discrepancies = find_discrepancies(contest, cvrs, sample_cvr)
+    discrepancies = compute_discrepancies(contest, cvrs, sample_cvr)
 
     for ballot in discrepancies:
         e_r = discrepancies[ballot]["weighted_error"]

--- a/server/audit_math/supersimple.py
+++ b/server/audit_math/supersimple.py
@@ -23,7 +23,7 @@ CVR = Dict[str, Dict[str, int]]
 class Discrepancy(TypedDict):
     counted_as: int
     weighted_error: float
-    discrepancy_cvr: CVR
+    discrepancy_cvr: CVRS
 
 
 def nMin(

--- a/server/audit_math/supersimple.py
+++ b/server/audit_math/supersimple.py
@@ -96,6 +96,10 @@ def compute_discrepancies(
 
     discrepancies: Dict[str, Discrepancy] = {}
     for ballot in sample_cvr:
+        # We want to be conservative, so we will ignore the case where there are
+        # negative errors (i.e. errors that favor the winner. We can do that
+        # by setting these to zero and evaluating whether an error is greater
+        # than zero (i.e. positive).
         e_r = 0.0
         e_int = 0
 

--- a/server/audit_math/supersimple.py
+++ b/server/audit_math/supersimple.py
@@ -229,7 +229,8 @@ def compute_risk(
     """
     p = 1.0
 
-    V = contest.diluted_margin * len(cvrs)
+    N = contest.ballots
+    V = contest.diluted_margin * N
 
     U = 2 * gamma / contest.diluted_margin
 
@@ -237,7 +238,7 @@ def compute_risk(
 
     discrepancies = compute_discrepancies(contest, cvrs, sample_cvr)
 
-    for ballot in discrepancies:
+    for ballot in sample_cvr:
         e_r = discrepancies[ballot]["weighted_error"]
 
         denom = (2 * gamma) / V

--- a/server/tests/audit_math/test_supersimple.py
+++ b/server/tests/audit_math/test_supersimple.py
@@ -60,6 +60,62 @@ def test_compute_diluted_margin(contests):
         )
 
 
+def test_find_no_discrepancies(contests, cvrs):
+
+    # Test no discrepancies
+    sample_cvr = {
+        0: {
+            "Contest A": {"winner": 1, "loser": 0},
+            "Contest B": {"winner": 1, "loser": 0},
+            "Contest C": {"winner": 1, "loser": 0},
+            "Contest D": {"winner": 1, "loser": 0},
+            "Contest E": {"winner": 1, "loser": 0},
+        }
+    }
+
+    for contest in contests:
+        discrepancies = supersimple.find_discrepancies(
+            contests[contest], cvrs, sample_cvr
+        )
+
+        assert discrepancies[0]["counted_as"] == 0
+        assert discrepancies[0]["weighted_error"] == 0
+        assert discrepancies[0]["cvr"] == discrepancies[0]["sample_cvr"]
+
+
+def test_find_one_discrepancy(contests, cvrs):
+
+    # Test no discrepancies
+    sample_cvr = {
+        0: {
+            "Contest A": {"winner": 0, "loser": 0},
+            "Contest B": {"winner": 1, "loser": 0},
+            "Contest C": {"winner": 1, "loser": 0},
+            "Contest D": {"winner": 1, "loser": 0},
+            "Contest E": {"winner": 1, "loser": 0},
+        }
+    }
+
+    for contest in contests:
+        discrepancies = supersimple.find_discrepancies(
+            contests[contest], cvrs, sample_cvr
+        )
+        if contest == "Contest A":
+            assert discrepancies[0]["counted_as"] == 1
+            assert discrepancies[0]["weighted_error"] == 1 / 20000
+            assert (
+                discrepancies[0]["cvr"][contest]
+                != discrepancies[0]["sample_cvr"][contest]
+            )
+        else:
+            assert discrepancies[0]["counted_as"] == 0
+            assert discrepancies[0]["weighted_error"] == 0
+            assert (
+                discrepancies[0]["cvr"][contest]
+                == discrepancies[0]["sample_cvr"][contest]
+            )
+
+
 def test_get_sample_sizes(contests):
     sample_results = {
         "sample_size": 0,

--- a/server/tests/audit_math/test_supersimple.py
+++ b/server/tests/audit_math/test_supersimple.py
@@ -78,9 +78,7 @@ def test_find_no_discrepancies(contests, cvrs):
             contests[contest], cvrs, sample_cvr
         )
 
-        assert discrepancies[0]["counted_as"] == 0
-        assert discrepancies[0]["weighted_error"] == 0
-        assert discrepancies[0]["cvr"] == discrepancies[0]["sample_cvr"]
+        assert not discrepancies
 
 
 def test_find_one_discrepancy(contests, cvrs):
@@ -104,16 +102,11 @@ def test_find_one_discrepancy(contests, cvrs):
             assert discrepancies[0]["counted_as"] == 1
             assert discrepancies[0]["weighted_error"] == 1 / 20000
             assert (
-                discrepancies[0]["cvr"][contest]
-                != discrepancies[0]["sample_cvr"][contest]
+                discrepancies[0]["discrepancy_cvr"]["reported_as"][contest]
+                != discrepancies[0]["discrepancy_cvr"]["audited_as"][contest]
             )
         else:
-            assert discrepancies[0]["counted_as"] == 0
-            assert discrepancies[0]["weighted_error"] == 0
-            assert (
-                discrepancies[0]["cvr"][contest]
-                == discrepancies[0]["sample_cvr"][contest]
-            )
+            assert not discrepancies
 
 
 def test_get_sample_sizes(contests):

--- a/server/tests/audit_math/test_supersimple.py
+++ b/server/tests/audit_math/test_supersimple.py
@@ -60,6 +60,7 @@ def test_compute_diluted_margin(contests):
         )
 
 
+<<<<<<< HEAD
 def test_find_no_discrepancies(contests, cvrs):
 
     # Test no discrepancies
@@ -116,6 +117,65 @@ def test_find_one_discrepancy(contests, cvrs):
             )
 
 
+||||||| parent of 0dba92f1... Added typed dict
+=======
+def test_find_no_discrepancies(contests, cvrs):
+
+    # Test no discrepancies
+    sample_cvr = {
+        0: {
+            "Contest A": {"winner": 1, "loser": 0},
+            "Contest B": {"winner": 1, "loser": 0},
+            "Contest C": {"winner": 1, "loser": 0},
+            "Contest D": {"winner": 1, "loser": 0},
+            "Contest E": {"winner": 1, "loser": 0},
+        }
+    }
+
+    for contest in contests:
+        discrepancies = supersimple.find_discrepancies(
+            contests[contest], cvrs, sample_cvr
+        )
+
+        assert discrepancies[0]["counted_as"] == 0
+        assert discrepancies[0]["weighted_error"] == 0
+        assert discrepancies[0]["cvr"] == discrepancies[0]["sample_cvr"]
+
+
+def test_find_one_discrepancy(contests, cvrs):
+
+    # Test no discrepancies
+    sample_cvr = {
+        0: {
+            "Contest A": {"winner": 0, "loser": 0},
+            "Contest B": {"winner": 1, "loser": 0},
+            "Contest C": {"winner": 1, "loser": 0},
+            "Contest D": {"winner": 1, "loser": 0},
+            "Contest E": {"winner": 1, "loser": 0},
+        }
+    }
+
+    for contest in contests:
+        discrepancies = supersimple.find_discrepancies(
+            contests[contest], cvrs, sample_cvr
+        )
+        if contest == "Contest A":
+            assert discrepancies[0]["counted_as"] == 1
+            assert discrepancies[0]["weighted_error"] == 1 / 20000
+            assert (
+                discrepancies[0]["cvr"][contest]
+                != discrepancies[0]["sample_cvr"][contest]
+            )
+        else:
+            assert discrepancies[0]["counted_as"] == 0
+            assert discrepancies[0]["weighted_error"] == 0
+            assert (
+                discrepancies[0]["cvr"][contest]
+                == discrepancies[0]["sample_cvr"][contest]
+            )
+
+
+>>>>>>> 0dba92f1... Added typed dict
 def test_get_sample_sizes(contests):
     sample_results = {
         "sample_size": 0,

--- a/server/tests/audit_math/test_supersimple.py
+++ b/server/tests/audit_math/test_supersimple.py
@@ -60,7 +60,6 @@ def test_compute_diluted_margin(contests):
         )
 
 
-<<<<<<< HEAD
 def test_find_no_discrepancies(contests, cvrs):
 
     # Test no discrepancies
@@ -86,7 +85,7 @@ def test_find_no_discrepancies(contests, cvrs):
 
 def test_find_one_discrepancy(contests, cvrs):
 
-    # Test no discrepancies
+    # Test one discrepancy
     sample_cvr = {
         0: {
             "Contest A": {"winner": 0, "loser": 0},
@@ -117,65 +116,6 @@ def test_find_one_discrepancy(contests, cvrs):
             )
 
 
-||||||| parent of 0dba92f1... Added typed dict
-=======
-def test_find_no_discrepancies(contests, cvrs):
-
-    # Test no discrepancies
-    sample_cvr = {
-        0: {
-            "Contest A": {"winner": 1, "loser": 0},
-            "Contest B": {"winner": 1, "loser": 0},
-            "Contest C": {"winner": 1, "loser": 0},
-            "Contest D": {"winner": 1, "loser": 0},
-            "Contest E": {"winner": 1, "loser": 0},
-        }
-    }
-
-    for contest in contests:
-        discrepancies = supersimple.compute_discrepancies(
-            contests[contest], cvrs, sample_cvr
-        )
-
-        assert discrepancies[0]["counted_as"] == 0
-        assert discrepancies[0]["weighted_error"] == 0
-        assert discrepancies[0]["cvr"] == discrepancies[0]["sample_cvr"]
-
-
-def test_find_one_discrepancy(contests, cvrs):
-
-    # Test no discrepancies
-    sample_cvr = {
-        0: {
-            "Contest A": {"winner": 0, "loser": 0},
-            "Contest B": {"winner": 1, "loser": 0},
-            "Contest C": {"winner": 1, "loser": 0},
-            "Contest D": {"winner": 1, "loser": 0},
-            "Contest E": {"winner": 1, "loser": 0},
-        }
-    }
-
-    for contest in contests:
-        discrepancies = supersimple.compute_discrepancies(
-            contests[contest], cvrs, sample_cvr
-        )
-        if contest == "Contest A":
-            assert discrepancies[0]["counted_as"] == 1
-            assert discrepancies[0]["weighted_error"] == 1 / 20000
-            assert (
-                discrepancies[0]["cvr"][contest]
-                != discrepancies[0]["sample_cvr"][contest]
-            )
-        else:
-            assert discrepancies[0]["counted_as"] == 0
-            assert discrepancies[0]["weighted_error"] == 0
-            assert (
-                discrepancies[0]["cvr"][contest]
-                == discrepancies[0]["sample_cvr"][contest]
-            )
-
-
->>>>>>> 0dba92f1... Added typed dict
 def test_get_sample_sizes(contests):
     sample_results = {
         "sample_size": 0,

--- a/server/tests/audit_math/test_supersimple.py
+++ b/server/tests/audit_math/test_supersimple.py
@@ -74,7 +74,7 @@ def test_find_no_discrepancies(contests, cvrs):
     }
 
     for contest in contests:
-        discrepancies = supersimple.find_discrepancies(
+        discrepancies = supersimple.compute_discrepancies(
             contests[contest], cvrs, sample_cvr
         )
 
@@ -97,7 +97,7 @@ def test_find_one_discrepancy(contests, cvrs):
     }
 
     for contest in contests:
-        discrepancies = supersimple.find_discrepancies(
+        discrepancies = supersimple.compute_discrepancies(
             contests[contest], cvrs, sample_cvr
         )
         if contest == "Contest A":

--- a/server/tests/audit_math/test_supersimple.py
+++ b/server/tests/audit_math/test_supersimple.py
@@ -133,7 +133,7 @@ def test_find_no_discrepancies(contests, cvrs):
     }
 
     for contest in contests:
-        discrepancies = supersimple.find_discrepancies(
+        discrepancies = supersimple.compute_discrepancies(
             contests[contest], cvrs, sample_cvr
         )
 
@@ -156,7 +156,7 @@ def test_find_one_discrepancy(contests, cvrs):
     }
 
     for contest in contests:
-        discrepancies = supersimple.find_discrepancies(
+        discrepancies = supersimple.compute_discrepancies(
             contests[contest], cvrs, sample_cvr
         )
         if contest == "Contest A":

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -41,8 +41,8 @@ Test Audit test_ballot_comparison_round_1,BALLOT_COMPARISON,10%,1234567890,Yes\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,11,No,1.1043717961,DATETIME,DATETIME,Choice 1-1: 4; Choice 1-2: 5\r
-1,Contest 2,Opportunistic,,No,0.4183843254,DATETIME,DATETIME,Choice 2-1: 4; Choice 2-2: 4; Choice 2-3: 0\r
+1,Contest 1,Targeted,11,No,0.7413124393,DATETIME,DATETIME,Choice 1-1: 4; Choice 1-2: 5\r
+1,Contest 2,Opportunistic,,No,0.3142300101,DATETIME,DATETIME,Choice 2-1: 4; Choice 2-2: 4; Choice 2-3: 0\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Batch Name,Ballot Position,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,Audit Result: Contest 2\r

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -7,33 +7,26 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_ballot_comparison_round_1 1'] = {
-    'key': 'supersimple',
-    'prob': None,
-    'size': 11
+snapshots["test_ballot_comparison_round_1 1"] = {
+    "key": "supersimple",
+    "prob": None,
+    "size": 11,
 }
 
-snapshots['test_set_contest_metadata_from_cvrs 1'] = {
-    'choices': [
-        {
-            'name': 'Choice 2-1',
-            'num_votes': 30
-        },
-        {
-            'name': 'Choice 2-2',
-            'num_votes': 14
-        },
-        {
-            'name': 'Choice 2-3',
-            'num_votes': 16
-        }
+snapshots["test_set_contest_metadata_from_cvrs 1"] = {
+    "choices": [
+        {"name": "Choice 2-1", "num_votes": 30},
+        {"name": "Choice 2-2", "num_votes": 14},
+        {"name": "Choice 2-3", "num_votes": 16},
     ],
-    'num_winners': 1,
-    'total_ballots_cast': 30,
-    'votes_allowed': 2
+    "num_winners": 1,
+    "total_ballots_cast": 30,
+    "votes_allowed": 2,
 }
 
-snapshots['test_ballot_comparison_round_1 2'] = '''######## ELECTION INFO ########\r
+snapshots[
+    "test_ballot_comparison_round_1 2"
+] = """######## ELECTION INFO ########\r
 Election Name,State\r
 Test Election,CA\r
 \r
@@ -63,4 +56,4 @@ J2,1 - 1,3,Round 1: 0.145351404354762545,AUDITED,Choice 1-1,Choice 2-1\r
 J2,1 - 2,1,Round 1: 0.261383583608008902,AUDITED,Choice 1-1,Choice 2-1\r
 J2,2 - 2,3,Round 1: 0.394565893682896974,AUDITED,Choice 1-2,Choice 2-2\r
 J2,2 - 2,4,Round 1: 0.267753678346758280,NOT_AUDITED,,\r
-'''
+"""

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -7,26 +7,33 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["test_ballot_comparison_round_1 1"] = {
-    "key": "supersimple",
-    "prob": None,
-    "size": 11,
+snapshots['test_ballot_comparison_round_1 1'] = {
+    'key': 'supersimple',
+    'prob': None,
+    'size': 11
 }
 
-snapshots["test_set_contest_metadata_from_cvrs 1"] = {
-    "choices": [
-        {"name": "Choice 2-1", "num_votes": 30},
-        {"name": "Choice 2-2", "num_votes": 14},
-        {"name": "Choice 2-3", "num_votes": 16},
+snapshots['test_set_contest_metadata_from_cvrs 1'] = {
+    'choices': [
+        {
+            'name': 'Choice 2-1',
+            'num_votes': 30
+        },
+        {
+            'name': 'Choice 2-2',
+            'num_votes': 14
+        },
+        {
+            'name': 'Choice 2-3',
+            'num_votes': 16
+        }
     ],
-    "num_winners": 1,
-    "total_ballots_cast": 30,
-    "votes_allowed": 2,
+    'num_winners': 1,
+    'total_ballots_cast': 30,
+    'votes_allowed': 2
 }
 
-snapshots[
-    "test_ballot_comparison_round_1 2"
-] = """######## ELECTION INFO ########\r
+snapshots['test_ballot_comparison_round_1 2'] = '''######## ELECTION INFO ########\r
 Election Name,State\r
 Test Election,CA\r
 \r
@@ -56,4 +63,4 @@ J2,1 - 1,3,Round 1: 0.145351404354762545,AUDITED,Choice 1-1,Choice 2-1\r
 J2,1 - 2,1,Round 1: 0.261383583608008902,AUDITED,Choice 1-1,Choice 2-1\r
 J2,2 - 2,3,Round 1: 0.394565893682896974,AUDITED,Choice 1-2,Choice 2-2\r
 J2,2 - 2,4,Round 1: 0.267753678346758280,NOT_AUDITED,,\r
-"""
+'''

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -41,8 +41,8 @@ Test Audit test_ballot_comparison_round_1,BALLOT_COMPARISON,10%,1234567890,Yes\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,11,No,0.7413124393,DATETIME,DATETIME,Choice 1-1: 4; Choice 1-2: 5\r
-1,Contest 2,Opportunistic,,No,0.3142300101,DATETIME,DATETIME,Choice 2-1: 4; Choice 2-2: 4; Choice 2-3: 0\r
+1,Contest 1,Targeted,11,No,36987.004694724,DATETIME,DATETIME,Choice 1-1: 4; Choice 1-2: 5\r
+1,Contest 2,Opportunistic,,No,28.4111710083,DATETIME,DATETIME,Choice 2-1: 4; Choice 2-2: 4; Choice 2-3: 0\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Batch Name,Ballot Position,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,Audit Result: Contest 2\r


### PR DESCRIPTION
**Description**
Exposes discrepancies between the sampled ballots and the CVRs via the `supersimple.find_discrepancies` function. Also refactors a bit to take advantage of the new function call. Closes #761.

**Testing**

Adds two new test cases to verify the new discrepancy finding is correct and doesn't monkey with the p-value calculations.

**Progress**

Ready.
