### PR TITLE
Adds round sizes to the audit_math.sampler_contest object

### DIFF
--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -345,7 +345,7 @@ def sampled_ballot_rows(election: Election, jurisdiction: Jurisdiction = None):
         }
         discrepancies_by_contest = {
             contest.id: supersimple.compute_discrepancies(
-                sampler_contest.from_db_contest(contest),
+                sampler_contest.from_db_contest(contest, election.rounds),
                 cvrs_by_contest[contest.id],
                 sampled_ballot_interpretations_to_cvrs(contest),
             )

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -303,7 +303,7 @@ def calculate_risk_measurements(election: Election, round: Round):
         if election.audit_type == AuditType.BALLOT_POLLING:
             p_values, is_complete = ballot_polling.compute_risk(
                 election.risk_limit,
-                sampler_contest.from_db_contest(contest),
+                sampler_contest.from_db_contest(contest, election.rounds),
                 contest_results_by_round(contest),
                 BallotPollingType.BRAVO,
             )
@@ -311,7 +311,7 @@ def calculate_risk_measurements(election: Election, round: Round):
         elif election.audit_type == AuditType.BATCH_COMPARISON:
             p_value, is_complete = macro.compute_risk(
                 election.risk_limit,
-                sampler_contest.from_db_contest(contest),
+                sampler_contest.from_db_contest(contest, election.rounds),
                 batch_tallies(election),
                 cumulative_batch_results(election),
             )
@@ -319,7 +319,7 @@ def calculate_risk_measurements(election: Election, round: Round):
             assert election.audit_type == AuditType.BALLOT_COMPARISON
             p_value, is_complete = supersimple.compute_risk(
                 election.risk_limit,
-                sampler_contest.from_db_contest(contest),
+                sampler_contest.from_db_contest(contest, election.rounds),
                 cvrs_for_contest(contest),
                 sampled_ballot_interpretations_to_cvrs(contest),
             )
@@ -585,7 +585,7 @@ def sample_batches(
 
     sample = sampler.draw_ppeb_sample(
         str(election.random_seed),
-        sampler_contest.from_db_contest(contest),
+        sampler_contest.from_db_contest(contest, election.rounds),
         sample_sizes[contest.id],
         num_previously_sampled,
         batch_tallies(election),

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -31,7 +31,7 @@ def sample_size_options(
             )
             sample_size_options = ballot_polling.get_sample_size(
                 election.risk_limit,
-                sampler_contest.from_db_contest(contest),
+                sampler_contest.from_db_contest(contest, election.rounds),
                 sample_results,
                 BallotPollingType.BRAVO,
             )
@@ -53,7 +53,7 @@ def sample_size_options(
                 }
             sample_size = macro.get_sample_sizes(
                 election.risk_limit,
-                sampler_contest.from_db_contest(contest),
+                sampler_contest.from_db_contest(contest, election.rounds),
                 rounds.batch_tallies(election),
                 cumulative_batch_results,
             )
@@ -63,7 +63,9 @@ def sample_size_options(
             assert election.audit_type == AuditType.BALLOT_COMPARISON
 
             set_contest_metadata_from_cvrs(contest)
-            contest_for_sampler = sampler_contest.from_db_contest(contest)
+            contest_for_sampler = sampler_contest.from_db_contest(
+                contest, election.rounds
+            )
 
             if round_one:
                 discrepancy_counts = None

--- a/server/audit_math/sampler_contest.py
+++ b/server/audit_math/sampler_contest.py
@@ -2,7 +2,7 @@
 A Module containing the Contest class, which encapsulates useful info for RLA
 computations.
 """
-from typing import Dict
+from typing import Dict, Any
 import operator
 
 
@@ -54,7 +54,7 @@ class Contest:
     diluted_margin: float  # The smallest diluted margin in this contest
     margins: Dict[str, Dict]  # Dict of the margins for this contest
 
-    def __init__(self, name: str, contest_info_dict: Dict[str, int]):
+    def __init__(self, name: str, contest_info_dict: Dict[str, Any]):
         """
         Initializes the contest info from a dict of the form:
             {

--- a/server/audit_math/sampler_contest.py
+++ b/server/audit_math/sampler_contest.py
@@ -6,7 +6,7 @@ from typing import Dict
 import operator
 
 
-def from_db_contest(db_contest):
+def from_db_contest(db_contest, db_rounds):
     """
     Builds sampler_contest object from the database
 
@@ -17,10 +17,15 @@ def from_db_contest(db_contest):
         Contest - A contest object
     """
     name = db_contest.id
+    round_sizes = {}
+    for rnd in db_rounds:
+        round_sizes[rnd.round_num] = len(rnd.sampled_ballot_draws)
+
     info_dict = {
         "ballots": db_contest.total_ballots_cast,
         "numWinners": db_contest.num_winners,
         "votesAllowed": db_contest.votes_allowed,
+        "roundSizes": round_sizes,
     }
 
     # Initialize the choices in this contest and how many votes each received
@@ -41,6 +46,7 @@ class Contest:
     votesAllowed: int  # How many voters are allowed in this contest
     ballots: int  # The total number of ballots cast in this contest
     name: str  # The name of the contest
+    round_sizes: Dict[int, int]  # Maps rounds to the number of draws in that round
 
     winners: Dict[str, int]  # List of all the winners
     losers: Dict[str, int]  # List of all the losers
@@ -65,6 +71,7 @@ class Contest:
         self.ballots = contest_info_dict["ballots"]
         self.num_winners = contest_info_dict["numWinners"]
         self.votes_allowed = contest_info_dict["votesAllowed"]
+        self.round_sizes = contest_info_dict["roundSizes"]
 
         self.candidates = {}
 
@@ -72,7 +79,7 @@ class Contest:
         self.losers = {}
 
         for cand in contest_info_dict:
-            if cand in ["ballots", "numWinners", "votesAllowed"]:
+            if cand in ["ballots", "numWinners", "votesAllowed", "roundSizes"]:
                 continue
 
             self.candidates[cand] = contest_info_dict[cand]

--- a/server/tests/audit_math/test_bravo.py
+++ b/server/tests/audit_math/test_bravo.py
@@ -397,6 +397,7 @@ def test_tied_contest():
         "cand2": 500,
         "ballots": 1000,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     }
 
@@ -433,6 +434,7 @@ bravo_contests = {
         "ballots": 1000,
         "numWinners": 1,
         "votesAllowed": 1,
+        "roundSizes": {},
     },
     "test2": {
         "cand1": 600,
@@ -441,15 +443,29 @@ bravo_contests = {
         "ballots": 900,
         "votesAllowed": 1,
         "numWinners": 1,
+        "roundSizes": {},
     },
-    "test3": {"cand1": 100, "ballots": 100, "votesAllowed": 1, "numWinners": 1},
-    "test4": {"cand1": 100, "ballots": 100, "votesAllowed": 1, "numWinners": 1},
+    "test3": {
+        "cand1": 100,
+        "ballots": 100,
+        "votesAllowed": 1,
+        "numWinners": 1,
+        "roundSizes": {},
+    },
+    "test4": {
+        "cand1": 100,
+        "ballots": 100,
+        "votesAllowed": 1,
+        "numWinners": 1,
+        "roundSizes": {},
+    },
     "test5": {
         "cand1": 500,
         "cand2": 500,
         "ballots": 1000,
         "votesAllowed": 1,
         "numWinners": 1,
+        "roundSizes": {},
     },
     "test6": {
         "cand1": 300,
@@ -458,6 +474,7 @@ bravo_contests = {
         "ballots": 1000,
         "votesAllowed": 1,
         "numWinners": 1,
+        "roundSizes": {},
     },
     "test7": {
         "cand1": 300,
@@ -466,6 +483,7 @@ bravo_contests = {
         "ballots": 700,
         "votesAllowed": 1,
         "numWinners": 2,
+        "roundSizes": {},
     },
     "test8": {
         "cand1": 300,
@@ -474,6 +492,7 @@ bravo_contests = {
         "ballots": 700,
         "votesAllowed": 1,
         "numWinners": 2,
+        "roundSizes": {},
     },
     "test9": {
         "cand1": 300,
@@ -481,6 +500,7 @@ bravo_contests = {
         "ballots": 700,
         "votesAllowed": 1,
         "numWinners": 2,
+        "roundSizes": {},
     },
     "test10": {
         "cand1": 600,
@@ -489,6 +509,7 @@ bravo_contests = {
         "ballots": 1000,
         "votesAllowed": 1,
         "numWinners": 2,
+        "roundSizes": {},
     },
     "test11": {
         "cand1": 1000,
@@ -496,6 +517,7 @@ bravo_contests = {
         "ballots": 1000,
         "votesAllowed": 1,
         "numWinners": 1,
+        "roundSizes": {},
     },
     "test12": {
         "cand1": 600,
@@ -504,6 +526,7 @@ bravo_contests = {
         "ballots": 1000,
         "votesAllowed": 1,
         "numWinners": 1,
+        "roundSizes": {},
     },
     "test_small_third_candidate": {
         "cand1": 10000,
@@ -512,6 +535,7 @@ bravo_contests = {
         "ballots": 20000,
         "votesAllowed": 1,
         "numWinners": 1,
+        "roundSizes": {},
     },
 }
 

--- a/server/tests/audit_math/test_macro.py
+++ b/server/tests/audit_math/test_macro.py
@@ -14,6 +14,7 @@ macro_contests = {
         "loser": 54000,
         "ballots": 120000,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     },
     "Contest B": {
@@ -21,6 +22,7 @@ macro_contests = {
         "loser": 24000,
         "ballots": 60000,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     },
     "Contest C": {
@@ -28,6 +30,7 @@ macro_contests = {
         "loser": 12600,
         "ballots": 36000,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     },
 }
@@ -62,12 +65,14 @@ def batches():
             "loser": 160,
             "ballots": 400,
             "numWinners": 1,
+            "roundSizes": {},
         }
         batches["Batch {} AV".format(i)]["Contest B"] = {
             "winner": 100,
             "loser": 80,
             "ballots": 200,
             "numWinners": 1,
+            "roundSizes": {},
         }
 
     for i in range(30):
@@ -76,12 +81,14 @@ def batches():
             "loser": 140,
             "ballots": 400,
             "numWinners": 1,
+            "roundSizes": {},
         }
         batches["Batch {} AV".format(i)]["Contest C"] = {
             "winner": 100,
             "loser": 70,
             "ballots": 200,
             "numWinners": 1,
+            "roundSizes": {},
         }
 
     for i in range(100, 130):
@@ -90,12 +97,14 @@ def batches():
             "loser": 140,
             "ballots": 400,
             "numWinners": 1,
+            "roundSizes": {},
         }
         batches["Batch {} AV".format(i)]["Contest C"] = {
             "winner": 100,
             "loser": 70,
             "ballots": 200,
             "numWinners": 1,
+            "roundSizes": {},
         }
 
     return batches
@@ -250,6 +259,7 @@ def test_tied_contest():
         "loser": 50000,
         "ballots": 100000,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     }
 
@@ -263,6 +273,7 @@ def test_tied_contest():
                 "loser": 500,
                 "ballots": 1000,
                 "numWinners": 1,
+                "roundSizes": {},
             }
         }
 
@@ -279,6 +290,7 @@ def test_tied_contest():
                 "loser": 500,
                 "ballots": 1000,
                 "numWinners": 1,
+                "roundSizes": {},
             }
         }
     }

--- a/server/tests/audit_math/test_sampler.py
+++ b/server/tests/audit_math/test_sampler.py
@@ -35,6 +35,7 @@ def macro_contest():
         "ballots": 1000,
         "numWinners": 1,
         "votesAllowed": 1,
+        "roundSizes": {},
     }
 
     return Contest(name, info_dict)

--- a/server/tests/audit_math/test_sampler_contest.py
+++ b/server/tests/audit_math/test_sampler_contest.py
@@ -82,6 +82,7 @@ bravo_contests = {
         "ballots": 1000,
         "numWinners": 1,
         "votesAllowed": 1,
+        "roundSizes": {},
     },
     "test2": {
         "cand1": 600,
@@ -90,15 +91,29 @@ bravo_contests = {
         "ballots": 900,
         "votesAllowed": 1,
         "numWinners": 1,
+        "roundSizes": {},
     },
-    "test3": {"cand1": 100, "ballots": 100, "votesAllowed": 1, "numWinners": 1},
-    "test4": {"cand1": 100, "ballots": 100, "votesAllowed": 1, "numWinners": 1},
+    "test3": {
+        "cand1": 100,
+        "ballots": 100,
+        "votesAllowed": 1,
+        "numWinners": 1,
+        "roundSizes": {},
+    },
+    "test4": {
+        "cand1": 100,
+        "ballots": 100,
+        "votesAllowed": 1,
+        "numWinners": 1,
+        "roundSizes": {},
+    },
     "test5": {
         "cand1": 500,
         "cand2": 500,
         "ballots": 1000,
         "votesAllowed": 1,
         "numWinners": 1,
+        "roundSizes": {},
     },
     "test6": {
         "cand1": 300,
@@ -107,6 +122,7 @@ bravo_contests = {
         "ballots": 1000,
         "votesAllowed": 1,
         "numWinners": 1,
+        "roundSizes": {},
     },
     "test7": {
         "cand1": 300,
@@ -115,6 +131,7 @@ bravo_contests = {
         "ballots": 700,
         "votesAllowed": 1,
         "numWinners": 2,
+        "roundSizes": {},
     },
     "test8": {
         "cand1": 300,
@@ -123,6 +140,7 @@ bravo_contests = {
         "ballots": 700,
         "votesAllowed": 1,
         "numWinners": 2,
+        "roundSizes": {},
     },
     "test9": {
         "cand1": 300,
@@ -130,6 +148,7 @@ bravo_contests = {
         "ballots": 700,
         "votesAllowed": 1,
         "numWinners": 2,
+        "roundSizes": {},
     },
     "test10": {
         "cand1": 600,
@@ -138,6 +157,7 @@ bravo_contests = {
         "ballots": 1000,
         "votesAllowed": 1,
         "numWinners": 2,
+        "roundSizes": {},
     },
 }
 

--- a/server/tests/audit_math/test_supersimple.py
+++ b/server/tests/audit_math/test_supersimple.py
@@ -336,6 +336,7 @@ def test_tied_contest():
         "loser": 50000,
         "ballots": 100000,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     }
 
@@ -388,6 +389,7 @@ def test_snapshot_test():
         "loser": 10,
         "ballots": 26,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     }
 
@@ -444,6 +446,7 @@ def test_multiplicity():
         "loser": 10,
         "ballots": 26,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     }
 
@@ -540,6 +543,7 @@ ss_contests = {
         "loser": 40000,
         "ballots": 100000,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     },
     "Contest B": {
@@ -547,6 +551,7 @@ ss_contests = {
         "loser": 24000,
         "ballots": 60000,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     },
     "Contest C": {
@@ -554,6 +559,7 @@ ss_contests = {
         "loser": 12600,
         "ballots": 36000,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     },
     "Contest D": {
@@ -561,6 +567,7 @@ ss_contests = {
         "loser": 6000,
         "ballots": 15000,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     },
     "Contest E": {
@@ -568,6 +575,7 @@ ss_contests = {
         "loser": 0,
         "ballots": 10000,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     },
     "Contest F": {
@@ -575,6 +583,7 @@ ss_contests = {
         "loser": 4,
         "ballots": 15,
         "numWinners": 1,
+        "roundSizes": {},
         "votesAllowed": 1,
     },
 }


### PR DESCRIPTION
**Description**

This PR changes the sampler_contest object to include the number of samples drawn per round, so that it may be consumed by Minerva. 

**Testing**
N/A

**Progress**

Ready
