### PR TITLE
Add UTC timezone to all timestamps

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
@@ -197,7 +197,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                   style={{ margin: '20px 0 20px 0' }}
                 >
                   Results finalized at{' '}
-                  {new Date(`${finalizedAt}Z`).toLocaleString()}
+                  {new Date(`${finalizedAt}`).toLocaleString()}
                 </Callout>
               )}
             </div>

--- a/server/api/audit_boards.py
+++ b/server/api/audit_boards.py
@@ -318,7 +318,7 @@ def sign_off_audit_board(
 ):
     validate_sign_off(request.get_json(), audit_board)
 
-    audit_board.signed_off_at = datetime.utcnow()
+    audit_board.signed_off_at = datetime.now(timezone.utc)
 
     if is_round_complete(election, round):
         end_round(election, round)

--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -81,7 +81,7 @@ def save_ballot_manifest_file(manifest, jurisdiction: Jurisdiction):
         id=str(uuid.uuid4()),
         name=manifest.filename,
         contents=manifest_string,
-        uploaded_at=datetime.utcnow(),
+        uploaded_at=datetime.now(timezone.utc),
     )
 
 

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -134,7 +134,7 @@ def upload_batch_tallies(
         id=str(uuid.uuid4()),
         name=batch_tallies.filename,
         contents=decode_csv_file(batch_tallies.read()),
-        uploaded_at=datetime.utcnow(),
+        uploaded_at=datetime.now(timezone.utc),
     )
     db_session.commit()
     return jsonify(status="ok")

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -234,7 +234,7 @@ def save_cvr_file(cvr, jurisdiction: Jurisdiction):
         id=str(uuid.uuid4()),
         name=cvr.filename,
         contents=cvr_string,
-        uploaded_at=datetime.utcnow(),
+        uploaded_at=datetime.now(timezone.utc),
     )
 
 

--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -393,7 +393,7 @@ def update_jurisdictions_file(election: Election):
         id=str(uuid.uuid4()),
         name=jurisdictions_file.filename,
         contents=jurisdictions_file_string,
-        uploaded_at=datetime.datetime.utcnow(),
+        uploaded_at=datetime.datetime.now(timezone.utc),
     )
 
     jurisdictions_csv = csv.DictReader(

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -344,7 +344,7 @@ def calculate_risk_measurements(election: Election, round: Round):
 def end_round(election: Election, round: Round):
     count_audited_votes(election, round)
     calculate_risk_measurements(election, round)
-    round.ended_at = datetime.utcnow()
+    round.ended_at = datetime.now(timezone.utc)
 
 
 def is_round_complete(election: Election, round: Round) -> bool:

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -99,7 +99,7 @@ def upload_standardized_contests_file(election: Election):
         id=str(uuid.uuid4()),
         name=file.filename,
         contents=decode_csv_file(file.read()),
-        uploaded_at=datetime.utcnow(),
+        uploaded_at=datetime.now(timezone.utc),
     )
     election.standardized_contests = None
     db_session.commit()

--- a/server/models.py
+++ b/server/models.py
@@ -4,6 +4,7 @@ from datetime import datetime as dt, timezone
 from werkzeug.exceptions import NotFound
 from sqlalchemy import *  # pylint: disable=wildcard-import
 from sqlalchemy.orm import relationship, backref, validates, deferred as sa_deferred
+from sqlalchemy.types import TypeDecorator
 from .database import Base  # pylint: disable=cyclic-import
 
 C = TypeVar("C")  # pylint: disable=invalid-name
@@ -13,11 +14,30 @@ def deferred(col: C) -> C:
     return typing_cast(C, sa_deferred(col))
 
 
+class UTCDateTime(TypeDecorator):  # pylint: disable=abstract-method
+    # Store with no timezone
+    impl = DateTime
+
+    # Ensure UTC timezone on write
+    def process_bind_param(self, value, dialect):
+        if value:
+            assert (
+                value.tzinfo == timezone.utc
+            ), "All datetimes must have UTC timezone - use datetime.now(timezone.utc)"
+        return value
+
+    # Repopulate UTC timezone on read
+    def process_result_value(self, value, dialect):
+        return value and value.replace(tzinfo=timezone.utc)
+
+
 class BaseModel(Base):
     __abstract__ = True
-    created_at = Column(DateTime, default=lambda: dt.now(timezone.utc), nullable=False)
+    created_at = Column(
+        UTCDateTime, default=lambda: dt.now(timezone.utc), nullable=False
+    )
     updated_at = Column(
-        DateTime,
+        UTCDateTime,
         default=lambda: dt.now(timezone.utc),
         onupdate=lambda: dt.now(timezone.utc),
         nullable=False,
@@ -177,7 +197,7 @@ class Jurisdiction(BaseModel):
     cvr_contests_metadata = Column(JSON)
 
     # For ballot polling audits where offline batch results are recorded
-    finalized_offline_batch_results_at = Column(DateTime)
+    finalized_offline_batch_results_at = Column(UTCDateTime)
 
     batches = relationship(
         "Batch", back_populates="jurisdiction", uselist=True, passive_deletes=True
@@ -395,7 +415,7 @@ class AuditBoard(BaseModel):
     member_2 = Column(String(200))
     member_2_affiliation = Column(Enum(Affiliation))
     passphrase = Column(String(1000), unique=True)
-    signed_off_at = Column(DateTime)
+    signed_off_at = Column(UTCDateTime)
 
     sampled_ballots = relationship(
         "SampledBallot",
@@ -416,7 +436,7 @@ class Round(BaseModel):
     election = relationship("Election", back_populates="rounds")
 
     round_num = Column(Integer, nullable=False)
-    ended_at = Column(DateTime)
+    ended_at = Column(UTCDateTime)
 
     __table_args__ = (UniqueConstraint("election_id", "round_num"),)
 
@@ -719,11 +739,11 @@ class File(BaseModel):
     id = Column(String(200), primary_key=True)
     name = Column(String(250), nullable=False)
     contents = deferred(Column(Text, nullable=False))
-    uploaded_at = Column(DateTime, nullable=False)
+    uploaded_at = Column(UTCDateTime, nullable=False)
 
     # Metadata for processing files in the background.
-    processing_started_at = Column(DateTime)
-    processing_completed_at = Column(DateTime)
+    processing_started_at = Column(UTCDateTime)
+    processing_completed_at = Column(UTCDateTime)
     processing_error = Column(Text)
 
 

--- a/server/models.py
+++ b/server/models.py
@@ -1,6 +1,6 @@
 import enum
 from typing import Type, TypeVar, cast as typing_cast
-from datetime import datetime as dt
+from datetime import datetime as dt, timezone
 from werkzeug.exceptions import NotFound
 from sqlalchemy import *  # pylint: disable=wildcard-import
 from sqlalchemy.orm import relationship, backref, validates, deferred as sa_deferred
@@ -15,8 +15,13 @@ def deferred(col: C) -> C:
 
 class BaseModel(Base):
     __abstract__ = True
-    created_at = Column(DateTime, default=dt.utcnow, nullable=False)
-    updated_at = Column(DateTime, default=dt.utcnow, onupdate=dt.utcnow, nullable=False)
+    created_at = Column(DateTime, default=lambda: dt.now(timezone.utc), nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=lambda: dt.now(timezone.utc),
+        onupdate=lambda: dt.now(timezone.utc),
+        nullable=False,
+    )
 
 
 # on-delete-cascade is done in SQLAlchemy like this:

--- a/server/tests/api/test_audit_boards.py
+++ b/server/tests/api/test_audit_boards.py
@@ -133,7 +133,7 @@ def test_audit_boards_list_one(
     audit_board = AuditBoard.query.get(audit_boards[0]["id"])
     for ballot in audit_board.sampled_ballots[10:]:
         audit_ballot(ballot, contest_ids[0], Interpretation.BLANK)
-    audit_board.signed_off_at = datetime.utcnow()
+    audit_board.signed_off_at = datetime.now(timezone.utc)
     db_session.commit()
 
     rv = client.get(
@@ -248,7 +248,7 @@ def test_audit_boards_list_two(
     audit_board_1 = AuditBoard.query.get(audit_boards[0]["id"])
     for ballot in audit_board_1.sampled_ballots[10:]:
         audit_ballot(ballot, contest_ids[0], Interpretation.BLANK)
-    audit_board_1.signed_off_at = datetime.utcnow()
+    audit_board_1.signed_off_at = datetime.now(timezone.utc)
     db_session.commit()
 
     rv = client.get(

--- a/server/tests/api/test_jurisdictions.py
+++ b/server/tests/api/test_jurisdictions.py
@@ -241,7 +241,7 @@ def test_jurisdictions_status_round_1_with_audit_boards(
     audit_board_1 = AuditBoard.query.get(audit_board_round_1_ids[0])
     for ballot in audit_board_1.sampled_ballots:
         ballot.status = BallotStatus.AUDITED
-    audit_board_1.signed_off_at = datetime.utcnow()
+    audit_board_1.signed_off_at = datetime.now(timezone.utc)
     db_session.commit()
 
     rv = client.get(f"/api/election/{election_id}/jurisdiction")
@@ -253,7 +253,7 @@ def test_jurisdictions_status_round_1_with_audit_boards(
     audit_board_2 = AuditBoard.query.get(audit_board_round_1_ids[1])
     for ballot in audit_board_2.sampled_ballots:
         ballot.status = BallotStatus.AUDITED
-    audit_board_2.signed_off_at = datetime.utcnow()
+    audit_board_2.signed_off_at = datetime.now(timezone.utc)
     db_session.commit()
 
     rv = client.get(f"/api/election/{election_id}/jurisdiction")
@@ -279,7 +279,7 @@ def test_jurisdictions_status_round_1_with_audit_boards_without_ballots(
     audit_board_2 = AuditBoard.query.get(audit_board_round_1_ids[1])
     for ballot in audit_board_2.sampled_ballots:
         ballot.status = BallotStatus.AUDITED
-    audit_board_2.signed_off_at = datetime.utcnow()
+    audit_board_2.signed_off_at = datetime.now(timezone.utc)
     db_session.commit()
 
     rv = client.get(f"/api/election/{election_id}/jurisdiction")

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -133,7 +133,7 @@ def create_election(
         client,
         "/api/election",
         {
-            "auditName": audit_name or f"Test Audit {datetime.utcnow()}",
+            "auditName": audit_name or f"Test Audit {datetime.now(timezone.utc)}",
             "auditType": audit_type,
             "auditMathType": audit_math_type,
             "organizationId": organization_id,

--- a/server/tests/test_migrations.py
+++ b/server/tests/test_migrations.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy_utils import create_database, drop_database
@@ -20,7 +20,7 @@ def alembic_config():
 
 @pytest.fixture
 def alembic_engine():
-    url = f"{DATABASE_URL}-migrations-{datetime.utcnow()}"
+    url = f"{DATABASE_URL}-migrations-{datetime.now(timezone.utc)}"
     create_database(url)
 
     engine = create_engine(url)

--- a/server/tests/util/test_process_file.py
+++ b/server/tests/util/test_process_file.py
@@ -13,7 +13,7 @@ def test_success():
         id=str(uuid.uuid4()),
         name="Test File",
         contents="abcdefg",
-        uploaded_at=datetime.datetime.utcnow(),
+        uploaded_at=datetime.datetime.now(timezone.utc),
     )
     db_session.add(file)
     db_session.commit()
@@ -37,7 +37,7 @@ def test_error():
         id=str(uuid.uuid4()),
         name="Test File",
         contents="abcdefg",
-        uploaded_at=datetime.datetime.utcnow(),
+        uploaded_at=datetime.datetime.now(timezone.utc),
     )
     db_session.add(file)
     db_session.commit()
@@ -64,7 +64,7 @@ def test_session_stuck():
         id=str(uuid.uuid4()),
         name="Test File",
         contents="abcdefg",
-        uploaded_at=datetime.datetime.utcnow(),
+        uploaded_at=datetime.datetime.now(timezone.utc),
     )
     db_session.add(file)
     db_session.commit()
@@ -79,7 +79,7 @@ def test_session_stuck():
                 id=file.id,
                 name="Test File2",
                 contents="abcdefg",
-                uploaded_at=datetime.datetime.utcnow(),
+                uploaded_at=datetime.datetime.now(timezone.utc),
             )
         )
 

--- a/server/tests/util/test_process_file.py
+++ b/server/tests/util/test_process_file.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 import uuid
 from sqlalchemy import insert
 from sqlalchemy.exc import SQLAlchemyError
@@ -13,7 +13,7 @@ def test_success():
         id=str(uuid.uuid4()),
         name="Test File",
         contents="abcdefg",
-        uploaded_at=datetime.datetime.now(timezone.utc),
+        uploaded_at=datetime.now(timezone.utc),
     )
     db_session.add(file)
     db_session.commit()
@@ -27,8 +27,8 @@ def test_success():
 
     process_file(db_session, file, process)
 
-    assert isinstance(file.processing_started_at, datetime.datetime)
-    assert isinstance(file.processing_completed_at, datetime.datetime)
+    assert isinstance(file.processing_started_at, datetime)
+    assert isinstance(file.processing_completed_at, datetime)
     assert file.processing_error is None
 
 
@@ -37,7 +37,7 @@ def test_error():
         id=str(uuid.uuid4()),
         name="Test File",
         contents="abcdefg",
-        uploaded_at=datetime.datetime.now(timezone.utc),
+        uploaded_at=datetime.now(timezone.utc),
     )
     db_session.add(file)
     db_session.commit()
@@ -54,8 +54,8 @@ def test_error():
     except Exception as error:
         assert str(error) == "NOPE"
 
-    assert isinstance(file.processing_started_at, datetime.datetime)
-    assert isinstance(file.processing_completed_at, datetime.datetime)
+    assert isinstance(file.processing_started_at, datetime)
+    assert isinstance(file.processing_completed_at, datetime)
     assert file.processing_error == "NOPE"
 
 
@@ -64,7 +64,7 @@ def test_session_stuck():
         id=str(uuid.uuid4()),
         name="Test File",
         contents="abcdefg",
-        uploaded_at=datetime.datetime.now(timezone.utc),
+        uploaded_at=datetime.now(timezone.utc),
     )
     db_session.add(file)
     db_session.commit()
@@ -79,7 +79,7 @@ def test_session_stuck():
                 id=file.id,
                 name="Test File2",
                 contents="abcdefg",
-                uploaded_at=datetime.datetime.now(timezone.utc),
+                uploaded_at=datetime.now(timezone.utc),
             )
         )
 
@@ -88,6 +88,6 @@ def test_session_stuck():
     except SQLAlchemyError:
         pass
 
-    assert isinstance(file.processing_started_at, datetime.datetime)
-    assert isinstance(file.processing_completed_at, datetime.datetime)
+    assert isinstance(file.processing_started_at, datetime)
+    assert isinstance(file.processing_completed_at, datetime)
     assert file.processing_error

--- a/server/util/csv_download.py
+++ b/server/util/csv_download.py
@@ -9,14 +9,14 @@ clean_name_re = re.compile(r"[^a-zA-Z0-9]+")
 
 def election_timestamp_name(election: Election) -> str:
     election_name = re.sub(clean_name_re, "-", str(election.audit_name))
-    now = datetime.utcnow().isoformat(timespec="minutes")
+    now = datetime.now(timezone.utc).isoformat(timespec="minutes")
     return f"{election_name}-{now}"
 
 
 def jurisdiction_timestamp_name(election: Election, jurisdiction: Jurisdiction) -> str:
     election_name = re.sub(clean_name_re, "-", str(election.audit_name))
     jurisdiction_name = re.sub(clean_name_re, "-", str(jurisdiction.name))
-    now = datetime.utcnow().isoformat(timespec="minutes")
+    now = datetime.now(timezone.utc).isoformat(timespec="minutes")
     return f"{jurisdiction_name}-{election_name}-{now}"
 
 

--- a/server/util/process_file.py
+++ b/server/util/process_file.py
@@ -19,7 +19,7 @@ def process_file(session: Session, file: File, callback: Callable[[], None]) -> 
 
     # Claim this file by updating the `processing_started_at` timestamp in such
     # a way that it must not have been set before.
-    processing_started_at = datetime.datetime.utcnow()
+    processing_started_at = datetime.datetime.now(timezone.utc)
     result = session.execute(
         update(File.__table__)  # pylint: disable=no-member
         .where(File.id == file.id)
@@ -33,14 +33,14 @@ def process_file(session: Session, file: File, callback: Callable[[], None]) -> 
     try:
         callback()
         file.processing_started_at = processing_started_at
-        file.processing_completed_at = datetime.datetime.utcnow()
+        file.processing_completed_at = datetime.datetime.now(timezone.utc)
         session.add(file)
         session.commit()
         return True
     except Exception as error:
         session.rollback()
         file.processing_started_at = processing_started_at
-        file.processing_completed_at = datetime.datetime.utcnow()
+        file.processing_completed_at = datetime.datetime.now(timezone.utc)
         # Some errors stringify nicely, some don't (e.g. StopIteration) so we
         # have to format them.
         file.processing_error = str(error) or str(


### PR DESCRIPTION
Because we store timestamps with no timezone info in the db, they were getting read from the db without timezone info, and therefore getting misinterpreted as local time by the frontend (instead of UTC time).

Here we make a few changes to fix this without modifying the database schema or changing timezones already in the database:
- Change everywhere we create datetimes from `datetime.utcnow` (which doesn't have timezone info) to use `datetime.now(timezone.utc)` (which does)
- Require that every datetime written to the db has timezone info
- When reading timezones from the db, set the timezone info to UTC

The latter two changes are accomplished with a custom sqlalchemy column type.

Lastly, we remove the workaround on the frontend that was appending `Z` to the timestamps to interpret them as UTC.