### PR TITLE
Opportunistic contests should not be required

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestForm.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestForm.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import React from 'react'
 import { useParams } from 'react-router-dom'
+import equal from 'fast-deep-equal'
 import { Formik, FormikProps, Field, FieldArray } from 'formik'
 import { Spinner } from '@blueprintjs/core'
 import FormWrapper from '../../../Atoms/Form/FormWrapper'
@@ -25,7 +26,7 @@ import { IContest, ICandidate, IAuditSettings } from '../../../../types'
 import DropdownCheckboxList from './DropdownCheckboxList'
 import Card from '../../../Atoms/SpacedCard'
 import { testNumber } from '../../../utilities'
-import { isObjectEmpty, isObjectEqual } from '../../../../utils/objects'
+import isObjectEmpty from '../../../../utils/objects'
 
 interface IProps {
   isTargeted: boolean
@@ -87,9 +88,7 @@ const ContestForm: React.FC<IProps> = ({
     values: { contests: IContest[] }
   ) => {
     return (
-      !isTargeted &&
-      isObjectEmpty(touched) &&
-      isObjectEqual(initialValues, values)
+      !isTargeted && (isObjectEmpty(touched) || equal(initialValues, values))
     )
   }
 

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestForm.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestForm.tsx
@@ -86,7 +86,11 @@ const ContestForm: React.FC<IProps> = ({
     touched: {},
     values: { contests: IContest[] }
   ) => {
-    return isObjectEmpty(touched) && isObjectEqual(initialValues, values)
+    return (
+      !isTargeted &&
+      isObjectEmpty(touched) &&
+      isObjectEqual(initialValues, values)
+    )
   }
 
   const goToNextStage = () => {
@@ -303,11 +307,11 @@ const ContestForm: React.FC<IProps> = ({
                 type="submit"
                 intent="primary"
                 disabled={nextStage.state === 'locked'}
-                onClick={() =>
-                  isOpportunisticFormClean(touched, values)
-                    ? goToNextStage()
-                    : handleSubmit()
-                }
+                onClick={e => {
+                  e.preventDefault()
+                  if (isOpportunisticFormClean(touched, values)) goToNextStage()
+                  else handleSubmit()
+                }}
               >
                 Save &amp; Next
               </FormButton>

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.test.tsx
@@ -258,6 +258,66 @@ describe('Audit Setup > Contests', () => {
     })
   })
 
+  it('it should skip to next stage when opportunistic contest form is clean and not touched', async () => {
+    const { findByText, getByText } = render(
+      <Contests
+        auditType="BALLOT_POLLING"
+        locked={false}
+        isTargeted={false}
+        nextStage={nextStage}
+        prevStage={prevStage}
+      />
+    )
+
+    await findByText('Opportunistic Contests')
+    fireEvent.click(getByText('Save & Next'), { bubbles: true })
+    await waitFor(() => {
+      expect(nextStage.activate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('it should not skip to next stage when targeted contest form is clean and not touched', async () => {
+    const { findByText, getByText } = render(
+      <Contests
+        auditType="BALLOT_POLLING"
+        locked={false}
+        isTargeted
+        nextStage={nextStage}
+        prevStage={prevStage}
+      />
+    )
+
+    await findByText('Target Contests')
+    fireEvent.click(getByText('Save & Next'), { bubbles: true })
+    await waitFor(() => {
+      expect(nextStage.activate).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  it('it should not skip to next stage when opportunistic contest form is touched', async () => {
+    const { findByText, findByLabelText, getByText } = render(
+      <Contests
+        auditType="BALLOT_POLLING"
+        locked={false}
+        isTargeted={false}
+        nextStage={nextStage}
+        prevStage={prevStage}
+      />
+    )
+
+    await findByText('Opportunistic Contests')
+    typeInto(
+      await findByLabelText('Votes Allowed', {
+        selector: 'input',
+      }),
+      '2'
+    )
+    fireEvent.click(getByText('Save & Next'), { bubbles: true })
+    await waitFor(() => {
+      expect(nextStage.activate).toHaveBeenCalledTimes(0)
+    })
+  })
+
   it('displays errors', async () => {
     const { getByLabelText, getByTestId, getByText, findByText } = render(
       <Contests

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.test.tsx
@@ -290,7 +290,7 @@ describe('Audit Setup > Contests', () => {
     await findByText('Target Contests')
     fireEvent.click(getByText('Save & Next'), { bubbles: true })
     await waitFor(() => {
-      expect(nextStage.activate).toHaveBeenCalledTimes(0)
+      expect(screen.queryAllByText('Required').length).toBe(5)
     })
   })
 

--- a/client/src/utils/objects.test.ts
+++ b/client/src/utils/objects.test.ts
@@ -1,62 +1,6 @@
-import { isObjectEmpty, isObjectEqual } from './objects'
+import isObjectEmpty from './objects'
 
 test('isObjectEmpty', () => {
   expect(isObjectEmpty({})).toBeTruthy()
   expect(isObjectEmpty({ key: 'value' })).toBeFalsy()
-})
-
-test('isObjectEqual', () => {
-  expect(isObjectEqual({}, {})).toBeTruthy()
-  const a = {
-    foods: {
-      fruits: ['orange', 'lemon'],
-    },
-    numbers: {
-      Decimal: {
-        tens: [40, 50, 20],
-        hundreds: [300, 500],
-      },
-      Roman: {
-        small: ['I', 'VII', 'IX'],
-        hundreds: [300, 500],
-      },
-    },
-    bikes: ['recumbent', 'upright'],
-  }
-  const b = {
-    foods: {
-      fruits: ['orange', 'lemon'],
-    },
-    numbers: {
-      Decimal: {
-        tens: [40, 50, 20],
-        hundreds: [300, 500],
-      },
-      Roman: {
-        small: ['I', 'VII', 'IX'],
-        hundreds: [300, 500],
-      },
-    },
-    bikes: ['recumbent', 'upright'],
-  }
-  const c = {
-    foods: {
-      fruits: ['orange', 'lemon'],
-    },
-    numbers: {
-      Decimal: {
-        tens: [40, 50, 20],
-        hundreds: [300, 700],
-      },
-      Roman: {
-        small: ['I', 'VII', 'IX'],
-        large: ['MCXVII', 'MCXXVIII', 'MMVIII'],
-      },
-    },
-    bikes: ['recumbent', 'upright'],
-  }
-
-  expect(isObjectEqual(a, b)).toBeTruthy()
-  expect(isObjectEqual(a, c)).toBeFalsy()
-  expect(isObjectEqual(b, c)).toBeFalsy()
 })

--- a/client/src/utils/objects.test.ts
+++ b/client/src/utils/objects.test.ts
@@ -1,0 +1,62 @@
+import { isObjectEmpty, isObjectEqual } from './objects'
+
+test('isObjectEmpty', () => {
+  expect(isObjectEmpty({})).toBeTruthy()
+  expect(isObjectEmpty({ key: 'value' })).toBeFalsy()
+})
+
+test('isObjectEqual', () => {
+  expect(isObjectEqual({}, {})).toBeTruthy()
+  const a = {
+    foods: {
+      fruits: ['orange', 'lemon'],
+    },
+    numbers: {
+      Decimal: {
+        tens: [40, 50, 20],
+        hundreds: [300, 500],
+      },
+      Roman: {
+        small: ['I', 'VII', 'IX'],
+        hundreds: [300, 500],
+      },
+    },
+    bikes: ['recumbent', 'upright'],
+  }
+  const b = {
+    foods: {
+      fruits: ['orange', 'lemon'],
+    },
+    numbers: {
+      Decimal: {
+        tens: [40, 50, 20],
+        hundreds: [300, 500],
+      },
+      Roman: {
+        small: ['I', 'VII', 'IX'],
+        hundreds: [300, 500],
+      },
+    },
+    bikes: ['recumbent', 'upright'],
+  }
+  const c = {
+    foods: {
+      fruits: ['orange', 'lemon'],
+    },
+    numbers: {
+      Decimal: {
+        tens: [40, 50, 20],
+        hundreds: [300, 700],
+      },
+      Roman: {
+        small: ['I', 'VII', 'IX'],
+        large: ['MCXVII', 'MCXXVIII', 'MMVIII'],
+      },
+    },
+    bikes: ['recumbent', 'upright'],
+  }
+
+  expect(isObjectEqual(a, b)).toBeTruthy()
+  expect(isObjectEqual(a, c)).toBeFalsy()
+  expect(isObjectEqual(b, c)).toBeFalsy()
+})

--- a/client/src/utils/objects.ts
+++ b/client/src/utils/objects.ts
@@ -1,0 +1,31 @@
+export function isObjectEmpty(object: {}): boolean {
+  return Object.keys(object).length === 0
+}
+
+interface IEqualityObject {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any
+}
+
+export function isObjectEqual(
+  object1: IEqualityObject,
+  object2: IEqualityObject
+): boolean {
+  if (object1 === object2) return true
+
+  const keys1 = Object.keys(object1)
+  const keys2 = Object.keys(object2)
+
+  if (keys1.length !== keys2.length) return false
+  for (const key of keys1) {
+    if (!keys2.includes(key)) return false
+
+    if (
+      typeof object1[key] === 'function' ||
+      typeof object2[key] === 'function'
+    ) {
+      if (object1[key].toString() !== object2[key].toString()) return false
+    } else if (!isObjectEqual(object1[key], object2[key])) return false
+  }
+  return true
+}

--- a/client/src/utils/objects.ts
+++ b/client/src/utils/objects.ts
@@ -1,31 +1,5 @@
-export function isObjectEmpty(object: {}): boolean {
+function isObjectEmpty(object: {}): boolean {
   return Object.keys(object).length === 0
 }
 
-interface IEqualityObject {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any
-}
-
-export function isObjectEqual(
-  object1: IEqualityObject,
-  object2: IEqualityObject
-): boolean {
-  if (object1 === object2) return true
-
-  const keys1 = Object.keys(object1)
-  const keys2 = Object.keys(object2)
-
-  if (keys1.length !== keys2.length) return false
-  for (const key of keys1) {
-    if (!keys2.includes(key)) return false
-
-    if (
-      typeof object1[key] === 'function' ||
-      typeof object2[key] === 'function'
-    ) {
-      if (object1[key].toString() !== object2[key].toString()) return false
-    } else if (!isObjectEqual(object1[key], object2[key])) return false
-  }
-  return true
-}
+export default isObjectEmpty


### PR DESCRIPTION
**Description**

Closes #836 

- On Opportunistic Contests doesn't submit or trigger validation of the form if the fields aren't touched or match the existing values
- Don't do this on Targeted Contests, and keep current behavior

**Testing**

- Testing the utilities created for deep equals and empty object testing
- Adding tests for above behavior

**Progress**

- Done