### PR TITLE
CVR file in status box

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -64,7 +64,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 84,
-        "branches": 78,
+        "branches": 77,
         "functions": 85,
         "lines": 85
       }

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/_mocks.ts
@@ -1,13 +1,7 @@
 import { IContest } from '../../../../types'
 
 export const contestMocks: {
-  [key in
-    | 'emptyTargeted'
-    | 'emptyOpportunistic'
-    | 'filledTargeted'
-    | 'filledOpportunistic'
-    | 'filledTargetedWithJurisdictionId'
-    | 'filledOpportunisticWithJurisdictionId']: { contests: IContest[] }
+  [key: string]: { contests: IContest[] }
 } = {
   emptyTargeted: {
     contests: [
@@ -139,6 +133,52 @@ export const contestMocks: {
       {
         id: 'contest-id',
         name: 'Contest Name',
+        isTargeted: false,
+        totalBallotsCast: '30',
+        numWinners: '1',
+        votesAllowed: '1',
+        jurisdictionIds: ['jurisdiction-id-1', 'jurisdiction-id-2'],
+        choices: [
+          {
+            id: 'choice-id-3',
+            name: 'Choice Three',
+            numVotes: '10',
+          },
+          {
+            id: 'choice-id-4',
+            name: 'Choice Four',
+            numVotes: '20',
+          },
+        ],
+      },
+    ],
+  },
+  filledTargetedAndOpportunistic: {
+    contests: [
+      {
+        id: 'contest-id',
+        name: 'Contest 1',
+        isTargeted: true,
+        totalBallotsCast: '30',
+        numWinners: '1',
+        votesAllowed: '1',
+        jurisdictionIds: ['jurisdiction-id-1', 'jurisdiction-id-2'],
+        choices: [
+          {
+            id: 'choice-id-1',
+            name: 'Choice One',
+            numVotes: '10',
+          },
+          {
+            id: 'choice-id-2',
+            name: 'Choice Two',
+            numVotes: '20',
+          },
+        ],
+      },
+      {
+        id: 'contest-id',
+        name: 'Contest 2',
         isTargeted: false,
         totalBallotsCast: '30',
         numWinners: '1',

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/ConfirmLaunch.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/ConfirmLaunch.tsx
@@ -6,14 +6,12 @@ const ConfirmLaunch = ({
   isOpen,
   handleClose,
   onLaunch,
-  numJurisdictions,
-  completedBallotUploads,
+  message,
 }: {
   isOpen: boolean
   handleClose: () => void
   onLaunch: () => void
-  numJurisdictions: number
-  completedBallotUploads: number
+  message?: string
 }) => {
   return (
     <Dialog
@@ -24,10 +22,7 @@ const ConfirmLaunch = ({
     >
       <div className={Classes.DIALOG_BODY}>
         <p>This action cannot be undone</p>
-        <p>
-          {completedBallotUploads} of {numJurisdictions} jurisdictions have
-          uploaded ballot manifests.
-        </p>
+        {message && <p>{message}</p>}
       </div>
       <div className={Classes.DIALOG_FOOTER}>
         <div className={Classes.DIALOG_FOOTER_ACTIONS}>

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
@@ -148,15 +148,15 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
     <form
       data-testid="sample-size-form"
     >
-      <div
-        class="sc-gzVnrw coBAaV"
-      >
-        <div
-          class="sc-htoDjs GlcDy"
+      <p>
+        All jurisdiction files must be uploaded to calculate the sample size.
+         
+        <a
+          href="/election/1/progress"
         >
-          Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
-        </div>
-      </div>
+          View jurisdiction upload progress.
+        </a>
+      </p>
       <div
         class="sc-htpNat gtULUV"
       >
@@ -336,103 +336,15 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
     <form
       data-testid="sample-size-form"
     >
-      <div
-        class="sc-gzVnrw coBAaV"
-      >
-        <div
-          class="sc-htoDjs GlcDy"
+      <p>
+        All jurisdiction files must be uploaded to calculate the sample size.
+         
+        <a
+          href="/election/1/progress"
         >
-          Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
-        </div>
-        <div
-          class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
-        >
-          <div
-            class="sc-htoDjs GlcDy"
-          >
-            <h4
-              class="bp3-heading"
-            >
-              Contest Name
-            </h4>
-            <div>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="asn"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                BRAVO Average Sample Number: 
-                46 samples
-                 (54% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.7"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                
-                67 samples
-                 (70% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.5"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                
-                88 samples
-                 (50% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.9"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                
-                125 samples
-                 (90% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="custom"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                Enter your own sample size (not recommended)
-              </label>
-            </div>
-          </div>
-        </div>
-      </div>
+          View jurisdiction upload progress.
+        </a>
+      </p>
       <div
         class="sc-htpNat gtULUV"
       >
@@ -636,6 +548,7 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
                 class="bp3-control bp3-radio"
               >
                 <input
+                  checked=""
                   name="sampleSizes[contest-id]"
                   type="radio"
                   value="asn"
@@ -910,6 +823,7 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
                 class="bp3-control bp3-radio"
               >
                 <input
+                  checked=""
                   name="sampleSizes[contest-id]"
                   type="radio"
                   value="asn"
@@ -1184,6 +1098,7 @@ exports[`Audit Setup > Review & Launch renders full state with batch comparison 
                 class="bp3-control bp3-radio"
               >
                 <input
+                  checked=""
                   name="sampleSizes[contest-id]"
                   type="radio"
                   value="asn"
@@ -1474,7 +1389,7 @@ exports[`Audit Setup > Review & Launch renders full state with batch comparison 
 </div>
 `;
 
-exports[`Audit Setup > Review & Launch renders full state with jurisdictions on opportunistic contest 1`] = `
+exports[`Audit Setup > Review & Launch renders full state with jurisdictions with targeted and opportunistic contests 1`] = `
 <div>
   <div>
     <h2
@@ -1586,7 +1501,16 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
             </th>
           </tr>
         </thead>
-        <tbody />
+        <tbody>
+          <tr>
+            <td>
+              Contest 1
+            </td>
+            <td>
+              Jurisdiction 1, Jurisdiction 2
+            </td>
+          </tr>
+        </tbody>
       </table>
       <table
         class="sc-jKJlTe gDHTyY"
@@ -1604,7 +1528,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
         <tbody>
           <tr>
             <td>
-              Contest Name
+              Contest 2
             </td>
             <td>
               Jurisdiction 1, Jurisdiction 2
@@ -1630,6 +1554,95 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
         >
           Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.
         </div>
+        <div
+          class="bp3-card bp3-elevation-2 sc-dxgOiQ jDdoJq"
+        >
+          <div
+            class="sc-htoDjs GlcDy"
+          >
+            <h4
+              class="bp3-heading"
+            >
+              Contest 1
+            </h4>
+            <div>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  checked=""
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="asn"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                BRAVO Average Sample Number: 
+                46 samples
+                 (54% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.7"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                67 samples
+                 (70% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.5"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                88 samples
+                 (50% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="0.9"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                
+                125 samples
+                 (90% chance of reaching risk limit and completing the audit in one round)
+              </label>
+              <label
+                class="bp3-control bp3-radio"
+              >
+                <input
+                  name="sampleSizes[contest-id]"
+                  type="radio"
+                  value="custom"
+                />
+                <span
+                  class="bp3-control-indicator"
+                />
+                Enter your own sample size (not recommended)
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
       <div
         class="sc-htpNat gtULUV"
@@ -1645,9 +1658,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions on 
           </span>
         </button>
         <button
-          class="bp3-button bp3-disabled bp3-intent-primary sc-EHOje gmpgQN"
-          disabled=""
-          tabindex="-1"
+          class="bp3-button bp3-intent-primary sc-EHOje gmpgQN"
           type="button"
         >
           <span
@@ -1834,6 +1845,7 @@ exports[`Audit Setup > Review & Launch renders full state with offline setting 1
                 class="bp3-control bp3-radio"
               >
                 <input
+                  checked=""
                   name="sampleSizes[contest-id]"
                   type="radio"
                   value="asn"

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
@@ -174,14 +174,14 @@ describe('Audit Setup > Review & Launch', () => {
     })
   })
 
-  it('renders full state with jurisdictions on opportunistic contest', async () => {
+  it('renders full state with jurisdictions with targeted and opportunistic contests', async () => {
     const expectedCalls = [
       apiCalls.getSettings(settingsMock.full),
       apiCalls.getJurisdictions({
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
-      apiCalls.getContests(contestMocks.filledOpportunisticWithJurisdictionId),
+      apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
       apiCalls.getSampleSizeOptions,
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -197,7 +197,6 @@ describe('Audit Setup > Review & Launch', () => {
       apiCalls.getJurisdictions({ jurisdictions: [] }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -212,7 +211,6 @@ describe('Audit Setup > Review & Launch', () => {
       apiCalls.getJurisdictions({ jurisdictions: [] }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledOpportunisticWithJurisdictionId),
-      apiCalls.getSampleSizeOptions,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -334,10 +334,7 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
                 intent="primary"
                 disabled={
                   locked ||
-                  !isSetupComplete(jurisdictions, contests, auditSettings) ||
-                  (auditType === 'BATCH_COMPARISON' &&
-                    !talliesUploadsCompleted &&
-                    !cvrsUploadsCompleted)
+                  !isSetupComplete(jurisdictions, contests, auditSettings)
                 }
                 onClick={handleSubmit}
               >

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -159,9 +159,13 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
             <tr>
               <td>Audit Type:</td>
               <td>
-                {auditType === 'BALLOT_POLLING'
-                  ? 'Ballot Polling'
-                  : 'Batch Comparison'}
+                {
+                  {
+                    BALLOT_POLLING: 'Ballot Polling',
+                    BATCH_COMPARISON: 'Batch Comparison',
+                    BALLOT_COMPARISON: 'Ballot Comparison',
+                  }[auditType]
+                }
               </td>
             </tr>
             <tr>

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
@@ -231,6 +231,9 @@ describe('StatusBox', () => {
             rounds={[]}
             auditBoards={[]}
             ballotManifest={{ file: null, processing: null }}
+            batchTallies={{ file: null, processing: null }}
+            cvrs={{ file: null, processing: null }}
+            auditType="BALLOT_POLLING"
           />
         </Router>
       )
@@ -248,6 +251,9 @@ describe('StatusBox', () => {
               file: null,
               processing: fileProcessingMocks.processed,
             }}
+            batchTallies={{ file: null, processing: null }}
+            cvrs={{ file: null, processing: null }}
+            auditType="BALLOT_POLLING"
           />
         </Router>
       )
@@ -266,6 +272,9 @@ describe('StatusBox', () => {
               file: null,
               processing: fileProcessingMocks.processed,
             }}
+            batchTallies={{ file: null, processing: null }}
+            cvrs={{ file: null, processing: null }}
+            auditType="BALLOT_POLLING"
           />
         </Router>
       )
@@ -283,6 +292,9 @@ describe('StatusBox', () => {
               file: null,
               processing: fileProcessingMocks.processed,
             }}
+            batchTallies={{ file: null, processing: null }}
+            cvrs={{ file: null, processing: null }}
+            auditType="BALLOT_POLLING"
           />
         </Router>
       )
@@ -300,6 +312,9 @@ describe('StatusBox', () => {
               file: null,
               processing: fileProcessingMocks.processed,
             }}
+            batchTallies={{ file: null, processing: null }}
+            cvrs={{ file: null, processing: null }}
+            auditType="BALLOT_POLLING"
           />
         </Router>
       )
@@ -318,6 +333,9 @@ describe('StatusBox', () => {
               file: null,
               processing: fileProcessingMocks.processed,
             }}
+            batchTallies={{ file: null, processing: null }}
+            cvrs={{ file: null, processing: null }}
+            auditType="BALLOT_POLLING"
           />
         </Router>
       )
@@ -337,6 +355,9 @@ describe('StatusBox', () => {
               file: null,
               processing: fileProcessingMocks.processed,
             }}
+            batchTallies={{ file: null, processing: null }}
+            cvrs={{ file: null, processing: null }}
+            auditType="BALLOT_POLLING"
           />
         </Router>
       )
@@ -352,4 +373,6 @@ describe('StatusBox', () => {
       )
     })
   })
+
+  // TODO test BATCH_COMPARISON and BALLOT_COMPARISON audits
 })

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -184,7 +184,10 @@ export const JurisdictionAdminView: React.FC = () => {
         <JurisdictionAdminStatusBox
           rounds={rounds}
           ballotManifest={ballotManifest}
+          batchTallies={batchTallies}
+          cvrs={cvrs}
           auditBoards={auditBoards}
+          auditType={auditSettings.auditType}
         />
         <VerticalInner>
           <H2Title>Audit Source Data</H2Title>
@@ -249,7 +252,10 @@ export const JurisdictionAdminView: React.FC = () => {
       <JurisdictionAdminStatusBox
         rounds={rounds}
         ballotManifest={ballotManifest}
+        batchTallies={batchTallies}
+        cvrs={cvrs}
         auditBoards={auditBoards}
+        auditType={auditSettings.auditType}
       />
       <Inner>
         <RoundManagement


### PR DESCRIPTION
Task: #758 

Status box
- Includes the CVR file when computing the status messages
- Also includes the batch tallies file (which we should have included before)

Review screen
- Add checks for all CVR/batch tallies files being uploaded to isSetupComplete
- Use isSetupComplete to decide when we load sample sizes as well as when we enable the launch button
- In the confirmation popup, only show a warning about how many jurisdictions uploaded ballot manifests for ballot polling audits (since in other audit types, all jurisdictions will have to have uploaded their manifests to get to this point)
- Change isSetupComplete and that warning to only factor in participating jurisdictions (i.e. ones that are part of a selected contest universe)

Misc
- Fix everywhere that we checked for `BALLOT_POLLING` audit type to check for `BATCH_COMPARISON` - that way we can treat `BALLOT_POLLING` and `BALLOT_COMPARISON` the same in all those cases, which is often what we want to do

Waiting to fix the failing tests until upstream branches fix their failing tests