### PR TITLE
Include ballots that are missing contest in sample_cvr

### DIFF
--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -280,8 +280,6 @@ def sampled_ballot_interpretations_to_cvrs(contest: Contest) -> supersimple.CVRS
     # - Audit board couldn't find the ballot - CVR should be None
     cvrs: supersimple.CVRS = {}
     for ballot_key, ballot in ballots:
-        assert ballot.status != BallotStatus.NOT_AUDITED
-
         # TODO add this in a separate PR just to ensure it doesn't impact the
         # test changes here
         # if ballot.status == BallotStatus.NOT_FOUND:

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -255,35 +255,57 @@ def cvrs_for_contest(contest: Contest) -> supersimple.CVRS:
 
 
 def sampled_ballot_interpretations_to_cvrs(contest: Contest) -> supersimple.CVRS:
-    interpretations_query = BallotInterpretation.query.filter_by(
-        contest_id=contest.id
-    ).outerjoin(BallotInterpretation.selected_choices)
+    ballots_query = (
+        SampledBallot.query.join(Batch)
+        .join(Jurisdiction)
+        .filter(Jurisdiction.contests.contains(contest))
+    )
     # For targeted contests, use the ticket number to key the ballots so that
     # we count all sample draws
     if contest.is_targeted:
-        interpretations = (
-            interpretations_query.join(
-                SampledBallotDraw,
-                BallotInterpretation.ballot_id == SampledBallotDraw.ballot_id,
-            )
-            .filter(SampledBallotDraw.contest_id == contest.id)
-            .with_entities(SampledBallotDraw.ticket_number, BallotInterpretation)
+        ballots = (
+            ballots_query.join(SampledBallotDraw)
+            .filter_by(contest_id=contest.id)
+            .with_entities(SampledBallotDraw.ticket_number, SampledBallot)
             .all()
         )
     # For opportunistic contests, use the ballot id to key the ballots so that
     # we only count unique ballots
     else:
-        interpretations = interpretations_query.with_entities(
-            BallotInterpretation.ballot_id, BallotInterpretation
-        ).all()
+        ballots = ballots_query.with_entities(SampledBallot.id, SampledBallot).all()
 
-    cvrs = {}
-    for ballot_key, interpretation in interpretations:
-        cvrs[ballot_key] = {contest.id: {choice.id: 0 for choice in contest.choices}}
-        # TODO maybe make Interpretation.CANT_AGREE a vote for the loser?
-        if interpretation.interpretation == Interpretation.VOTE:
-            for choice in interpretation.selected_choices:
-                cvrs[ballot_key][contest.id][choice.id] = 1
+    # The CVR we build should have a 1 for each choice that got voted for,
+    # and a 0 otherwise. There are a couple special cases:
+    # - Contest wasn't on the ballot - CVR should be an empty object
+    # - Audit board couldn't find the ballot - CVR should be None
+    cvrs: supersimple.CVRS = {}
+    for ballot_key, ballot in ballots:
+        assert ballot.status != BallotStatus.NOT_AUDITED
+
+        # TODO add this in a separate PR just to ensure it doesn't impact the
+        # test changes here
+        # if ballot.status == BallotStatus.NOT_FOUND:
+        #     cvrs[ballot_key] = None
+        #     continue
+
+        if ballot.status == BallotStatus.AUDITED:
+            interpretation = next(
+                (
+                    interpretation
+                    for interpretation in ballot.interpretations
+                    if interpretation.contest_id == contest.id
+                ),
+                None,
+            )
+            if interpretation is None:  # Contest not on ballot
+                cvrs[ballot_key] = {}
+            else:
+                cvrs[ballot_key] = {
+                    contest.id: {choice.id: 0 for choice in contest.choices}
+                }
+                if interpretation.interpretation == Interpretation.VOTE:
+                    for choice in interpretation.selected_choices:
+                        cvrs[ballot_key][contest.id][choice.id] = 1
 
     return cvrs
 

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -62,8 +62,8 @@ J2,Audit Board #1,,,,\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,22,No,0.3226521852,DATETIME,DATETIME,Choice 1-1: 10; Choice 1-2: 9\r
-1,Contest 2,Opportunistic,,No,0.1449790463,DATETIME,DATETIME,Choice 2-1: 15; Choice 2-2: 9; Choice 2-3: 8\r
+1,Contest 1,Targeted,22,No,0.1495325187,DATETIME,DATETIME,Choice 1-1: 10; Choice 1-2: 9\r
+1,Contest 2,Opportunistic,,No,0.1124219565,DATETIME,DATETIME,Choice 2-1: 15; Choice 2-2: 9; Choice 2-3: 8\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Discrepancy: Contest 2\r
@@ -83,7 +83,7 @@ J2,TABULATOR2,BATCH1,1,2-1-1,Round 1: 0.174827909206366766,AUDITED,Choice 1-2,Ch
 J2,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.185417954749015145,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J2,TABULATOR2,BATCH2,3,2-2-3,"Round 1: 0.179114059650472941, 0.443867094961314498",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR2,BATCH2,5,2-2-5,Round 1: 0.462119987445142117,AUDITED,Choice 1-1,,0,,"Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH2,5,2-2-5,Round 1: 0.462119987445142117,AUDITED,Choice 1-1,,0,,"Choice 2-1, Choice 2-2",1\r
 J2,TABULATOR2,BATCH2,6,2-2-6,Round 1: 0.414184312862040881,AUDITED,,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 """
 
@@ -109,10 +109,10 @@ J2,Audit Board #1,,,,\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,22,No,0.3226521852,DATETIME,DATETIME,Choice 1-1: 10; Choice 1-2: 9\r
-1,Contest 2,Opportunistic,,No,0.1449790463,DATETIME,DATETIME,Choice 2-1: 15; Choice 2-2: 9; Choice 2-3: 8\r
-2,Contest 1,Targeted,41,Yes,0.0061544544,DATETIME,DATETIME,Choice 1-1: 24; Choice 1-2: 17\r
-2,Contest 2,Opportunistic,,Yes,0.0146966498,DATETIME,DATETIME,Choice 2-1: 21; Choice 2-2: 10; Choice 2-3: 13\r
+1,Contest 1,Targeted,22,No,0.1495325187,DATETIME,DATETIME,Choice 1-1: 10; Choice 1-2: 9\r
+1,Contest 2,Opportunistic,,No,0.1124219565,DATETIME,DATETIME,Choice 2-1: 15; Choice 2-2: 9; Choice 2-3: 8\r
+2,Contest 1,Targeted,41,Yes,0.0013218788,DATETIME,DATETIME,Choice 1-1: 24; Choice 1-2: 17\r
+2,Contest 2,Opportunistic,,Yes,0.0113963098,DATETIME,DATETIME,Choice 2-1: 21; Choice 2-2: 10; Choice 2-3: 13\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Discrepancy: Contest 2\r
@@ -132,7 +132,7 @@ J2,TABULATOR2,BATCH1,1,2-1-1,"Round 1: 0.174827909206366766, Round 2: 0.63875989
 J2,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.185417954749015145,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438, Round 2: 0.770913121904276479",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J2,TABULATOR2,BATCH2,3,2-2-3,"Round 1: 0.179114059650472941, 0.443867094961314498, Round 2: 0.553767880261132538",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.462119987445142117, Round 2: 0.593645562906652185, 0.727818415897312844",AUDITED,Choice 1-1,,0,,"Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.462119987445142117, Round 2: 0.593645562906652185, 0.727818415897312844",AUDITED,Choice 1-1,,0,,"Choice 2-1, Choice 2-2",1\r
 J2,TABULATOR2,BATCH2,6,2-2-6,Round 1: 0.414184312862040881,AUDITED,,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J1,TABULATOR1,BATCH1,2,1-1-2,Round 2: 0.658361514845611561,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J1,TABULATOR1,BATCH2,1,1-2-1,"Round 2: 0.789999110379954007, 0.795280178707820266",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r


### PR DESCRIPTION
Task: #741 

Currently, when constructing the `sample_cvr` object to pass to the
`supersimple` audit math, we omit any ballot that the audit board did
not record any interpretation for (i.e. the contest was missing from
that ballot).

This impacts `supersimple.compute_risk`, since it iterates over the
`sample_cvr` to compute the p-value.