### PR TITLE
Add CVRs file status to AA jurisdictions endpoint

### DIFF
--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -30,6 +30,11 @@ def serialize_jurisdiction(
             "file": serialize_file(jurisdiction.batch_tallies_file),
             "processing": serialize_file_processing(jurisdiction.batch_tallies_file),
         }
+    if election.audit_type == AuditType.BALLOT_COMPARISON:
+        json_jurisdiction["cvrs"] = {
+            "file": serialize_file(jurisdiction.cvr_file),
+            "processing": serialize_file_processing(jurisdiction.cvr_file),
+        }
     return json_jurisdiction
 
 


### PR DESCRIPTION
Task #781 

Same pattern as ballot manifest and batch tallies files. Used for the
audit setup flow to figure out when all the CVRs have been uploaded and
also to show upload status in the progress view.