### PR TITLE
CSV file upload improvements

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/CSVForm/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/CSVForm/index.tsx
@@ -52,11 +52,11 @@ const CSVFileForm = ({
 
   return (
     <Formik
-      initialValues={{ csv: null }}
+      initialValues={{ csv: isProcessing ? new File([], file!.name) : null }}
       validationSchema={schema}
       onSubmit={async (values: IValues) => {
         if (values.csv) {
-          uploadCSVFile(values.csv)
+          await uploadCSVFile(values.csv)
         }
       }}
     >
@@ -67,6 +67,7 @@ const CSVFileForm = ({
         touched,
         errors,
         handleBlur,
+        isSubmitting,
       }: FormikProps<IValues>) => (
         <form>
           <FormWrapper>
@@ -107,7 +108,7 @@ const CSVFileForm = ({
                     hasSelection={!!values.csv}
                     text={values.csv ? values.csv.name : 'Select a CSV...'}
                     onBlur={handleBlur}
-                    disabled={isProcessing || !enabled}
+                    disabled={isSubmitting || isProcessing || !enabled}
                   />
                   {errors.csv && touched.csv && (
                     <ErrorLabel>{errors.csv}</ErrorLabel>
@@ -130,7 +131,7 @@ const CSVFileForm = ({
                   type="submit"
                   intent="primary"
                   onClick={handleSubmit}
-                  loading={isProcessing}
+                  loading={isSubmitting || isProcessing}
                   disabled={!enabled}
                 >
                   Upload File


### PR DESCRIPTION
- Show a spinner on the upload button while uploading the file to the
server, not just while processing the file on the backend
- Show the file name in the file selector while processing

Before:
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/530106/99320961-9d1eb800-2821-11eb-803a-ff2f4889b9f3.gif)

After:
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/530106/99320948-998b3100-2821-11eb-96d5-f0e985159524.gif)
