### PR TITLE
Add link to reference docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Like any open-source software, Arlo welcomes suggested changes in the form of pu
 
 Before submitting a pull request, please review our [Contribution Guidelines](./docs/contribution-guidelines.md).
 
+## Reference Docs
+https://docs.contour.so/votingworks/arlo/getting-started
+
 ### Configuration
 
 [Auth0](https://auth0.com/) is used for authentication, as documented at [Auth0](docs/auth0.md).


### PR DESCRIPTION
**Description**

Hi there!

My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!

**Testing**

[List all new test cases added to cover new functionality, including steps to reproduce expected results and contrasting with actual results.]

**Progress**

[List any work left to do or outstanding questions.]
