### PR TITLE
Download standardized contests file

### DIFF
--- a/client/src/components/HomeScreen.test.tsx
+++ b/client/src/components/HomeScreen.test.tsx
@@ -124,7 +124,6 @@ describe('Home screen', () => {
       ...setupScreenCalls,
       aaApiCalls.getSettings(auditSettings.blank),
       aaApiCalls.getJurisdictionFile,
-      aaApiCalls.getStandardizedContestsFile,
       aaApiCalls.getJurisdictionFile,
       aaApiCalls.getRounds([]),
       ...setupScreenCalls,
@@ -137,7 +136,6 @@ describe('Home screen', () => {
       aaApiCalls.getRounds([]),
       aaApiCalls.getSettings(auditSettings.blank),
       aaApiCalls.getJurisdictionFile,
-      aaApiCalls.getStandardizedContestsFile,
       ...setupScreenCalls,
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -204,7 +202,6 @@ describe('Home screen', () => {
       ...setupScreenCalls,
       aaApiCalls.getSettings(auditSettings.blank),
       aaApiCalls.getJurisdictionFile,
-      aaApiCalls.getStandardizedContestsFile,
       aaApiCalls.getJurisdictionFile,
       aaApiCalls.getRounds([]),
       ...setupScreenCalls,

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Participants/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Participants/index.test.tsx
@@ -99,7 +99,6 @@ describe('Audit Setup > Participants', () => {
     const expectedCalls = [
       aaApiCalls.getSettings(auditSettings.blank),
       apiCalls.getJurisdictionsFile(fileMocks.empty),
-      apiCalls.getStandardizedContestsFile(fileMocks.empty),
       apiCalls.putJurisdictionsFile(jurisdictionFile),
       apiCalls.getJurisdictionsFile(fileMocks.processed),
       apiCalls.putJurisdictionsFile(anotherFile),

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Participants/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Participants/index.tsx
@@ -27,7 +27,7 @@ const Participants: React.FC<IProps> = ({ nextStage, refresh }: IProps) => {
   const [
     standardizedContestsFile,
     uploadStandardizedContestsFile,
-  ] = useStandardizedContestsFile(electionId)
+  ] = useStandardizedContestsFile(electionId, auditSettings)
 
   // Once the file uploads are complete, we need to notify the setupMenuItems to
   // refresh and unlock the next stage.

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
@@ -87,7 +87,9 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
                 href="/api/election/1/jurisdiction/file/csv"
                 rel="noopener noreferrer"
                 target="_blank"
-              />
+              >
+                jurisdictions.csv
+              </a>
             </td>
           </tr>
           <tr>
@@ -276,7 +278,9 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
                 href="/api/election/1/jurisdiction/file/csv"
                 rel="noopener noreferrer"
                 target="_blank"
-              />
+              >
+                jurisdictions.csv
+              </a>
             </td>
           </tr>
           <tr>
@@ -465,7 +469,9 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
                 href="/api/election/1/jurisdiction/file/csv"
                 rel="noopener noreferrer"
                 target="_blank"
-              />
+              >
+                jurisdictions.csv
+              </a>
             </td>
           </tr>
           <tr>
@@ -741,7 +747,9 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
                 href="/api/election/1/jurisdiction/file/csv"
                 rel="noopener noreferrer"
                 target="_blank"
-              />
+              >
+                jurisdictions.csv
+              </a>
             </td>
           </tr>
           <tr>
@@ -1017,7 +1025,9 @@ exports[`Audit Setup > Review & Launch renders full state with batch comparison 
                 href="/api/election/1/jurisdiction/file/csv"
                 rel="noopener noreferrer"
                 target="_blank"
-              />
+              >
+                jurisdictions.csv
+              </a>
             </td>
           </tr>
           <tr>
@@ -1293,7 +1303,9 @@ exports[`Audit Setup > Review & Launch renders full state with batch comparison 
                 href="/api/election/1/jurisdiction/file/csv"
                 rel="noopener noreferrer"
                 target="_blank"
-              />
+              >
+                jurisdictions.csv
+              </a>
             </td>
           </tr>
           <tr>
@@ -1482,7 +1494,9 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions wit
                 href="/api/election/1/jurisdiction/file/csv"
                 rel="noopener noreferrer"
                 target="_blank"
-              />
+              >
+                jurisdictions.csv
+              </a>
             </td>
           </tr>
           <tr>
@@ -1767,7 +1781,9 @@ exports[`Audit Setup > Review & Launch renders full state with offline setting 1
                 href="/api/election/1/jurisdiction/file/csv"
                 rel="noopener noreferrer"
                 target="_blank"
-              />
+              >
+                jurisdictions.csv
+              </a>
             </td>
           </tr>
           <tr>

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
@@ -66,8 +66,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
               Risk Limit:
             </td>
             <td>
-              10
-              %
+              10%
             </td>
           </tr>
           <tr>
@@ -257,8 +256,7 @@ exports[`Audit Setup > Review & Launch renders despite missing jurisdictions on 
               Risk Limit:
             </td>
             <td>
-              10
-              %
+              10%
             </td>
           </tr>
           <tr>
@@ -448,8 +446,7 @@ exports[`Audit Setup > Review & Launch renders empty state 1`] = `
               Risk Limit:
             </td>
             <td>
-              10
-              %
+              10%
             </td>
           </tr>
           <tr>
@@ -726,8 +723,7 @@ exports[`Audit Setup > Review & Launch renders full state 1`] = `
               Risk Limit:
             </td>
             <td>
-              10
-              %
+              10%
             </td>
           </tr>
           <tr>
@@ -1004,8 +1000,7 @@ exports[`Audit Setup > Review & Launch renders full state with batch comparison 
               Risk Limit:
             </td>
             <td>
-              10
-              %
+              10%
             </td>
           </tr>
           <tr>
@@ -1282,8 +1277,7 @@ exports[`Audit Setup > Review & Launch renders full state with batch comparison 
               Risk Limit:
             </td>
             <td>
-              10
-              %
+              10%
             </td>
           </tr>
           <tr>
@@ -1473,8 +1467,7 @@ exports[`Audit Setup > Review & Launch renders full state with jurisdictions wit
               Risk Limit:
             </td>
             <td>
-              10
-              %
+              10%
             </td>
           </tr>
           <tr>
@@ -1760,8 +1753,7 @@ exports[`Audit Setup > Review & Launch renders full state with offline setting 1
               Risk Limit:
             </td>
             <td>
-              10
-              %
+              10%
             </td>
           </tr>
           <tr>

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -168,7 +168,7 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
             </tr>
             <tr>
               <td>Risk Limit:</td>
-              <td>{riskLimit}%</td>
+              <td>{riskLimit && `${riskLimit}%`}</td>
             </tr>
             <tr>
               <td>Random Seed:</td>

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -21,7 +21,11 @@ import ConfirmLaunch from './ConfirmLaunch'
 import FormField from '../../../Atoms/Form/FormField'
 import ElevatedCard from '../../../Atoms/SpacedCard'
 import useSampleSizes, { IStringSampleSizeOption } from './useSampleSizes'
-import { useJurisdictionsFile, isFileProcessed } from '../../useCSV'
+import {
+  useJurisdictionsFile,
+  isFileProcessed,
+  useStandardizedContestsFile,
+} from '../../useCSV'
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: 'percent',
@@ -42,6 +46,10 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
   const [auditSettings] = useAuditSettings(electionId)
   const jurisdictions = useJurisdictions(electionId)
   const [jurisdictionsFile] = useJurisdictionsFile(electionId)
+  const [standardizedContestsFile] = useStandardizedContestsFile(
+    electionId,
+    auditSettings
+  )
   const [contests] = useContests(electionId)
   const history = useHistory()
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false)
@@ -180,6 +188,22 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
                 </a>
               </td>
             </tr>
+            {auditType === 'BALLOT_COMPARISON' && (
+              <tr>
+                <td>Standardized Contests:</td>
+                <td>
+                  <a
+                    href={`/api/election/${electionId}/standardized-contests/file/csv`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {standardizedContestsFile && standardizedContestsFile.file
+                      ? standardizedContestsFile.file.name
+                      : ''}
+                  </a>
+                </td>
+              </tr>
+            )}
             <tr>
               <td>Audit Board Data Entry:</td>
               <td>{online ? 'Online' : 'Offline'}</td>

--- a/client/src/components/MultiJurisdictionAudit/AASetup/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/__snapshots__/index.test.tsx.snap
@@ -3304,8 +3304,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
               Risk Limit:
             </td>
             <td>
-              10
-              %
+              10%
             </td>
           </tr>
           <tr>
@@ -3489,8 +3488,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
               Risk Limit:
             </td>
             <td>
-              10
-              %
+              10%
             </td>
           </tr>
           <tr>
@@ -3674,8 +3672,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
               Risk Limit:
             </td>
             <td>
-              10
-              %
+              10%
             </td>
           </tr>
           <tr>

--- a/client/src/components/MultiJurisdictionAudit/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.test.tsx
@@ -78,7 +78,6 @@ describe('AA setup flow', () => {
       ...loadEach,
       aaApiCalls.getSettings(auditSettings.all),
       aaApiCalls.getJurisdictionFile,
-      aaApiCalls.getStandardizedContestsFile,
       ...loadEach,
       aaApiCalls.getSettings(auditSettings.all),
       ...loadEach,
@@ -162,7 +161,6 @@ describe('AA setup flow', () => {
       ...loadEach,
       aaApiCalls.getSettings(auditSettings.all),
       aaApiCalls.getJurisdictionFile,
-      aaApiCalls.getStandardizedContestsFile,
       ...loadEach,
     ]
     await withMockFetch(expectedCalls, async () => {

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -10,6 +10,7 @@ from ..auth import restrict_access, UserType
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from ..util.csv_parse import decode_csv_file, parse_csv, CSVColumnType, CSVValueType
+from ..util.csv_download import csv_response
 from ..util.process_file import (
     process_file,
     UserError,
@@ -120,3 +121,15 @@ def get_standardized_contests_file(election: Election):
 @restrict_access([UserType.AUDIT_ADMIN])
 def get_standardized_contests(election: Election):
     return jsonify(election.standardized_contests)
+
+
+@api.route("/election/<election_id>/standardized-contests/file/csv", methods=["GET"])
+@restrict_access([UserType.AUDIT_ADMIN])
+def download_standardized_contests_file(election: Election):
+    if not election.standardized_contests_file:
+        return NotFound()
+
+    return csv_response(
+        election.standardized_contests_file.contents,
+        election.standardized_contests_file.name,
+    )

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -10,16 +10,17 @@ from ...bgcompute import bgcompute_update_standardized_contests_file
 def test_upload_standardized_contests(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
+    standardized_contests_file = (
+        "Contest Name,Jurisdictions\n"
+        "Contest 1,all\n"
+        'Contest 2,"J1, J3"\n'
+        "Contest 3,J2 \n"
+    )
     rv = client.put(
         f"/api/election/{election_id}/standardized-contests/file",
         data={
             "standardized-contests": (
-                io.BytesIO(
-                    b"Contest Name,Jurisdictions\n"
-                    b"Contest 1,all\n"
-                    b'Contest 2,"J1, J3"\n'
-                    b"Contest 3,J2 \n"
-                ),
+                io.BytesIO(standardized_contests_file.encode()),
                 "standardized-contests.csv",
             )
         },
@@ -71,6 +72,13 @@ def test_upload_standardized_contests(
         },
         {"name": "Contest 3", "jurisdictionIds": [jurisdiction_ids[1]]},
     ]
+
+    rv = client.get(f"/api/election/{election_id}/standardized-contests/file/csv")
+    assert (
+        rv.headers["Content-Disposition"]
+        == 'attachment; filename="standardized-contests.csv"'
+    )
+    assert rv.data.decode("utf-8") == standardized_contests_file
 
 
 def test_standardized_contests_replace(
@@ -292,41 +300,7 @@ def test_standardized_contests_newlines(
     )
     assert_ok(rv)
 
-    rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
-    compare_json(
-        json.loads(rv.data),
-        {
-            "file": {
-                "name": "standardized-contests.csv",
-                "uploadedAt": assert_is_date,
-            },
-            "processing": {
-                "status": ProcessingStatus.READY_TO_PROCESS,
-                "startedAt": None,
-                "completedAt": None,
-                "error": None,
-            },
-        },
-    )
-
     bgcompute_update_standardized_contests_file(election_id)
-
-    rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
-    compare_json(
-        json.loads(rv.data),
-        {
-            "file": {
-                "name": "standardized-contests.csv",
-                "uploadedAt": assert_is_date,
-            },
-            "processing": {
-                "status": ProcessingStatus.PROCESSED,
-                "startedAt": assert_is_date,
-                "completedAt": assert_is_date,
-                "error": None,
-            },
-        },
-    )
 
     rv = client.get(f"/api/election/{election_id}/standardized-contests")
     assert json.loads(rv.data) == [
@@ -358,41 +332,7 @@ def test_standardized_contests_dominion_vote_for(
     )
     assert_ok(rv)
 
-    rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
-    compare_json(
-        json.loads(rv.data),
-        {
-            "file": {
-                "name": "standardized-contests.csv",
-                "uploadedAt": assert_is_date,
-            },
-            "processing": {
-                "status": ProcessingStatus.READY_TO_PROCESS,
-                "startedAt": None,
-                "completedAt": None,
-                "error": None,
-            },
-        },
-    )
-
     bgcompute_update_standardized_contests_file(election_id)
-
-    rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
-    compare_json(
-        json.loads(rv.data),
-        {
-            "file": {
-                "name": "standardized-contests.csv",
-                "uploadedAt": assert_is_date,
-            },
-            "processing": {
-                "status": ProcessingStatus.PROCESSED,
-                "startedAt": assert_is_date,
-                "completedAt": assert_is_date,
-                "error": None,
-            },
-        },
-    )
 
     rv = client.get(f"/api/election/{election_id}/standardized-contests")
     assert json.loads(rv.data) == [


### PR DESCRIPTION
- Endpoint to download standardized contests file
- Standardized contests file download link in Review screen

(Also change useStandardizedContestsFile to only make API requests if it's a ballot comparison audit.)
(Also fix a small bug so we don't show a % sign in the risk limit field until the risk limit is set)

<img width="778" alt="Screen Shot 2020-12-07 at 12 56 18 PM" src="https://user-images.githubusercontent.com/530106/101404523-9bc63580-388b-11eb-9331-1a568f4a9de3.png">