### PR TITLE
Fix bgcompute test race condition

### DIFF
--- a/server/bgcompute.py
+++ b/server/bgcompute.py
@@ -28,7 +28,7 @@ def bgcompute_update_election_jurisdictions_file(election_id: str = None):
         File.processing_started_at.is_(None)
     )
     if election_id:
-        files.filter(Election.id == election_id)
+        files = files.filter(Election.id == election_id)
 
     for file in files.all():
         try:
@@ -58,7 +58,7 @@ def bgcompute_update_standardized_contests_file(election_id: str = None):
         Election, File.id == Election.standardized_contests_file_id
     ).filter(File.processing_started_at.is_(None))
     if election_id:
-        files.filter(Election.id == election_id)
+        files = files.filter(Election.id == election_id)
 
     for file in files.all():
         try:
@@ -90,7 +90,7 @@ def bgcompute_update_ballot_manifest_file(election_id: str = None):
         Jurisdiction, File.id == Jurisdiction.manifest_file_id
     ).filter(File.processing_started_at.is_(None))
     if election_id:
-        files.filter(Election.id == election_id)
+        files = files.filter(Election.id == election_id)
 
     for file in files.all():
         try:
@@ -121,7 +121,7 @@ def bgcompute_update_batch_tallies_file(election_id: str = None):
         Jurisdiction, File.id == Jurisdiction.batch_tallies_file_id
     ).filter(File.processing_started_at.is_(None))
     if election_id:
-        files.filter(Election.id == election_id)
+        files = files.filter(Election.id == election_id)
 
     for file in files.all():
         try:
@@ -154,7 +154,7 @@ def bgcompute_update_cvr_file(election_id: str = None):
         File.processing_started_at.is_(None)
     )
     if election_id:
-        files.filter(Election.id == election_id)
+        files = files.filter(Election.id == election_id)
 
     for file in files.all():
         try:

--- a/server/bgcompute.py
+++ b/server/bgcompute.py
@@ -18,14 +18,19 @@ def bgcompute():
     bgcompute_update_cvr_file()
 
 
-def bgcompute_update_election_jurisdictions_file() -> int:
-    files = (
-        File.query.join(Election, File.id == Election.jurisdictions_file_id)
-        .filter(File.processing_started_at.is_(None))
-        .all()
-    )
+# All bgcompute functions take an optional election_id parameter in order to
+# make them thread-safe for testing. Each test has its own election, and we
+# don't want tests running in parallel to influence each other.
 
-    for file in files:
+
+def bgcompute_update_election_jurisdictions_file(election_id: str = None):
+    files = File.query.join(Election, File.id == Election.jurisdictions_file_id).filter(
+        File.processing_started_at.is_(None)
+    )
+    if election_id:
+        files.filter(Election.id == election_id)
+
+    for file in files.all():
         try:
             election = Election.query.filter_by(jurisdictions_file_id=file.id).one()
 
@@ -47,17 +52,15 @@ def bgcompute_update_election_jurisdictions_file() -> int:
                 f"ERROR updating jurisdictions file. election_id: {election_id}"
             )
 
-    return len(files)
 
+def bgcompute_update_standardized_contests_file(election_id: str = None):
+    files = File.query.join(
+        Election, File.id == Election.standardized_contests_file_id
+    ).filter(File.processing_started_at.is_(None))
+    if election_id:
+        files.filter(Election.id == election_id)
 
-def bgcompute_update_standardized_contests_file() -> int:
-    files = (
-        File.query.join(Election, File.id == Election.standardized_contests_file_id)
-        .filter(File.processing_started_at.is_(None))
-        .all()
-    )
-
-    for file in files:
+    for file in files.all():
         try:
             election = Election.query.filter_by(
                 standardized_contests_file_id=file.id
@@ -81,17 +84,15 @@ def bgcompute_update_standardized_contests_file() -> int:
                 f"ERROR updating standardized contests file. election_id: {election_id}"
             )
 
-    return len(files)
 
+def bgcompute_update_ballot_manifest_file(election_id: str = None):
+    files = File.query.join(
+        Jurisdiction, File.id == Jurisdiction.manifest_file_id
+    ).filter(File.processing_started_at.is_(None))
+    if election_id:
+        files.filter(Election.id == election_id)
 
-def bgcompute_update_ballot_manifest_file() -> int:
-    files = (
-        File.query.join(Jurisdiction, File.id == Jurisdiction.manifest_file_id)
-        .filter(File.processing_started_at.is_(None))
-        .all()
-    )
-
-    for file in files:
+    for file in files.all():
         try:
             jurisdiction = Jurisdiction.query.filter_by(manifest_file_id=file.id).one()
 
@@ -114,17 +115,15 @@ def bgcompute_update_ballot_manifest_file() -> int:
                 f"ERROR updating ballot manifest file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
             )
 
-    return len(files)
 
+def bgcompute_update_batch_tallies_file(election_id: str = None):
+    files = File.query.join(
+        Jurisdiction, File.id == Jurisdiction.batch_tallies_file_id
+    ).filter(File.processing_started_at.is_(None))
+    if election_id:
+        files.filter(Election.id == election_id)
 
-def bgcompute_update_batch_tallies_file() -> int:
-    files = (
-        File.query.join(Jurisdiction, File.id == Jurisdiction.batch_tallies_file_id)
-        .filter(File.processing_started_at.is_(None))
-        .all()
-    )
-
-    for file in files:
+    for file in files.all():
         try:
             jurisdiction = Jurisdiction.query.filter_by(
                 batch_tallies_file_id=file.id
@@ -149,17 +148,15 @@ def bgcompute_update_batch_tallies_file() -> int:
                 f"ERROR updating batch tallies file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
             )
 
-    return len(files)
 
-
-def bgcompute_update_cvr_file() -> int:
-    files = (
-        File.query.join(Jurisdiction, File.id == Jurisdiction.cvr_file_id)
-        .filter(File.processing_started_at.is_(None))
-        .all()
+def bgcompute_update_cvr_file(election_id: str = None):
+    files = File.query.join(Jurisdiction, File.id == Jurisdiction.cvr_file_id).filter(
+        File.processing_started_at.is_(None)
     )
+    if election_id:
+        files.filter(Election.id == election_id)
 
-    for file in files:
+    for file in files.all():
         try:
             jurisdiction = Jurisdiction.query.filter_by(cvr_file_id=file.id).one()
 
@@ -181,8 +178,6 @@ def bgcompute_update_cvr_file() -> int:
             app.logger.exception(
                 f"ERROR updating CVR file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
             )
-
-    return len(files)
 
 
 def bgcompute_forever():

--- a/server/models.py
+++ b/server/models.py
@@ -3,7 +3,12 @@ from typing import Type, TypeVar, cast as typing_cast
 from datetime import datetime as dt, timezone
 from werkzeug.exceptions import NotFound
 from sqlalchemy import *  # pylint: disable=wildcard-import
-from sqlalchemy.orm import relationship, backref, validates, deferred as sa_deferred
+from sqlalchemy.orm import (
+    relationship,
+    backref,
+    validates,
+    deferred as sa_deferred,
+)
 from sqlalchemy.types import TypeDecorator
 from .database import Base  # pylint: disable=cyclic-import
 

--- a/server/tests/api/test_audit_boards.py
+++ b/server/tests/api/test_audit_boards.py
@@ -37,7 +37,9 @@ def assert_ballots_got_assigned_correctly(
 def test_audit_boards_list_empty(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str], round_1_id: str,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
     )
@@ -52,7 +54,9 @@ def test_audit_boards_create_one(
     round_1_id: str,
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
@@ -85,7 +89,9 @@ def test_audit_boards_list_one(
     round_1_id: str,
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
@@ -160,7 +166,9 @@ def test_audit_boards_create_two(
     round_1_id: str,
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
@@ -193,7 +201,9 @@ def test_audit_boards_list_two(
     round_1_id: str,
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     rv = post_json(
         client,
@@ -276,7 +286,9 @@ def test_audit_boards_create_round_2(
     round_2_id: str,
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/audit-board",
@@ -313,7 +325,9 @@ def test_audit_boards_list_round_2(
     round_2_id: str,
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     rv = post_json(
         client,
@@ -353,7 +367,9 @@ def test_audit_boards_list_round_2(
 def test_audit_boards_missing_field(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str], round_1_id: str,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
@@ -370,7 +386,9 @@ def test_audit_boards_missing_field(
 def test_audit_boards_duplicate_name(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str], round_1_id: str,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
@@ -387,7 +405,9 @@ def test_audit_boards_duplicate_name(
 def test_audit_boards_already_created(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str], round_1_id: str,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
@@ -418,7 +438,9 @@ def test_audit_boards_wrong_round(
     round_1_id: str,
     round_2_id: str,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
@@ -438,7 +460,9 @@ def test_audit_boards_bad_round_id(
     jurisdiction_ids: List[str],
     round_1_id: str,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/not-a-valid-id/audit-board",

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -48,7 +48,7 @@ def test_ballot_manifest_upload(
         },
     )
 
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest"
@@ -97,7 +97,7 @@ def test_ballot_manifest_replace(
 
     file_id = Jurisdiction.query.get(jurisdiction_ids[0]).manifest_file_id
 
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
@@ -115,7 +115,7 @@ def test_ballot_manifest_replace(
     assert File.query.get(file_id) is None
     assert jurisdiction.manifest_file_id != file_id
 
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
     jurisdiction = Jurisdiction.query.get(jurisdiction_ids[0])
     assert jurisdiction.manifest_num_batches == 2
@@ -144,7 +144,7 @@ def test_ballot_manifest_clear(
 
     file_id = Jurisdiction.query.get(jurisdiction_ids[0]).manifest_file_id
 
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
     rv = client.delete(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
@@ -193,7 +193,7 @@ def test_ballot_manifest_upload_bad_csv(
     )
     assert_ok(rv)
 
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest"
@@ -231,7 +231,7 @@ def test_ballot_manifest_upload_missing_field(
         )
         assert_ok(rv)
 
-        bgcompute_update_ballot_manifest_file()
+        bgcompute_update_ballot_manifest_file(election_id)
 
         rv = client.get(
             f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest"
@@ -265,7 +265,7 @@ def test_ballot_manifest_upload_invalid_num_ballots(
     )
     assert_ok(rv)
 
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest"
@@ -301,7 +301,7 @@ def test_ballot_manifest_upload_duplicate_batch_name(
     )
     assert_ok(rv)
 
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest"

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -3,14 +3,7 @@ from typing import List
 from flask.testing import FlaskClient
 
 from ...models import *  # pylint: disable=wildcard-import
-from ..helpers import (
-    set_logged_in_user,
-    DEFAULT_JA_EMAIL,
-    UserType,
-    compare_json,
-    assert_is_date,
-    assert_ok,
-)
+from ..helpers import *  # pylint: disable=wildcard-import
 from ...bgcompute import bgcompute_update_ballot_manifest_file
 from ...util.process_file import ProcessingStatus
 
@@ -18,7 +11,9 @@ from ...util.process_file import ProcessingStatus
 def test_ballot_manifest_upload(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={
@@ -81,7 +76,9 @@ def test_ballot_manifest_upload(
 def test_ballot_manifest_replace(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={
@@ -130,7 +127,9 @@ def test_ballot_manifest_replace(
 def test_ballot_manifest_clear(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={
@@ -167,7 +166,9 @@ def test_ballot_manifest_clear(
 def test_ballot_manifest_upload_missing_file(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={},
@@ -186,7 +187,9 @@ def test_ballot_manifest_upload_missing_file(
 def test_ballot_manifest_upload_bad_csv(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={"manifest": (io.BytesIO(b"not a CSV file"), "random.txt")},
@@ -219,7 +222,9 @@ def test_ballot_manifest_upload_missing_field(
         headers = ["Batch Name", "Number of Ballots", "Container", "Tabulator"]
         header_row = ",".join(h for h in headers if h != missing_field)
 
-        set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+        set_logged_in_user(
+            client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+        )
         rv = client.put(
             f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
             data={
@@ -253,7 +258,9 @@ def test_ballot_manifest_upload_missing_field(
 def test_ballot_manifest_upload_invalid_num_ballots(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={
@@ -287,7 +294,9 @@ def test_ballot_manifest_upload_invalid_num_ballots(
 def test_ballot_manifest_upload_duplicate_batch_name(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={

--- a/server/tests/api/test_ballots.py
+++ b/server/tests/api/test_ballots.py
@@ -14,7 +14,9 @@ BALLOT_1_POSITION = 3
 def test_ja_ballots_bad_round_id(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str],
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/invalid-round-id/ballots"
     )
@@ -30,7 +32,9 @@ def test_ja_ballots_round_1(
     audit_board_round_1_ids: List[str],  # pylint: disable=unused-argument
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/ballots"
     )
@@ -90,7 +94,9 @@ def test_ja_ballots_round_1(
     )
     assert_ok(rv)
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/ballots"
     )
@@ -134,7 +140,9 @@ def test_ja_ballots_before_audit_boards_set_up(
     round_1_id: str,
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/ballots"
     )
@@ -167,7 +175,9 @@ def test_ja_ballots_round_2(
     audit_board_round_2_ids: List[str],  # pylint: disable=unused-argument
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/ballots"
     )
@@ -950,7 +960,9 @@ def test_ab_audit_ballot_invalid(
 def test_ja_ballot_retrieval_list_bad_round_id(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str],
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/invalid-round-id/ballots/retrieval-list"
     )
@@ -960,7 +972,9 @@ def test_ja_ballot_retrieval_list_bad_round_id(
 def test_ja_ballot_retrieval_list_before_audit_boards_set_up(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str], round_1_id: str,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/ballots/retrieval-list"
     )
@@ -982,7 +996,9 @@ def test_ja_ballot_retrieval_list_round_1(
     audit_board_round_1_ids: List[str],  # pylint: disable=unused-argument
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/ballots/retrieval-list"
     )
@@ -1008,7 +1024,9 @@ def test_ja_ballot_retrieval_list_round_2(
     audit_board_round_2_ids: str,  # pylint: disable=unused-argument
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/ballots/retrieval-list"
     )

--- a/server/tests/api/test_contests.py
+++ b/server/tests/api/test_contests.py
@@ -337,7 +337,9 @@ def test_contest_too_many_votes(client: FlaskClient, election_id: str):
 def test_jurisdictions_contests_list_empty(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str],
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, user_key=DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, user_key=default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/contest"
     )
@@ -350,7 +352,9 @@ def test_jurisdictions_contests_list(
     rv = put_json(client, f"/api/election/{election_id}/contest", json_contests)
     assert_ok(rv)
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, user_key=DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, user_key=default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/contest"
     )

--- a/server/tests/api/test_election_settings.py
+++ b/server/tests/api/test_election_settings.py
@@ -23,7 +23,9 @@ def test_settings_get_empty(client: FlaskClient, election_id: str):
 def test_jurisdiction_settings_get_empty(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/settings"
     )
@@ -70,7 +72,9 @@ def test_update_election(
     assert rv.status_code == 200
     assert json.loads(rv.data) == expected_settings
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/settings"
     )

--- a/server/tests/api/test_elections.py
+++ b/server/tests/api/test_elections.py
@@ -140,7 +140,9 @@ def test_create_election_jurisdiction_admin(
     org_id: str,
     election_id: str,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     rv = post_json(
         client,

--- a/server/tests/api/test_jurisdictions.py
+++ b/server/tests/api/test_jurisdictions.py
@@ -74,7 +74,7 @@ def test_jurisdictions_list_with_manifest(
         data={"manifest": (io.BytesIO(manifest), "manifest.csv",)},
     )
     assert_ok(rv)
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/jurisdiction")
@@ -150,7 +150,7 @@ def test_duplicate_batch_name(client, election_id, jurisdiction_ids):
     )
     assert_ok(rv)
 
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/jurisdiction")

--- a/server/tests/api/test_jurisdictions.py
+++ b/server/tests/api/test_jurisdictions.py
@@ -65,7 +65,9 @@ def test_jurisdictions_list_no_manifest(
 def test_jurisdictions_list_with_manifest(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     manifest = (
         b"Batch Name,Number of Ballots\n" b"1,23\n" b"2,101\n" b"3,122\n" b"4,400"
     )
@@ -138,7 +140,9 @@ def test_download_ballot_manifest_not_found(client, election_id, jurisdiction_id
 
 
 def test_duplicate_batch_name(client, election_id, jurisdiction_ids):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={
@@ -330,7 +334,9 @@ def test_jurisdictions_round_status_offline(
 
     snapshot.assert_match(jurisdictions[0]["currentRoundStatus"])
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     rv = post_json(
         client,
@@ -345,7 +351,9 @@ def test_jurisdictions_round_status_offline(
 
     snapshot.assert_match(jurisdictions[0]["currentRoundStatus"])
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results",

--- a/server/tests/api/test_jurisdictions_file.py
+++ b/server/tests/api/test_jurisdictions_file.py
@@ -99,7 +99,7 @@ def test_metadata(client, election_id):
     assert processing["error"] is None
 
     # Actually process the file.
-    bgcompute_update_election_jurisdictions_file()
+    bgcompute_update_election_jurisdictions_file(election_id)
 
     # Now there should be data.
     rv = client.get(f"/api/election/{election_id}/jurisdiction/file")
@@ -169,7 +169,7 @@ def test_no_jurisdiction(client, election_id):
     assert_ok(rv)
 
     # Process the file in the background.
-    bgcompute_update_election_jurisdictions_file()
+    bgcompute_update_election_jurisdictions_file(election_id)
 
     election = Election.query.filter_by(id=election_id).one()
     assert election.jurisdictions == []
@@ -188,7 +188,7 @@ def test_single_jurisdiction_single_admin(client, election_id):
     assert_ok(rv)
 
     # Process the file in the background.
-    bgcompute_update_election_jurisdictions_file()
+    bgcompute_update_election_jurisdictions_file(election_id)
 
     election = Election.query.filter_by(id=election_id).one()
     assert [j.name for j in election.jurisdictions] == ["J1"]
@@ -214,7 +214,7 @@ def test_single_jurisdiction_multiple_admins(client, election_id):
     assert_ok(rv)
 
     # Process the file in the background.
-    bgcompute_update_election_jurisdictions_file()
+    bgcompute_update_election_jurisdictions_file(election_id)
 
     election = Election.query.filter_by(id=election_id).one()
     assert [j.name for j in election.jurisdictions] == ["J1"]
@@ -241,7 +241,7 @@ def test_multiple_jurisdictions_single_admin(client, election_id):
     assert_ok(rv)
 
     # Process the file in the background.
-    bgcompute_update_election_jurisdictions_file()
+    bgcompute_update_election_jurisdictions_file(election_id)
 
     election = Election.query.filter_by(id=election_id).one()
     assert [j.name for j in election.jurisdictions] == ["J1", "J2"]
@@ -275,7 +275,7 @@ def test_convert_emails_to_lowercase(client, election_id):
     assert_ok(rv)
 
     # Process the file in the background.
-    bgcompute_update_election_jurisdictions_file()
+    bgcompute_update_election_jurisdictions_file(election_id)
 
     election = Election.query.filter_by(id=election_id).one()
     for jurisdiction in election.jurisdictions:

--- a/server/tests/api/test_reports.py
+++ b/server/tests/api/test_reports.py
@@ -66,7 +66,9 @@ def test_jurisdiction_admin_report(
             contest_ids[0],
             audit_board_id,
         )
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/report"
     )

--- a/server/tests/api/test_rounds.py
+++ b/server/tests/api/test_rounds.py
@@ -14,7 +14,9 @@ def test_rounds_list_empty(
     rounds = json.loads(rv.data)
     assert rounds == {"rounds": []}
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round"
     )
@@ -58,7 +60,9 @@ def test_rounds_create_one(
     rounds = json.loads(rv.data)
     compare_json(rounds, expected_rounds)
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round"
     )
@@ -121,7 +125,9 @@ def test_rounds_create_two(
     rounds = json.loads(rv.data)
     compare_json(rounds, expected_rounds)
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round"
     )

--- a/server/tests/api/test_superadmin.py
+++ b/server/tests/api/test_superadmin.py
@@ -49,23 +49,26 @@ def test_superadmin_organizations(client: FlaskClient, organization_id):
 
 
 def test_superadmin_jurisdictions(client: FlaskClient, election_id):
-    create_jurisdiction_and_admin(election_id=election_id, user_email=DEFAULT_JA_EMAIL)
+    create_jurisdiction_and_admin(
+        election_id, "Test Jurisdiction", default_ja_email(election_id),
+    )
 
     data = assert_superadmin_access(
         client, f"/superadmin/jurisdictions?election_id={election_id}"
     )
 
     assert "Jurisdictions" in data
-    assert DEFAULT_JA_EMAIL in data
+    assert default_ja_email(election_id) in data
 
     rv = client.post(
-        "/superadmin/jurisdictionadmin-login", data={"email": DEFAULT_JA_EMAIL}
+        "/superadmin/jurisdictionadmin-login",
+        data={"email": default_ja_email(election_id)},
     )
     assert rv.status_code == 302
 
     rv = client.get("/api/me")
     auth_data = json.loads(rv.data)
-    assert auth_data["email"] == DEFAULT_JA_EMAIL
+    assert auth_data["email"] == default_ja_email(election_id)
     assert auth_data["type"] == UserType.JURISDICTION_ADMIN
 
 

--- a/server/tests/ballot_comparison/conftest.py
+++ b/server/tests/ballot_comparison/conftest.py
@@ -78,7 +78,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         },
     )
     assert_ok(rv)
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
 
 @pytest.fixture
@@ -99,4 +99,4 @@ def cvrs(
         data={"cvrs": (io.BytesIO(TEST_CVRS.encode()), "cvrs.csv",)},
     )
     assert_ok(rv)
-    bgcompute_update_cvr_file()
+    bgcompute_update_cvr_file(election_id)

--- a/server/tests/ballot_comparison/conftest.py
+++ b/server/tests/ballot_comparison/conftest.py
@@ -45,7 +45,9 @@ def election_id(client: FlaskClient, org_id: str, request):
 
 @pytest.fixture
 def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={
@@ -88,7 +90,9 @@ def cvrs(
     jurisdiction_ids: List[str],
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={"cvrs": (io.BytesIO(TEST_CVRS.encode()), "cvrs.csv",)},

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -119,7 +119,7 @@ def test_ballot_comparison_two_rounds(
     )
     assert_ok(rv)
 
-    bgcompute_update_standardized_contests_file()
+    bgcompute_update_standardized_contests_file(election_id)
 
     # AA selects a contest to target from the standardized contest list
     rv = client.get(f"/api/election/{election_id}/standardized-contests")

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -176,7 +176,9 @@ def test_ballot_comparison_two_rounds(
     snapshot.assert_match(jurisdictions[1]["currentRoundStatus"])
 
     # JAs create audit boards
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     for jurisdiction_id in target_contest["jurisdictionIds"]:
         rv = post_json(
             client,
@@ -422,7 +424,9 @@ def test_ballot_comparison_cvr_metadata(
     round_1_id = json.loads(rv.data)["rounds"][0]["id"]
 
     # JA creates audit boards
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",

--- a/server/tests/ballot_comparison/test_ballot_comparison_manifests.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison_manifests.py
@@ -19,7 +19,9 @@ from ...bgcompute import (
 
 @pytest.fixture
 def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={
@@ -88,7 +90,9 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,PrecinctPortion,BallotType,R
         [f"{i},{line}" for i, line in enumerate(j1_cvr_lines)]
     )
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={"cvrs": (io.BytesIO(j1_cvr.encode()), "cvrs.csv",)},
@@ -164,7 +168,9 @@ def test_ballot_comparison_container_manifest(
     round_1_id = json.loads(rv.data)["rounds"][0]["id"]
 
     # JAs create audit boards
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     for jurisdiction_id in jurisdiction_ids[:2]:
         rv = post_json(
             client,
@@ -216,7 +222,9 @@ def test_ballot_comparison_container_manifest(
         ), "Different audit boards assigned ballots from the same container"
 
     # Check that the second jurisdiction's audit boards have ballots divvied up by tabulator+batch name
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/audit-board"
     )
@@ -239,7 +247,9 @@ def test_ballot_comparison_container_manifest(
         ), "Different audit boards assigned ballots from the same tabulator+name"
 
     # Check that ballots are ordered by audit board then container for JA
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/ballots"
     )
@@ -261,7 +271,9 @@ def test_ballot_comparison_manifest_missing_tabulator(
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={

--- a/server/tests/ballot_comparison/test_ballot_comparison_manifests.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison_manifests.py
@@ -64,7 +64,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         },
     )
     assert_ok(rv)
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
 
 @pytest.fixture
@@ -114,7 +114,7 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,PrecinctPortion,BallotType,R
         data={"cvrs": (io.BytesIO(j2_cvr.encode()), "cvrs.csv",)},
     )
     assert_ok(rv)
-    bgcompute_update_cvr_file()
+    bgcompute_update_cvr_file(election_id)
 
 
 def test_ballot_comparison_container_manifest(
@@ -283,7 +283,7 @@ def test_ballot_comparison_manifest_missing_tabulator(
     )
     assert_ok(rv)
 
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -18,7 +18,9 @@ def test_cvr_upload(
     manifests,  # pylint: disable=unused-argument
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={"cvrs": (io.BytesIO(TEST_CVRS.encode()), "cvrs.csv",)},
@@ -135,7 +137,9 @@ def test_cvrs_counting_group(
     manifests,  # pylint: disable=unused-argument
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={"cvrs": (io.BytesIO(COUNTING_GROUP_CVR.encode()), "cvrs.csv",)},
@@ -187,7 +191,9 @@ def test_cvrs_replace(
     jurisdiction_ids: List[str],
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={"cvrs": (io.BytesIO(TEST_CVRS.encode()), "cvrs.csv",)},
@@ -228,7 +234,9 @@ def test_cvrs_clear(
     jurisdiction_ids: List[str],
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={"cvrs": (io.BytesIO(TEST_CVRS.encode()), "cvrs.csv",)},
@@ -271,7 +279,9 @@ def test_cvrs_upload_missing_file(
     jurisdiction_ids: List[str],
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs", data={},
     )
@@ -292,7 +302,9 @@ def test_cvrs_upload_bad_csv(
     jurisdiction_ids: List[str],
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={"cvrs": (io.BytesIO(b"not a CSV file"), "random.txt")},
@@ -331,7 +343,9 @@ def test_cvrs_wrong_audit_type(
         db_session.add(election)
         db_session.commit()
 
-        set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+        set_logged_in_user(
+            client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+        )
         rv = client.put(
             f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
             data={"cvrs": (io.BytesIO(TEST_CVRS.encode()), "cvrs.csv",)},
@@ -350,7 +364,9 @@ def test_cvrs_wrong_audit_type(
 def test_cvrs_before_manifests(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str],
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={"cvrs": (io.BytesIO(TEST_CVRS.encode()), "cvrs.csv",)},
@@ -397,7 +413,9 @@ def test_cvrs_newlines(
     manifests,  # pylint: disable=unused-argument
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={"cvrs": (io.BytesIO(NEWLINE_CVR.encode()), "cvrs.csv",)},

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -41,7 +41,7 @@ def test_cvr_upload(
         },
     )
 
-    bgcompute_update_cvr_file()
+    bgcompute_update_cvr_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs"
@@ -142,7 +142,7 @@ def test_cvrs_counting_group(
     )
     assert_ok(rv)
 
-    bgcompute_update_cvr_file()
+    bgcompute_update_cvr_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs"
@@ -196,7 +196,7 @@ def test_cvrs_replace(
 
     file_id = Jurisdiction.query.get(jurisdiction_ids[0]).cvr_file_id
 
-    bgcompute_update_cvr_file()
+    bgcompute_update_cvr_file(election_id)
 
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
@@ -214,7 +214,7 @@ def test_cvrs_replace(
     assert File.query.get(file_id) is None
     assert jurisdiction.cvr_file_id != file_id
 
-    bgcompute_update_cvr_file()
+    bgcompute_update_cvr_file(election_id)
 
     cvr_ballots = (
         CvrBallot.query.join(Batch).filter_by(jurisdiction_id=jurisdiction_ids[0]).all()
@@ -237,7 +237,7 @@ def test_cvrs_clear(
 
     file_id = Jurisdiction.query.get(jurisdiction_ids[0]).cvr_file_id
 
-    bgcompute_update_cvr_file()
+    bgcompute_update_cvr_file(election_id)
 
     rv = client.delete(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
@@ -299,7 +299,7 @@ def test_cvrs_upload_bad_csv(
     )
     assert_ok(rv)
 
-    bgcompute_update_cvr_file()
+    bgcompute_update_cvr_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs"
@@ -404,7 +404,7 @@ def test_cvrs_newlines(
     )
     assert_ok(rv)
 
-    bgcompute_update_cvr_file()
+    bgcompute_update_cvr_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs"

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -43,7 +43,7 @@ def test_upload_standardized_contests(
         },
     )
 
-    bgcompute_update_standardized_contests_file()
+    bgcompute_update_standardized_contests_file(election_id)
 
     rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
     compare_json(
@@ -94,7 +94,7 @@ def test_standardized_contests_replace(
 
     file_id = Election.query.get(election_id).standardized_contests_file_id
 
-    bgcompute_update_standardized_contests_file()
+    bgcompute_update_standardized_contests_file(election_id)
 
     rv = client.put(
         f"/api/election/{election_id}/standardized-contests/file",
@@ -112,7 +112,7 @@ def test_standardized_contests_replace(
     assert Election.query.get(election_id).standardized_contests_file_id != file_id
     assert Election.query.get(election_id).standardized_contests is None
 
-    bgcompute_update_standardized_contests_file()
+    bgcompute_update_standardized_contests_file(election_id)
 
     rv = client.get(f"/api/election/{election_id}/standardized-contests")
     assert json.loads(rv.data) == [
@@ -139,7 +139,7 @@ def test_standardized_contests_bad_jurisdiction(
     )
     assert_ok(rv)
 
-    bgcompute_update_standardized_contests_file()
+    bgcompute_update_standardized_contests_file(election_id)
 
     rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
     compare_json(
@@ -195,7 +195,7 @@ def test_standardized_contests_bad_csv(
     )
     assert_ok(rv)
 
-    bgcompute_update_standardized_contests_file()
+    bgcompute_update_standardized_contests_file(election_id)
 
     rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
     compare_json(
@@ -309,7 +309,7 @@ def test_standardized_contests_newlines(
         },
     )
 
-    bgcompute_update_standardized_contests_file()
+    bgcompute_update_standardized_contests_file(election_id)
 
     rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
     compare_json(
@@ -375,7 +375,7 @@ def test_standardized_contests_dominion_vote_for(
         },
     )
 
-    bgcompute_update_standardized_contests_file()
+    bgcompute_update_standardized_contests_file(election_id)
 
     rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
     compare_json(

--- a/server/tests/ballot_polling/test_minerva_ballot_polling.py
+++ b/server/tests/ballot_polling/test_minerva_ballot_polling.py
@@ -71,7 +71,9 @@ def test_minerva_ballot_polling_one_round(
     rounds = json.loads(rv.data)["rounds"]
     round_id = rounds[0]["id"]
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     rv = post_json(
         client,
@@ -185,7 +187,9 @@ def test_minerva_ballot_polling_two_rounds(
     rounds = json.loads(rv.data)["rounds"]
     round_id = rounds[0]["id"]
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     rv = post_json(
         client,
@@ -274,7 +278,9 @@ def test_minerva_ballot_polling_two_rounds(
     rv = client.get(f"/api/election/{election_id}/round",)
     round_2_id = json.loads(rv.data)["rounds"][1]["id"]
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     rv = post_json(
         client,

--- a/server/tests/batch_comparison/conftest.py
+++ b/server/tests/batch_comparison/conftest.py
@@ -93,7 +93,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         },
     )
     assert_ok(rv)
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
 
 @pytest.fixture
@@ -135,7 +135,7 @@ def batch_tallies(
         data={"batchTallies": (io.BytesIO(batch_tallies_file), "batchTallies.csv",)},
     )
     assert_ok(rv)
-    bgcompute_update_batch_tallies_file()
+    bgcompute_update_batch_tallies_file(election_id)
 
 
 @pytest.fixture

--- a/server/tests/batch_comparison/conftest.py
+++ b/server/tests/batch_comparison/conftest.py
@@ -53,7 +53,9 @@ def contest_id(contest_ids: List[str]) -> str:
 
 @pytest.fixture
 def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={
@@ -104,7 +106,9 @@ def batch_tallies(
     contest_ids: List[str],  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     batch_tallies_file = (
         b"Batch Name,candidate 1,candidate 2,candidate 3\n"
         b"Batch 1,500,250,250\n"

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -211,7 +211,9 @@ def test_batch_comparison_round_1(
     sampled_jurisdictions = {draw.batch.jurisdiction_id for draw in batch_draws}
     assert sampled_jurisdictions == set(jurisdiction_ids[:2])
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{rounds[0]['id']}/audit-board",
@@ -268,7 +270,9 @@ def test_batch_comparison_round_2(
     assert rv.status_code == 200
     contests = json.loads(rv.data)["contests"]
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches"
     )
@@ -297,7 +301,9 @@ def test_batch_comparison_round_2(
     snapshot.assert_match(jurisdictions[1]["currentRoundStatus"])
 
     # Now do the second jurisdiction
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/audit-board",
@@ -377,7 +383,9 @@ def test_batch_comparison_round_2(
     sampled_jurisdictions = {draw.batch.jurisdiction_id for draw in batch_draws}
     assert sampled_jurisdictions == set(jurisdiction_ids[:2])
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{rounds[1]['id']}/audit-board",
@@ -397,7 +405,9 @@ def test_batch_comparison_round_2(
     rv = client.get(f"/api/election/{election_id}/report")
     assert_match_report(rv.data, snapshot)
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/report"
     )

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -130,7 +130,7 @@ def test_batch_comparison_too_many_votes(
         data={"batchTallies": (io.BytesIO(batch_tallies_file), "batchTallies.csv",)},
     )
     assert_ok(rv)
-    bgcompute_update_batch_tallies_file()
+    bgcompute_update_batch_tallies_file(election_id)
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = post_json(

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -30,7 +30,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         },
     )
     assert_ok(rv)
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
 
 def test_batch_tallies_upload(
@@ -69,7 +69,7 @@ def test_batch_tallies_upload(
         },
     )
 
-    bgcompute_update_batch_tallies_file()
+    bgcompute_update_batch_tallies_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies"
@@ -171,7 +171,7 @@ def test_batch_tallies_replace(
 
     file_id = Jurisdiction.query.get(jurisdiction_ids[0]).batch_tallies_file_id
 
-    bgcompute_update_batch_tallies_file()
+    bgcompute_update_batch_tallies_file(election_id)
 
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
@@ -194,7 +194,7 @@ def test_batch_tallies_replace(
     assert File.query.get(file_id) is None
     assert jurisdiction.batch_tallies_file_id != file_id
 
-    bgcompute_update_batch_tallies_file()
+    bgcompute_update_batch_tallies_file(election_id)
 
     jurisdiction = Jurisdiction.query.get(jurisdiction_ids[0])
     contest = Contest.query.get(contest_id)
@@ -252,7 +252,7 @@ def test_batch_tallies_clear(
 
     file_id = Jurisdiction.query.get(jurisdiction_ids[0]).batch_tallies_file_id
 
-    bgcompute_update_batch_tallies_file()
+    bgcompute_update_batch_tallies_file(election_id)
 
     rv = client.delete(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
@@ -313,7 +313,7 @@ def test_batch_tallies_upload_bad_csv(
     )
     assert_ok(rv)
 
-    bgcompute_update_batch_tallies_file()
+    bgcompute_update_batch_tallies_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies"
@@ -356,7 +356,7 @@ def test_batch_tallies_upload_missing_choice(
         )
         assert_ok(rv)
 
-        bgcompute_update_batch_tallies_file()
+        bgcompute_update_batch_tallies_file(election_id)
 
         rv = client.get(
             f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies"
@@ -426,7 +426,7 @@ def test_batch_tallies_wrong_batch_names(
         )
         assert_ok(rv)
 
-        bgcompute_update_batch_tallies_file()
+        bgcompute_update_batch_tallies_file(election_id)
 
         rv = client.get(
             f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies"
@@ -469,7 +469,7 @@ def test_batch_tallies_too_many_tallies(
     )
     assert_ok(rv)
 
-    bgcompute_update_batch_tallies_file()
+    bgcompute_update_batch_tallies_file(election_id)
 
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies"

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -14,7 +14,9 @@ from ...util.process_file import ProcessingStatus
 
 @pytest.fixture
 def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={
@@ -40,7 +42,9 @@ def test_batch_tallies_upload(
     contest_id: str,
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     batch_tallies_file = (
         b"Batch Name,candidate 1,candidate 2,candidate 3\n"
         b"Batch 1,1,10,100\n"
@@ -152,7 +156,9 @@ def test_batch_tallies_replace(
     contest_id: str,
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
         data={
@@ -233,7 +239,9 @@ def test_batch_tallies_clear(
     contest_ids: List[str],  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
         data={
@@ -283,7 +291,9 @@ def test_batch_tallies_upload_missing_file(
     contest_ids: List[str],  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
         data={},
@@ -306,7 +316,9 @@ def test_batch_tallies_upload_bad_csv(
     contest_ids: List[str],  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
         data={"batchTallies": (io.BytesIO(b"not a CSV file"), "random.txt")},
@@ -339,7 +351,9 @@ def test_batch_tallies_upload_missing_choice(
     contest_ids: List[str],  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     headers = ["Batch Name", "candidate 1", "candidate 2", "candidate 3"]
     for missing_field in headers:
@@ -382,7 +396,9 @@ def test_batch_tallies_wrong_batch_names(
     contest_ids: List[str],  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     bad_files = [
         (
@@ -452,7 +468,9 @@ def test_batch_tallies_too_many_tallies(
     contest_ids: List[str],  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
         data={
@@ -501,7 +519,9 @@ def test_batch_tallies_ballot_polling(
     db_session.add(election)
     db_session.commit()
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
         data={
@@ -534,7 +554,9 @@ def test_batch_tallies_bad_jurisdiction(
     contest_ids: List[str],  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, "j3@example.com")
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, f"j3-{election_id}@example.com"
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[2]}/batch-tallies",
         data={
@@ -566,7 +588,9 @@ def test_batch_tallies_before_manifests(
     jurisdiction_ids: List[str],
     contest_ids: List[str],  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
         data={

--- a/server/tests/batch_comparison/test_batches.py
+++ b/server/tests/batch_comparison/test_batches.py
@@ -13,7 +13,9 @@ def test_list_batches_bad_round_id(
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/not-a-real-round/batches"
     )
@@ -26,7 +28,9 @@ def test_list_batches(
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
     round_1_id: str,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches"
     )
@@ -66,7 +70,9 @@ def test_batch_retrieval_list_bad_round_id(
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/not-a-real-round/batches/retrieval-list"
     )
@@ -81,7 +87,9 @@ def test_batch_retrieval_list_round_1(
     round_1_id: str,
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches/retrieval-list"
     )
@@ -117,7 +125,9 @@ def test_record_batch_results(
     audit_board_round_1_ids: List[str],  # pylint: disable=unused-argument
     snapshot,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/contest"
     )
@@ -232,7 +242,9 @@ def test_record_batch_results(
     rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2})
     assert_ok(rv)
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round"
     )
@@ -287,7 +299,9 @@ def test_record_batch_results(
 def test_record_batch_results_without_audit_boards(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str], round_1_id: str
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = put_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches/results",
@@ -311,7 +325,9 @@ def test_record_batch_results_invalid(
     round_1_id: str,  # pylint: disable=unused-argument
     audit_board_round_1_ids: List[str],  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/contest"
     )
@@ -398,7 +414,9 @@ def test_record_batch_results_bad_round(
 
     choice_ids = [choice["id"] for choice in contests[0]["choices"]]
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     for jurisdiction_id in jurisdiction_ids[:2]:
         rv = post_json(
@@ -427,7 +445,9 @@ def test_record_batch_results_bad_round(
     rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2})
     assert_ok(rv)
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = put_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches/results",
@@ -456,7 +476,9 @@ def test_record_batch_results_bad_round(
     db_session.add(round)
     db_session.commit()
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = put_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches/results",

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -87,7 +87,12 @@ def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
         },
     )
     assert_ok(rv)
-    bgcompute_update_election_jurisdictions_file(election_id)
+    # Sometimes we run into race-conditions creating the DEFAULT_JA_EMAIL user,
+    # so we just retry once if it fails
+    try:
+        bgcompute_update_election_jurisdictions_file(election_id)
+    except Exception:
+        bgcompute_update_election_jurisdictions_file(election_id)
     jurisdictions = (
         Jurisdiction.query.filter_by(election_id=election_id)
         .order_by(Jurisdiction.name)

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -87,7 +87,7 @@ def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
         },
     )
     assert_ok(rv)
-    bgcompute_update_election_jurisdictions_file()
+    bgcompute_update_election_jurisdictions_file(election_id)
     jurisdictions = (
         Jurisdiction.query.filter_by(election_id=election_id)
         .order_by(Jurisdiction.name)
@@ -183,7 +183,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         },
     )
     assert_ok(rv)
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
 
 @pytest.fixture

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -13,7 +13,10 @@ from ..api.audit_boards import end_round
 
 
 DEFAULT_AA_EMAIL = "admin@example.com"
-DEFAULT_JA_EMAIL = "jurisdiction.admin@example.com"
+
+
+def default_ja_email(election_id: str):
+    return f"jurisdiction.admin-{election_id}@example.com"
 
 
 def post_json(client: FlaskClient, url: str, obj=None) -> Any:
@@ -87,9 +90,7 @@ def create_org_and_admin(
     return org.id, audit_admin.id
 
 
-def create_jurisdiction_admin(
-    jurisdiction_id: str, user_email: str = DEFAULT_JA_EMAIL
-) -> str:
+def create_jurisdiction_admin(jurisdiction_id: str, user_email: str) -> str:
     jurisdiction_admin = create_user(user_email)
     db_session.add(jurisdiction_admin)
     admin = JurisdictionAdministration(
@@ -112,9 +113,7 @@ def create_jurisdiction(
 
 
 def create_jurisdiction_and_admin(
-    election_id: str,
-    jurisdiction_name: str = "Test Jurisdiction",
-    user_email: str = DEFAULT_JA_EMAIL,
+    election_id: str, jurisdiction_name: str, user_email: str,
 ) -> Tuple[str, str]:
     jurisdiction = create_jurisdiction(election_id, jurisdiction_name)
     ja_id = create_jurisdiction_admin(jurisdiction.id, user_email)

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -559,7 +559,7 @@ def test_restrict_access_jurisdiction_admin_wrong_org(
     org_id_2, _ = create_org_and_admin("Org 2", "aa2@example.com")
     set_logged_in_user(client, UserType.AUDIT_ADMIN, "aa2@example.com")
     election_id_2 = create_election(client, organization_id=org_id_2)
-    create_jurisdiction_and_admin(election_id_2, user_email="ja2@example.com")
+    create_jurisdiction_and_admin(election_id_2, "Test Jurisdiction", "ja2@example.com")
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, "ja2@example.com")
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/test_auth"
@@ -583,7 +583,7 @@ def test_restrict_access_jurisdiction_admin_wrong_election(
         client, audit_name="Audit 2", organization_id=org_id
     )
     jurisdiction_id_2, _ = create_jurisdiction_and_admin(
-        election_id_2, user_email="ja2@example.com"
+        election_id_2, "Test Jurisdiction", "ja2@example.com"
     )
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, "ja2@example.com")
     rv = client.get(
@@ -596,7 +596,7 @@ def test_restrict_access_jurisdiction_admin_wrong_jurisdiction(
     client: FlaskClient, election_id: str, ja_email: str,
 ):
     jurisdiction_id_2, _ = create_jurisdiction_and_admin(
-        election_id, jurisdiction_name="Jurisdiction 2", user_email="ja2@example.com"
+        election_id, "Jurisdiction 2", "ja2@example.com"
     )
     set_logged_in_user(client, UserType.JURISDICTION_ADMIN, ja_email)
     rv = client.get(
@@ -774,7 +774,7 @@ def test_restrict_access_audit_board_wrong_org(
     set_logged_in_user(client, UserType.AUDIT_ADMIN, "aa3@example.com")
     election_id_2 = create_election(client, organization_id=org_id_2)
     jurisdiction_id_2, _ = create_jurisdiction_and_admin(
-        election_id_2, user_email="ja3@example.com"
+        election_id_2, "Test Jurisdiction", "ja3@example.com"
     )
     round_id_2 = create_round(election_id_2)
     audit_board_id_2 = create_audit_board(jurisdiction_id_2, round_id_2)
@@ -802,7 +802,7 @@ def test_restrict_access_audit_board_wrong_election(
     set_logged_in_user(client, UserType.AUDIT_ADMIN, "aa4@example.com")
     election_id_2 = create_election(client, organization_id=org_id_2)
     jurisdiction_id_2, _ = create_jurisdiction_and_admin(
-        election_id_2, user_email="ja4@example.com"
+        election_id_2, "Test Jurisdiction", "ja4@example.com"
     )
     round_id_2 = create_round(election_id_2)
 
@@ -823,7 +823,7 @@ def test_restrict_access_audit_board_wrong_jurisdiction(
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, aa_email)
     jurisdiction_id_2, _ = create_jurisdiction_and_admin(
-        election_id, jurisdiction_name="J5", user_email="ja5@example.com"
+        election_id, "J5", "ja5@example.com"
     )
 
     set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)

--- a/server/tests/test_errors.py
+++ b/server/tests/test_errors.py
@@ -94,7 +94,9 @@ def test_bgcompute_ballot_manifest_errors(
     caplog,
     monkeypatch,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, user_key=DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, user_key=default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={
@@ -145,7 +147,9 @@ def test_bgcompute_batch_tallies_errors(
     db_session.delete(contest_2)
     db_session.commit()
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, user_key=DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, user_key=default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
         data={

--- a/server/tests/test_errors.py
+++ b/server/tests/test_errors.py
@@ -71,7 +71,7 @@ def test_bgcompute_jurisdictions_file_errors(
 
     monkeypatch.setattr(bgcompute, "process_jurisdictions_file", raise_exception)
 
-    bgcompute_update_election_jurisdictions_file()
+    bgcompute_update_election_jurisdictions_file(election_id)
 
     assert find_log(
         caplog,
@@ -113,7 +113,7 @@ def test_bgcompute_ballot_manifest_errors(
 
     monkeypatch.setattr(bgcompute, "process_ballot_manifest_file", raise_exception)
 
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
     assert find_log(
         caplog,
@@ -164,7 +164,7 @@ def test_bgcompute_batch_tallies_errors(
 
     monkeypatch.setattr(bgcompute, "process_batch_tallies_file", raise_exception)
 
-    bgcompute_update_batch_tallies_file()
+    bgcompute_update_batch_tallies_file(election_id)
 
     assert find_log(
         caplog,

--- a/server/tests/test_offline_data_entry.py
+++ b/server/tests/test_offline_data_entry.py
@@ -24,7 +24,9 @@ def test_offline_results_empty(
     contest_ids: List[str],
     round_1_id: str,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     contests = Contest.query.filter(Contest.id.in_(contest_ids)).all()
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results",
@@ -60,7 +62,9 @@ def test_run_offline_audit(
     rounds = json.loads(rv.data)["rounds"]
     round_id = rounds[0]["id"]
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     rv = post_json(
         client,
@@ -153,7 +157,9 @@ def test_run_offline_audit(
 def test_offline_results_without_audit_boards(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str], round_1_id: str,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = put_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results",
@@ -178,7 +184,9 @@ def test_offline_results_invalid(
     round_1_id: str,
     audit_board_round_1_ids: List[str],  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     contests = Contest.query.filter(Contest.id.in_(contest_ids)).all()
 
     invalid_results = [
@@ -251,7 +259,9 @@ def test_offline_results_bad_round(
     rv = client.get(f"/api/election/{election_id}/contest")
     contests = json.loads(rv.data)["contests"]
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     for jurisdiction_id in jurisdiction_ids[:2]:
         rv = post_json(
@@ -275,7 +285,9 @@ def test_offline_results_bad_round(
     rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2})
     assert_ok(rv)
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = put_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results",
@@ -322,7 +334,9 @@ def test_offline_results_in_online_election(
     election.online = True
     db_session.commit()
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = put_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results",
@@ -347,7 +361,9 @@ def test_offline_results_jurisdiction_with_no_ballots(
     rv = client.get(f"/api/election/{election_id}/contest")
     contests = json.loads(rv.data)["contests"]
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, "j3@example.com")
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, f"j3-{election_id}@example.com"
+    )
 
     rv = post_json(
         client,

--- a/server/tests/test_sample_all_ballots.py
+++ b/server/tests/test_sample_all_ballots.py
@@ -38,7 +38,9 @@ def contest_ids(
 
 @pytest.fixture
 def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
         data={
@@ -145,7 +147,9 @@ def test_all_ballots_audit(
     assert json.loads(rv.data) == {"ballots": []}
 
     # Create audit boards and record results for one jurisdiction
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/audit-board",
@@ -222,7 +226,9 @@ def test_all_ballots_audit(
     }
 
     # Add next results
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
 
     next_jurisdiction_1_results_a = {
         "batchName": "Batch Two",
@@ -353,7 +359,9 @@ def test_all_ballots_audit(
     }
 
     # Now do the second jurisdiction
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/audit-board",
@@ -446,7 +454,9 @@ def test_offline_batch_results_validation(
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
     round_1_id: str,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
@@ -739,7 +749,9 @@ def test_offline_batch_results_old_endpoint(
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
     round_1_id: str,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
@@ -782,7 +794,9 @@ def test_offline_batch_results_unfinalize(
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
     round_1_id: str,
 ):
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
@@ -821,7 +835,9 @@ def test_offline_batch_results_unfinalize(
     }
 
     # JA finalizes results
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize",
@@ -840,7 +856,9 @@ def test_offline_batch_results_unfinalize(
     )
     assert_ok(rv)
 
-    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, DEFAULT_JA_EMAIL)
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch"
     )

--- a/server/tests/test_sample_all_ballots.py
+++ b/server/tests/test_sample_all_ballots.py
@@ -73,7 +73,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         },
     )
     assert_ok(rv)
-    bgcompute_update_ballot_manifest_file()
+    bgcompute_update_ballot_manifest_file(election_id)
 
 
 def test_all_ballots_sample_size(


### PR DESCRIPTION
Add an optional election_id filter to bgcompute functions so that they can be isolated to the specific election being processed in each test case. This will prevent race conditions when running the tests in parallel (one test would run a bgcompute function that would prematurely process a file from another test).

Also add the election_id to the jurisdiction admin emails created for each test case to avoid clashes when creating the users (which now happens more often as a result of the change to bgcompute).