### PR TITLE
Improve launching audit UX

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/ConfirmLaunch.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/ConfirmLaunch.tsx
@@ -5,12 +5,14 @@ import FormButton from '../../../Atoms/Form/FormButton'
 const ConfirmLaunch = ({
   isOpen,
   handleClose,
-  onLaunch,
+  handleSubmit,
+  isSubmitting,
   message,
 }: {
   isOpen: boolean
   handleClose: () => void
-  onLaunch: () => void
+  handleSubmit: () => void
+  isSubmitting: boolean
   message?: string
 }) => {
   return (
@@ -26,8 +28,14 @@ const ConfirmLaunch = ({
       </div>
       <div className={Classes.DIALOG_FOOTER}>
         <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          <FormButton onClick={handleClose}>Close Without Launching</FormButton>
-          <FormButton intent={Intent.PRIMARY} onClick={onLaunch}>
+          <FormButton disabled={isSubmitting} onClick={handleClose}>
+            Cancel
+          </FormButton>
+          <FormButton
+            intent={Intent.PRIMARY}
+            onClick={handleSubmit}
+            loading={isSubmitting}
+          >
             Launch Audit
           </FormButton>
         </div>

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
@@ -258,7 +258,7 @@ describe('Audit Setup > Review & Launch', () => {
       const launchButton = screen.getByText('Launch Audit')
       userEvent.click(launchButton)
       await screen.findByText('Are you sure you want to launch the audit?')
-      const cancelLaunchButton = screen.getByText('Close Without Launching')
+      const cancelLaunchButton = screen.getByText('Cancel')
       userEvent.click(cancelLaunchButton)
       await waitFor(() => expect(refreshMock).not.toHaveBeenCalled())
     })

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
@@ -193,7 +193,10 @@ const Progress: React.FC<IProps> = ({
           ),
       }
     )
-    if (jurisdictions[0].currentRoundStatus!.numBatchesAudited !== undefined) {
+    if (
+      jurisdictions[0].currentRoundStatus &&
+      jurisdictions[0].currentRoundStatus.numBatchesAudited !== undefined
+    ) {
       columns.push({
         Header: 'Batches Audited',
         accessor: ({ currentRoundStatus: s }) =>


### PR DESCRIPTION
- Fix a bug on the audit progress screen where it would crash right
after launching the audit since the jurisdiction data hadn't been
refreshed yet (so currentRoundStatus wasn't populated yet)
- Add a spinner to the launch button until the request finishes
- Change the "Close without launching" button to just say "Cancel" (more
conventional language) and disable it while launching