### PR TITLE
Add num winners field to contest select for ballot comparison

### DIFF
--- a/client/src/components/Atoms/Table.tsx
+++ b/client/src/components/Atoms/Table.tsx
@@ -92,17 +92,19 @@ export const Table = <T extends object>({ data, columns }: ITableProps<T>) => {
                 <span style={{ marginRight: '5px' }}>
                   {column.render('Header')}
                 </span>
-                <span>
-                  {column.isSorted ? (
-                    column.isSortedDesc ? (
-                      <Icon icon="caret-down" />
+                {column.canSort && (
+                  <span>
+                    {column.isSorted ? (
+                      column.isSortedDesc ? (
+                        <Icon icon="caret-down" />
+                      ) : (
+                        <Icon icon="caret-up" />
+                      )
                     ) : (
-                      <Icon icon="caret-up" />
-                    )
-                  ) : (
-                    <Icon icon="double-caret-vertical" />
-                  )}
-                </span>
+                      <Icon icon="double-caret-vertical" />
+                    )}
+                  </span>
+                )}
               </div>
             </th>
           ))}

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.test.tsx
@@ -1,0 +1,302 @@
+import React from 'react'
+import { Route } from 'react-router-dom'
+import { screen, within, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithRouter, withMockFetch } from '../../../testUtilities'
+import relativeStages from '../_mocks'
+import Contests from '.'
+import { aaApiCalls } from '../../_mocks'
+import { IContest, INewContest } from '../../useContestsBallotComparison'
+
+const { nextStage, prevStage } = relativeStages('target-contests')
+
+const render = (isTargeted: boolean = true) =>
+  renderWithRouter(
+    <Route path="/election/:electionId/setup">
+      <Contests
+        auditType="BALLOT_COMPARISON"
+        locked={false}
+        isTargeted={isTargeted}
+        nextStage={nextStage}
+        prevStage={prevStage}
+      />
+    </Route>,
+    { route: '/election/1/setup' }
+  )
+
+const apiCalls = {
+  getStandardizedContests: {
+    url: '/api/election/1/standardized-contests',
+    response: [
+      {
+        name: 'Contest 1',
+        jurisdictionIds: ['jurisdiction-id-1', 'jurisdiction-id-2'],
+      },
+      {
+        name: 'Contest 2',
+        jurisdictionIds: ['jurisdiction-id-1'],
+      },
+      { name: 'Contest 3', jurisdictionIds: ['jurisdiction-id-2'] },
+    ],
+  },
+  getContests: (contests: IContest[]) => ({
+    url: '/api/election/1/contest',
+    response: { contests },
+  }),
+  putContests: (contests: INewContest[]) => ({
+    url: '/api/election/1/contest',
+    options: {
+      method: 'PUT',
+      body: JSON.stringify(contests),
+      headers: { 'Content-Type': 'application/json' },
+    },
+    response: { status: 'ok' },
+  }),
+}
+
+jest.mock('uuidv4', () => {
+  let id = 0
+  return () => {
+    id += 1
+    return id.toString()
+  }
+})
+
+describe('Audit Setup > Contests (Ballot Comparison)', () => {
+  const expectedNewContestsRequest = [
+    {
+      name: 'Contest 1',
+      id: '1',
+      isTargeted: true,
+      numWinners: 2,
+      jurisdictionIds: ['jurisdiction-id-1', 'jurisdiction-id-2'],
+    },
+    {
+      name: 'Contest 2',
+      id: '2',
+      isTargeted: true,
+      numWinners: 1,
+      jurisdictionIds: ['jurisdiction-id-1'],
+    },
+  ]
+  const newContests: IContest[] = expectedNewContestsRequest.map(c => ({
+    ...c,
+    votesAllowed: null,
+    totalBallotsCast: null,
+    choices: [],
+  }))
+
+  it('shows table of standardized contests with checkboxes', async () => {
+    const expectedCalls = [
+      apiCalls.getStandardizedContests,
+      apiCalls.getContests([]),
+      aaApiCalls.getJurisdictions,
+      apiCalls.putContests(expectedNewContestsRequest),
+      apiCalls.getContests(newContests),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render()
+      await screen.findByRole('heading', { name: 'Target Contests' })
+
+      const headers = screen.getAllByRole('columnheader')
+      expect(headers).toHaveLength(4)
+      expect(headers[0]).toHaveTextContent(/Select/)
+      expect(headers[1]).toHaveTextContent(/Contest Name/)
+      expect(headers[2]).toHaveTextContent(/Jurisdictions/)
+      expect(headers[3]).toHaveTextContent(/Winners/)
+
+      const rows = screen.getAllByRole('row')
+      expect(rows).toHaveLength(3 + 1) // Includes headers
+      expect(within(rows[1]).getByRole('checkbox')).not.toBeChecked()
+      expect(within(rows[1]).getAllByRole('cell')[1]).toHaveTextContent(
+        'Contest 1'
+      )
+      expect(within(rows[1]).getAllByRole('cell')[2]).toHaveTextContent('All')
+      expect(within(rows[1]).getByRole('spinbutton')).toBeDisabled()
+      expect(within(rows[2]).getByRole('checkbox')).not.toBeChecked()
+      expect(within(rows[2]).getAllByRole('cell')[1]).toHaveTextContent(
+        'Contest 2'
+      )
+      expect(within(rows[2]).getAllByRole('cell')[2]).toHaveTextContent(
+        'Jurisdiction One'
+      )
+      expect(within(rows[2]).getByRole('spinbutton')).toBeDisabled()
+      expect(within(rows[3]).getByRole('checkbox')).not.toBeChecked()
+      expect(within(rows[3]).getAllByRole('cell')[1]).toHaveTextContent(
+        'Contest 3'
+      )
+      expect(within(rows[3]).getAllByRole('cell')[2]).toHaveTextContent(
+        'Jurisdiction Two'
+      )
+      expect(within(rows[3]).getByRole('spinbutton')).toBeDisabled()
+
+      // Select Contest 1
+      userEvent.click(within(rows[1]).getByRole('checkbox'))
+      expect(within(rows[1]).getByRole('checkbox')).toBeChecked()
+
+      // Adjust num winners
+      const winnersInput = within(rows[1]).getByRole('spinbutton')
+      expect(winnersInput).toBeEnabled()
+      expect(winnersInput).toHaveValue(1)
+      userEvent.click(
+        within(rows[1]).getByRole('button', { name: 'chevron-up' })
+      )
+      expect(within(rows[1]).getByRole('spinbutton')).toHaveValue(2)
+      userEvent.click(
+        within(rows[1]).getByRole('button', { name: 'chevron-up' })
+      )
+
+      expect(within(rows[1]).getByRole('spinbutton')).toHaveValue(3)
+      userEvent.click(
+        within(rows[1]).getByRole('button', { name: 'chevron-down' })
+      )
+      expect(within(rows[1]).getByRole('spinbutton')).toHaveValue(2)
+
+      // Select Contest 3
+      userEvent.click(within(rows[3]).getByRole('checkbox'))
+      expect(within(rows[3]).getByRole('checkbox')).toBeChecked()
+
+      // Select Contest 2
+      userEvent.click(within(rows[2]).getByRole('checkbox'))
+      expect(within(rows[2]).getByRole('checkbox')).toBeChecked()
+
+      // Deselect Contest 3
+      userEvent.click(within(rows[3]).getByRole('checkbox'))
+      expect(within(rows[3]).getByRole('checkbox')).not.toBeChecked()
+
+      // Submit the form
+      userEvent.click(screen.getByRole('button', { name: 'Save & Next' }))
+      await waitFor(() => expect(nextStage.activate).toHaveBeenCalled())
+    })
+  })
+
+  it('disables already selected targeted contests on opportunistic contest form', async () => {
+    const newContest3 = {
+      name: 'Contest 3',
+      id: '5',
+      isTargeted: false,
+      numWinners: 1,
+      jurisdictionIds: ['jurisdiction-id-2'],
+    }
+    const expectedCalls = [
+      apiCalls.getStandardizedContests,
+      apiCalls.getContests(newContests),
+      aaApiCalls.getJurisdictions,
+      apiCalls.putContests(expectedNewContestsRequest.concat([newContest3])),
+      apiCalls.getContests(
+        newContests.concat([
+          {
+            ...newContest3,
+            votesAllowed: null,
+            totalBallotsCast: null,
+            choices: [],
+          },
+        ])
+      ),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render(false)
+      await screen.findByRole('heading', { name: 'Opportunistic Contests' })
+
+      const rows = screen.getAllByRole('row')
+      expect(rows).toHaveLength(3 + 1) // Includes headers
+      expect(within(rows[1]).getByRole('checkbox')).toBeChecked()
+      expect(within(rows[1]).getByRole('checkbox')).toBeDisabled()
+      expect(within(rows[1]).getAllByRole('cell')[1]).toHaveTextContent(
+        'Contest 1'
+      )
+      expect(within(rows[1]).getByRole('spinbutton')).toBeDisabled()
+
+      expect(within(rows[2]).getByRole('checkbox')).toBeChecked()
+      expect(within(rows[2]).getByRole('checkbox')).toBeDisabled()
+      expect(within(rows[2]).getAllByRole('cell')[1]).toHaveTextContent(
+        'Contest 2'
+      )
+      expect(within(rows[2]).getByRole('spinbutton')).toBeDisabled()
+
+      expect(within(rows[3]).getByRole('checkbox')).not.toBeChecked()
+      expect(within(rows[3]).getAllByRole('cell')[1]).toHaveTextContent(
+        'Contest 3'
+      )
+      expect(within(rows[3]).getByRole('spinbutton')).toBeDisabled()
+
+      // Select Contest 3
+      userEvent.click(within(rows[3]).getByRole('checkbox'))
+      expect(within(rows[3]).getByRole('checkbox')).toBeChecked()
+
+      // Submit the form
+      userEvent.click(screen.getByRole('button', { name: 'Save & Next' }))
+      await waitFor(() => expect(nextStage.activate).toHaveBeenCalled())
+    })
+  })
+
+  it('filters and sorts contests', async () => {
+    const expectedCalls = [
+      apiCalls.getStandardizedContests,
+      apiCalls.getContests([]),
+      aaApiCalls.getJurisdictions,
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render()
+      await screen.findByRole('heading', { name: 'Target Contests' })
+
+      // Reverse sort by Contest Name
+      const contestNameHeader = screen.getByRole('columnheader', {
+        name: 'Contest Name',
+      })
+      userEvent.click(contestNameHeader)
+      userEvent.click(contestNameHeader)
+
+      let rows = screen.getAllByRole('row')
+      within(rows[1]).getByText('Contest 3')
+      within(rows[2]).getByText('Contest 2')
+      within(rows[3]).getByText('Contest 1')
+
+      // Select Contest 1
+      userEvent.click(within(rows[3]).getByRole('checkbox'))
+
+      // Now reset sorting and confirmed it's still checked
+      userEvent.click(contestNameHeader)
+      rows = screen.getAllByRole('row')
+      within(rows[1]).getByText('Contest 1')
+      expect(within(rows[1]).getByRole('checkbox')).toBeChecked()
+      expect(within(rows[2]).getByRole('checkbox')).not.toBeChecked()
+      expect(within(rows[3]).getByRole('checkbox')).not.toBeChecked()
+
+      // Filter by contest name
+      userEvent.type(screen.getByRole('textbox'), 'contest 2')
+      rows = screen.getAllByRole('row')
+      expect(rows).toHaveLength(1 + 1) // Includes headers
+      within(rows[1]).getByText('Contest 2')
+
+      // Select Contest 2
+      userEvent.click(within(rows[1]).getByRole('checkbox'))
+
+      // Now reset filter and confirmed it's still checked
+      userEvent.clear(screen.getByRole('textbox'))
+      rows = screen.getAllByRole('row')
+      expect(rows).toHaveLength(3 + 1) // Includes headers
+      expect(within(rows[1]).getByRole('checkbox')).toBeChecked()
+      expect(within(rows[2]).getByRole('checkbox')).toBeChecked()
+      expect(within(rows[3]).getByRole('checkbox')).not.toBeChecked()
+
+      // Filter by jurisdiction name
+      userEvent.type(screen.getByRole('textbox'), 'one')
+      rows = screen.getAllByRole('row')
+      expect(rows).toHaveLength(2 + 1) // Includes headers
+      within(rows[1]).getByText('Contest 1')
+      within(rows[2]).getByText('Contest 2')
+
+      // Deselect Contest 1
+      userEvent.click(within(rows[1]).getByRole('checkbox'))
+
+      // Now reset filter and confirmed it's still unchecked
+      userEvent.clear(screen.getByRole('textbox'))
+      rows = screen.getAllByRole('row')
+      expect(rows).toHaveLength(3 + 1) // Includes headers
+      expect(within(rows[1]).getByRole('checkbox')).not.toBeChecked()
+      expect(within(rows[2]).getByRole('checkbox')).toBeChecked()
+      expect(within(rows[3]).getByRole('checkbox')).not.toBeChecked()
+    })
+  })
+})

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.tsx
@@ -14,7 +14,7 @@ import useJurisdictions from '../../useJurisdictions'
 import { Table, FilterInput } from '../../../Atoms/Table'
 import { IAuditSettings } from '../../useAuditSettings'
 import useContestsBallotComparison, {
-  IContest,
+  INewContest,
 } from '../../useContestsBallotComparison'
 import FormField from '../../../Atoms/Form/FormField'
 
@@ -67,7 +67,7 @@ const ContestSelect: React.FC<IProps> = ({
   )
 
   const submit = async (values: IFormValues) => {
-    const newContests: IContest[] = Object.entries(values)
+    const newContests: INewContest[] = Object.entries(values)
       .filter(([_, { checked }]) => checked)
       // eslint-disable-next-line no-shadow
       .map(([name, { id, isTargeted, numWinners, jurisdictionIds }]) => ({

--- a/client/src/components/MultiJurisdictionAudit/useContestsBallotComparison.ts
+++ b/client/src/components/MultiJurisdictionAudit/useContestsBallotComparison.ts
@@ -1,12 +1,18 @@
 import { useEffect, useState } from 'react'
 import { api } from '../utilities'
 
-export interface IContest {
+export interface INewContest {
   id: string
   name: string
   isTargeted: boolean
   numWinners: number
   jurisdictionIds: string[]
+}
+
+export interface IContest extends INewContest {
+  votesAllowed: null
+  totalBallotsCast: null
+  choices: []
 }
 
 const getContests = async (electionId: string): Promise<IContest[] | null> => {
@@ -18,7 +24,7 @@ const getContests = async (electionId: string): Promise<IContest[] | null> => {
 
 const putContests = async (
   electionId: string,
-  newContests: IContest[]
+  newContests: INewContest[]
 ): Promise<boolean> =>
   !!api(`/election/${electionId}/contest`, {
     method: 'PUT',
@@ -28,10 +34,10 @@ const putContests = async (
 
 const useContestsBallotComparison = (
   electionId: string
-): [IContest[] | null, (newContests: IContest[]) => Promise<boolean>] => {
+): [IContest[] | null, (newContests: INewContest[]) => Promise<boolean>] => {
   const [contests, setContests] = useState<IContest[] | null>(null)
 
-  const updateContests = async (newContests: IContest[]) => {
+  const updateContests = async (newContests: INewContest[]) => {
     if (putContests(electionId, newContests)) {
       setContests(await getContests(electionId))
       return true

--- a/client/src/components/MultiJurisdictionAudit/useContestsBallotComparison.ts
+++ b/client/src/components/MultiJurisdictionAudit/useContestsBallotComparison.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import { api } from '../utilities'
+
+export interface IContest {
+  id: string
+  name: string
+  isTargeted: boolean
+  numWinners: number
+  jurisdictionIds: string[]
+}
+
+const getContests = async (electionId: string): Promise<IContest[] | null> => {
+  const response = await api<{ contests: IContest[] }>(
+    `/election/${electionId}/contest`
+  )
+  return response && response.contests
+}
+
+const putContests = async (
+  electionId: string,
+  newContests: IContest[]
+): Promise<boolean> =>
+  !!api(`/election/${electionId}/contest`, {
+    method: 'PUT',
+    body: JSON.stringify(newContests),
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const useContestsBallotComparison = (
+  electionId: string
+): [IContest[] | null, (newContests: IContest[]) => Promise<boolean>] => {
+  const [contests, setContests] = useState<IContest[] | null>(null)
+
+  const updateContests = async (newContests: IContest[]) => {
+    if (putContests(electionId, newContests)) {
+      setContests(await getContests(electionId))
+      return true
+    }
+    return false
+  }
+
+  useEffect(() => {
+    ;(async () => {
+      setContests(await getContests(electionId))
+    })()
+  }, [electionId])
+
+  return [contests, updateContests]
+}
+
+export default useContestsBallotComparison

--- a/client/src/components/MultiJurisdictionAudit/useStandardizedContests.ts
+++ b/client/src/components/MultiJurisdictionAudit/useStandardizedContests.ts
@@ -1,111 +1,30 @@
 import { useEffect, useState } from 'react'
-import uuidv4 from 'uuidv4'
-import { api, areArraysEqualSets } from '../utilities'
-import { IContest } from '../../types'
+import { api } from '../utilities'
 
 export interface IStandardizedContest {
   name: string
   jurisdictionIds: string[]
 }
 
-export interface IStandardizedContestOption extends IStandardizedContest {
-  id: string
-  checked: boolean
-  isTargeted: boolean
-}
-
-type ISubmitContest = Pick<
-  IStandardizedContestOption,
-  'id' | 'name' | 'isTargeted' | 'jurisdictionIds'
->
-
 const getStandardizedContests = async (
   electionId: string
 ): Promise<IStandardizedContest[] | null> =>
-  api<IStandardizedContest[]>(`/election/${electionId}/standardized-contests`)
-
-const getContests = async (electionId: string): Promise<IContest[] | null> => {
-  const response = await api<{ contests: IContest[] }>(
-    `/election/${electionId}/contest`
-  )
-  if (!response) return null
-  return response.contests
-}
+  api(`/election/${electionId}/standardized-contests`)
 
 const useStandardizedContests = (
-  electionId: string,
-  targetedView: boolean,
-  refreshId?: string
-): [
-  IStandardizedContestOption[] | null,
-  (arg0: IStandardizedContestOption[]) => Promise<boolean>
-] => {
+  electionId: string
+): IStandardizedContest[] | null => {
   const [standardizedContests, setStandardizedContests] = useState<
-    IStandardizedContestOption[] | null
+    IStandardizedContest[] | null
   >(null)
-  const [contests, setContests] = useState<IContest[] | null>(null)
-
-  const updateContests = async (
-    newContests: IStandardizedContestOption[]
-  ): Promise<boolean> => {
-    if (!standardizedContests || !contests) return false
-
-    const mergedContests: ISubmitContest[] = newContests.reduce(
-      (
-        a: ISubmitContest[],
-        {
-          id,
-          name,
-          isTargeted,
-          jurisdictionIds,
-          checked,
-        }: IStandardizedContestOption
-      ) => {
-        if (isTargeted !== targetedView || checked)
-          return [...a, { id, name, isTargeted, jurisdictionIds }]
-        return a
-      },
-      []
-    )
-
-    const response = await api(`/election/${electionId}/contest`, {
-      method: 'PUT',
-      body: JSON.stringify(mergedContests),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
-    if (!response) return false
-    setStandardizedContests(newContests)
-    return true
-  }
 
   useEffect(() => {
     ;(async () => {
-      const newContests = await getContests(electionId)
-      const newStandardizedContests = await getStandardizedContests(electionId)
-      if (!newContests || !newStandardizedContests) return
-      setStandardizedContests(
-        newStandardizedContests.map(sc => {
-          const selectedContest = newContests.find(
-            c =>
-              c.name === sc.name &&
-              areArraysEqualSets(c.jurisdictionIds, sc.jurisdictionIds)
-          )
-          return {
-            ...sc,
-            id: selectedContest ? selectedContest.id : uuidv4(),
-            isTargeted: selectedContest
-              ? selectedContest.isTargeted
-              : targetedView,
-            checked: !!selectedContest,
-          }
-        })
-      )
-      setContests(newContests)
+      setStandardizedContests(await getStandardizedContests(electionId))
     })()
-  }, [electionId, refreshId, targetedView])
-  return [standardizedContests, updateContests]
+  }, [electionId])
+
+  return standardizedContests
 }
 
 export default useStandardizedContests

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -48,19 +48,20 @@ CONTEST_SCHEMA = {
 }
 
 # In ballot comparison audits, the AA selects contests from the standardized
-# contests file, so we create contests without choices, totalBallotsCast,
-# numWinners, and votesAllowed. We later populate these fields using the
-# metadata in the CVRs that the jurisdictions provide.
+# contests file, so we create contests without choices, totalBallotsCast, and
+# votesAllowed. We later populate these fields using the metadata in the CVRs
+# that the jurisdictions provide.
 BALLOT_COMPARISON_CONTEST_SCHEMA = {
     "type": "object",
     "properties": {
         "id": {"type": "string"},
         "name": {"type": "string"},
         "isTargeted": {"type": "boolean"},
+        "numWinners": {"type": "integer", "minimum": 1},
         "jurisdictionIds": {"type": "array", "items": {"type": "string"}},
     },
     "additionalProperties": False,
-    "required": ["id", "name", "isTargeted", "jurisdictionIds"],
+    "required": ["id", "name", "isTargeted", "numWinners", "jurisdictionIds"],
 }
 
 

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -30,7 +30,6 @@ def set_contest_metadata_from_cvrs(contest: Contest):
     if contest.total_ballots_cast is not None:
         return
 
-    contest.num_winners = 1  # TODO how do we get this from the CVRs?
     contest.total_ballots_cast = 0
 
     for jurisdiction in contest.jurisdictions:

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -144,7 +144,6 @@ snapshots["test_set_contest_metadata_from_cvrs 1"] = {
         {"name": "Choice 2-2", "num_votes": 12},
         {"name": "Choice 2-3", "num_votes": 16},
     ],
-    "num_winners": 1,
     "total_ballots_cast": 30,
     "votes_allowed": 2,
 }

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -25,6 +25,7 @@ def test_set_contest_metadata_from_cvrs(
             {
                 "id": contest_id,
                 "name": "Contest 2",
+                "numWinners": 1,
                 "jurisdictionIds": jurisdiction_ids[:2],
                 "isTargeted": True,
             }
@@ -35,7 +36,6 @@ def test_set_contest_metadata_from_cvrs(
     contest = Contest.query.get(contest_id)
     assert contest.total_ballots_cast is None
     assert contest.votes_allowed is None
-    assert contest.num_winners is None
     assert contest.choices == []
 
     set_contest_metadata_from_cvrs(contest)
@@ -44,7 +44,6 @@ def test_set_contest_metadata_from_cvrs(
         dict(
             total_ballots_cast=contest.total_ballots_cast,
             votes_allowed=contest.votes_allowed,
-            num_winners=contest.num_winners,
             choices=[
                 dict(name=choice.name, num_votes=choice.num_votes,)
                 for choice in contest.choices
@@ -70,6 +69,7 @@ def test_require_cvr_uploads(
             {
                 "id": str(uuid.uuid4()),
                 "name": "Contest 1",
+                "numWinners": 1,
                 "jurisdictionIds": jurisdiction_ids[:2],
                 "isTargeted": True,
             },
@@ -134,12 +134,14 @@ def test_ballot_comparison_two_rounds(
             {
                 "id": str(uuid.uuid4()),
                 "name": target_contest["name"],
+                "numWinners": 1,
                 "jurisdictionIds": target_contest["jurisdictionIds"],
                 "isTargeted": True,
             },
             {
                 "id": str(uuid.uuid4()),
                 "name": opportunistic_contest["name"],
+                "numWinners": 1,
                 "jurisdictionIds": opportunistic_contest["jurisdictionIds"],
                 "isTargeted": False,
             },
@@ -395,12 +397,14 @@ def test_ballot_comparison_cvr_metadata(
             {
                 "id": str(uuid.uuid4()),
                 "name": "Contest 2",
+                "numWinners": 1,
                 "jurisdictionIds": jurisdiction_ids[:2],
                 "isTargeted": True,
             },
             {
                 "id": str(uuid.uuid4()),
                 "name": "Contest 1",
+                "numWinners": 1,
                 "jurisdictionIds": jurisdiction_ids[:2],
                 "isTargeted": False,
             },

--- a/server/tests/ballot_comparison/test_ballot_comparison_manifests.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison_manifests.py
@@ -140,6 +140,7 @@ def test_ballot_comparison_container_manifest(
             {
                 "id": str(uuid.uuid4()),
                 "name": "Contest 1",
+                "numWinners": 1,
                 "jurisdictionIds": jurisdiction_ids[:2],
                 "isTargeted": True,
             },


### PR DESCRIPTION
Task: #954 (also fixes #926)

- Updates the /contest endpoint to accept numWinners
- Reworks the ContestSelect component to key contests by name to avoid issues with filtering by index
- Adds a "Winners" column to the ContestSelect table
- Adds filtering contests by jurisdiction name (an outstanding TODO in the code)

![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/530106/101557774-8415ac80-3972-11eb-9fdb-4a2581aa4c4f.gif)
