### PR TITLE
Parse CSVs with carriage return newlines

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -64,7 +64,9 @@ def process_cvr_file(session: Session, jurisdiction: Jurisdiction, file: File):
     assert jurisdiction.cvr_file_id == file.id
 
     def process():
-        cvrs = csv.reader(io.StringIO(jurisdiction.cvr_file.contents), delimiter=",")
+        cvrs = csv.reader(
+            io.StringIO(jurisdiction.cvr_file.contents, newline=None), delimiter=","
+        )
 
         # Parse out all the initial metadata
         _election_name = next(cvrs)[0]

--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -396,7 +396,9 @@ def update_jurisdictions_file(election: Election):
         uploaded_at=datetime.datetime.utcnow(),
     )
 
-    jurisdictions_csv = csv.DictReader(io.StringIO(jurisdictions_file_string))
+    jurisdictions_csv = csv.DictReader(
+        io.StringIO(jurisdictions_file_string, newline=None)
+    )
 
     missing_fields = [
         field

--- a/server/tests/util/test_csv_parse.py
+++ b/server/tests/util/test_csv_parse.py
@@ -440,6 +440,15 @@ def test_parse_csv_empty_trailing_columns():
     assert parsed == [{"Batch Name": "Batch A", "Number of Ballots": 20}]
 
 
+def test_parse_csv_excel_mac_newlines():
+    parsed = list(
+        parse_csv("Batch Name,Number of Ballots\rBatch 1,20", BALLOT_MANIFEST_COLUMNS,)
+    )
+    assert parsed == [
+        {"Batch Name": "Batch 1", "Number of Ballots": 20},
+    ]
+
+
 REAL_WORLD_REJECTED_CSVS = [
     (
         """Batch Name,,Number of Ballots,

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -38,7 +38,9 @@ CSVDictIterator = Iterator[Dict[str, Any]]
 # https://en.wikipedia.org/wiki/Robustness_principle
 def parse_csv(csv_string: str, columns: List[CSVColumnType]) -> CSVDictIterator:
     validate_is_csv(csv_string)
-    csv: CSVIterator = py_csv.reader(io.StringIO(csv_string), delimiter=",")
+    csv: CSVIterator = py_csv.reader(
+        io.StringIO(csv_string, newline=None), delimiter=","
+    )
     csv = strip_whitespace(csv)
     csv = reject_no_rows(csv)
     csv = skip_empty_trailing_columns(csv)


### PR DESCRIPTION
If you use Excel and export Mac CSV format, the newlines are delimited
by single carriage returns. Previously, that caused a parsing error:
"new-line character seen in unquoted field - do you need to open the
file in universal-newline mode?"

By passing newline=None to io.StringIO it enables universal newlines
mode: https://docs.python.org/3/glossary.html#term-universal-newlines