### PR TITLE
Sampler manifest list of ballot positions

### DIFF
--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -534,7 +534,9 @@ def sample_ballots(
         # (deterministic real world ids) instead of the jurisdiction and batch
         # ids (non-deterministic uuids that we generate for each audit).
         manifest = {
-            (jurisdiction.name, batch.tabulator, batch.name): batch.num_ballots
+            (jurisdiction.name, batch.tabulator, batch.name): list(
+                range(1, batch.num_ballots + 1)
+            )
             for jurisdiction in contest.jurisdictions
             for batch in jurisdiction.batches
         }

--- a/server/audit_math/sampler.py
+++ b/server/audit_math/sampler.py
@@ -9,7 +9,7 @@ from .sampler_contest import Contest
 
 
 def draw_sample(
-    seed: str, manifest: Dict[Any, int], sample_size: int, num_sampled=0
+    seed: str, manifest: Dict[Any, List[int]], sample_size: int, num_sampled=0
 ) -> List[Tuple[str, Tuple[Any, int], int]]:
     """
     Draws uniform random sample with replacement of size <sample_size> from the
@@ -38,17 +38,18 @@ def draw_sample(
                 ]
     """
 
-    ballots: List[Tuple[str, int]] = []
-    # First build a faux list of ballots
-    for batch in manifest:
-        for i in range(manifest[batch]):
-            ballots.append((batch, i + 1))
+    # First build a list of ballots
+    ballots: List[Tuple[Any, int]] = [
+        (batch, ballot_position)
+        for batch, ballot_positions in manifest.items()
+        for ballot_position in ballot_positions
+    ]
 
     return cast(
         # The signature of `consistent_sampler.sampler` can't be represented by
         # mypy yet, so it is typed as a less specific version of what it really
         # is. This casts it back to the more specific version.
-        List[Tuple[str, Tuple[str, int], int]],
+        List[Tuple[str, Tuple[Any, int], int]],
         list(
             consistent_sampler.sampler(
                 ballots,

--- a/server/tests/audit_math/test_sampler.py
+++ b/server/tests/audit_math/test_sampler.py
@@ -69,10 +69,10 @@ def close_macro_contest():
 def test_draw_sample(snapshot):
     # Test getting a sample
     manifest = {
-        "pct 1": 25,
-        "pct 2": 25,
-        "pct 3": 25,
-        "pct 4": 25,
+        "pct 1": list(range(1, 26)),
+        "pct 2": list(range(1, 26)),
+        "pct 3": list(range(1, 26)),
+        "pct 4": list(range(1, 26)),
     }
 
     sample = sampler.draw_sample(SEED, manifest, 20, 0)
@@ -82,10 +82,10 @@ def test_draw_sample(snapshot):
 def test_draw_more_samples(snapshot):
     # Test getting a sample
     manifest = {
-        "pct 1": 25,
-        "pct 2": 25,
-        "pct 3": 25,
-        "pct 4": 25,
+        "pct 1": list(range(1, 26)),
+        "pct 2": list(range(1, 26)),
+        "pct 3": list(range(1, 26)),
+        "pct 4": list(range(1, 26)),
     }
 
     sample = sampler.draw_sample(SEED, manifest, 10, 0)
@@ -136,7 +136,10 @@ def test_macro_recount_sample(close_macro_batches, close_macro_contest, snapshot
 
 def random_manifest():
     rand = random.Random(12345)
-    return {f"pct {n}": rand.randint(1, 10) for n in range(rand.randint(1, 10))}
+    return {
+        f"pct {n}": list(range(1, rand.randint(2, 11)))
+        for n in range(rand.randint(1, 10))
+    }
 
 
 def test_ballot_labels():
@@ -144,4 +147,4 @@ def test_ballot_labels():
         manifest = random_manifest()
         sample = sampler.draw_sample(SEED, manifest, 100, 0)
         for (_, (batch, ballot_number), _) in sample:
-            assert 1 <= ballot_number <= manifest[batch]
+            assert 1 <= ballot_number <= max(manifest[batch])


### PR DESCRIPTION
Change the interface to the sampler to take a list of ballot positions
instead of just a number of ballots. This will allow us to use the CVR
to generate the actual list of ballot positions (which aren't always
consecutive) and prevent sampling ballots that don't have the given
contest on them.