### PR TITLE
Expire sessions

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -19,11 +19,7 @@ jest.unmock('react-toastify')
 const apiMocks = {
   failedAuth: {
     url: '/api/me',
-    response: {},
-    error: {
-      status: 401,
-      statusText: 'UNAUTHORIZED',
-    },
+    response: null,
   },
   abAuth: {
     url: '/api/me',

--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -694,34 +694,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders unauthentic
 <div>
   <div
     class="Toastify"
-  >
-    <div
-      class="Toastify__toast-container Toastify__toast-container--top-right"
-    >
-      <div
-        class="Toastify__toast Toastify__toast--error Toastify__bounce-enter--top-right"
-        style="animation-fill-mode: forwards; animation-duration: 0.75s;"
-      >
-        <div
-          class="Toastify__toast-body"
-          role="alert"
-        >
-          UNAUTHORIZED
-        </div>
-        <button
-          aria-label="close"
-          class="Toastify__close-button Toastify__close-button--error"
-          type="button"
-        >
-          ✖
-        </button>
-        <div
-          class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--error"
-          style="animation-duration: 5000ms; animation-play-state: running; opacity: 1;"
-        />
-      </div>
-    </div>
-  </div>
+  />
   <div
     class="sc-cIShpX dhyUlm"
   >
@@ -1208,34 +1181,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders unauthen
 <div>
   <div
     class="Toastify"
-  >
-    <div
-      class="Toastify__toast-container Toastify__toast-container--top-right"
-    >
-      <div
-        class="Toastify__toast Toastify__toast--error Toastify__bounce-enter--top-right"
-        style="animation-fill-mode: forwards; animation-duration: 0.75s;"
-      >
-        <div
-          class="Toastify__toast-body"
-          role="alert"
-        >
-          UNAUTHORIZED
-        </div>
-        <button
-          aria-label="close"
-          class="Toastify__close-button Toastify__close-button--error"
-          type="button"
-        >
-          ✖
-        </button>
-        <div
-          class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--error"
-          style="animation-duration: 5000ms; animation-play-state: running; opacity: 1;"
-        />
-      </div>
-    </div>
-  </div>
+  />
   <div
     class="sc-cIShpX dhyUlm"
   >

--- a/client/src/components/HomeScreen.test.tsx
+++ b/client/src/components/HomeScreen.test.tsx
@@ -101,7 +101,7 @@ describe('Home screen', () => {
   it('shows a message when logged out for inactivity', async () => {
     const expectedCalls = [apiCalls.unauthenticatedUser]
     await withMockFetch(expectedCalls, async () => {
-      renderView('/?logged-out=1')
+      renderView('/#logged-out')
       await screen.findByText('You have been logged out due to inactivity.')
     })
   })

--- a/client/src/components/HomeScreen.test.tsx
+++ b/client/src/components/HomeScreen.test.tsx
@@ -9,11 +9,7 @@ import { auditSettings } from './MultiJurisdictionAudit/useSetupMenuItems/_mocks
 const apiCalls = {
   unauthenticatedUser: {
     url: '/api/me',
-    response: {},
-    error: {
-      status: 401,
-      statusText: 'UNAUTHORIZED',
-    },
+    response: null,
   },
   postNewAudit: (body: {}) => ({
     url: '/api/election',
@@ -99,6 +95,14 @@ describe('Home screen', () => {
         name: 'Log in as an admin',
       })
       expect(aaLoginButton).toHaveAttribute('href', '/auth/auditadmin/start')
+    })
+  })
+
+  it('shows a message when logged out for inactivity', async () => {
+    const expectedCalls = [apiCalls.unauthenticatedUser]
+    await withMockFetch(expectedCalls, async () => {
+      renderView('/?logged-out=1')
+      await screen.findByText('You have been logged out due to inactivity.')
     })
   })
 

--- a/client/src/components/HomeScreen.tsx
+++ b/client/src/components/HomeScreen.tsx
@@ -5,8 +5,9 @@ import {
   RadioGroup,
   Radio,
   HTMLSelect,
+  Callout,
 } from '@blueprintjs/core'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import { Formik, FormikProps, Field } from 'formik'
 import { useAuthDataContext } from './UserContext'
@@ -72,9 +73,20 @@ const LoginWrapper = styled.div`
 `
 
 const LoginScreen: React.FC = () => {
+  const query = new URLSearchParams(useLocation().search)
+
   return (
     <LoginWrapper>
       <img height="50px" src="/arlo.png" alt="Arlo, by VotingWorks" />
+      {query.get('logged-out') && (
+        <Callout
+          icon="lock"
+          intent="warning"
+          style={{ margin: '20px 0 20px 0' }}
+        >
+          You have been logged out due to inactivity.
+        </Callout>
+      )}
       <Card style={{ margin: '25px 0 15px 0' }}>
         <p>Participating in an audit in your local jurisdiction?</p>
         <AnchorButton

--- a/client/src/components/HomeScreen.tsx
+++ b/client/src/components/HomeScreen.tsx
@@ -73,12 +73,12 @@ const LoginWrapper = styled.div`
 `
 
 const LoginScreen: React.FC = () => {
-  const query = new URLSearchParams(useLocation().search)
+  const wasLoggedOut = useLocation().hash === '#logged-out'
 
   return (
     <LoginWrapper>
       <img height="50px" src="/arlo.png" alt="Arlo, by VotingWorks" />
-      {query.get('logged-out') && (
+      {wasLoggedOut && (
         <Callout
           icon="lock"
           intent="warning"

--- a/client/src/components/testUtilities.tsx
+++ b/client/src/components/testUtilities.tsx
@@ -73,7 +73,7 @@ export const renderWithRouter = (
 interface FetchRequest {
   url: string
   options?: RequestInit
-  response: object
+  response: object | null
   skipBody?: boolean
   error?: {
     status: number

--- a/client/src/components/utilities.ts
+++ b/client/src/components/utilities.ts
@@ -18,6 +18,13 @@ export const api = async <T>(
   try {
     const response = await fetch(`/api${endpoint}`, options)
     if (!response.ok) {
+      // If we get a 401, it most likely means the session expired, so we
+      // redirect to the login screen with a flag to show a message.
+      if (response.status === 401) {
+        window.location.href = '/?logged-out=1'
+        return null
+      }
+
       const responseText = await response.text()
       const { errors } = tryJson(responseText)
       const error =

--- a/client/src/components/utilities.ts
+++ b/client/src/components/utilities.ts
@@ -21,7 +21,7 @@ export const api = async <T>(
       // If we get a 401, it most likely means the session expired, so we
       // redirect to the login screen with a flag to show a message.
       if (response.status === 401) {
-        window.location.href = '/?logged-out=1'
+        window.location.replace('/#logged-out')
         return null
       }
 

--- a/server/app.py
+++ b/server/app.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from urllib.parse import urlparse
 from flask import Flask
 from flask_talisman import Talisman
@@ -41,6 +42,7 @@ T = Talisman(
     },
 )
 app.secret_key = SESSION_SECRET
+app.permanent_session_lifetime = timedelta(hours=2)
 
 init_db()
 

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -311,6 +311,12 @@ def test_auth_me_not_logged_in(client: FlaskClient):
 def test_session_expiration(client: FlaskClient, aa_email: str):
     original_session_lifetime = app.permanent_session_lifetime
     assert original_session_lifetime > timedelta(minutes=1)
+
+    # In order to make sure the session only expires after the user has been
+    # inactive for the specified amount of time, we need to make sure the
+    # session gets refreshed every request. This is turned on by default in
+    # Flask, so we just check to make sure it didn't accidentally get turned
+    # off.
     assert app.config["SESSION_REFRESH_EACH_REQUEST"] is True
 
     app.permanent_session_lifetime = timedelta(milliseconds=1)

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -311,6 +311,8 @@ def test_auth_me_not_logged_in(client: FlaskClient):
 def test_session_expiration(client: FlaskClient, aa_email: str):
     original_session_lifetime = app.permanent_session_lifetime
     assert original_session_lifetime > timedelta(minutes=1)
+    assert app.config["SESSION_REFRESH_EACH_REQUEST"] is True
+
     app.permanent_session_lifetime = timedelta(milliseconds=1)
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, aa_email)

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -1,3 +1,5 @@
+import time
+from datetime import timedelta
 import json, re, uuid
 from typing import List, Optional
 from unittest.mock import Mock, MagicMock
@@ -10,6 +12,7 @@ from ..auth.routes import auth0_sa, auth0_aa, auth0_ja
 from ..models import *  # pylint: disable=wildcard-import
 from ..util.jsonschema import JSONDict
 from .helpers import *  # pylint: disable=wildcard-import
+from ..app import app
 
 
 SA_EMAIL = "sa@voting.works"
@@ -303,6 +306,23 @@ def test_auth_me_not_logged_in(client: FlaskClient):
     rv = client.get("/api/me")
     assert rv.status_code == 200
     assert json.loads(rv.data) is None
+
+
+def test_session_expiration(client: FlaskClient, aa_email: str):
+    original_session_lifetime = app.permanent_session_lifetime
+    assert original_session_lifetime > timedelta(minutes=1)
+    app.permanent_session_lifetime = timedelta(milliseconds=1)
+
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, aa_email)
+    rv = client.get("/api/me")
+    assert json.loads(rv.data) is not None
+
+    time.sleep(1.0)
+
+    rv = client.get("/api/me")
+    assert json.loads(rv.data) is None
+
+    app.permanent_session_lifetime = original_session_lifetime
 
 
 # Tests for route decorators. We have added special routes to test the


### PR DESCRIPTION
Task: #850 

Configures Flask to expire session cookies after 2 hours of inactivity. Also updates
the frontend to display a message when this happens (note: we just
display the message when the frontend gets a 401, which could also
happen from trying to access a route while not logged in for some other
reason, but this is the most common case so I figured why not).