### PR TITLE
Change UserContext data format

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -24,7 +24,10 @@ const apiMocks = {
   },
   abAuth: {
     url: '/api/me',
-    response: { type: 'audit_board', ...dummyBoards()[1] },
+    response: {
+      type: 'audit_board',
+      ...dummyBoards()[1],
+    },
   },
 }
 
@@ -36,7 +39,7 @@ describe('App', () => {
       const expectedCalls = [apiMocks.failedAuth]
       await withMockFetch(expectedCalls, async () => {
         const { container } = renderView('/')
-        await screen.findByAltText('Arlo, by VotingWorks')
+        await screen.findByRole('button', { name: 'Log in to your audit' })
         expect(container).toMatchSnapshot()
       })
     })
@@ -75,7 +78,7 @@ describe('App', () => {
         const { container } = renderView(
           '/election/1/audit-board/audit-board-1'
         )
-        await screen.findByAltText('Arlo, by VotingWorks')
+        await screen.findByRole('button', { name: 'Log in to your audit' })
         expect(container).toMatchSnapshot()
       })
     })
@@ -126,7 +129,7 @@ describe('App', () => {
         const { container } = renderView(
           '/election/1/jurisdiction/jurisdiction-id-1'
         )
-        await screen.findByAltText('Arlo, by VotingWorks')
+        await screen.findByRole('button', { name: 'Log in to your audit' })
         expect(container).toMatchSnapshot()
       })
     })

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { Route, RouteProps, Switch, Redirect } from 'react-router-dom'
 import './App.css'
 import styled from 'styled-components'
@@ -12,8 +12,10 @@ import {
 import DataEntry from './components/DataEntry'
 import HomeScreen from './components/HomeScreen'
 import 'react-toastify/dist/ReactToastify.css'
-import AuthDataProvider, { AuthDataContext } from './components/UserContext'
-import { IUserMeta } from './types'
+import AuthDataProvider, {
+  IUser,
+  useAuthDataContext,
+} from './components/UserContext'
 
 const Main = styled.div`
   display: flex;
@@ -23,19 +25,19 @@ const Main = styled.div`
 `
 
 interface PrivateRouteProps extends RouteProps {
-  userType: IUserMeta['type']
+  userType: IUser['type']
 }
 
 const PrivateRoute: React.FC<PrivateRouteProps> = ({
   userType,
   ...props
 }: PrivateRouteProps) => {
-  const { isAuthenticated, meta } = useContext(AuthDataContext)
-  if (isAuthenticated === null) {
+  const auth = useAuthDataContext()
+  if (auth === null) {
     // Still loading /api/me, don't show anything
     return <></>
   }
-  if (isAuthenticated && userType === meta!.type) {
+  if (auth.user && userType === auth.user.type) {
     return <Route {...props} />
   }
   return (

--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -253,9 +253,6 @@ exports[`App / renders ja logged in properly 1`] = `
               />
             </a>
           </div>
-          <div
-            class="bp3-navbar-heading"
-          />
         </div>
         <div
           class="bp3-navbar-group bp3-align-right"
@@ -992,9 +989,6 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ja logged i
               />
             </a>
           </div>
-          <div
-            class="bp3-navbar-heading"
-          />
         </div>
         <div
           class="bp3-navbar-group bp3-align-right"
@@ -1421,7 +1415,8 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders ja logge
           <div
             class="bp3-navbar-heading"
           >
-            Jurisdiction: Jurisdiction One
+            Jurisdiction: 
+            Jurisdiction One
           </div>
         </div>
         <div

--- a/client/src/components/DataEntry/BoardTable.tsx
+++ b/client/src/components/DataEntry/BoardTable.tsx
@@ -4,9 +4,10 @@ import { H1 } from '@blueprintjs/core'
 import { Link } from 'react-router-dom'
 import { Column } from 'react-table'
 import { Table } from '../Atoms/Table'
-import { IAuditBoard, BallotStatus } from '../../types'
+import { BallotStatus } from '../../types'
 import LinkButton from '../Atoms/LinkButton'
 import { IBallot } from '../MultiJurisdictionAudit/RoundManagement/useBallots'
+import { IAuditBoard } from '../UserContext'
 
 const RightWrapper = styled.div`
   display: flex;

--- a/client/src/components/DataEntry/MemberForm.tsx
+++ b/client/src/components/DataEntry/MemberForm.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { H1, RadioGroup, Radio } from '@blueprintjs/core'
 import { Formik, FormikProps, getIn } from 'formik'
 import FormSection from '../Atoms/Form/FormSection'
-import { IAuditBoardMember } from '../../types'
 import FormButton from '../Atoms/Form/FormButton'
 import { LabelText, NameField } from './Atoms'
+import { IAuditBoardMember } from '../UserContext'
 
 interface IProps {
   boardName: string

--- a/client/src/components/DataEntry/SignOff.tsx
+++ b/client/src/components/DataEntry/SignOff.tsx
@@ -4,7 +4,7 @@ import { H1 } from '@blueprintjs/core'
 import FormSection from '../Atoms/Form/FormSection'
 import { LabelText, NameField } from './Atoms'
 import FormButton from '../Atoms/Form/FormButton'
-import { IAuditBoard } from '../../types'
+import { IAuditBoard } from '../UserContext'
 
 export interface IProps {
   auditBoard: IAuditBoard

--- a/client/src/components/DataEntry/_mocks.ts
+++ b/client/src/components/DataEntry/_mocks.ts
@@ -1,11 +1,13 @@
-import { IAuditBoard, BallotStatus, Interpretation } from '../../types'
+import { BallotStatus, Interpretation } from '../../types'
 import { contestMocks } from '../MultiJurisdictionAudit/AASetup/Contests/_mocks'
 import { IBallot } from '../MultiJurisdictionAudit/RoundManagement/useBallots'
+import { IAuditBoard } from '../UserContext'
 
 export const contest = contestMocks.filledTargeted.contests[0]
 
 export const dummyBoards = (): IAuditBoard[] => [
   {
+    type: 'audit_board',
     id: 'audit-board-1',
     name: 'Audit Board #1',
     jurisdictionId: 'jurisdiction-1',
@@ -24,6 +26,7 @@ export const dummyBoards = (): IAuditBoard[] => [
     signedOffAt: null,
   },
   {
+    type: 'audit_board',
     id: 'audit-board-2',
     name: 'Audit Board #2',
     jurisdictionId: 'jurisdiction-1',

--- a/client/src/components/DataEntry/index.tsx
+++ b/client/src/components/DataEntry/index.tsx
@@ -2,13 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { H1 } from '@blueprintjs/core'
 import { Route, Switch, useParams, useHistory } from 'react-router-dom'
 import styled from 'styled-components'
-import {
-  IAuditBoard,
-  IBallotInterpretation,
-  IAuditBoardMember,
-  IContest,
-  BallotStatus,
-} from '../../types'
+import { IBallotInterpretation, IContest, BallotStatus } from '../../types'
 import { api } from '../utilities'
 import BoardTable from './BoardTable'
 import MemberForm from './MemberForm'
@@ -16,14 +10,13 @@ import Ballot from './Ballot'
 import SignOff from './SignOff'
 import { Wrapper, Inner } from '../Atoms/Wrapper'
 import { IBallot } from '../MultiJurisdictionAudit/RoundManagement/useBallots'
+import { IAuditBoard, IAuditBoardMember } from '../UserContext'
 
 const PaddedInner = styled(Inner)`
   padding-top: 30px;
 `
 
-const loadAuditBoard = async (): Promise<IAuditBoard | null> => {
-  return api(`/me`)
-}
+const loadAuditBoard = async (): Promise<IAuditBoard | null> => api(`/me`)
 
 const loadContests = async (
   electionId: string,

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -50,14 +50,16 @@ const Header: React.FC<{}> = () => {
     | null = useRouteMatch(
     '/election/:electionId/jurisdiction/:jurisdictionId?'
   )
-  const { isAuthenticated, meta } = useAuthDataContext()
+  const auth = useAuthDataContext()
   const electionId = electionMatch ? electionMatch.params.electionId : undefined
   const jurisdiction =
-    jurisdictionMatch && meta
-      ? meta.jurisdictions.find(
-          j => j.id === jurisdictionMatch.params.jurisdictionId
-        )
-      : undefined
+    jurisdictionMatch &&
+    auth &&
+    auth.user &&
+    auth.user.type === 'jurisdiction_admin' &&
+    auth.user.jurisdictions.find(
+      j => j.id === jurisdictionMatch.params.jurisdictionId
+    )
   return (
     <Nav>
       <InnerBar>
@@ -67,14 +69,12 @@ const Header: React.FC<{}> = () => {
               <img src="/arlo.png" alt="Arlo, by VotingWorks" />
             </Link>
           </NavbarHeading>
-          {isAuthenticated && meta!.type === 'jurisdiction_admin' && (
-            <NavbarHeading>
-              {jurisdiction && `Jurisdiction: ${jurisdiction.name}`}
-            </NavbarHeading>
+          {jurisdiction && (
+            <NavbarHeading>Jurisdiction: {jurisdiction.name}</NavbarHeading>
           )}
         </NavbarGroup>
         <NavbarGroup align={Alignment.RIGHT}>
-          {isAuthenticated && electionId && meta!.type === 'audit_admin' && (
+          {electionId && auth && auth.user && auth.user.type === 'audit_admin' && (
             <>
               <NavbarHeading>
                 <Link to={`/election/${electionId}/setup`}>Audit Setup</Link>
@@ -97,7 +97,7 @@ const Header: React.FC<{}> = () => {
           )}
           <ButtonBar id="reset-button-wrapper" />
           {/* istanbul ignore next */
-          isAuthenticated && (
+          auth && auth.user && (
             <FormButton
               size="sm"
               onClick={

--- a/client/src/components/HomeScreen.tsx
+++ b/client/src/components/HomeScreen.tsx
@@ -10,9 +10,12 @@ import {
 import { useHistory, useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import { Formik, FormikProps, Field } from 'formik'
-import { useAuthDataContext } from './UserContext'
+import {
+  useAuthDataContext,
+  IAuditAdmin,
+  IJurisdictionAdmin,
+} from './UserContext'
 import { api } from './utilities'
-import { IUserMeta } from '../types'
 import LinkButton from './Atoms/LinkButton'
 import FormSection from './Atoms/Form/FormSection'
 import FormButton from './Atoms/Form/FormButton'
@@ -22,13 +25,14 @@ import { groupBy, sortBy } from '../utils/array'
 import { IAuditSettings } from './MultiJurisdictionAudit/useAuditSettings'
 
 const HomeScreen: React.FC = () => {
-  const { isAuthenticated, meta } = useAuthDataContext()
+  const auth = useAuthDataContext()
 
-  if (isAuthenticated === null) return null // Still loading
+  if (auth === null) return null // Still loading
 
-  if (!isAuthenticated) return <LoginScreen />
+  const { user } = auth
+  if (!user) return <LoginScreen />
 
-  switch (meta!.type) {
+  switch (user.type) {
     case 'audit_admin':
       return (
         <Wrapper>
@@ -37,7 +41,7 @@ const HomeScreen: React.FC = () => {
               <ListAuditsAuditAdmin />
             </div>
             <div style={{ width: '50%' }}>
-              <CreateAudit />
+              <CreateAudit user={user} />
             </div>
           </Inner>
         </Wrapper>
@@ -47,7 +51,7 @@ const HomeScreen: React.FC = () => {
         <Wrapper>
           <Inner>
             <div style={{ width: '50%' }}>
-              <ListAuditsJurisdictionAdmin />
+              <ListAuditsJurisdictionAdmin user={user} />
             </div>
           </Inner>
         </Wrapper>
@@ -124,24 +128,24 @@ const ListAuditsAuditAdmin: React.FC = () => {
   // time this component renders. It's a bit hacky and inefficient, but this is
   // the only screen that should have this issue. A better solution might be to
   // decouple loading the list of audits from loading the user data.
-  const [meta, setMeta] = useState<IUserMeta | null>(null)
+  const [user, setUser] = useState<IAuditAdmin | null>(null)
 
   useEffect(() => {
     ;(async () => {
       try {
-        const userMeta: IUserMeta | null = await api('/me')
-        setMeta(userMeta)
+        const response = await api<IAuditAdmin | null>('/me')
+        setUser(response)
       } catch (err) /* istanbul ignore next */ {
-        setMeta(null)
+        setUser(null)
       }
     })()
   }, [])
 
-  if (!meta) return null // Still loading
+  if (!user) return null // Still loading
 
   return (
     <ListAuditsWrapper>
-      {sortBy(meta.organizations, o => o.name).map(organization => (
+      {sortBy(user.organizations, o => o.name).map(organization => (
         <div key={organization.id}>
           <h2>Audits - {organization.name}</h2>
           {organization.elections.length === 0 ? (
@@ -167,9 +171,12 @@ const ListAuditsAuditAdmin: React.FC = () => {
   )
 }
 
-const ListAuditsJurisdictionAdmin: React.FC = () => {
-  const { meta } = useAuthDataContext()
-  const jurisdictionsByAudit = groupBy(meta!.jurisdictions, j => j.election.id)
+const ListAuditsJurisdictionAdmin = ({
+  user,
+}: {
+  user: IJurisdictionAdmin
+}) => {
+  const jurisdictionsByAudit = groupBy(user.jurisdictions, j => j.election.id)
   return (
     <ListAuditsWrapper>
       {sortBy(
@@ -220,8 +227,7 @@ const WideField = styled(FormField)`
   width: 100%;
 `
 
-const CreateAudit: React.FC = () => {
-  const { meta } = useAuthDataContext()
+const CreateAudit = ({ user }: { user: IAuditAdmin }) => {
   const history = useHistory()
   const [submitting, setSubmitting] = useState(false)
 
@@ -255,7 +261,7 @@ const CreateAudit: React.FC = () => {
     <Formik
       onSubmit={onSubmit}
       initialValues={{
-        organizationId: meta!.organizations[0].id,
+        organizationId: user.organizations[0].id,
         auditName: '',
         auditType: 'BALLOT_POLLING',
         auditMathType: 'BRAVO',
@@ -271,7 +277,7 @@ const CreateAudit: React.FC = () => {
           <h2>New Audit</h2>
           <FormSection>
             {/* eslint-disable jsx-a11y/label-has-associated-control */}
-            {meta!.organizations.length > 1 && (
+            {user.organizations.length > 1 && (
               <label htmlFor="organizationId">
                 <p>Organization</p>
                 <HTMLSelect
@@ -281,7 +287,7 @@ const CreateAudit: React.FC = () => {
                     setFieldValue('organizationId', e.currentTarget.value)
                   }
                   value={values.organizationId}
-                  options={meta!.organizations.map(({ id, name }) => ({
+                  options={user.organizations.map(({ id, name }) => ({
                     label: name,
                     value: id,
                   }))}

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
@@ -16,7 +16,7 @@ import QRs from './QRs'
 import RoundDataEntry from './RoundDataEntry'
 import useAuditSettingsJurisdictionAdmin from './useAuditSettingsJurisdictionAdmin'
 import BatchRoundDataEntry from './BatchRoundDataEntry'
-import { useAuthDataContext } from '../../UserContext'
+import { useAuthDataContext, IJurisdictionAdmin } from '../../UserContext'
 import useBallots, { IBallot } from './useBallots'
 import { IRound } from '../useRoundsAuditAdmin'
 import OfflineBatchRoundDataEntry from './OfflineBatchRoundDataEntry'
@@ -53,16 +53,18 @@ const RoundManagement = ({
     electionId: string
     jurisdictionId: string
   }>()
-  const { meta } = useAuthDataContext()
+  const auth = useAuthDataContext()
   const ballots = useBallots(electionId, jurisdictionId, round.id, auditBoards)
   const auditSettings = useAuditSettingsJurisdictionAdmin(
     electionId,
     jurisdictionId
   )
 
-  if (!meta || !ballots || !auditSettings) return null // Still loading
+  if (!auth || !auth.user || !ballots || !auditSettings) return null // Still loading
 
-  const jurisdiction = meta.jurisdictions.find(j => j.id === jurisdictionId)!
+  const jurisdiction = (auth.user as IJurisdictionAdmin).jurisdictions.find(
+    j => j.id === jurisdictionId
+  )!
   const { roundNum } = round
 
   if (round.isAuditComplete) {

--- a/client/src/components/MultiJurisdictionAudit/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.test.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { waitFor, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
@@ -25,7 +25,7 @@ import {
   withMockFetch,
   renderWithRouter,
 } from '../testUtilities'
-import AuthDataProvider, { AuthDataContext } from '../UserContext'
+import AuthDataProvider, { useAuthDataContext } from '../UserContext'
 import getJurisdictionFileStatus from './useSetupMenuItems/getJurisdictionFileStatus'
 import getRoundStatus from './useSetupMenuItems/getRoundStatus'
 import { jaApiCalls, aaApiCalls } from './_mocks'
@@ -60,8 +60,8 @@ describe('AA setup flow', () => {
   // AuditAdminView will only be rendered once the user is logged in, so
   // we simulate that.
   const AuditAdminViewWithAuth: React.FC = () => {
-    const { isAuthenticated } = useContext(AuthDataContext)
-    return isAuthenticated ? <AuditAdminView /> : null
+    const auth = useAuthDataContext()
+    return auth ? <AuditAdminView /> : null
   }
 
   const loadEach = [
@@ -245,8 +245,8 @@ describe('JA setup', () => {
   // JurisdictionAdminView will only be rendered once the user is logged in, so
   // we simulate that.
   const JurisdictionAdminViewWithAuth: React.FC = () => {
-    const { isAuthenticated } = useContext(AuthDataContext)
-    return isAuthenticated ? <JurisdictionAdminView /> : null
+    const auth = useAuthDataContext()
+    return auth ? <JurisdictionAdminView /> : null
   }
 
   const renderView = () =>

--- a/client/src/components/MultiJurisdictionAudit/timers.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/timers.test.tsx
@@ -2,13 +2,13 @@
  * These tests are segregated from index.test.tsx because they were creating unreliable interference
  */
 
-import React, { ReactElement, useContext } from 'react'
+import React, { ReactElement } from 'react'
 import { screen, act } from '@testing-library/react'
 import { Route } from 'react-router-dom'
 import FakeTimers from '@sinonjs/fake-timers'
 import { AuditAdminView } from './index'
 import { renderWithRouter, withMockFetch } from '../testUtilities'
-import AuthDataProvider, { AuthDataContext } from '../UserContext'
+import AuthDataProvider, { useAuthDataContext } from '../UserContext'
 import getJurisdictionFileStatus from './useSetupMenuItems/getJurisdictionFileStatus'
 import getRoundStatus from './useSetupMenuItems/getRoundStatus'
 import { aaApiCalls } from './_mocks'
@@ -25,8 +25,8 @@ getRoundStatusMock.mockReturnValue(false)
 // AuditAdminView will only be rendered once the user is logged in, so
 // we simulate that.
 const AuditAdminViewWithAuth: React.FC = () => {
-  const { isAuthenticated } = useContext(AuthDataContext)
-  return isAuthenticated ? <AuditAdminView /> : null
+  const auth = useAuthDataContext()
+  return auth ? <AuditAdminView /> : null
 }
 
 const renderWithRoute = (route: string, component: ReactElement) =>

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -45,57 +45,8 @@ export enum BallotStatus {
   NOT_FOUND = 'NOT_FOUND',
 }
 
-export interface IAuditBoardMember {
-  name: string
-  affiliation: string | null
-}
-
-export interface IAuditBoard {
-  id: string
-  name: string
-  jurisdictionId: string
-  jurisdictionName: string
-  roundId: string
-  members: IAuditBoardMember[]
-  signedOffAt: string | null
-  passphrase?: string
-}
-
 export interface ISampleSizeOption {
   size: number | string
   prob: number | null
   key: string
-}
-
-export interface IElectionMeta {
-  id: string
-  auditName: string
-  electionName: string
-  state: string
-}
-
-export interface IOrganizationMeta {
-  id: string
-  name: string
-  elections: IElectionMeta[]
-}
-
-export interface IJurisdictionMeta {
-  id: string
-  name: string
-  election: IElectionMeta
-  numBallots: number | null
-}
-
-export interface IUserMeta {
-  name: string
-  email: string
-  type: 'audit_admin' | 'jurisdiction_admin' | 'audit_board'
-  organizations: IOrganizationMeta[]
-  jurisdictions: IJurisdictionMeta[]
-}
-
-export interface IAuthData {
-  isAuthenticated: boolean | null
-  meta?: IUserMeta
 }


### PR DESCRIPTION
- Use `null` to represent data still being loaded (our standard pattern)
- Put the `/me` response in a `{ user }` object so that we can easily
extend it with superadmin user info (in a PR coming soon)
- Remove `isAuthenticated`, since it's redundant with `user`, which is
`null` when not authenticated (plus, the meaning of this field will be
less clear once we also have superadmin user info).
- Move the relevant types into the UserContext module