### PR TITLE
Offline batch results form improvements

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
@@ -26,13 +26,12 @@ import useOfflineBatchResults, {
 import { testNumber } from '../../utilities'
 
 const OfflineBatchResultsForm = styled.form`
+  /* Disable up/down toggle arrows on number inputs */
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {
     margin: 0;
     -webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
   }
-
-  /* Firefox */
   input[type='number'] {
     -moz-appearance: textfield; /* stylelint-disable-line property-no-vendor-prefix */
   }
@@ -136,6 +135,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
         values,
         isSubmitting,
         errors,
+        dirty,
       }: FormikProps<{ results: IResultRow[] }>) => (
         <OfflineBatchResultsForm>
           <div style={{ width: '510px', marginBottom: '20px' }}>
@@ -255,7 +255,10 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                     >
                       Save Results
                     </Button>
-                    <Button onClick={() => setIsConfirmOpen(true)}>
+                    <Button
+                      onClick={() => setIsConfirmOpen(true)}
+                      disabled={dirty}
+                    >
                       Finalize Results
                     </Button>
                   </div>

--- a/server/api/offline_batch_results.py
+++ b/server/api/offline_batch_results.py
@@ -34,7 +34,13 @@ OFFLINE_BATCH_RESULTS_SCHEMA = {
             },
             "choiceResults": {
                 "type": "object",
-                "patternProperties": {"^.*$": {"type": "integer", "minimum": 0},},
+                "patternProperties": {
+                    "^.*$": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 1000 * 1000 * 1000,
+                    },
+                },
             },
         },
         "required": ["batchName", "batchType", "choiceResults"],
@@ -88,16 +94,6 @@ def validate_offline_batch_results(
             raise BadRequest(
                 f"Invalid choice ids for batch {batch_results['batchName']}"
             )
-
-    total_results = sum(
-        sum(batch_results["choiceResults"].values())
-        for batch_results in offline_batch_results
-    )
-    assert jurisdiction.manifest_num_ballots
-    if total_results > jurisdiction.manifest_num_ballots:
-        raise BadRequest(
-            f"Total results ({total_results}) cannot be greater than the number of ballots reported in the ballot manifest ({jurisdiction.manifest_num_ballots})"
-        )
 
 
 def load_offline_batch_results(jurisdiction: Jurisdiction) -> List[OfflineBatchResult]:

--- a/server/tests/test_sample_all_ballots.py
+++ b/server/tests/test_sample_all_ballots.py
@@ -457,19 +457,6 @@ def test_offline_batch_results_validation(
             [
                 {
                     "batchName": "Batch 1",
-                    "batchType": "bad type",
-                    "choiceResults": {
-                        choice["id"]: choice["numVotes"] / 4
-                        for choice in contest["choices"]
-                    },
-                }
-            ],
-            "'bad type' is not one of ['Absentee By Mail', 'Advance', 'Election Day', 'Provisional', 'Other']",
-        ),
-        (
-            [
-                {
-                    "batchName": "Batch 1",
                     "batchType": "Provisional",
                     "choiceResults": {
                         choice["id"]: choice["numVotes"] / 4
@@ -495,12 +482,12 @@ def test_offline_batch_results_validation(
                     "batchName": "Batch 1",
                     "batchType": "Provisional",
                     "choiceResults": {
-                        choice["id"]: choice["numVotes"]
+                        choice["id"]: 1000 * 1000 * 1000 + 1
                         for choice in contest["choices"]
                     },
                 }
             ],
-            "Total results (2000000) cannot be greater than the number of ballots reported in the ballot manifest (1000000)",
+            "1000000001 is greater than the maximum of 1000000000",
         ),
         (
             [

--- a/server/tests/test_sample_all_ballots.py
+++ b/server/tests/test_sample_all_ballots.py
@@ -155,8 +155,6 @@ def test_all_ballots_audit(
     )
     contest = json.loads(rv.data)["contests"][0]
 
-    # TODO test trying to record more results than were in the manifest
-
     # Record partial results
     jurisdiction_1_results = [
         {
@@ -382,3 +380,186 @@ def test_all_ballots_audit(
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/report")
     assert_match_report(rv.data, snapshot)
+
+
+def test_offline_batch_results_validation(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+    round_1_id: str,
+):
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
+        [{"name": "Audit Board #1"}, {"name": "Audit Board #2"}],
+    )
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/contest"
+    )
+    contest = json.loads(rv.data)["contests"][0]
+
+    # Record invalid results
+    invalid_results = [
+        (
+            [
+                {
+                    "batchName": "",
+                    "batchType": "Provisional",
+                    "choiceResults": {
+                        choice["id"]: choice["numVotes"] / 4
+                        for choice in contest["choices"]
+                    },
+                }
+            ],
+            "'' is too short",
+        ),
+        (
+            [
+                {
+                    "batchName": None,
+                    "batchType": "Provisional",
+                    "choiceResults": {
+                        choice["id"]: choice["numVotes"] / 4
+                        for choice in contest["choices"]
+                    },
+                }
+            ],
+            "None is not of type 'string'",
+        ),
+        (
+            [
+                {
+                    "batchType": "Provisional",
+                    "choiceResults": {
+                        choice["id"]: choice["numVotes"] / 4
+                        for choice in contest["choices"]
+                    },
+                }
+            ],
+            "'batchName' is a required property",
+        ),
+        (
+            [
+                {
+                    "batchName": "Batch 1",
+                    "batchType": "bad type",
+                    "choiceResults": {
+                        choice["id"]: choice["numVotes"] / 4
+                        for choice in contest["choices"]
+                    },
+                }
+            ],
+            "'bad type' is not one of ['Absentee By Mail', 'Advance', 'Election Day', 'Provisional', 'Other']",
+        ),
+        (
+            [
+                {
+                    "batchName": "Batch 1",
+                    "batchType": "bad type",
+                    "choiceResults": {
+                        choice["id"]: choice["numVotes"] / 4
+                        for choice in contest["choices"]
+                    },
+                }
+            ],
+            "'bad type' is not one of ['Absentee By Mail', 'Advance', 'Election Day', 'Provisional', 'Other']",
+        ),
+        (
+            [
+                {
+                    "batchName": "Batch 1",
+                    "batchType": "Provisional",
+                    "choiceResults": {
+                        choice["id"]: choice["numVotes"] / 4
+                        for choice in contest["choices"][:1]
+                    },
+                }
+            ],
+            "Invalid choice ids for batch Batch 1",
+        ),
+        (
+            [
+                {
+                    "batchName": "Batch 1",
+                    "batchType": "Provisional",
+                    "choiceResults": {"not a real id": 0},
+                }
+            ],
+            "Invalid choice ids for batch Batch 1",
+        ),
+        (
+            [
+                {
+                    "batchName": "Batch 1",
+                    "batchType": "Provisional",
+                    "choiceResults": {
+                        choice["id"]: choice["numVotes"]
+                        for choice in contest["choices"]
+                    },
+                }
+            ],
+            "Total results (2000000) cannot be greater than the number of ballots reported in the ballot manifest (1000000)",
+        ),
+        (
+            [
+                {
+                    "batchName": "Batch 1",
+                    "batchType": "Provisional",
+                    "choiceResults": {
+                        choice["id"]: choice["numVotes"] / 4
+                        for choice in contest["choices"]
+                    },
+                },
+                {
+                    "batchName": "Batch 1",
+                    "batchType": "Election Day",
+                    "choiceResults": {
+                        choice["id"]: choice["numVotes"] / 4
+                        for choice in contest["choices"]
+                    },
+                },
+            ],
+            "Batch names must be unique",
+        ),
+    ]
+
+    for invalid_result, expected_message in invalid_results:
+        rv = put_json(
+            client,
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch",
+            invalid_result,
+        )
+        assert rv.status_code == 400
+        assert json.loads(rv.data) == {
+            "errors": [{"errorType": "Bad Request", "message": expected_message}]
+        }
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize",
+    )
+    assert_ok(rv)
+
+    # Can't save results after finalizing
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch",
+        [
+            {
+                "batchName": "Batch 1",
+                "batchType": "Provisional",
+                "choiceResults": {
+                    choice["id"]: choice["numVotes"] / 4
+                    for choice in contest["choices"]
+                },
+            }
+        ],
+    )
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {"errorType": "Conflict", "message": "Results have already been finalized"}
+        ]
+    }


### PR DESCRIPTION
- Disable finalizing when form is unsaved
- Validate that total results don't exceed number of ballots in manifest (also defends against integer overflow errors)
- Don't allow saving results after finalizing
- Test and improve basic request validation