### PR TITLE
Set session.permanent on login

### DIFF
--- a/server/auth/lib.py
+++ b/server/auth/lib.py
@@ -30,6 +30,7 @@ _USER = "_user"
 
 def set_loggedin_user(user_type: UserType, user_key: str):
     session[_USER] = {"type": user_type, "key": user_key}
+    session.permanent = True
 
 
 def get_loggedin_user() -> Union[Tuple[UserType, str], Tuple[None, None]]:
@@ -51,6 +52,7 @@ def clear_loggedin_user():
 ## to re-login
 def set_superadmin():
     session[_SUPERADMIN] = True  # pragma: no cover
+    session.permanent = True
 
 
 def clear_superadmin():  # pragma: no cover

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -46,6 +46,7 @@ def set_logged_in_user(
 ):
     with client.session_transaction() as session:  # type: ignore
         session[_USER] = {"type": user_type, "key": user_key}
+        session.permanent = True
 
 
 def clear_logged_in_user(client: FlaskClient):
@@ -56,6 +57,7 @@ def clear_logged_in_user(client: FlaskClient):
 def set_superadmin(client: FlaskClient):
     with client.session_transaction() as session:  # type: ignore
         session[_SUPERADMIN] = True
+        session.permanent = True
 
 
 def clear_superadmin(client: FlaskClient):


### PR DESCRIPTION
This ensures that the session expiration will actually be refreshed each
request. We mistakenly thought that setting the permanent session
lifetime config parameter turned on this behavior, but you also need to
set it on the session on login.