### PR TITLE
Sentry: lower traces sample rate

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -12,7 +12,7 @@ Sentry.init({
   dsn: process.env.REACT_APP_SENTRY_DSN,
   environment: process.env.REACT_APP_ENV || 'development',
   integrations: [new Integrations.BrowserTracing()],
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.2,
 })
 
 ReactDOM.render(

--- a/server/app.py
+++ b/server/app.py
@@ -67,5 +67,5 @@ sentry_sdk.init(
     SENTRY_DSN,
     environment=FLASK_ENV,
     integrations=[FlaskIntegration()],
-    traces_sample_rate=1.0,
+    traces_sample_rate=0.2,
 )


### PR DESCRIPTION
We don't want to send every transaction to Sentry (both because it's
expensive in perf and money), instead we sample a proportion. This is a
recommended change that I forgot to make earlier.
