### PR TITLE
Set Election.online based on audit type

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Settings/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Settings/index.tsx
@@ -50,12 +50,7 @@ const Settings: React.FC<IProps> = ({
     electionName: electionName === null ? '' : electionName,
     randomSeed: randomSeed === null ? '' : randomSeed,
     riskLimit: riskLimit === null ? 10 : riskLimit,
-    online:
-      auditType === 'BATCH_COMPARISON' // batch comparison audits are always offline
-        ? false
-        : online === null
-        ? true
-        : online,
+    online,
   }
   return (
     <Formik

--- a/server/api/routes.py
+++ b/server/api/routes.py
@@ -266,7 +266,7 @@ def election_new():
     validate_new_election(election, organization_id)
 
     online = {
-        AuditType.BALLOT_POLLING: False,
+        AuditType.BALLOT_POLLING: True,
         AuditType.BATCH_COMPARISON: False,
         AuditType.BALLOT_COMPARISON: True,
     }[election["auditType"]]

--- a/server/api/routes.py
+++ b/server/api/routes.py
@@ -265,12 +265,19 @@ def election_new():
 
     validate_new_election(election, organization_id)
 
+    online = {
+        AuditType.BALLOT_POLLING: False,
+        AuditType.BATCH_COMPARISON: False,
+        AuditType.BALLOT_COMPARISON: True,
+    }[election["auditType"]]
+
     election = Election(
         id=str(uuid.uuid4()),
         audit_name=election["auditName"],
         audit_type=election["auditType"],
         organization_id=organization_id,
         is_multi_jurisdiction=election["isMultiJurisdiction"],
+        online=online,
     )
 
     check_access([UserType.AUDIT_ADMIN], election)
@@ -936,6 +943,7 @@ def audit_reset(election):
         audit_type=election.audit_type,
         organization_id=election.organization_id,
         is_multi_jurisdiction=election.is_multi_jurisdiction,
+        online=election.online,
     )
     db_session.add(election)
     db_session.commit()

--- a/server/api/routes.py
+++ b/server/api/routes.py
@@ -266,7 +266,7 @@ def election_new():
     validate_new_election(election, organization_id)
 
     online = {
-        AuditType.BALLOT_POLLING: True,
+        AuditType.BALLOT_POLLING: False,
         AuditType.BATCH_COMPARISON: False,
         AuditType.BALLOT_COMPARISON: True,
     }[election["auditType"]]

--- a/server/models.py
+++ b/server/models.py
@@ -44,7 +44,9 @@ class Election(BaseModel):
     risk_limit = Column(Integer)
     random_seed = Column(String(100))
 
-    # an election is "online" if every ballot is entered online, vs. offline in a tally sheet.
+    # An audit is "online" if each ballot's audit results are entered in Arlo
+    # individually, vs. written in a tally sheet and then totaled before
+    # submitting to Arlo.
     online = Column(Boolean, nullable=False)
 
     # False for our old single-jurisdiction flow,

--- a/server/models.py
+++ b/server/models.py
@@ -45,7 +45,7 @@ class Election(BaseModel):
     random_seed = Column(String(100))
 
     # an election is "online" if every ballot is entered online, vs. offline in a tally sheet.
-    online = Column(Boolean, nullable=False, default=False)
+    online = Column(Boolean, nullable=False)
 
     # False for our old single-jurisdiction flow,
     # True for our new multi-jurisdiction flow

--- a/server/tests/api/test_election_settings.py
+++ b/server/tests/api/test_election_settings.py
@@ -10,7 +10,7 @@ def test_settings_get_empty(client: FlaskClient, election_id: str):
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
         "electionName": None,
-        "online": False,
+        "online": True,
         "randomSeed": None,
         "riskLimit": None,
         "state": None,
@@ -29,7 +29,7 @@ def test_jurisdiction_settings_get_empty(
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
         "electionName": None,
-        "online": False,
+        "online": True,
         "randomSeed": None,
         "riskLimit": None,
         "state": None,
@@ -45,7 +45,7 @@ def test_update_election(
 
     election = json.loads(rv.data)
     election["electionName"] = "An Updated Name"
-    election["online"] = True
+    election["online"] = False
     election["randomSeed"] = "a new random seed"
     election["riskLimit"] = 15
     election["state"] = USState.Mississippi
@@ -55,7 +55,7 @@ def test_update_election(
 
     expected_settings = {
         "electionName": "An Updated Name",
-        "online": True,
+        "online": False,
         "randomSeed": "a new random seed",
         "riskLimit": 15,
         "state": "MS",

--- a/server/tests/api/test_election_settings.py
+++ b/server/tests/api/test_election_settings.py
@@ -10,7 +10,7 @@ def test_settings_get_empty(client: FlaskClient, election_id: str):
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
         "electionName": None,
-        "online": True,
+        "online": False,
         "randomSeed": None,
         "riskLimit": None,
         "state": None,
@@ -29,7 +29,7 @@ def test_jurisdiction_settings_get_empty(
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
         "electionName": None,
-        "online": True,
+        "online": False,
         "randomSeed": None,
         "riskLimit": None,
         "state": None,

--- a/server/tests/api/test_new_election.py
+++ b/server/tests/api/test_new_election.py
@@ -77,7 +77,7 @@ def test_in_org_with_logged_in_admin(client: FlaskClient):
     response = json.loads(rv.data)
     election_id = response.get("electionId", None)
     assert election_id, response
-    assert Election.query.get(election_id).online is False
+    assert Election.query.get(election_id).online is True
 
     rv = client.get(f"/api/election/{election_id}/audit/status")
 

--- a/server/tests/api/test_new_election.py
+++ b/server/tests/api/test_new_election.py
@@ -77,7 +77,7 @@ def test_in_org_with_logged_in_admin(client: FlaskClient):
     response = json.loads(rv.data)
     election_id = response.get("electionId", None)
     assert election_id, response
-    assert Election.query.get(election_id).online is True
+    assert Election.query.get(election_id).online is False
 
     rv = client.get(f"/api/election/{election_id}/audit/status")
 

--- a/server/tests/api/test_new_election.py
+++ b/server/tests/api/test_new_election.py
@@ -77,6 +77,7 @@ def test_in_org_with_logged_in_admin(client: FlaskClient):
     response = json.loads(rv.data)
     election_id = response.get("electionId", None)
     assert election_id, response
+    assert Election.query.get(election_id).online is False
 
     rv = client.get(f"/api/election/{election_id}/audit/status")
 
@@ -97,7 +98,8 @@ def test_new_batch_comparison_audit(client: FlaskClient, org_id: str):
         },
     )
     assert rv.status_code == 200
-    assert "electionId" in json.loads(rv.data)
+    election_id = json.loads(rv.data)["electionId"]
+    assert Election.query.get(election_id).online is False
 
 
 def test_new_ballot_comparison_audit(client: FlaskClient, org_id: str):
@@ -114,7 +116,10 @@ def test_new_ballot_comparison_audit(client: FlaskClient, org_id: str):
         },
     )
     assert rv.status_code == 200
-    assert "electionId" in json.loads(rv.data)
+    election_id = json.loads(rv.data)["electionId"]
+    assert election_id
+
+    assert Election.query.get(election_id).online is True
 
 
 def test_in_org_with_logged_in_admin_without_access(client: FlaskClient):


### PR DESCRIPTION
Ballot polling audits are the only ones that have the configurable
online setting. This change sets online to the correct value for ballot
comparison and batch comparison audits on audit creation. It removes
setting of the online value from the frontend, except in the case of
ballot polling audits.
