### PR TITLE
Format numbers in audit progress table

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
@@ -62,7 +62,7 @@ describe('Progress screen', () => {
     within(rows[2]).getByRole('cell', { name: 'Jurisdiction 2' })
     within(rows[2]).getByRole('cell', { name: 'No manifest uploaded' })
     within(rows[3]).getByRole('cell', { name: 'Jurisdiction 3' })
-    within(rows[3]).getByRole('cell', { name: '2117' })
+    within(rows[3]).getByRole('cell', { name: '2,117' })
     within(rows[3]).getByRole('cell', { name: 'Manifest uploaded' })
   })
 
@@ -86,7 +86,7 @@ describe('Progress screen', () => {
     within(rows[1]).getByRole('cell', { name: 'Jurisdiction 1' })
     within(rows[1]).getByRole('cell', { name: 'In progress' })
     within(rows[1]).getByRole('cell', { name: '4' })
-    within(rows[1]).getByRole('cell', { name: '2117' })
+    within(rows[1]).getByRole('cell', { name: '2,117' })
     within(rows[1]).getByRole('cell', { name: '6' })
     within(rows[2]).getByRole('cell', { name: 'Jurisdiction 2' })
     within(rows[2]).getByRole('cell', { name: 'Not started' })
@@ -96,7 +96,7 @@ describe('Progress screen', () => {
     within(rows[3]).getByRole('cell', { name: 'Jurisdiction 3' })
     within(rows[3]).getByRole('cell', { name: 'Complete' })
     within(rows[3]).getByRole('cell', { name: '30' })
-    within(rows[3]).getByRole('cell', { name: '2117' })
+    within(rows[3]).getByRole('cell', { name: '2,117' })
     within(rows[3]).getByRole('cell', { name: '0' })
   })
 

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
@@ -34,6 +34,8 @@ const TableControls = styled.div`
   }
 `
 
+const formatNumber = (n: number | null) => n && n.toLocaleString()
+
 interface IProps {
   jurisdictions: IJurisdiction[]
   auditSettings: IAuditSettings
@@ -159,7 +161,8 @@ const Progress: React.FC<IProps> = ({
     },
     {
       Header: 'Total in Manifest',
-      accessor: ({ ballotManifest: { numBallots } }) => numBallots,
+      accessor: ({ ballotManifest: { numBallots } }) =>
+        formatNumber(numBallots),
     },
   ]
   if (round) {
@@ -167,15 +170,20 @@ const Progress: React.FC<IProps> = ({
       {
         Header: 'Audited',
         accessor: ({ currentRoundStatus: s }) =>
-          s && (isShowingUnique ? s.numUniqueAudited : s.numSamplesAudited),
+          s &&
+          formatNumber(
+            isShowingUnique ? s.numUniqueAudited : s.numSamplesAudited
+          ),
       },
       {
         Header: 'Still to Audit',
         accessor: ({ currentRoundStatus: s }) =>
           s &&
-          (isShowingUnique
-            ? s.numUnique - s.numUniqueAudited
-            : s.numSamples - s.numSamplesAudited),
+          formatNumber(
+            isShowingUnique
+              ? s.numUnique - s.numUniqueAudited
+              : s.numSamples - s.numSamplesAudited
+          ),
       }
     )
   }


### PR DESCRIPTION
Basically, big numbers need a comma in them.