### PR TITLE
Offline batch results: assorted fixes

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
@@ -46,6 +46,7 @@ const OfflineBatchResultsForm = styled.form`
     th,
     td {
       vertical-align: middle;
+      word-wrap: break-word;
     }
   }
 `
@@ -394,6 +395,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                       await finalizeResults()
                       setIsConfirmOpen(false)
                     }}
+                    disabled={results.length === 0}
                   >
                     Finalize Results
                   </Button>

--- a/server/api/offline_batch_results.py
+++ b/server/api/offline_batch_results.py
@@ -1,6 +1,6 @@
 import enum
 from typing import List
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import defaultdict
 from flask import jsonify, request
 from werkzeug.exceptions import BadRequest, Conflict
@@ -27,7 +27,7 @@ OFFLINE_BATCH_RESULTS_SCHEMA = {
     "items": {
         "type": "object",
         "properties": {
-            "batchName": {"type": "string", "minLength": 1},
+            "batchName": {"type": "string", "minLength": 1, "maxLength": 200},
             "batchType": {
                 "type": "string",
                 "enum": [batch_type.value for batch_type in BatchType],
@@ -195,7 +195,7 @@ def finalize_offline_batch_results(
     jurisdiction: Jurisdiction,
     round: Round,
 ):
-    jurisdiction.finalized_offline_batch_results_at = datetime.utcnow()
+    jurisdiction.finalized_offline_batch_results_at = datetime.now(timezone.utc)
 
     sum_results_by_choice = (
         OfflineBatchResult.query.filter_by(jurisdiction_id=jurisdiction.id)

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -210,7 +210,9 @@ def run_audit_round(
     db_session.commit()
 
 
-DATETIME_REGEX = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}.\d{6})?")
+DATETIME_REGEX = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}.\d{6})?(\+\d\d:\d\d)?"
+)
 
 
 def scrub_datetime(string: str) -> str:

--- a/server/tests/test_sample_all_ballots.py
+++ b/server/tests/test_sample_all_ballots.py
@@ -421,6 +421,19 @@ def test_offline_batch_results_validation(
         (
             [
                 {
+                    "batchName": "a" * 201,
+                    "batchType": "Provisional",
+                    "choiceResults": {
+                        choice["id"]: choice["numVotes"] / 4
+                        for choice in contest["choices"]
+                    },
+                }
+            ],
+            f"'{'a' * 201}' is too long",
+        ),
+        (
+            [
+                {
                     "batchName": None,
                     "batchType": "Provisional",
                     "choiceResults": {


### PR DESCRIPTION
- max length of 200 characters for batch names
- wrap words in cells
- use a timezone for finalized_at
- disable finalizing when no results recorded