### PR TITLE
Audit board jurisdiction name in /api/me response

### DIFF
--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -108,6 +108,7 @@ def auth_me():
             type=user_type,
             id=audit_board.id,
             jurisdictionId=audit_board.jurisdiction_id,
+            jurisdictionName=audit_board.jurisdiction.name,
             roundId=audit_board.round_id,
             name=audit_board.name,
             members=serialize_members(audit_board),

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -355,6 +355,7 @@ def test_auth_me_audit_board(
         "type": UserType.AUDIT_BOARD,
         "id": audit_board.id,
         "jurisdictionId": audit_board.jurisdiction_id,
+        "jurisdictionName": audit_board.jurisdiction.name,
         "roundId": audit_board.round_id,
         "name": audit_board.name,
         "members": [],


### PR DESCRIPTION
Updated: originally just wanted to remove this field from the frontend, but instead decided to add it to /api/me so that the frontend can continue to use it.
