### PR TITLE
Fix offline batch results copy/paste

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -86,6 +86,7 @@
     "@types/styled-components": "^5.1.2",
     "@types/uuidv4": "^2.0.0",
     "@types/yup": "^0.26.22",
+    "copy-to-clipboard": "^3.3.1",
     "fast-deep-equal": "^3.1.3",
     "formik": "^2.2.0",
     "history": "^4.9.0",

--- a/client/src/components/Atoms/CopyToClipboard.test.tsx
+++ b/client/src/components/Atoms/CopyToClipboard.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import copy from 'copy-to-clipboard'
+import CopyToClipboard from './CopyToClipboard'
+
+jest.mock('copy-to-clipboard', () => jest.fn(() => true))
+
+describe('CopyToClipboard', () => {
+  it('renders a button that copies when clicked', async () => {
+    render(<CopyToClipboard getText={() => 'text to copy'} />)
+    const button = screen.getByRole('button', { name: /Copy to clipboard/ })
+
+    userEvent.click(button)
+
+    expect(copy).toHaveBeenCalledWith('text to copy', { format: 'text/html' })
+
+    // Button text should change to Copied
+    screen.getByRole('button', { name: /Copied/ })
+  })
+})

--- a/client/src/components/Atoms/CopyToClipboard.tsx
+++ b/client/src/components/Atoms/CopyToClipboard.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react'
+import copy from 'copy-to-clipboard'
+import { Button } from '@blueprintjs/core'
+
+const CopyToClipboard = ({ getText }: { getText: () => string }) => {
+  const [copied, setCopied] = useState(false)
+  return (
+    <Button
+      icon={copied ? 'tick-circle' : 'clipboard'}
+      onClick={() => {
+        const success = copy(getText(), { format: 'text/html' })
+        if (success) {
+          setCopied(true)
+          setTimeout(() => setCopied(false), 3000)
+        }
+      }}
+      style={{ width: '160px' }}
+    >
+      {copied ? 'Copied' : 'Copy to clipboard'}
+    </Button>
+  )
+}
+
+export default CopyToClipboard

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
@@ -196,7 +196,9 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
               <HTMLTable striped bordered>
                 <thead>
                   <tr>
-                    <th />
+                    {/* Add a space to the first header so that the headers
+                    copy-paste with the same length as the body rows */}
+                    <th>&nbsp;</th>
                     <th>Batch Name</th>
                     <th>Batch Type</th>
                     {contest.choices.map(choice => (

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
@@ -49,6 +49,14 @@ const OfflineBatchResultsForm = styled.form`
       vertical-align: middle;
       word-wrap: break-word;
     }
+
+    /* Exclude edit buttons from copy/paste */
+    th:first-child,
+    td:first-child {
+      -moz-user-select: none; /* stylelint-disable-line property-no-vendor-prefix */
+      -webkit-user-select: none; /* stylelint-disable-line property-no-vendor-prefix */
+      user-select: none;
+    }
   }
 `
 
@@ -196,9 +204,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
               <HTMLTable striped bordered>
                 <thead>
                   <tr>
-                    {/* Add a space to the first header so that the headers
-                    copy-paste with the same length as the body rows */}
-                    <th>&nbsp;</th>
+                    <th />
                     <th>Batch Name</th>
                     <th>Batch Type</th>
                     {contest.choices.map(choice => (

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
@@ -25,6 +25,7 @@ import useOfflineBatchResults, {
   IOfflineBatchResult,
 } from './useOfflineBatchResults'
 import { testNumber } from '../../utilities'
+import CopyToClipboard from '../../Atoms/CopyToClipboard'
 
 const sum = (nums: number[]) => nums.reduce((a, b) => a + b, 0)
 
@@ -201,7 +202,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
               )}
             </div>
             <fieldset disabled={!!finalizedAt}>
-              <HTMLTable striped bordered>
+              <HTMLTable striped bordered id="results-table">
                 <thead>
                   <tr>
                     <th />
@@ -286,6 +287,11 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                 >
                   Add batch
                 </Button>
+                <CopyToClipboard
+                  getText={() =>
+                    document.getElementById('results-table')!.outerHTML
+                  }
+                />
                 <Button onClick={() => setIsConfirmOpen(true)}>
                   Finalize Results
                 </Button>

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4129,6 +4129,13 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-to-clipboard@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 core-js-compat@^3.6.2:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.6.4.tgz#938476569ebb6cda80d339bcf199fae4f16fff17"
@@ -13354,6 +13361,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The empty table header above the edit buttons wasn't getting copied, so
the header row was one shorter than the body rows, which meant the
headers were off by one when pasting the results into a spreadsheet.

So we just exclude the whole column from copy/paste.

Also adds a "Copy to clipboard" button

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/530106/99432902-a8c1bb80-28c1-11eb-9454-54cf9be4134e.gif)
