### PR TITLE
useJurisdictions return null while still loading

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestForm.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestForm.tsx
@@ -68,7 +68,7 @@ const ContestForm: React.FC<IProps> = ({
   const [contests, updateContests] = useContests(electionId)
   const jurisdictions = useJurisdictions(electionId)
 
-  if (!contests) return null // Still loading
+  if (!jurisdictions || !contests) return null // Still loading
   const filteredContests = contests.filter(c => c.isTargeted === isTargeted)
 
   const isBatch = auditType === 'BATCH_COMPARISON'

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.tsx
@@ -38,7 +38,7 @@ const ContestSelect: React.FC<IProps> = ({
   const [filter, setFilter] = useState('')
   const jurisdictions = useJurisdictions(electionId)
 
-  if (!standardizedContests || !jurisdictions.length) return null // Still loading
+  if (!standardizedContests || !jurisdictions) return null // Still loading
 
   const submit = async ({
     contests,

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -48,6 +48,7 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false)
 
   const shouldShowSampleSizes =
+    !!jurisdictions &&
     !!contests &&
     !!auditSettings &&
     isSetupComplete(jurisdictions, contests, auditSettings)
@@ -57,6 +58,7 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
   )
 
   if (
+    !jurisdictions ||
     !contests ||
     !auditSettings ||
     (shouldShowSampleSizes && !sampleSizeOptions)

--- a/client/src/components/MultiJurisdictionAudit/AASetup/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/index.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { useParams, MemoryRouter } from 'react-router-dom'
-import { render, waitFor } from '@testing-library/react'
-import { auditSettings } from '../useSetupMenuItems/_mocks'
+import { render, waitFor, screen } from '@testing-library/react'
+import { auditSettings, jurisdictionMocks } from '../useSetupMenuItems/_mocks'
 import * as utilities from '../../utilities'
 import Setup from './index'
 import relativeStages from './_mocks'
 import { contestMocks } from './Contests/_mocks'
 import useContests from '../useContests'
 import useAuditSettings from '../useAuditSettings'
+import useJurisdictions from '../useJurisdictions'
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
@@ -18,6 +19,10 @@ const checkAndToastMock: jest.SpyInstance<
   Parameters<typeof utilities.checkAndToast>
 > = jest.spyOn(utilities, 'checkAndToast').mockReturnValue(false)
 apiMock.mockImplementation(async () => {})
+
+const useJurisdictionsMock = useJurisdictions as jest.Mock
+jest.mock('../useJurisdictions')
+useJurisdictionsMock.mockImplementation(() => jurisdictionMocks.noManifests)
 
 const useContestsMock = useContests as jest.Mock
 jest.mock('../useContests')
@@ -109,7 +114,7 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
-    await waitFor(() => expect(apiMock).toHaveBeenCalled())
+    screen.getByText('Target Contests')
     expect(container).toMatchSnapshot()
   })
 
@@ -124,7 +129,7 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
-    await waitFor(() => expect(apiMock).toHaveBeenCalled())
+    screen.getByText('Target Contests')
     expect(container).toMatchSnapshot()
   })
 
@@ -139,7 +144,7 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
-    await waitFor(() => expect(apiMock).toHaveBeenCalled())
+    screen.getByText('Target Contests')
     expect(container).toMatchSnapshot()
   })
 
@@ -158,7 +163,7 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
-    await waitFor(() => expect(apiMock).toHaveBeenCalled())
+    screen.getByText('Opportunistic Contests')
     expect(container).toMatchSnapshot()
   })
 
@@ -179,7 +184,7 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
-    await waitFor(() => expect(apiMock).toHaveBeenCalled())
+    screen.getByText('Opportunistic Contests')
     expect(container).toMatchSnapshot()
   })
 
@@ -200,7 +205,7 @@ describe('Setup', () => {
         />
       </MemoryRouter>
     )
-    await waitFor(() => expect(apiMock).toHaveBeenCalled())
+    screen.getByText('Opportunistic Contests')
     expect(container).toMatchSnapshot()
   })
 

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -60,7 +60,7 @@ export const AuditAdminView: React.FC = () => {
 
   useEffect(refresh, [refresh, isBallotComparison])
 
-  if (!contests || !rounds || !auditSettings) return null // Still loading
+  if (!jurisdictions || !contests || !rounds || !auditSettings) return null // Still loading
 
   // TODO support multiple contests in batch comparison audits
   const isBatch = auditSettings.auditType === 'BATCH_COMPARISON'

--- a/client/src/components/MultiJurisdictionAudit/useJurisdictions.ts
+++ b/client/src/components/MultiJurisdictionAudit/useJurisdictions.ts
@@ -47,8 +47,13 @@ export interface IJurisdiction {
   } | null
 }
 
-const useJurisdictions = (electionId: string, refreshId?: string) => {
-  const [jurisdictions, setJurisdictions] = useState<IJurisdiction[]>([])
+const useJurisdictions = (
+  electionId: string,
+  refreshId?: string
+): IJurisdiction[] | null => {
+  const [jurisdictions, setJurisdictions] = useState<IJurisdiction[] | null>(
+    null
+  )
   useEffect(() => {
     ;(async () => {
       const response = await api<{ jurisdictions: IJurisdiction[] }>(


### PR DESCRIPTION
This is the pattern used by all our other data fetching hooks.
Previously, there was no way to check if the jurisdictions list was
empty or still loading, which meant that components were being rendered
that depended on the jurisdictions list before it was loaded.