### PR TITLE
CVR file status in Audit Progress screen

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
@@ -104,6 +104,13 @@ const JurisdictionDetail = ({
             downloadUrl={`/api/election/${electionId}/jurisdiction/${jurisdiction.id}/batch-tallies/csv`}
           />
         )}
+        {jurisdiction.cvrs && (
+          <FileStatusCard
+            title="Cast Vote Records (CVR)"
+            fileInfo={jurisdiction.cvrs}
+            downloadUrl={`/api/election/${electionId}/jurisdiction/${jurisdiction.id}/cvrs/csv`}
+          />
+        )}
       </Section>
       {round && (
         <RoundStatusSection

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
@@ -197,7 +197,9 @@ const Progress: React.FC<IProps> = ({
         <Switch
           checked={isShowingUnique}
           label={`Count unique sampled ${
-            auditSettings.auditType === 'BALLOT_POLLING' ? 'ballots' : 'batches'
+            auditSettings.auditType === 'BATCH_COMPARISON'
+              ? 'batches'
+              : 'ballots'
           }`}
           onChange={() => setIsShowingUnique(!isShowingUnique)}
         />

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
@@ -76,6 +76,7 @@ const Progress: React.FC<IProps> = ({
           currentRoundStatus,
           ballotManifest,
           batchTallies,
+          cvrs,
         } = jurisdiction
 
         const Status = (props: Omit<ITagProps, 'minimal'>) => (
@@ -89,6 +90,7 @@ const Progress: React.FC<IProps> = ({
         if (!currentRoundStatus) {
           const files: IFileInfo['processing'][] = [ballotManifest.processing]
           if (batchTallies) files.push(batchTallies.processing)
+          if (cvrs) files.push(cvrs.processing)
 
           const numComplete = files.filter(
             f => f && f.status === FileProcessingStatus.PROCESSED
@@ -131,10 +133,11 @@ const Progress: React.FC<IProps> = ({
         }[currentRoundStatus.status]
       },
       sortType: sortByRank(
-        ({ currentRoundStatus, ballotManifest, batchTallies }) => {
+        ({ currentRoundStatus, ballotManifest, batchTallies, cvrs }) => {
           if (!currentRoundStatus) {
             const files: IFileInfo['processing'][] = [ballotManifest.processing]
             if (batchTallies) files.push(batchTallies.processing)
+            if (cvrs) files.push(cvrs.processing)
 
             const numComplete = files.filter(
               f => f && f.status === FileProcessingStatus.PROCESSED


### PR DESCRIPTION
Task: #768 

Followed the pattern used by batch tallies file to put the CVR file in
the progress table and the jurisdiction detail modal.

Tests to be added in a separate PR

<img width="822" alt="Screen Shot 2020-10-19 at 2 43 28 PM" src="https://user-images.githubusercontent.com/530106/96515057-7ddc3d00-1219-11eb-8129-efd19d911dd0.png">
