### PR TITLE
Fix mismatched names

### DIFF
--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -57,13 +57,14 @@ def process_standardized_contests_file(
                         f"Invalid jurisdictions for contest {row[CONTEST_NAME]}: {', '.join(sorted(invalid_jurisdictions))}"
                     )
 
+            contest_name = " ".join(row[CONTEST_NAME].splitlines())
             # Strip off Dominion's vote-for designation"
-            match = re.match(
-                r"^(.+) \(Vote For=(\d+)\)$", " ".join(row[CONTEST_NAME].splitlines())
-            )
+            if "Vote For=" in contest_name:
+                contest_name = re.match(r"^(.+) \(Vote For=(\d+)\)$", contest_name)[1]
+
             standardized_contests.append(
                 dict(
-                    name=match[1],
+                    name=contest_name,
                     jurisdictionIds=[jurisdiction.id for jurisdiction in jurisdictions],
                 )
             )

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -1,4 +1,5 @@
 import uuid
+import re
 from datetime import datetime
 from flask import request, jsonify, Request
 from sqlalchemy.orm.session import Session
@@ -56,9 +57,13 @@ def process_standardized_contests_file(
                         f"Invalid jurisdictions for contest {row[CONTEST_NAME]}: {', '.join(sorted(invalid_jurisdictions))}"
                     )
 
+            # Strip off Dominion's vote-for designation"
+            match = re.match(
+                r"^(.+) \(Vote For=(\d+)\)$", " ".join(row[CONTEST_NAME].splitlines())
+            )
             standardized_contests.append(
                 dict(
-                    name=(" ".join(row[CONTEST_NAME].splitlines())),
+                    name=match[1],
                     jurisdictionIds=[jurisdiction.id for jurisdiction in jurisdictions],
                 )
             )


### PR DESCRIPTION
**Description**

Standardized contests wasn't stripping out `(Vote For=X)`, but cvrs.py was. This fixes it. 

**Testing**
Adds test that verifies that standardized contest names can have `(Vote For=X)` or not and it gets handled appropriately. 

**Progress**

Ready to go. 
