### PR TITLE
Defer loading of File.contents

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -3,7 +3,7 @@ from typing import Type
 from datetime import datetime as dt
 from werkzeug.exceptions import NotFound
 from sqlalchemy import *  # pylint: disable=wildcard-import
-from sqlalchemy.orm import relationship, backref, validates
+from sqlalchemy.orm import relationship, backref, validates, deferred
 from .database import Base  # pylint: disable=cyclic-import
 
 
@@ -707,7 +707,7 @@ class CvrBallot(Base):
 class File(BaseModel):
     id = Column(String(200), primary_key=True)
     name = Column(String(250), nullable=False)
-    contents = Column(Text, nullable=False)
+    contents = deferred(Column(Text, nullable=False))
     uploaded_at = Column(DateTime, nullable=False)
 
     # Metadata for processing files in the background.

--- a/server/models.py
+++ b/server/models.py
@@ -1,10 +1,16 @@
 import enum
-from typing import Type
+from typing import Type, TypeVar, cast as typing_cast
 from datetime import datetime as dt
 from werkzeug.exceptions import NotFound
 from sqlalchemy import *  # pylint: disable=wildcard-import
-from sqlalchemy.orm import relationship, backref, validates, deferred
+from sqlalchemy.orm import relationship, backref, validates, deferred as sa_deferred
 from .database import Base  # pylint: disable=cyclic-import
+
+C = TypeVar("C")  # pylint: disable=invalid-name
+
+# Workaround to make sqlalchemy.orm.deferred have the right type
+def deferred(col: C) -> C:
+    return typing_cast(C, sa_deferred(col))
 
 
 class BaseModel(Base):


### PR DESCRIPTION
When polling for file processing status, particularly in the case of CVR files (which can be large), we were previously loading the entire File database object, which implicitly loads the file contents. This was causing memory spikes (and potentially leaks). This change defers loading File.contents to when that property is accessed.