### PR TITLE
Reenable HomeScreen tests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "yarn lint --fix",
     "start": "react-scripts start",
     "test": "is-ci \"test:ci\" \"test:watch\"",
-    "test:ci": "CI=true tsc && react-scripts test --maxWorkers 4 --env=jest-environment-jsdom-sixteen --coverage",
+    "test:ci": "CI=true tsc && react-scripts test --env=jest-environment-jsdom-sixteen --coverage",
     "test:coverage": "react-scripts test --coverage --watchAll=false --env=jest-environment-jsdom-sixteen",
     "test:update": "react-scripts test -u  --watchAll=false --env=jest-environment-jsdom-sixteen",
     "test:watch": "react-scripts test --env=jest-environment-jsdom-sixteen"

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -19,11 +19,7 @@ jest.unmock('react-toastify')
 const apiMocks = {
   failedAuth: {
     url: '/api/me',
-    response: {},
-    error: {
-      status: 401,
-      statusText: 'UNAUTHORIZED',
-    },
+    response: null,
   },
   abAuth: {
     url: '/api/me',

--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -694,34 +694,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders unauthentic
 <div>
   <div
     class="Toastify"
-  >
-    <div
-      class="Toastify__toast-container Toastify__toast-container--top-right"
-    >
-      <div
-        class="Toastify__toast Toastify__toast--error Toastify__bounce-enter--top-right"
-        style="animation-fill-mode: forwards; animation-duration: 0.75s;"
-      >
-        <div
-          class="Toastify__toast-body"
-          role="alert"
-        >
-          UNAUTHORIZED
-        </div>
-        <button
-          aria-label="close"
-          class="Toastify__close-button Toastify__close-button--error"
-          type="button"
-        >
-          ✖
-        </button>
-        <div
-          class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--error"
-          style="animation-duration: 5000ms; animation-play-state: running; opacity: 1;"
-        />
-      </div>
-    </div>
-  </div>
+  />
   <div
     class="sc-cIShpX dhyUlm"
   >
@@ -1208,34 +1181,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders unauthen
 <div>
   <div
     class="Toastify"
-  >
-    <div
-      class="Toastify__toast-container Toastify__toast-container--top-right"
-    >
-      <div
-        class="Toastify__toast Toastify__toast--error Toastify__bounce-enter--top-right"
-        style="animation-fill-mode: forwards; animation-duration: 0.75s;"
-      >
-        <div
-          class="Toastify__toast-body"
-          role="alert"
-        >
-          UNAUTHORIZED
-        </div>
-        <button
-          aria-label="close"
-          class="Toastify__close-button Toastify__close-button--error"
-          type="button"
-        >
-          ✖
-        </button>
-        <div
-          class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--error"
-          style="animation-duration: 5000ms; animation-play-state: running; opacity: 1;"
-        />
-      </div>
-    </div>
-  </div>
+  />
   <div
     class="sc-cIShpX dhyUlm"
   >

--- a/client/src/components/HomeScreen.test.tsx
+++ b/client/src/components/HomeScreen.test.tsx
@@ -9,11 +9,7 @@ import { auditSettings } from './MultiJurisdictionAudit/useSetupMenuItems/_mocks
 const apiCalls = {
   unauthenticatedUser: {
     url: '/api/me',
-    response: {},
-    error: {
-      status: 401,
-      statusText: 'UNAUTHORIZED',
-    },
+    response: null,
   },
   postNewAudit: (body: {}) => ({
     url: '/api/election',
@@ -79,6 +75,17 @@ const setupScreenCalls = [
   aaApiCalls.getContests,
   aaApiCalls.getSettings(auditSettings.blank),
 ]
+const refreshCalls = [
+  ...setupScreenCalls,
+  aaApiCalls.getJurisdictionFile,
+  aaApiCalls.getRounds,
+  ...setupScreenCalls,
+  aaApiCalls.getJurisdictionFile,
+  aaApiCalls.getRounds,
+  ...setupScreenCalls,
+  aaApiCalls.getSettings(auditSettings.blank),
+  aaApiCalls.getJurisdictionFile,
+]
 
 const renderView = (route: string) => renderWithRouter(<App />, { route })
 
@@ -102,8 +109,7 @@ describe('Home screen', () => {
     })
   })
 
-  it.skip('shows a list of audits and create audit form for audit admins', async () => {
-    // TEST TODO
+  it('shows a list of audits and create audit form for audit admins', async () => {
     const expectedCalls = [
       aaApiCalls.getUser,
       aaApiCalls.getUser, // Extra call to load the list of audits
@@ -112,19 +118,9 @@ describe('Home screen', () => {
         auditName: 'November Presidential Election 2020',
         auditType: 'BATCH_COMPARISON',
       }),
-      ...setupScreenCalls,
-      aaApiCalls.getJurisdictionFile,
-      aaApiCalls.getRounds,
-      ...setupScreenCalls,
-      aaApiCalls.getSettings(auditSettings.blank),
-      aaApiCalls.getJurisdictionFile,
+      ...refreshCalls,
       apiCalls.getUserWithAudit,
-      ...setupScreenCalls,
-      aaApiCalls.getJurisdictionFile,
-      aaApiCalls.getRounds,
-      ...setupScreenCalls,
-      aaApiCalls.getSettings(auditSettings.blank),
-      aaApiCalls.getJurisdictionFile,
+      ...refreshCalls,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { history } = renderView('/')
@@ -173,8 +169,7 @@ describe('Home screen', () => {
     })
   })
 
-  it.skip('shows a list of audits and create audit form for audit admins with multiple orgs', async () => {
-    // TEST TODO
+  it('shows a list of audits and create audit form for audit admins with multiple orgs', async () => {
     const expectedCalls = [
       apiCalls.getUserMultipleOrgs,
       apiCalls.getUserMultipleOrgs,
@@ -183,12 +178,7 @@ describe('Home screen', () => {
         auditName: 'Presidential Primary',
         auditType: 'BALLOT_POLLING',
       }),
-      ...setupScreenCalls,
-      aaApiCalls.getJurisdictionFile,
-      aaApiCalls.getRounds,
-      ...setupScreenCalls,
-      aaApiCalls.getSettings(auditSettings.blank),
-      aaApiCalls.getJurisdictionFile,
+      ...refreshCalls,
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView('/')
@@ -236,14 +226,14 @@ describe('Home screen', () => {
     })
   })
 
-  it.skip('shows a list of audits for jurisdiction admins', async () => {
-    // TEST TODO
+  it('shows a list of audits for jurisdiction admins', async () => {
     const expectedCalls = [
       jaApiCalls.getUser,
       jaApiCalls.getSettings(auditSettings.blank),
       jaApiCalls.getRounds,
       jaApiCalls.getBallotManifestFile({ file: null, processing: null }),
       jaApiCalls.getBatchTalliesFile({ file: null, processing: null }),
+      jaApiCalls.getCvrsFile({ file: null, processing: null }),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView('/')

--- a/client/src/components/MultiJurisdictionAudit/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/_mocks.ts
@@ -9,7 +9,6 @@ import { FileProcessingStatus } from './useSetupMenuItems/getJurisdictionFileSta
 import { IAuditSettings } from '../../types'
 import { IBallot } from './RoundManagement/useBallots'
 import { IAuditBoard } from './useAuditBoards'
-import { IStandardizedContest } from './useStandardizedContests'
 
 const manifestFormData: FormData = new FormData()
 manifestFormData.append('manifest', manifestFile, manifestFile.name)
@@ -68,6 +67,10 @@ export const jaApiCalls = {
   }),
   getBatchTalliesFile: (response: IFileInfo) => ({
     url: '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies',
+    response,
+  }),
+  getCvrsFile: (response: IFileInfo) => ({
+    url: '/api/election/1/jurisdiction/jurisdiction-id-1/cvrs',
     response,
   }),
   getSettings: (response: IAuditSettings) => ({

--- a/client/src/components/testUtilities.tsx
+++ b/client/src/components/testUtilities.tsx
@@ -73,7 +73,7 @@ export const renderWithRouter = (
 interface FetchRequest {
   url: string
   options?: RequestInit
-  response: object
+  response: object | null
   skipBody?: boolean
   error?: {
     status: number


### PR DESCRIPTION
Fixes a few things:
- API mocks for /api/me now return `null` for unauthenticated users
- Updating the expected API call list for refreshing the audit admin
view
- Added a new mock for the JA API call to get CVR file status
