### PR TITLE
Handle invalid audit board passphrases

### DIFF
--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -203,11 +203,18 @@ def jurisdictionadmin_login_callback():
 
 
 @auth.route("/auditboard/<passphrase>", methods=["GET"])
-def auditboard_passphrase(passphrase):
-    auditboard = AuditBoard.query.filter_by(passphrase=passphrase).one()
-    set_loggedin_user(session, UserType.AUDIT_BOARD, auditboard.id)
+def auditboard_passphrase(passphrase: str):
+    audit_board = AuditBoard.query.filter_by(passphrase=passphrase).one_or_none()
+    if not audit_board:
+        return redirect(
+            "/?"
+            + urlencode(
+                {"error": "audit_board_not_found", "message": "Audit board not found."}
+            )
+        )
+    set_loggedin_user(session, UserType.AUDIT_BOARD, audit_board.id)
     return redirect(
-        f"/election/{auditboard.jurisdiction.election.id}/audit-board/{auditboard.id}"
+        f"/election/{audit_board.jurisdiction.election.id}/audit-board/{audit_board.id}"
     )
 
 

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -286,6 +286,19 @@ def test_auth0_error(client: FlaskClient):
     )
 
 
+def test_audit_board_not_found(client: FlaskClient,):
+    rv = client.get("/auditboard/not-a-real-passphrase")
+    assert rv.status_code == 302
+    location = urlparse(rv.location)
+    assert location.path == "/"
+    assert (
+        location.query == "error=audit_board_not_found&message=Audit+board+not+found."
+    )
+
+    with client.session_transaction() as session:  # type: ignore
+        assert session.get("_user") is None
+
+
 # Tests for /api/me
 
 


### PR DESCRIPTION
Currently, using an invalid audit board passphrase leads to a database exception. This has happened a few times in production: https://sentry.io/organizations/votingworks/issues/2028541746/.

Instead, we redirect to the login screen with an error message.