### PR TITLE
Don't default a sample size option as selected after audit launches

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -108,15 +108,16 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
       ),
     }))
 
-  const initialValues: IFormOptions = sampleSizeOptions
-    ? Object.keys(sampleSizeOptions).reduce(
-        (a, contestId) => ({
-          ...a,
-          [contestId]: sampleSizeOptions[contestId][0],
-        }),
-        {}
-      )
-    : {}
+  const initialValues: IFormOptions =
+    sampleSizeOptions && !locked
+      ? Object.keys(sampleSizeOptions).reduce(
+          (a, contestId) => ({
+            ...a,
+            [contestId]: sampleSizeOptions[contestId][0],
+          }),
+          {}
+        )
+      : {}
 
   const participatingJurisdictions = contests
     ? jurisdictions.filter(({ id }) =>


### PR DESCRIPTION
They might not have selected the first sample size option, so this is
misleading.

Ideally, we'd send back the option they selected when launching the
audit, but currently we're only storing the sample size number, not
which option they picked (and the options aren't guaranteed to have a
unique number), so this would be a bigger change.