### PR TITLE
Show Auth0 login errors to users

### DIFF
--- a/client/src/components/HomeScreen.test.tsx
+++ b/client/src/components/HomeScreen.test.tsx
@@ -98,10 +98,12 @@ describe('Home screen', () => {
     })
   })
 
-  it('shows a message when logged out for inactivity', async () => {
+  it('shows a message when an auth error occurs', async () => {
     const expectedCalls = [apiCalls.unauthenticatedUser]
     await withMockFetch(expectedCalls, async () => {
-      renderView('/#logged-out')
+      renderView(
+        '/?error=unauthorized&message=You+have+been+logged+out+due+to+inactivity.'
+      )
       await screen.findByText('You have been logged out due to inactivity.')
     })
   })

--- a/client/src/components/HomeScreen.tsx
+++ b/client/src/components/HomeScreen.tsx
@@ -73,18 +73,16 @@ const LoginWrapper = styled.div`
 `
 
 const LoginScreen: React.FC = () => {
-  const wasLoggedOut = useLocation().hash === '#logged-out'
+  // Support two query parameters: 'error' and 'message'
+  // We use these to communicate authentication errors to the user.
+  const query = new URLSearchParams(useLocation().search)
 
   return (
     <LoginWrapper>
       <img height="50px" src="/arlo.png" alt="Arlo, by VotingWorks" />
-      {wasLoggedOut && (
-        <Callout
-          icon="lock"
-          intent="warning"
-          style={{ margin: '20px 0 20px 0' }}
-        >
-          You have been logged out due to inactivity.
+      {query.get('error') && (
+        <Callout intent="danger" style={{ margin: '20px 0 20px 0' }}>
+          {query.get('message')}
         </Callout>
       )}
       <Card style={{ margin: '25px 0 15px 0' }}>

--- a/client/src/components/utilities.ts
+++ b/client/src/components/utilities.ts
@@ -21,7 +21,11 @@ export const api = async <T>(
       // If we get a 401, it most likely means the session expired, so we
       // redirect to the login screen with a flag to show a message.
       if (response.status === 401) {
-        window.location.replace('/#logged-out')
+        window.location.replace(
+          encodeURI(
+            '/?error=unauthorized&message=You have been logged out due to inactivity.'
+          )
+        )
         return null
       }
 

--- a/client/src/components/utilities.ts
+++ b/client/src/components/utilities.ts
@@ -21,7 +21,7 @@ export const api = async <T>(
       // If we get a 401, it most likely means the session expired, so we
       // redirect to the login screen with a flag to show a message.
       if (response.status === 401) {
-        window.location.replace(
+        window.location.assign(
           encodeURI(
             '/?error=unauthorized&message=You have been logged out due to inactivity.'
           )

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -8,7 +8,6 @@ import './index.css'
 import App from './App'
 import * as serviceWorker from './serviceWorker'
 
-console.log(process.env)
 Sentry.init({
   dsn: process.env.REACT_APP_SENTRY_DSN,
   environment: process.env.NODE_ENV,

--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -1,6 +1,6 @@
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlencode
 from flask import redirect, jsonify, request
-from authlib.integrations.flask_client import OAuth
+from authlib.integrations.flask_client import OAuth, OAuthError
 
 from . import auth
 from ..models import *  # pylint: disable=wildcard-import
@@ -200,4 +200,19 @@ def auditboard_passphrase(passphrase):
     set_loggedin_user(UserType.AUDIT_BOARD, auditboard.id)
     return redirect(
         f"/election/{auditboard.jurisdiction.election.id}/audit-board/{auditboard.id}"
+    )
+
+
+@auth.errorhandler(OAuthError)
+def handle_oauth_error(error):
+    # If Auth0 sends an error to one of the callbacks, we want to redirect the
+    # user to the login screen and display the error.
+    return redirect(
+        "/?"
+        + urlencode(
+            {
+                "error": "oauth",
+                "message": f"Login error: {error.error} - {error.description}",
+            }
+        )
     )


### PR DESCRIPTION
Task: #876 

If something goes wrong in the OAuth flow, Auth0 sends an error message
to the callback. We catch those errors and redirect the user to the
login screen, displaying the error.

Two changes to make this possible:
- Standardize the way we show pass messages to the login screen
- Change the auth tests to use the `patch` method of the mocking module,
which automatically clears the mocks out once the test is done
(previously, they were carrying over between tests)