### PR TITLE
Expire session based on inactivity or lifetime

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from urllib.parse import urlparse
 from flask import Flask
 from flask_talisman import Talisman
@@ -42,7 +41,6 @@ T = Talisman(
     },
 )
 app.secret_key = SESSION_SECRET
-app.permanent_session_lifetime = timedelta(hours=5)
 
 init_db()
 

--- a/server/config.py
+++ b/server/config.py
@@ -1,9 +1,8 @@
 import os
 import logging
 from typing import Tuple
+from datetime import timedelta
 
-###
-###
 
 DEVELOPMENT_ENVS = ("development", "test")
 
@@ -105,6 +104,11 @@ def read_session_secret() -> str:
 
 
 SESSION_SECRET = read_session_secret()
+
+# Max time a session can be used after it's created
+SESSION_LIFETIME = timedelta(hours=8)
+# Max time a session can be used after the last request
+SESSION_INACTIVITY_TIMEOUT = timedelta(hours=1)
 
 
 def read_http_origin() -> str:

--- a/server/superadmin.py
+++ b/server/superadmin.py
@@ -1,4 +1,4 @@
-from flask import render_template, redirect, request, Blueprint
+from flask import render_template, redirect, request, Blueprint, session
 from werkzeug.exceptions import Forbidden
 
 from .models import *  # pylint: disable=wildcard-import
@@ -38,7 +38,7 @@ def superadmin_jurisdictions():
 @restrict_access_superadmin
 def superadmin_auditadmin_login():
     user_email = request.form["email"]
-    set_loggedin_user(UserType.AUDIT_ADMIN, user_email)
+    set_loggedin_user(session, UserType.AUDIT_ADMIN, user_email, from_superadmin=True)
     return redirect("/")
 
 
@@ -48,7 +48,9 @@ def superadmin_auditadmin_login():
 @restrict_access_superadmin
 def superadmin_jurisdictionadmin_login():
     user_email = request.form["email"]
-    set_loggedin_user(UserType.JURISDICTION_ADMIN, user_email)
+    set_loggedin_user(
+        session, UserType.JURISDICTION_ADMIN, user_email, from_superadmin=True
+    )
     return redirect("/")
 
 

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -5,11 +5,8 @@ from flask.testing import FlaskClient
 from werkzeug.wrappers import Response
 from sqlalchemy.exc import IntegrityError
 
-from ..auth.lib import (
-    UserType,
-    _USER,
-    _SUPERADMIN,
-)
+from ..auth.lib import UserType
+from ..auth import lib as auth_lib
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from ..api.audit_boards import end_round
@@ -42,26 +39,28 @@ def assert_ok(rv: Response):
 
 
 def set_logged_in_user(
-    client: FlaskClient, user_type: UserType, user_key=DEFAULT_AA_EMAIL
+    client: FlaskClient,
+    user_type: UserType,
+    user_key=DEFAULT_AA_EMAIL,
+    from_superadmin=False,
 ):
     with client.session_transaction() as session:  # type: ignore
-        session[_USER] = {"type": user_type, "key": user_key}
+        auth_lib.set_loggedin_user(session, user_type, user_key, from_superadmin)
 
 
 def clear_logged_in_user(client: FlaskClient):
     with client.session_transaction() as session:  # type: ignore
-        session[_USER] = None
+        auth_lib.clear_loggedin_user(session)
 
 
 def set_superadmin(client: FlaskClient):
     with client.session_transaction() as session:  # type: ignore
-        session[_SUPERADMIN] = True
+        auth_lib.set_superadmin(session)
 
 
 def clear_superadmin(client: FlaskClient):
     with client.session_transaction() as session:  # type: ignore
-        if _SUPERADMIN in session:
-            del session[_SUPERADMIN]
+        auth_lib.clear_superadmin(session)
 
 
 def create_user(email=DEFAULT_AA_EMAIL) -> User:


### PR DESCRIPTION
Since Flask's permanent session feature only supports one timeout, we build our own expiration scheme on top of the session.

The session has two fields, _created_at (set on login) and _last_request_at (set on request, only if authorization is successful). We check these fields and corresponding timeouts every request when authorizing.

There's a small wrinkle for superadmins: since they can log in as other users, we ensure _created_at doesn't get set when they log in as other users, since that would allow someone with a superadmin cookie to keep the cookie alive by logging in as other users repeatedly.

We also update the test helpers for auth to use the actual session manipulation code rather than try to replicate it, since it's getting more complex.