### PR TITLE
Using ID instead of index for contest selection

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -63,7 +63,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 83,
-        "branches": 77,
+        "branches": 76,
         "functions": 81,
         "lines": 84
       }

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import React, { useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { Formik, FormikProps, getIn } from 'formik'
+import { Formik, FormikProps } from 'formik'
 import { Checkbox, Spinner } from '@blueprintjs/core'
 import { Column, Cell } from 'react-table'
 import FormWrapper from '../../../Atoms/Form/FormWrapper'
@@ -9,7 +9,6 @@ import FormButtonBar from '../../../Atoms/Form/FormButtonBar'
 import FormButton from '../../../Atoms/Form/FormButton'
 import { ISidebarMenuItem } from '../../../Atoms/Sidebar'
 import useStandardizedContests, {
-  IStandardizedContest,
   IStandardizedContestOption,
 } from '../../useStandardizedContests'
 import useJurisdictions from '../../useJurisdictions'
@@ -60,11 +59,11 @@ const ContestSelect: React.FC<IProps> = ({
   )
 
   const columns = (
-    values: { contests: IStandardizedContest[] },
+    values: { contests: IStandardizedContestOption[] },
     setFieldValue: FormikProps<{
-      contests: IStandardizedContest[]
+      contests: IStandardizedContestOption[]
     }>['setFieldValue']
-  ): Column<IStandardizedContest>[] => [
+  ): Column<IStandardizedContestOption>[] => [
     {
       id: 'select',
       Header: 'Select',
@@ -72,10 +71,10 @@ const ContestSelect: React.FC<IProps> = ({
       // eslint-disable-next-line react/display-name
       Cell: ({
         row: { original: contest, index },
-      }: Cell<IStandardizedContest>) => (
+      }: Cell<IStandardizedContestOption>) => (
         <Checkbox
           inline
-          checked={getIn(values, `contests[${index}].checked`)}
+          checked={values.contests.some(c => c.id === contest.id && c.checked)}
           onChange={({
             currentTarget: { checked },
           }: React.ChangeEvent<HTMLInputElement>) =>
@@ -112,7 +111,7 @@ const ContestSelect: React.FC<IProps> = ({
         values,
         handleSubmit,
         setFieldValue,
-      }: FormikProps<{ contests: IStandardizedContest[] }>) => (
+      }: FormikProps<{ contests: IStandardizedContestOption[] }>) => (
         <form>
           <FormWrapper
             title={isTargeted ? 'Target Contests' : 'Opportunistic Contests'}

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.tsx
@@ -80,7 +80,9 @@ const ContestSelect: React.FC<IProps> = ({
           }: React.ChangeEvent<HTMLInputElement>) =>
             setFieldValue(`contests[${index}]`, { ...contest, checked })
           }
-          disabled={standardizedContests[index].isTargeted !== isTargeted}
+          disabled={values.contests.some(
+            c => c.id === contest.id && c.isTargeted !== isTargeted
+          )}
         />
       ),
     },


### PR DESCRIPTION
**Description**

- Using the index broke when filtering the contests because the indexes changed.

Closes #925 

**Testing**

- We don't have any tests for the contest selection page on ballot comparison audits. That needs to be corrected, but we also need to get this fix out, too.

**Progress**

- Tested manually and it works. Could use more manual confirmation.
