### PR TITLE
Fix display of finalized timestamp

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
@@ -187,7 +187,8 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                   intent="success"
                   style={{ margin: '20px 0 20px 0' }}
                 >
-                  Results finalized at {new Date(finalizedAt).toLocaleString()}
+                  Results finalized at{' '}
+                  {new Date(`${finalizedAt}Z`).toLocaleString()}
                 </Callout>
               )}
             </div>


### PR DESCRIPTION
We store UTC timestamps in the db, but they don't have timezone info attached. This changes the frontend to interpret the timestamps with the UTC timezone.

Note that there's an additional bug: even though we create our timestamps with the UTC timezone, the way they get stored in the database actually depends on the local timezone of the servers. It appears that Heroku has UTC as the local timezone, whereas my machine has PT:

On Heroku:
```
>>> datetime.now().isoformat()
'2020-11-16T22:10:24.927692'
```

On my machine:
```
>>> datetime.now().isoformat()
'2020-11-16T14:10:24.927692'
```

We should probably resolve this at the database level eventually.