### PR TITLE
Pass discrepancies into sample size calculator

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -25,6 +25,10 @@ from ..util.jsonschema import JSONDict
 
 
 def set_contest_metadata_from_cvrs(contest: Contest):
+    # Only set the contest metadata if it hasn't been set already
+    if contest.total_ballots_cast is not None:
+        return
+
     contest.num_winners = 1  # TODO how do we get this from the CVRs?
     contest.total_ballots_cast = 0
 

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -657,17 +657,16 @@ def create_round(election: Election):
     # For round 1, use the given sample size for each contest.
     if json_round["roundNum"] == 1:
         sample_sizes = json_round["sampleSizes"]
-    # In later rounds, use:
-    # - the 90% probability sample size for ballot polling audits
-    # - the macro sample size for batch comparison audits
+    # In later rounds, select a sample size automatically.
     else:
         sample_size_options = sample_sizes_module.sample_size_options(election)
+        sample_size_key = {
+            AuditType.BALLOT_POLLING: "0.9",
+            AuditType.BATCH_COMPARISON: "macro",
+            AuditType.BALLOT_COMPARISON: "supersimple",
+        }[AuditType(election.audit_type)]
         sample_sizes = {
-            contest_id: (
-                options["0.9"]["size"]
-                if election.audit_type == AuditType.BALLOT_POLLING
-                else options["macro"]["size"]
-            )
+            contest_id: options[sample_size_key]["size"]
             for contest_id, options in sample_size_options.items()
         }
 

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -67,6 +67,11 @@ def sample_size_options(
             set_contest_metadata_from_cvrs(contest)
             contest_for_sampler = sampler_contest.from_db_contest(contest)
 
+            num_previous_samples = (
+                SampledBallotDraw.query.join(Round)
+                .filter_by(election_id=election.id)
+                .count()
+            )
             discrepancies = supersimple.compute_discrepancies(
                 contest_for_sampler,
                 rounds.cvrs_for_contest(contest),
@@ -76,7 +81,7 @@ def sample_size_options(
                 discrepancies.values(), lambda d: d["counted_as"]
             )
             discrepancy_counts = {
-                "sample_size": len(discrepancies),  # TODO is this the right value?
+                "sample_size": num_previous_samples,
                 "1-under": len(discrepancy_groups.get(-1, [])),
                 "1-over": len(discrepancy_groups.get(1, [])),
                 "2-under": len(discrepancy_groups.get(-2, [])),

--- a/server/audit_math/supersimple.py
+++ b/server/audit_math/supersimple.py
@@ -1,6 +1,6 @@
 # pylint: disable=invalid-name
 import math
-from typing import Dict, Tuple, Union, TypedDict
+from typing import Dict, Tuple, TypedDict
 
 from .sampler_contest import Contest
 
@@ -132,7 +132,7 @@ def compute_discrepancies(
 
 
 def get_sample_sizes(
-    risk_limit: float, contest: Contest, sample_results: Dict[str, Union[int, float]]
+    risk_limit: float, contest: Contest, sample_results: Dict[str, int]
 ) -> float:
     """
     Computes initial sample sizes parameterized by likelihood that the

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -7,12 +7,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["test_ballot_comparison_round_1 1"] = {
-    "key": "supersimple",
-    "prob": None,
-    "size": 11,
-}
-
 snapshots["test_set_contest_metadata_from_cvrs 1"] = {
     "choices": [
         {"name": "Choice 2-1", "num_votes": 30},
@@ -24,8 +18,14 @@ snapshots["test_set_contest_metadata_from_cvrs 1"] = {
     "votes_allowed": 2,
 }
 
+snapshots["test_ballot_comparison_two_rounds 1"] = {
+    "key": "supersimple",
+    "prob": None,
+    "size": 11,
+}
+
 snapshots[
-    "test_ballot_comparison_round_1 2"
+    "test_ballot_comparison_two_rounds 2"
 ] = """######## ELECTION INFO ########\r
 Election Name,State\r
 Test Election,CA\r
@@ -37,7 +37,7 @@ Contest 2,Opportunistic,1,2,30,Choice 2-1: 30; Choice 2-2: 14; Choice 2-3: 16\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Risk Limit,Random Seed,Online Data Entry?\r
-Test Audit test_ballot_comparison_round_1,BALLOT_COMPARISON,10%,1234567890,Yes\r
+Test Audit test_ballot_comparison_two_rounds,BALLOT_COMPARISON,10%,1234567890,Yes\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
@@ -50,10 +50,57 @@ J1,1 - 2,1,Round 1: 0.372324681332676827,AUDITED,Choice 1-1,Choice 2-1\r
 J1,1 - 2,3,"Round 1: 0.159718557209511424, 0.357700029068711883",AUDITED,Choice 1-2,Choice 2-2\r
 J1,2 - 1,2,Round 1: 0.221314572958397938,AUDITED,Choice 1-2,Choice 2-2\r
 J1,2 - 2,2,Round 1: 0.373070595354246113,AUDITED,Choice 1-2,Choice 2-2\r
-J1,2 - 2,4,Round 1: 0.236178593368060699,NOT_AUDITED,,\r
+J1,2 - 2,4,Round 1: 0.236178593368060699,AUDITED,,\r
 J2,1 - 1,1,Round 1: 0.387534455946293789,AUDITED,Choice 1-1,Choice 2-1\r
 J2,1 - 1,3,Round 1: 0.145351404354762545,AUDITED,Choice 1-1,Choice 2-1\r
 J2,1 - 2,1,Round 1: 0.261383583608008902,AUDITED,Choice 1-1,Choice 2-1\r
 J2,2 - 2,3,Round 1: 0.394565893682896974,AUDITED,Choice 1-2,Choice 2-2\r
-J2,2 - 2,4,Round 1: 0.267753678346758280,NOT_AUDITED,,\r
+J2,2 - 2,4,Round 1: 0.267753678346758280,AUDITED,,\r
+"""
+
+snapshots[
+    "test_ballot_comparison_two_rounds 3"
+] = """######## ELECTION INFO ########\r
+Election Name,State\r
+Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
+Contest 1,Targeted,1,1,24,Choice 1-1: 24; Choice 1-2: 12\r
+Contest 2,Opportunistic,1,2,30,Choice 2-1: 30; Choice 2-2: 14; Choice 2-3: 16\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_ballot_comparison_two_rounds,BALLOT_COMPARISON,10%,1234567890,Yes\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
+1,Contest 1,Targeted,11,No,0.7413124393,DATETIME,DATETIME,Choice 1-1: 4; Choice 1-2: 5\r
+1,Contest 2,Opportunistic,,No,0.3142300101,DATETIME,DATETIME,Choice 2-1: 4; Choice 2-2: 4; Choice 2-3: 0\r
+2,Contest 1,Targeted,24,Yes,0.00000857,DATETIME,DATETIME,Choice 1-1: 22; Choice 1-2: 0\r
+2,Contest 2,Opportunistic,,Yes,0.026669516,DATETIME,DATETIME,Choice 2-1: 13; Choice 2-2: 0; Choice 2-3: 0\r
+\r
+######## SAMPLED BALLOTS ########\r
+Jurisdiction Name,Batch Name,Ballot Position,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,Audit Result: Contest 2\r
+J1,1 - 2,1,"Round 1: 0.372324681332676827, Round 2: 0.584479790136279181, 0.687173344675526679",AUDITED,Choice 1-1,Choice 2-1\r
+J1,1 - 2,3,"Round 1: 0.159718557209511424, 0.357700029068711883",AUDITED,Choice 1-2,Choice 2-2\r
+J1,2 - 1,2,Round 1: 0.221314572958397938,AUDITED,Choice 1-2,Choice 2-2\r
+J1,2 - 2,2,Round 1: 0.373070595354246113,AUDITED,Choice 1-2,Choice 2-2\r
+J1,2 - 2,4,Round 1: 0.236178593368060699,AUDITED,,\r
+J2,1 - 1,1,"Round 1: 0.387534455946293789, Round 2: 0.395908685820550185, 0.442344554159074925, 0.593953914323203317, 0.687833931481944664",AUDITED,Choice 1-1,Choice 2-1\r
+J2,1 - 1,3,"Round 1: 0.145351404354762545, Round 2: 0.457536337124203040",AUDITED,Choice 1-1,Choice 2-1\r
+J2,1 - 2,1,Round 1: 0.261383583608008902,AUDITED,Choice 1-1,Choice 2-1\r
+J2,2 - 2,3,Round 1: 0.394565893682896974,AUDITED,Choice 1-2,Choice 2-2\r
+J2,2 - 2,4,"Round 1: 0.267753678346758280, Round 2: 0.687217715186795526",AUDITED,,\r
+J1,1 - 1,1,Round 2: 0.517926507869833233,AUDITED,Choice 1-1,Choice 2-1\r
+J1,1 - 1,2,Round 2: 0.503617173857366940,AUDITED,Choice 1-1,Choice 2-1\r
+J1,1 - 1,3,Round 2: 0.586522879228736417,AUDITED,Choice 1-1,Choice 2-1\r
+J1,2 - 2,3,"Round 2: 0.421436777998024570, 0.549045630218345248, 0.561997693947248718",AUDITED,Choice 1-1,Choice 2-1\r
+J1,2 - 2,6,Round 2: 0.621059454153611572,AUDITED,,\r
+J2,1 - 2,2,"Round 2: 0.470573353321054019, 0.494144712697157651",AUDITED,Choice 1-1,Choice 2-1\r
+J2,2 - 1,1,Round 2: 0.624098313040011078,AUDITED,Choice 1-1,Choice 2-1\r
+J2,2 - 1,2,Round 2: 0.680982106712868379,AUDITED,Choice 1-1,Choice 2-1\r
+J2,2 - 1,3,Round 2: 0.434824005636328804,AUDITED,Choice 1-1,Choice 2-1\r
+J2,2 - 2,1,"Round 2: 0.537842375851419072, 0.594412040305777634",AUDITED,Choice 1-1,Choice 2-1\r
+J2,2 - 2,2,"Round 2: 0.420155343074912050, 0.549893345341670917",AUDITED,Choice 1-1,Choice 2-1\r
 """


### PR DESCRIPTION
In ballot comparison audits, for rounds after the first round, the
sampler needs to know the results from the previous round in terms of
the discrepancies found.