### PR TITLE
Use REACT_APP_ENV instead of NODE_ENV to toggle Minerva 

### DIFF
--- a/client/src/components/HomeScreen.tsx
+++ b/client/src/components/HomeScreen.tsx
@@ -321,7 +321,7 @@ const CreateAudit: React.FC = () => {
               >
                 <Radio value="BALLOT_POLLING">Ballot Polling</Radio>
                 {/* For now, disable switching audit math type in production */}
-                {process.env.NODE_ENV !== 'production' &&
+                {process.env.REACT_APP_ENV !== 'production' &&
                 values.auditType === 'BALLOT_POLLING' ? (
                   <BallotPollingWrapper>
                     <label htmlFor="auditMathType">

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -10,7 +10,7 @@ import * as serviceWorker from './serviceWorker'
 
 Sentry.init({
   dsn: process.env.REACT_APP_SENTRY_DSN,
-  environment: process.env.NODE_ENV,
+  environment: process.env.REACT_APP_ENV || 'development',
   integrations: [new Integrations.BrowserTracing()],
   tracesSampleRate: 1.0,
 })


### PR DESCRIPTION
The NODE_ENV variable is set to `production` whenever a built version of
the client is running (as opposed to running with `npm start`), so it
doesn't actually distinguish our different deployment environments.

Instead, we'll use a new env var, REACT_APP_ENV, which will correspond
to FLASK_ENV. (To pass env vars to the frontend, you need to prefix them
with REACT_APP_)
