### PR TITLE
Enable Minerva math in dev/staging but not production

### DIFF
--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -138,7 +138,7 @@ exports[`App / renders aa logged in properly 1`] = `
                     Ballot Polling
                   </label>
                   <div
-                    class="sc-ktHwxA leegmq"
+                    class="sc-ktHwxA bgUWdN"
                   >
                     <label
                       for="auditMathType"
@@ -564,7 +564,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders aa logged i
                     Ballot Polling
                   </label>
                   <div
-                    class="sc-ktHwxA leegmq"
+                    class="sc-ktHwxA bgUWdN"
                   >
                     <label
                       for="auditMathType"
@@ -992,7 +992,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders aa logge
                     Ballot Polling
                   </label>
                   <div
-                    class="sc-ktHwxA leegmq"
+                    class="sc-ktHwxA bgUWdN"
                   >
                     <label
                       for="auditMathType"

--- a/client/src/components/HomeScreen.tsx
+++ b/client/src/components/HomeScreen.tsx
@@ -208,9 +208,7 @@ const CreateAuditWrapper = styled.div`
   padding: 30px;
 `
 
-// TODO: remove "display: none;" when we implement Minerva
 const BallotPollingWrapper = styled.div`
-  display: none;
   margin: 20px 0;
   background-color: #ffffff;
   padding-top: 10px;
@@ -324,7 +322,9 @@ const CreateAudit: React.FC = () => {
                 selectedValue={values.auditType}
               >
                 <Radio value="BALLOT_POLLING">Ballot Polling</Radio>
-                {values.auditType === 'BALLOT_POLLING' ? (
+                {/* For now, disable switching audit math type in production */}
+                {process.env.NODE_ENV !== 'production' &&
+                values.auditType === 'BALLOT_POLLING' ? (
                   <BallotPollingWrapper>
                     <label htmlFor="auditMathType">
                       <p>Ballot polling type</p>


### PR DESCRIPTION
Rather than implement a feature flag, we simply disable the Minerva math
selection in production. Since we don't really need a lot of
configurability, this is a quick solution for today.

Replaces #877 