### PR TITLE
Count not found ballots as two-vote overstatement

### DIFF
--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -96,8 +96,10 @@ def pretty_ballot_interpretation(
 def pretty_cvr_interpretation(
     ballot: SampledBallot, contest: Contest, contest_cvrs: supersimple.CVRS
 ) -> str:
-    cvrs_by_choice = contest_cvrs[ballot.id].get(contest.id)
+    ballot_cvr = contest_cvrs[ballot.id]
+    assert ballot_cvr is not None
 
+    cvrs_by_choice = ballot_cvr.get(contest.id)
     # If CVR was empty for this contest for this ballot, skip it
     if not cvrs_by_choice:
         return ""

--- a/server/audit_math/supersimple.py
+++ b/server/audit_math/supersimple.py
@@ -168,7 +168,13 @@ def compute_discrepancies(
                     if e:
                         # we found a discrepancy!
                         found = True
-                    e_weighted = Decimal(e) / Decimal(V_wl)
+
+                    if V_wl == 0:
+                        # In this case the error is undefined
+                        e_weighted = Decimal("inf")
+                    else:
+                        e_weighted = Decimal(e) / Decimal(V_wl)
+
                     if e_weighted > e_r:
                         e_r = e_weighted
                         e_int = e

--- a/server/audit_math/supersimple.py
+++ b/server/audit_math/supersimple.py
@@ -16,14 +16,16 @@ u1: Decimal = Decimal(0.001)
 o2: Decimal = Decimal(0.0001)
 u2: Decimal = Decimal(0.0001)
 
-# { ballot_id: { contest_id: { choice_id: 0 | 1 }}}
+
+# CVR: { contest_id: { choice_id: 0 | 1 }}
+# CVRS: { ballot_id: CVR }
 CVR = Dict[str, Dict[str, int]]
-CVRS = Dict[str, CVR]
+CVRS = Dict[str, Optional[CVR]]
 
 
 class SampleCVR(TypedDict):
     times_sampled: int
-    cvr: CVR
+    cvr: Optional[CVR]
 
 
 SAMPLE_CVRS = Dict[str, SampleCVR]
@@ -118,6 +120,11 @@ def compute_discrepancies(
 
     discrepancies: Dict[str, Discrepancy] = {}
     for ballot in sample_cvr:
+        # Typechecker needs us to pull these out into variables
+        ballot_sample_cvr = sample_cvr[ballot]["cvr"]
+        ballot_cvr = cvrs[ballot]
+        assert ballot_cvr is not None
+
         # We want to be conservative, so we will ignore the case where there are
         # negative errors (i.e. errors that favor the winner. We can do that
         # by setting these to zero and evaluating whether an error is greater
@@ -126,48 +133,53 @@ def compute_discrepancies(
         e_int = 0
 
         found = False
-        for winner in contest.winners:
-            for loser in contest.losers:
 
-                if contest.name in cvrs[ballot]:
-                    v_w = cvrs[ballot][contest.name][winner]
-                    v_l = cvrs[ballot][contest.name][loser]
-                else:
-                    v_w = 0
-                    v_l = 0
+        # Special case: if ballot can't be found by audit board, count it as a
+        # two-vote overstatement
+        if ballot_sample_cvr is None:
+            e_int = 2
+            e_weighted = Decimal(e_int) / Decimal(
+                contest.diluted_margin * contest.ballots
+            )
+            found = True
 
-                if contest.name in sample_cvr[ballot]["cvr"]:
-                    a_w = sample_cvr[ballot]["cvr"][contest.name][winner]
-                    a_l = sample_cvr[ballot]["cvr"][contest.name][loser]
-                else:
-                    a_w = 0
-                    a_l = 0
+        else:
+            for winner in contest.winners:
+                for loser in contest.losers:
 
-                V_wl = contest.candidates[winner] - contest.candidates[loser]
+                    if contest.name in ballot_cvr:
+                        v_w = ballot_cvr[contest.name][winner]
+                        v_l = ballot_cvr[contest.name][loser]
+                    else:
+                        v_w = 0
+                        v_l = 0
 
-                e = (v_w - a_w) - (v_l - a_l)
+                    if contest.name in ballot_sample_cvr:
+                        a_w = ballot_sample_cvr[contest.name][winner]
+                        a_l = ballot_sample_cvr[contest.name][loser]
+                    else:
+                        a_w = 0
+                        a_l = 0
 
-                if e:
-                    # we found a discrepancy!
-                    found = True
+                    V_wl = contest.candidates[winner] - contest.candidates[loser]
 
-                if V_wl == 0:
-                    # In this case the error is undefined
-                    e_weighted = Decimal("inf")
-                else:
+                    e = (v_w - a_w) - (v_l - a_l)
+
+                    if e:
+                        # we found a discrepancy!
+                        found = True
                     e_weighted = Decimal(e) / Decimal(V_wl)
-
-                if e_weighted > e_r:
-                    e_r = e_weighted
-                    e_int = e
+                    if e_weighted > e_r:
+                        e_r = e_weighted
+                        e_int = e
 
         if found:
             discrepancies[ballot] = Discrepancy(
                 counted_as=e_int,
                 weighted_error=e_weighted,
                 discrepancy_cvr={
-                    "reported_as": cvrs[ballot],
-                    "audited_as": sample_cvr[ballot]["cvr"],
+                    "reported_as": ballot_cvr,
+                    "audited_as": ballot_sample_cvr,
                 },
             )
 

--- a/server/tests/audit_math/test_supersimple.py
+++ b/server/tests/audit_math/test_supersimple.py
@@ -165,7 +165,7 @@ def test_race_not_in_sample_discrepancy(contests, cvrs):
 
 
 def test_ballot_not_found_discrepancy(contests, cvrs):
-    sample_cvr = {0: None}
+    sample_cvr = {0: {"times_sampled": 1, "cvr": None}}
 
     discrepancies = supersimple.compute_discrepancies(
         contests["Contest D"], cvrs, sample_cvr

--- a/server/tests/audit_math/test_supersimple.py
+++ b/server/tests/audit_math/test_supersimple.py
@@ -164,6 +164,19 @@ def test_race_not_in_sample_discrepancy(contests, cvrs):
     assert "Contest D" not in discrepancies[0]["discrepancy_cvr"]["audited_as"]
 
 
+def test_ballot_not_found_discrepancy(contests, cvrs):
+    sample_cvr = {0: None}
+
+    discrepancies = supersimple.compute_discrepancies(
+        contests["Contest D"], cvrs, sample_cvr
+    )
+
+    assert discrepancies
+    assert discrepancies[0]["counted_as"] == 2
+    assert discrepancies[0]["weighted_error"] == Decimal(2) / Decimal(2000)
+    assert discrepancies[0]["discrepancy_cvr"]["audited_as"] is None
+
+
 def test_get_sample_sizes(contests):
     for contest in contests:
         computed = supersimple.get_sample_sizes(RISK_LIMIT, contests[contest], None)

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -64,8 +64,8 @@ J2,Audit Board #1,,,,\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,22,No,0.1495325187,DATETIME,DATETIME,Choice 1-1: 10; Choice 1-2: 9\r
-1,Contest 2,Opportunistic,,No,0.1199013987,DATETIME,DATETIME,Choice 2-1: 15; Choice 2-2: 9; Choice 2-3: 8\r
+1,Contest 1,Targeted,22,No,3.9787903602,DATETIME,DATETIME,Choice 1-1: 10; Choice 1-2: 8\r
+1,Contest 2,Opportunistic,,No,3.1903597519,DATETIME,DATETIME,Choice 2-1: 14; Choice 2-2: 8; Choice 2-3: 8\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Discrepancy: Contest 2\r
@@ -79,7 +79,7 @@ J1,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.442956417641278897, 0.49263883897033325
 J1,TABULATOR2,BATCH2,6,2-2-6,Round 1: 0.300053574780458718,AUDITED,,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.476019554092109137,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J2,TABULATOR1,BATCH1,2,1-1-2,Round 1: 0.511105635717372621,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR1,BATCH1,3,1-1-3,Round 1: 0.242392535590495322,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR1,BATCH1,3,1-1-3,Round 1: 0.242392535590495322,NOT_FOUND,,Choice 1-2,2,,"Choice 2-1, Choice 2-2",2\r
 J2,TABULATOR1,BATCH2,1,1-2-1,Round 1: 0.200269401620671924,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR2,BATCH1,1,2-1-1,Round 1: 0.174827909206366766,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J2,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.185417954749015145,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
@@ -111,39 +111,36 @@ J2,Audit Board #1,,,,\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,22,No,0.1495325187,DATETIME,DATETIME,Choice 1-1: 10; Choice 1-2: 9\r
-1,Contest 2,Opportunistic,,No,0.1199013987,DATETIME,DATETIME,Choice 2-1: 15; Choice 2-2: 9; Choice 2-3: 8\r
-2,Contest 1,Targeted,41,Yes,<0.0000000001,DATETIME,DATETIME,Choice 1-1: 24; Choice 1-2: 17\r
-2,Contest 2,Opportunistic,,Yes,0.0175059952,DATETIME,DATETIME,Choice 2-1: 21; Choice 2-2: 10; Choice 2-3: 13\r
+1,Contest 1,Targeted,22,No,3.9787903602,DATETIME,DATETIME,Choice 1-1: 10; Choice 1-2: 8\r
+1,Contest 2,Opportunistic,,No,3.1903597519,DATETIME,DATETIME,Choice 2-1: 14; Choice 2-2: 8; Choice 2-3: 8\r
+2,Contest 1,Targeted,24,Yes,<0.0000000001,DATETIME,DATETIME,Choice 1-1: 12; Choice 1-2: 7\r
+2,Contest 2,Opportunistic,,No,0.8846022263,DATETIME,DATETIME,Choice 2-1: 15; Choice 2-2: 5; Choice 2-3: 12\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Discrepancy: Contest 2\r
-J1,TABULATOR1,BATCH1,1,1-1-1,"Round 1: 0.243550726331576894, Round 2: 0.686337915847173217, 0.780585292625102279",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J1,TABULATOR1,BATCH1,1,1-1-1,"Round 1: 0.243550726331576894, Round 2: 0.686337915847173217",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J1,TABULATOR1,BATCH2,2,1-2-2,"Round 1: 0.125871889047705889, Round 2: 0.752068917437552786",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
-J1,TABULATOR1,BATCH2,3,1-2-3,"Round 1: 0.126622033568908859, Round 2: 0.570682515619614792, 0.834196264967811357",AUDITED,"Choice 1-1, Choice 1-2",Choice 1-1,1,"Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-3",2\r
-J1,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.053992217600758631, Round 2: 0.528652598036440834, 0.764288236446565653, 0.820175995974143805",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2, Choice 2-3",0\r
+J1,TABULATOR1,BATCH2,3,1-2-3,"Round 1: 0.126622033568908859, Round 2: 0.570682515619614792",AUDITED,"Choice 1-1, Choice 1-2",Choice 1-1,1,"Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-3",2\r
+J1,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.053992217600758631, Round 2: 0.528652598036440834",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2, Choice 2-3",0\r
 J1,TABULATOR2,BATCH2,3,2-2-3,Round 1: 0.255119157791673311,AUDITED,BLANK,Choice 1-1,1,BLANK,"Choice 2-1, Choice 2-3",1\r
 J1,TABULATOR2,BATCH2,4,2-2-4,"Round 1: 0.064984443990590400, 0.069414660569975443, Round 2: 0.662654312843285447, 0.739178008942093721",AUDITED,,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J1,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.442956417641278897, 0.492638838970333256",AUDITED,,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J1,TABULATOR2,BATCH2,6,2-2-6,"Round 1: 0.300053574780458718, Round 2: 0.539920212714138536, 0.614239889448737812",AUDITED,,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR1,BATCH1,1,1-1-1,"Round 1: 0.476019554092109137, Round 2: 0.762943953776491170",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.476019554092109137,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J2,TABULATOR1,BATCH1,2,1-1-2,"Round 1: 0.511105635717372621, Round 2: 0.583472201399663519",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR1,BATCH1,3,1-1-3,"Round 1: 0.242392535590495322, Round 2: 0.705264140168043487",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR1,BATCH1,3,1-1-3,"Round 1: 0.242392535590495322, Round 2: 0.705264140168043487",NOT_FOUND,,Choice 1-2,2,,"Choice 2-1, Choice 2-2",2\r
 J2,TABULATOR1,BATCH2,1,1-2-1,"Round 1: 0.200269401620671924, Round 2: 0.588219390083415326",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR2,BATCH1,1,2-1-1,"Round 1: 0.174827909206366766, Round 2: 0.638759896009674755, 0.666161104573622944, 0.688295361956370024, 0.773068356532987654",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH1,1,2-1-1,"Round 1: 0.174827909206366766, Round 2: 0.638759896009674755, 0.666161104573622944, 0.688295361956370024",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J2,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.185417954749015145,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438, Round 2: 0.770913121904276479",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2, Choice 2-3",0\r
+J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2, Choice 2-3",0\r
 J2,TABULATOR2,BATCH2,3,2-2-3,"Round 1: 0.179114059650472941, 0.443867094961314498, Round 2: 0.553767880261132538",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.462119987445142117, Round 2: 0.593645562906652185, 0.727818415897312844",AUDITED,Choice 1-1,,0,,"Choice 2-1, Choice 2-2",1\r
 J2,TABULATOR2,BATCH2,6,2-2-6,Round 1: 0.414184312862040881,AUDITED,,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J1,TABULATOR1,BATCH1,2,1-1-2,Round 2: 0.658361514845611561,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J1,TABULATOR1,BATCH2,1,1-2-1,"Round 2: 0.789999110379954007, 0.795280178707820266",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J1,TABULATOR2,BATCH1,2,2-1-2,Round 2: 0.651118570553261125,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J1,TABULATOR2,BATCH2,1,2-2-1,"Round 2: 0.607927957276839128, 0.787278086653253195",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR1,BATCH2,2,1-2-2,"Round 2: 0.802360074986437243, 0.820653389137078523",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J1,TABULATOR2,BATCH2,1,2-2-1,Round 2: 0.607927957276839128,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR1,BATCH2,3,1-2-3,Round 2: 0.556310137163677574,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR2,BATCH1,2,2-1-2,"Round 2: 0.677864268646804078, 0.852896835996908532, 0.856103819529989087, 0.857728105355769040",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR2,BATCH1,3,2-1-3,"Round 2: 0.803716379074313244, 0.853400178985340640",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH1,2,2-1-2,Round 2: 0.677864268646804078,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR2,BATCH2,4,2-2-4,"Round 2: 0.583133559190710795, 0.685610948371080498",AUDITED,,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 """
 

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -202,7 +202,7 @@ def test_ballot_comparison_two_rounds(
         ("J1", "TABULATOR2", "BATCH2", 6): ",,1,0,1",
         ("J2", "TABULATOR1", "BATCH1", 1): "0,1,1,1,0",
         ("J2", "TABULATOR1", "BATCH1", 2): "1,0,1,0,1",
-        ("J2", "TABULATOR1", "BATCH1", 3): "0,1,1,1,0",
+        ("J2", "TABULATOR1", "BATCH1", 3): "not found",  # CVR: 0,1,1,1,0
         ("J2", "TABULATOR1", "BATCH2", 1): "1,0,1,0,1",
         ("J2", "TABULATOR2", "BATCH1", 1): "0,1,1,1,0",
         ("J2", "TABULATOR2", "BATCH2", 1): "1,0,1,0,1",
@@ -239,8 +239,13 @@ def test_ballot_comparison_two_rounds(
         assert sorted(sampled_ballot_keys) == sorted(list(audit_results.keys()))
 
         for ballot in sampled_ballots:
-            ballot.status = BallotStatus.AUDITED
             interpretation_str = audit_results[ballot_key(ballot)]
+
+            if interpretation_str == "not found":
+                ballot.status = BallotStatus.NOT_FOUND
+                continue
+
+            ballot.status = BallotStatus.AUDITED
 
             if interpretation_str == "blank":
                 audit_ballot(ballot, target_contest_id, Interpretation.BLANK)
@@ -302,13 +307,10 @@ def test_ballot_comparison_two_rounds(
     # For round 2, audit results should match the CVR exactly.
     audit_results = {
         ("J1", "TABULATOR1", "BATCH1", 2): "1,0,1,0,1",
-        ("J1", "TABULATOR1", "BATCH2", 1): "1,0,1,0,1",
         ("J1", "TABULATOR2", "BATCH1", 2): "1,0,1,0,1",
         ("J1", "TABULATOR2", "BATCH2", 1): "1,0,1,0,1",
-        ("J2", "TABULATOR1", "BATCH2", 2): "0,1,1,1,0",
         ("J2", "TABULATOR1", "BATCH2", 3): "1,0,1,0,1",
         ("J2", "TABULATOR2", "BATCH1", 2): "1,0,1,0,1",
-        ("J2", "TABULATOR2", "BATCH1", 3): "1,0,1,1,0",
         ("J2", "TABULATOR2", "BATCH2", 4): ",,1,0,1",
     }
 


### PR DESCRIPTION
Task: #741 

If an audit board can't find a ballot, the research says we should
conservatively count that as a two-vote overstatement.

We pass `None` as the `sample_cvr` value for this case, and then
interpret that in `compute_discrepancies`.

Note: the typechecker is not smart enough to deal with this change to
the type, so there are also some other changes to accommodate that.
