### PR TITLE
Support Tools interface

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -41,6 +41,7 @@ typing-extensions = "*"
 pytest-testmon = "*"
 sentry-sdk = {extras = ["flask"], version = "*"}
 athena = {git = "https://github.com/filipzz/athena.git", editable = true, ref = "v0.8.3"}
+auth0-python = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aeef311f465504ee8f4fcb6cfb20a2353503309a6fff846aa50be17e35937e94"
+            "sha256": "7e66f98367a2abee6193aa68db298eea12dd8b0a49178ad8024f5a9f0d28daf6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -37,6 +37,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.3.0"
         },
+        "auth0-python": {
+            "hashes": [
+                "sha256:2e968d01364c8c94fbe85154ab77ebe9e51a3f8282405bb33748071452063004",
+                "sha256:42b0174fd00655b4d238bdc4afd592cee5508c166a3eaeba7321b3fa59d4caba"
+            ],
+            "index": "pypi",
+            "version": "==3.13.0"
+        },
         "authlib": {
             "hashes": [
                 "sha256:078b900fa9fbebf9f8dae1d5dc1ca857b6a742493093ef9b0b36ad926f36e41f",
@@ -53,10 +61,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd",
-                "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2020.11.8"
+            "version": "==2020.12.5"
         },
         "cffi": {
             "hashes": [
@@ -81,12 +89,14 @@
                 "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35",
                 "sha256:9f7a31251289b2ab6d4012f6e83e58bc3b96bd151f5b5262467f4bb6b34a7c26",
                 "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b",
+                "sha256:a5ed8c05548b54b998b9498753fb9cadbfd92ee88e884641377d8a8b291bcc01",
                 "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb",
                 "sha256:af5c59122a011049aad5dd87424b8e65a80e4a6477419c0c1015f73fb5ea0293",
                 "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd",
                 "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d",
                 "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3",
                 "sha256:c6332685306b6417a91b1ff9fae889b3ba65c2292d64bd9245c093b1b284809d",
+                "sha256:d5ff0621c88ce83a28a10d2ce719b2ee85635e85c515f12bac99a95306da4b2e",
                 "sha256:d9efd8b7a3ef378dd61a1e77367f1924375befc2eba06168b6ebfa903a5e59ca",
                 "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d",
                 "sha256:ebb253464a5d0482b191274f1c8bf00e33f7e0b9c66405fbffc61ed2c839c775",
@@ -163,31 +173,23 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:07ca431b788249af92764e3be9a488aa1d39a0bc3be313d826bbec690417e538",
-                "sha256:13b88a0bd044b4eae1ef40e265d006e34dbcde0c2f1e15eb9896501b2d8f6c6f",
-                "sha256:32434673d8505b42c0de4de86da8c1620651abd24afe91ae0335597683ed1b77",
-                "sha256:3cd75a683b15576cfc822c7c5742b3276e50b21a06672dc3a800a2d5da4ecd1b",
-                "sha256:4e7268a0ca14536fecfdf2b00297d4e407da904718658c1ff1961c713f90fd33",
-                "sha256:545a8550782dda68f8cdc75a6e3bf252017aa8f75f19f5a9ca940772fc0cb56e",
-                "sha256:55d0b896631412b6f0c7de56e12eb3e261ac347fbaa5d5e705291a9016e5f8cb",
-                "sha256:5849d59358547bf789ee7e0d7a9036b2d29e9a4ddf1ce5e06bb45634f995c53e",
-                "sha256:6dc59630ecce8c1f558277ceb212c751d6730bd12c80ea96b4ac65637c4f55e7",
-                "sha256:7117319b44ed1842c617d0a452383a5a052ec6aa726dfbaffa8b94c910444297",
-                "sha256:75e8e6684cf0034f6bf2a97095cb95f81537b12b36a8fedf06e73050bb171c2d",
-                "sha256:7b8d9d8d3a9bd240f453342981f765346c87ade811519f98664519696f8e6ab7",
-                "sha256:a035a10686532b0587d58a606004aa20ad895c60c4d029afa245802347fab57b",
-                "sha256:a4e27ed0b2504195f855b52052eadcc9795c59909c9d84314c5408687f933fc7",
-                "sha256:a733671100cd26d816eed39507e585c156e4498293a907029969234e5e634bc4",
-                "sha256:a75f306a16d9f9afebfbedc41c8c2351d8e61e818ba6b4c40815e2b5740bb6b8",
-                "sha256:bd717aa029217b8ef94a7d21632a3bb5a4e7218a4513d2521c2a2fd63011e98b",
-                "sha256:d25cecbac20713a7c3bc544372d42d8eafa89799f492a43b79e1dfd650484851",
-                "sha256:d26a2557d8f9122f9bf445fc7034242f4375bd4e95ecda007667540270965b13",
-                "sha256:d3545829ab42a66b84a9aaabf216a4dce7f16dbc76eb69be5c302ed6b8f4a29b",
-                "sha256:d3d5e10be0cf2a12214ddee45c6bd203dab435e3d83b4560c03066eda600bfe3",
-                "sha256:efe15aca4f64f3a7ea0c09c87826490e50ed166ce67368a68f315ea0807a20df"
+                "sha256:0003a52a123602e1acee177dc90dd201f9bb1e73f24a070db7d36c588e8f5c7d",
+                "sha256:0e85aaae861d0485eb5a79d33226dd6248d2a9f133b81532c8f5aae37de10ff7",
+                "sha256:594a1db4511bc4d960571536abe21b4e5c3003e8750ab8365fafce71c5d86901",
+                "sha256:69e836c9e5ff4373ce6d3ab311c1a2eed274793083858d3cd4c7d12ce20d5f9c",
+                "sha256:788a3c9942df5e4371c199d10383f44a105d67d401fb4304178020142f020244",
+                "sha256:7e177e4bea2de937a584b13645cab32f25e3d96fc0bc4a4cf99c27dc77682be6",
+                "sha256:83d9d2dfec70364a74f4e7c70ad04d3ca2e6a08b703606993407bf46b97868c5",
+                "sha256:84ef7a0c10c24a7773163f917f1cb6b4444597efd505a8aed0a22e8c4780f27e",
+                "sha256:9e21301f7a1e7c03dbea73e8602905a4ebba641547a462b26dd03451e5769e7c",
+                "sha256:9f6b0492d111b43de5f70052e24c1f0951cb9e6022188ebcb1cc3a3d301469b0",
+                "sha256:a69bd3c68b98298f490e84519b954335154917eaab52cf582fa2c5c7efc6e812",
+                "sha256:b4890d5fb9b7a23e3bf8abf5a8a7da8e228f1e97dc96b30b95685df840b6914a",
+                "sha256:c366df0401d1ec4e548bebe8f91d55ebcc0ec3137900d214dd7aac8427ef3030",
+                "sha256:dc42f645f8f3a489c3dd416730a514e7a91a59510ddaadc09d04224c098d3302"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==3.2.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==3.3.1"
         },
         "cryptorandom": {
             "hashes": [
@@ -255,11 +257,11 @@
         },
         "joblib": {
             "hashes": [
-                "sha256:698c311779f347cf6b7e6b8a39bb682277b8ee4aba8cf9507bc0cf4cd4737b72",
-                "sha256:9e284edd6be6b71883a63c9b7f124738a3c16195513ad940eae7e3438de885d5"
+                "sha256:75ead23f13484a2a414874779d69ade40d4fa1abe62b222a23cd50d4bc822f6f",
+                "sha256:7ad866067ac1fdec27d51c8678ea760601b70e32ff1881d4dc8e1171f2b64b24"
             ],
             "index": "pypi",
-            "version": "==0.17.0"
+            "version": "==1.0.0"
         },
         "jsonschema": {
             "hashes": [
@@ -358,11 +360,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:05af3bb85d320377db281cf254ab050e1a7ebcbf5410685a9a407e18a1f81236",
-                "sha256:eb41423378682dadb7166144a4926e443093863024de508ca5c9737d6bc08376"
+                "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
+                "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.7"
+            "version": "==20.8"
         },
         "pluggy": {
             "hashes": [
@@ -415,11 +417,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
-                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.9.0"
+            "version": "==1.10.0"
         },
         "pycparser": {
             "hashes": [
@@ -446,11 +448,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe",
-                "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"
+                "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8",
+                "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==6.1.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==6.2.1"
         },
         "pytest-testmon": {
             "hashes": [
@@ -521,11 +523,11 @@
                 "flask"
             ],
             "hashes": [
-                "sha256:1052f0ed084e532f66cb3e4ba617960d820152aee8b93fc6c05bd53861768c1c",
-                "sha256:4c42910a55a6b1fe694d5e4790d5188d105d77b5a6346c1c64cbea8c06c0e8b7"
+                "sha256:0a711ec952441c2ec89b8f5d226c33bc697914f46e876b44a4edd3e7864cf4d0",
+                "sha256:737a094e49a529dd0fdcaafa9e97cf7c3d5eb964bd229821d640bc77f3502b3f"
             ],
             "index": "pypi",
-            "version": "==0.19.4"
+            "version": "==0.19.5"
         },
         "six": {
             "hashes": [
@@ -914,11 +916,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:05af3bb85d320377db281cf254ab050e1a7ebcbf5410685a9a407e18a1f81236",
-                "sha256:eb41423378682dadb7166144a4926e443093863024de508ca5c9737d6bc08376"
+                "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
+                "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.7"
+            "version": "==20.8"
         },
         "pathspec": {
             "hashes": [
@@ -937,11 +939,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
-                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.9.0"
+            "version": "==1.10.0"
         },
         "pylint": {
             "hashes": [
@@ -961,11 +963,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe",
-                "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"
+                "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8",
+                "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==6.1.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==6.2.1"
         },
         "pytest-alembic": {
             "hashes": [
@@ -993,11 +995,11 @@
         },
         "pytest-xdist": {
             "hashes": [
-                "sha256:7c629016b3bb006b88ac68e2b31551e7becf173c76b977768848e2bbed594d90",
-                "sha256:82d938f1a24186520e2d9d3a64ef7d9ac7ecdf1a0659e095d18e596b8cbd0672"
+                "sha256:1d8edbb1a45e8e1f8e44b1260583107fc23f8bc8da6d18cb331ff61d41258ecf",
+                "sha256:f127e11e84ad37cc1de1088cb2990f3c354630d428af3f71282de589c5bb779b"
             ],
             "index": "pypi",
-            "version": "==2.1.0"
+            "version": "==2.2.0"
         },
         "python-dateutil": {
             "hashes": [

--- a/client/package.json
+++ b/client/package.json
@@ -96,6 +96,8 @@
     "react": "16.13.1",
     "react-app-polyfill": "^1.0.1",
     "react-dom": "^16.13.1",
+    "react-hook-form": "^6.13.1",
+    "react-query": "^3.2.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.0",
     "react-table": "^7.1.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ import AuthDataProvider, {
   IUser,
   useAuthDataContext,
 } from './components/UserContext'
+import SupportTools from './components/SupportTools'
 
 const Main = styled.div`
   display: flex;
@@ -78,6 +79,9 @@ const App: React.FC = () => {
               path="/election/:electionId/:view?"
               component={AuditAdminView}
             />
+            <Route path="/support">
+              <SupportTools />
+            </Route>
             <Route>
               <Wrapper>404 Not Found</Wrapper>
             </Route>

--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`App / renders aa logged in properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-iELTvK dOFDOj"
+    class="sc-jwKygS ctegmc"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -257,7 +257,7 @@ exports[`App / renders ja logged in properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-iELTvK dOFDOj"
+    class="sc-jwKygS ctegmc"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -399,7 +399,7 @@ exports[`App / renders unauthenticated properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-iELTvK dOFDOj"
+    class="sc-jwKygS ctegmc"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -475,7 +475,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders aa logged i
     class="Toastify"
   />
   <div
-    class="sc-iELTvK dOFDOj"
+    class="sc-jwKygS ctegmc"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -726,7 +726,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ab logged i
     class="Toastify"
   />
   <div
-    class="sc-iELTvK dOFDOj"
+    class="sc-jwKygS ctegmc"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -1066,7 +1066,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ja logged i
     class="Toastify"
   />
   <div
-    class="sc-iELTvK dOFDOj"
+    class="sc-jwKygS ctegmc"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -1208,7 +1208,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders unauthentic
     class="Toastify"
   />
   <div
-    class="sc-iELTvK dOFDOj"
+    class="sc-jwKygS ctegmc"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -1284,7 +1284,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders aa logge
     class="Toastify"
   />
   <div
-    class="sc-iELTvK dOFDOj"
+    class="sc-jwKygS ctegmc"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -1535,7 +1535,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders ja logge
     class="Toastify"
   />
   <div
-    class="sc-iELTvK dOFDOj"
+    class="sc-jwKygS ctegmc"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -1782,7 +1782,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders unauthen
     class="Toastify"
   />
   <div
-    class="sc-iELTvK dOFDOj"
+    class="sc-jwKygS ctegmc"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"

--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`App / renders aa logged in properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-jwKygS ctegmc"
+    class="sc-btzYZH dFjlDG"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -257,7 +257,7 @@ exports[`App / renders ja logged in properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-jwKygS ctegmc"
+    class="sc-btzYZH dFjlDG"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -399,7 +399,7 @@ exports[`App / renders unauthenticated properly 1`] = `
     class="Toastify"
   />
   <div
-    class="sc-jwKygS ctegmc"
+    class="sc-btzYZH dFjlDG"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -475,7 +475,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders aa logged i
     class="Toastify"
   />
   <div
-    class="sc-jwKygS ctegmc"
+    class="sc-btzYZH dFjlDG"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -726,7 +726,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ab logged i
     class="Toastify"
   />
   <div
-    class="sc-jwKygS ctegmc"
+    class="sc-btzYZH dFjlDG"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -1066,7 +1066,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ja logged i
     class="Toastify"
   />
   <div
-    class="sc-jwKygS ctegmc"
+    class="sc-btzYZH dFjlDG"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -1208,7 +1208,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders unauthentic
     class="Toastify"
   />
   <div
-    class="sc-jwKygS ctegmc"
+    class="sc-btzYZH dFjlDG"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -1284,7 +1284,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders aa logge
     class="Toastify"
   />
   <div
-    class="sc-jwKygS ctegmc"
+    class="sc-btzYZH dFjlDG"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -1535,7 +1535,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders ja logge
     class="Toastify"
   />
   <div
-    class="sc-jwKygS ctegmc"
+    class="sc-btzYZH dFjlDG"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"
@@ -1782,7 +1782,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders unauthen
     class="Toastify"
   />
   <div
-    class="sc-jwKygS ctegmc"
+    class="sc-btzYZH dFjlDG"
   >
     <div
       class="bp3-navbar sc-bxivhb jDnGce"

--- a/client/src/components/Header.test.tsx
+++ b/client/src/components/Header.test.tsx
@@ -165,13 +165,13 @@ describe('Header', () => {
   it('shows Support Tools navbar when authenticated as a superadmin', async () => {
     const expectedCalls = [superadminApiCalls.getUser]
     await withMockFetch(expectedCalls, async () => {
-      renderHeader('/superadmin/')
+      renderHeader('/support')
 
       // Support tools link
       const supportToolsLink = await screen.findByRole('link', {
         name: /Support Tools/,
       })
-      expect(supportToolsLink).toHaveAttribute('href', '/superadmin/')
+      expect(supportToolsLink).toHaveAttribute('href', '/support')
 
       // Superadmin user email
       screen.getByText('superadmin@example.com')
@@ -181,13 +181,11 @@ describe('Header', () => {
       expect(logOutButton).toHaveAttribute('href', '/auth/superadmin/logout')
 
       // No regular navbar
-      // TODO once we actually move the Support Tools interface to the React App
-      // - currently we don't actually render the navbar on /superadmin/
-      // expect(
-      //   screen.queryByRole('link', {
-      //     name: 'Arlo, by VotingWorks',
-      //   })
-      // ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('link', {
+          name: 'Arlo, by VotingWorks',
+        })
+      ).not.toBeInTheDocument()
     })
   })
 
@@ -202,7 +200,7 @@ describe('Header', () => {
       const supportToolsLink = await screen.findByRole('link', {
         name: /Support Tools/,
       })
-      expect(supportToolsLink).toHaveAttribute('href', '/superadmin/')
+      expect(supportToolsLink).toHaveAttribute('href', '/support')
 
       // Superadmin user email
       screen.getByText('superadmin@example.com')
@@ -243,7 +241,7 @@ describe('Header', () => {
       const supportToolsLink = await screen.findByRole('link', {
         name: /Support Tools/,
       })
-      expect(supportToolsLink).toHaveAttribute('href', '/superadmin/')
+      expect(supportToolsLink).toHaveAttribute('href', '/support')
 
       // Superadmin user email
       screen.getByText('superadmin@example.com')

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -24,6 +24,7 @@ const SupportBar = styled(Navbar)`
   height: 35px;
   padding: 0;
   color: ${Colors.WHITE};
+  font-weight: 500;
 
   .bp3-navbar-group {
     height: 35px;
@@ -32,8 +33,8 @@ const SupportBar = styled(Navbar)`
   a {
     text-decoration: none;
     color: ${Colors.WHITE};
-    span {
-      margin-left: 8px;
+    .bp3-icon {
+      margin-right: 8px;
     }
   }
 
@@ -84,6 +85,7 @@ const Header: React.FC<{}> = () => {
     | null = useRouteMatch(
     '/election/:electionId/jurisdiction/:jurisdictionId?'
   )
+  const supportMatch = useRouteMatch('/support')
   const auth = useAuthDataContext()
   const electionId = electionMatch ? electionMatch.params.electionId : undefined
   const jurisdiction =
@@ -100,9 +102,9 @@ const Header: React.FC<{}> = () => {
         <SupportBar>
           <InnerBar>
             <NavbarGroup align={Alignment.LEFT}>
-              <a href="/superadmin/">
+              <a href="/support">
                 <Icon icon="eye-open" />
-                <span>Support Tools</span>
+                <span>Arlo Support Tools</span>
               </a>
             </NavbarGroup>
             <NavbarGroup align={Alignment.RIGHT}>
@@ -113,68 +115,70 @@ const Header: React.FC<{}> = () => {
           </InnerBar>
         </SupportBar>
       )}
-      <Nav>
-        <InnerBar>
-          <NavbarGroup align={Alignment.LEFT}>
-            <NavbarHeading>
-              <Link to="/">
-                <img src="/arlo.png" alt="Arlo, by VotingWorks" />
-              </Link>
-            </NavbarHeading>
-            {jurisdiction && (
-              <NavbarHeading>Jurisdiction: {jurisdiction.name}</NavbarHeading>
-            )}
-          </NavbarGroup>
-          {auth && auth.user && (
-            <NavbarGroup align={Alignment.RIGHT}>
-              {electionId && auth.user.type === 'audit_admin' && (
-                <>
-                  <LinkButton
-                    to={`/election/${electionId}/setup`}
-                    minimal
-                    icon="wrench"
-                  >
-                    Audit Setup
-                  </LinkButton>
-                  <LinkButton
-                    to={`/election/${electionId}/progress`}
-                    minimal
-                    icon="horizontal-bar-chart"
-                  >
-                    Audit Progress
-                  </LinkButton>
-                  <LinkButton to="/" minimal icon="projects">
-                    View Audits
-                  </LinkButton>
-                  <LinkButton to="/" minimal icon="insert">
-                    New Audit
-                  </LinkButton>
-                  <NavbarDivider />
-                </>
+      {!supportMatch && (
+        <Nav>
+          <InnerBar>
+            <NavbarGroup align={Alignment.LEFT}>
+              <NavbarHeading>
+                <Link to="/">
+                  <img src="/arlo.png" alt="Arlo, by VotingWorks" />
+                </Link>
+              </NavbarHeading>
+              {jurisdiction && (
+                <NavbarHeading>Jurisdiction: {jurisdiction.name}</NavbarHeading>
               )}
-              <UserMenu>
-                <Popover
-                  content={
-                    <Menu>
-                      <MenuItem text="Log out" href="/auth/logout" />
-                    </Menu>
-                  }
-                  usePortal={false}
-                  position={Position.BOTTOM}
-                  minimal
-                  fill
-                >
-                  <Button icon="user" minimal>
-                    {auth.user.type === 'audit_board'
-                      ? auth.user.name
-                      : auth.user.email}
-                  </Button>
-                </Popover>
-              </UserMenu>
             </NavbarGroup>
-          )}
-        </InnerBar>
-      </Nav>
+            {auth && auth.user && (
+              <NavbarGroup align={Alignment.RIGHT}>
+                {electionId && auth.user.type === 'audit_admin' && (
+                  <>
+                    <LinkButton
+                      to={`/election/${electionId}/setup`}
+                      minimal
+                      icon="wrench"
+                    >
+                      Audit Setup
+                    </LinkButton>
+                    <LinkButton
+                      to={`/election/${electionId}/progress`}
+                      minimal
+                      icon="horizontal-bar-chart"
+                    >
+                      Audit Progress
+                    </LinkButton>
+                    <LinkButton to="/" minimal icon="projects">
+                      View Audits
+                    </LinkButton>
+                    <LinkButton to="/" minimal icon="insert">
+                      New Audit
+                    </LinkButton>
+                    <NavbarDivider />
+                  </>
+                )}
+                <UserMenu>
+                  <Popover
+                    content={
+                      <Menu>
+                        <MenuItem text="Log out" href="/auth/logout" />
+                      </Menu>
+                    }
+                    usePortal={false}
+                    position={Position.BOTTOM}
+                    minimal
+                    fill
+                  >
+                    <Button icon="user" minimal>
+                      {auth.user.type === 'audit_board'
+                        ? auth.user.name
+                        : auth.user.email}
+                    </Button>
+                  </Popover>
+                </UserMenu>
+              </NavbarGroup>
+            )}
+          </InnerBar>
+        </Nav>
+      )}
     </>
   )
 }

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -1,0 +1,201 @@
+import React from 'react'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { withMockFetch, renderWithRouter } from '../testUtilities'
+import SupportTools from './SupportTools'
+import AuthDataProvider from '../UserContext'
+import { superadminApiCalls } from '../MultiJurisdictionAudit/_mocks'
+
+const apiCalls = {
+  getOrganizations: {
+    url: '/api/support/organizations',
+    response: [
+      { id: 'organization-id-1', name: 'Organization 1' },
+      { id: 'organization-id-2', name: 'Organization 2' },
+    ],
+  },
+  getOrganization: {
+    url: '/api/support/organizations/organization-id-1',
+    response: {
+      id: 'organization-id-1',
+      name: 'Organization 1',
+      elections: [
+        {
+          id: 'election-id-1',
+          auditName: 'Audit 1',
+          auditType: 'BALLOT_POLLING',
+        },
+        {
+          id: 'election-id-2',
+          auditName: 'Audit 2',
+          auditType: 'BALLOT_COMPARISON',
+        },
+      ],
+      auditAdmins: [
+        { email: 'audit-admin-1@example.org' },
+        { email: 'audit-admin-2@example.org' },
+      ],
+    },
+  },
+  getElection: {
+    url: '/api/support/elections/election-id-1',
+    response: {
+      id: 'election-id-1',
+      auditName: 'Audit 1',
+      auditType: 'BALLOT_POLLING',
+      jurisdictions: [
+        {
+          id: 'jurisdiction-id-1',
+          name: 'Jurisdiction 1',
+          jurisdictionAdmins: [
+            { email: 'jurisdiction-admin-1@example.org' },
+            { email: 'jurisdiction-admin-2@example.org' },
+          ],
+        },
+        {
+          id: 'jurisdiction-id-2',
+          name: 'Jurisdiction 2',
+          jurisdictionAdmins: [{ email: 'jurisdiction-admin-3@example.org' }],
+        },
+      ],
+    },
+  },
+  postAuditAdmin: {
+    url: '/api/support/organizations/organization-id-1/audit-admins',
+    options: {
+      method: 'POST',
+      body: JSON.stringify({
+        email: 'audit-admin-3@example.org',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    },
+    response: { status: 'ok' },
+  },
+}
+
+const renderRoute = (route: string) =>
+  renderWithRouter(
+    <AuthDataProvider>
+      <SupportTools />
+    </AuthDataProvider>,
+    { route }
+  )
+
+describe('Support Tools', () => {
+  it('home screen shows a list of orgs', async () => {
+    const expectedCalls = [
+      superadminApiCalls.getUser,
+      apiCalls.getOrganizations,
+      apiCalls.getOrganization,
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { history } = renderRoute('/support')
+
+      await screen.findByRole('heading', { name: 'Organizations' })
+
+      screen.getByRole('button', { name: 'Organization 2' })
+      userEvent.click(screen.getByRole('button', { name: 'Organization 1' }))
+
+      await screen.findByRole('heading', { name: 'Organization 1' })
+      expect(history.location.pathname).toEqual(
+        '/support/orgs/organization-id-1'
+      )
+    })
+  })
+
+  it('org screen shows a list of audits', async () => {
+    const expectedCalls = [
+      superadminApiCalls.getUser,
+      apiCalls.getOrganization,
+      apiCalls.getElection,
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { history } = renderRoute('/support/orgs/organization-id-1')
+
+      await screen.findByRole('heading', { name: 'Organization 1' })
+
+      screen.getByRole('button', { name: 'Audit 2' })
+      userEvent.click(screen.getByRole('button', { name: 'Audit 1' }))
+
+      await screen.findByRole('heading', { name: 'Audit 1' })
+      expect(history.location.pathname).toEqual('/support/audits/election-id-1')
+    })
+  })
+
+  it('org screen shows a list of audit admins and a form to create a new audit admin', async () => {
+    const expectedCalls = [
+      superadminApiCalls.getUser,
+      apiCalls.getOrganization,
+      apiCalls.postAuditAdmin,
+      {
+        ...apiCalls.getOrganization,
+        response: {
+          ...apiCalls.getOrganization.response,
+          auditAdmins: [
+            ...apiCalls.getOrganization.response.auditAdmins,
+            { email: 'audit-admin-3@example.org' },
+          ],
+        },
+      },
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderRoute('/support/orgs/organization-id-1')
+
+      await screen.findByRole('heading', { name: 'Organization 1' })
+
+      // List of admins with log in buttons
+      screen.getByText('audit-admin-2@example.org')
+      const logInAsButton = within(
+        screen.getByText('audit-admin-1@example.org').closest('tr')!
+      ).getByRole('button', { name: /Log in as/ })
+      expect(logInAsButton).toHaveAttribute(
+        'href',
+        '/api/support/audit-admins/audit-admin-1@example.org/login'
+      )
+
+      // Create a new admin
+      userEvent.type(
+        screen.getByPlaceholderText('New admin email'),
+        'audit-admin-3@example.org'
+      )
+      userEvent.click(
+        screen.getByRole('button', { name: /Create Audit Admin/ })
+      )
+
+      expect(screen.getByPlaceholderText('New admin email')).toHaveTextContent(
+        ''
+      )
+      await screen.findByText('audit-admin-3@example.org')
+    })
+  })
+
+  it('audit screen shows a list of jurisdiction admins', async () => {
+    const expectedCalls = [superadminApiCalls.getUser, apiCalls.getElection]
+    await withMockFetch(expectedCalls, async () => {
+      renderRoute('/support/audits/election-id-1')
+
+      await screen.findByRole('heading', { name: 'Audit 1' })
+      screen.getByText('Ballot Polling')
+
+      // List of jurisdictions
+      screen.getByRole('heading', { name: 'Jurisdiction 2' })
+      const jurisdiction1Container = screen
+        .getByRole('heading', { name: 'Jurisdiction 1' })
+        .closest('div')!
+
+      // List of jurisdiction admins with log in buttons
+      within(jurisdiction1Container).getByText(
+        'jurisdiction-admin-2@example.org'
+      )
+      const logInAsButton = within(
+        within(jurisdiction1Container)
+          .getByText('jurisdiction-admin-1@example.org')
+          .closest('tr')!
+      ).getByRole('button', { name: /Log in as/ })
+      expect(logInAsButton).toHaveAttribute(
+        'href',
+        '/api/support/jurisdiction-admins/jurisdiction-admin-1@example.org/login'
+      )
+    })
+  })
+})

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -13,6 +13,10 @@ import {
   AnchorButton,
   Tag,
   H4,
+  ButtonGroup,
+  Alignment,
+  Colors,
+  Intent,
 } from '@blueprintjs/core'
 import { useForm } from 'react-hook-form'
 import { useAuthDataContext } from '../UserContext'
@@ -27,7 +31,14 @@ import {
   IElection,
 } from './support-api'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient(
+  // Turn off query retries in test so we can mock effectively
+  process.env.NODE_ENV === 'test'
+    ? {
+        defaultOptions: { queries: { retry: false } },
+      }
+    : {}
+)
 
 const SupportTools = () => {
   const auth = useAuthDataContext()
@@ -55,18 +66,32 @@ const SupportTools = () => {
           </div>
         </Inner>
       </Wrapper>
-      <ReactQueryDevtools initialIsOpen={false} />
+      {process.env.NODE_ENV !== 'test' && (
+        // Dev tools are automatically excluded from production, but we also
+        // don't want them clogging up the DOM output in test
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
     </QueryClientProvider>
   )
 }
 
-const UL = styled.ul`
-  padding: 0;
-  list-style-type: none;
-  li {
-    padding: 5px 0;
-    > .bp3-button:first-child {
-      margin-left: -10px;
+const Column = styled.div`
+  width: 50%;
+  padding-right: 30px;
+`
+
+const ButtonList = styled(ButtonGroup).attrs({
+  vertical: true,
+  minimal: true,
+  large: true,
+  alignText: Alignment.LEFT,
+})`
+  border: 1px solid ${Colors.LIGHT_GRAY3};
+  width: 100%;
+  .bp3-button {
+    border-radius: 0;
+    &:not(:first-child) {
+      border-top: 1px solid ${Colors.LIGHT_GRAY3};
     }
   }
 `
@@ -80,29 +105,33 @@ const Organizations = () => {
   }
 
   return (
-    <div>
+    <Column>
       <H2>Organizations</H2>
-      <UL>
+      <ButtonList style={{ border: `1px solid ${Colors.LIGHT_GRAY3}` }}>
         {organizations.data.map(organization => (
-          <li key={organization.id}>
-            <LinkButton to={`/support/orgs/${organization.id}`} minimal>
-              {organization.name}
-            </LinkButton>
-          </li>
+          <LinkButton
+            key={organization.id}
+            to={`/support/orgs/${organization.id}`}
+            intent={Intent.PRIMARY}
+          >
+            {organization.name}
+          </LinkButton>
         ))}
-      </UL>
-    </div>
+      </ButtonList>
+    </Column>
   )
 }
 
 const Table = styled(HTMLTable)`
   margin-top: 10px;
-  width: 380px;
+  width: 100%;
   table-layout: fixed;
   td:first-child {
-    width: 230px;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+  td:last-child {
+    width: 150px;
   }
   tr td {
     vertical-align: baseline;
@@ -136,27 +165,33 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
     <div style={{ width: '100%' }}>
       <H2>{name}</H2>
       <div style={{ display: 'flex', width: '100%' }}>
-        <div style={{ width: '50%' }}>
+        <Column>
           <H3>Audits</H3>
-          <UL>
+          <ButtonList>
             {elections.map(election => (
-              <li key={election.id}>
-                <LinkButton to={`/support/audits/${election.id}`} minimal>
-                  {election.auditName}
-                </LinkButton>
-              </li>
+              <LinkButton
+                key={election.id}
+                to={`/support/audits/${election.id}`}
+                intent={Intent.PRIMARY}
+              >
+                {election.auditName}
+              </LinkButton>
             ))}
-          </UL>
-        </div>
-        <div style={{ width: '50%' }}>
+          </ButtonList>
+        </Column>
+        <Column>
           <H3>Audit Admins</H3>
-          <form onSubmit={handleSubmit(onSubmitCreateAuditAdmin)}>
+          <form
+            style={{ display: 'flex' }}
+            onSubmit={handleSubmit(onSubmitCreateAuditAdmin)}
+          >
             <input
               type="text"
               name="email"
               className={Classes.INPUT}
               placeholder="New admin email"
               ref={register}
+              style={{ flexGrow: 1 }}
             />
             <Button
               type="submit"
@@ -185,7 +220,7 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
               ))}
             </tbody>
           </Table>
-        </div>
+        </Column>
       </div>
     </div>
   )
@@ -210,7 +245,7 @@ const Audit = ({ electionId }: { electionId: string }) => {
   const { auditName, auditType, jurisdictions } = election.data
 
   return (
-    <div>
+    <Column>
       <H2>{auditName}</H2>
       <Tag large style={{ marginBottom: '15px' }}>
         {prettyAuditType(auditType)}
@@ -239,7 +274,7 @@ const Audit = ({ electionId }: { electionId: string }) => {
           </Table>
         </div>
       ))}
-    </div>
+    </Column>
   )
 }
 

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -1,0 +1,246 @@
+import React from 'react'
+import { ReactQueryDevtools } from 'react-query/devtools'
+import { QueryClientProvider, QueryClient } from 'react-query'
+import { Redirect, Route, Switch } from 'react-router-dom'
+import { toast } from 'react-toastify'
+import styled from 'styled-components'
+import {
+  H3,
+  Button,
+  HTMLTable,
+  Classes,
+  H2,
+  AnchorButton,
+  Tag,
+  H4,
+} from '@blueprintjs/core'
+import { useForm } from 'react-hook-form'
+import { useAuthDataContext } from '../UserContext'
+import LinkButton from '../Atoms/LinkButton'
+import { Wrapper, Inner } from '../Atoms/Wrapper'
+import {
+  useOrganizations,
+  useOrganization,
+  useCreateAuditAdmin,
+  useElection,
+  IAuditAdmin,
+  IElection,
+} from './support-api'
+
+const queryClient = new QueryClient()
+
+const SupportTools = () => {
+  const auth = useAuthDataContext()
+  if (!auth) return null // Still loading
+  if (!auth.superadminUser) return <Redirect to="/" />
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Wrapper>
+        <Inner>
+          <div style={{ margin: '30px 0', width: '100%' }}>
+            <Switch>
+              <Route exact path="/support">
+                <Organizations />
+              </Route>
+              <Route path="/support/orgs/:organizationId">
+                {({ match }) => (
+                  <Organization organizationId={match!.params.organizationId} />
+                )}
+              </Route>
+              <Route path="/support/audits/:electionId">
+                {({ match }) => <Audit electionId={match!.params.electionId} />}
+              </Route>
+            </Switch>
+          </div>
+        </Inner>
+      </Wrapper>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  )
+}
+
+const UL = styled.ul`
+  padding: 0;
+  list-style-type: none;
+  li {
+    padding: 5px 0;
+    > .bp3-button:first-child {
+      margin-left: -10px;
+    }
+  }
+`
+
+const Organizations = () => {
+  const organizations = useOrganizations()
+  if (organizations.isLoading || organizations.isIdle) return null
+  if (organizations.isError) {
+    toast.error(organizations.error.message)
+    return null
+  }
+
+  return (
+    <div>
+      <H2>Organizations</H2>
+      <UL>
+        {organizations.data.map(organization => (
+          <li key={organization.id}>
+            <LinkButton to={`/support/orgs/${organization.id}`} minimal>
+              {organization.name}
+            </LinkButton>
+          </li>
+        ))}
+      </UL>
+    </div>
+  )
+}
+
+const Table = styled(HTMLTable)`
+  margin-top: 10px;
+  width: 380px;
+  table-layout: fixed;
+  td:first-child {
+    width: 230px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  tr td {
+    vertical-align: baseline;
+  }
+`
+
+const Organization = ({ organizationId }: { organizationId: string }) => {
+  const organization = useOrganization(organizationId)
+  const createAuditAdmin = useCreateAuditAdmin()
+
+  const { register, handleSubmit, reset, formState } = useForm<IAuditAdmin>()
+
+  if (organization.isLoading || organization.isIdle) return null
+  if (organization.isError) {
+    toast.error(organization.error.message)
+    return null
+  }
+
+  const onSubmitCreateAuditAdmin = async (auditAdmin: IAuditAdmin) => {
+    try {
+      await createAuditAdmin.mutateAsync({ organizationId, auditAdmin })
+      reset()
+    } catch (error) {
+      toast.error(error.message)
+    }
+  }
+
+  const { name, elections, auditAdmins } = organization.data
+
+  return (
+    <div style={{ width: '100%' }}>
+      <H2>{name}</H2>
+      <div style={{ display: 'flex', width: '100%' }}>
+        <div style={{ width: '50%' }}>
+          <H3>Audits</H3>
+          <UL>
+            {elections.map(election => (
+              <li key={election.id}>
+                <LinkButton to={`/support/audits/${election.id}`} minimal>
+                  {election.auditName}
+                </LinkButton>
+              </li>
+            ))}
+          </UL>
+        </div>
+        <div style={{ width: '50%' }}>
+          <H3>Audit Admins</H3>
+          <form onSubmit={handleSubmit(onSubmitCreateAuditAdmin)}>
+            <input
+              type="text"
+              name="email"
+              className={Classes.INPUT}
+              placeholder="New admin email"
+              ref={register}
+            />
+            <Button
+              type="submit"
+              icon="new-person"
+              style={{ marginLeft: '20px' }}
+              loading={formState.isSubmitting}
+            >
+              Create Audit Admin
+            </Button>
+          </form>
+          <Table striped>
+            <tbody>
+              {auditAdmins.map(auditAdmin => (
+                <tr key={auditAdmin.email}>
+                  <td>{auditAdmin.email}</td>
+                  <td>
+                    <AnchorButton
+                      icon="log-in"
+                      style={{ marginLeft: '20px' }}
+                      href={`/api/support/audit-admins/${auditAdmin.email}/login`}
+                    >
+                      Log in as
+                    </AnchorButton>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const prettyAuditType = (auditType: IElection['auditType']) =>
+  ({
+    BALLOT_POLLING: 'Ballot Polling',
+    BALLOT_COMPARISON: 'Ballot Comparison',
+    BATCH_COMPARISON: 'Batch Comparison',
+  }[auditType])
+
+const Audit = ({ electionId }: { electionId: string }) => {
+  const election = useElection(electionId)
+
+  if (election.isLoading || election.isIdle) return null
+  if (election.isError) {
+    toast.error(election.error.message)
+    return null
+  }
+
+  const { auditName, auditType, jurisdictions } = election.data
+
+  return (
+    <div>
+      <H2>{auditName}</H2>
+      <Tag large style={{ marginBottom: '15px' }}>
+        {prettyAuditType(auditType)}
+      </Tag>
+      <H3>Jurisdictions</H3>
+      {jurisdictions.map(jurisdiction => (
+        <div key={jurisdiction.id} style={{ marginTop: '15px' }}>
+          <H4>{jurisdiction.name}</H4>
+          <Table striped>
+            <tbody>
+              {jurisdiction.jurisdictionAdmins.map(jurisdictionAdmin => (
+                <tr key={jurisdictionAdmin.email}>
+                  <td>{jurisdictionAdmin.email}</td>
+                  <td>
+                    <AnchorButton
+                      icon="log-in"
+                      style={{ marginLeft: '20px' }}
+                      href={`/api/support/jurisdiction-admins/${jurisdictionAdmin.email}/login`}
+                    >
+                      Log in as
+                    </AnchorButton>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default SupportTools

--- a/client/src/components/SupportTools/index.tsx
+++ b/client/src/components/SupportTools/index.tsx
@@ -1,0 +1,3 @@
+import SupportTools from './SupportTools'
+
+export default SupportTools

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -1,0 +1,82 @@
+import { useQuery, useMutation, useQueryClient } from 'react-query'
+import { tryJson } from '../utilities'
+
+const fetchApi = async (url: string, options?: RequestInit) => {
+  const response = await fetch(url, options)
+  if (response.ok) return response.json()
+  const text = await response.text()
+  const { errors } = tryJson(text)
+  const error = errors && errors.length && errors[0].message
+  throw new Error(error || text)
+}
+
+export interface IOrganizationBase {
+  id: string
+  name: string
+}
+
+export interface IOrganization extends IOrganizationBase {
+  elections: IElectionBase[]
+  auditAdmins: IAuditAdmin[]
+}
+
+export interface IElectionBase {
+  id: string
+  auditName: string
+  auditType: 'BALLOT_POLLING' | 'BALLOT_COMPARISON' | 'BATCH_COMPARISON'
+}
+
+export interface IAuditAdmin {
+  email: string
+}
+
+export interface IElection extends IElectionBase {
+  jurisdictions: IJurisdiction[]
+}
+
+export interface IJurisdiction {
+  id: string
+  name: string
+  jurisdictionAdmins: IJurisdictionAdmin[]
+}
+
+export interface IJurisdictionAdmin {
+  email: string
+}
+
+export const useOrganizations = () =>
+  useQuery<IOrganizationBase[], Error>('organizations', () =>
+    fetchApi('/api/support/organizations')
+  )
+
+export const useOrganization = (organizationId: string) =>
+  useQuery<IOrganization, Error>(['organization', organizationId], () =>
+    fetchApi(`/api/support/organizations/${organizationId}`)
+  )
+
+export const useCreateAuditAdmin = () => {
+  const postAuditAdmin = async ({
+    organizationId,
+    auditAdmin,
+  }: {
+    organizationId: string
+    auditAdmin: IAuditAdmin
+  }) =>
+    fetchApi(`/api/support/organizations/${organizationId}/audit-admins`, {
+      method: 'POST',
+      body: JSON.stringify(auditAdmin),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+  const queryClient = useQueryClient()
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return useMutation<any, Error, any>(postAuditAdmin, {
+    onSuccess: () => queryClient.invalidateQueries('organization'),
+  })
+}
+
+export const useElection = (electionId: string) =>
+  useQuery<IElection, Error>(['election', electionId], () =>
+    fetchApi(`/api/support/elections/${electionId}`)
+  )

--- a/client/src/components/utilities.ts
+++ b/client/src/components/utilities.ts
@@ -3,7 +3,7 @@ import { toast } from 'react-toastify'
 import number from '../utils/number-schema'
 import { IErrorResponse } from '../types'
 
-const tryJson = (responseText: string) => {
+export const tryJson = (responseText: string) => {
   try {
     return JSON.parse(responseText)
   } catch (err) {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1071,6 +1071,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.5.4":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
@@ -8849,6 +8856,14 @@ markdown-table@^1.1.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
+match-sorter@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.0.2.tgz#91bbab14c28a87f4a67755b7a194c0d11dedc080"
+  integrity sha512-SDRLNlWof9GnAUEyhKP0O5525MMGXUGt+ep4MrrqQ2StAh3zjvICVZseiwg7Zijn3GazpJDiwuRr/mFDHd92NQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 mathml-tag-names@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz#6dff66c99d55ecf739ca53c492e626f1d12a33cc"
@@ -11399,6 +11414,11 @@ react-fast-compare@^2.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-hook-form@^6.13.1:
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.13.1.tgz#b9c0aa61f746db8169ed5e1050de21cacb1947d6"
+  integrity sha512-Q0N7MYcbA8SigYufb02h9z97ZKCpIbe62rywOTPsK4Ntvh6fRTGDXSuzWuRhLHhArLoWbGrWYSNSS4tlb+OFXg==
+
 react-is@^16.12.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -11430,6 +11450,14 @@ react-popper@^1.3.3:
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
     warning "^4.0.2"
+
+react-query@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.2.0.tgz#c13264941249867c5a5640ec0be8343a55a13158"
+  integrity sha512-P1uErndQIOIhrCLrsw7G3pRPe/S1qL0almPZhYjh/ggRNHwiu8ZRrPh2yTnD8zqDYMvdk+ARJ6VtjukjgX/UZg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    match-sorter "^6.0.2"
 
 react-router-dom@^5.1.2:
   version "5.1.2"
@@ -11816,6 +11844,11 @@ remark@^10.0.1:
     remark-parse "^6.0.0"
     remark-stringify "^6.0.0"
     unified "^7.0.0"
+
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"

--- a/mypy.ini
+++ b/mypy.ini
@@ -53,3 +53,6 @@ ignore_missing_imports = True
 
 [mypy-filelock]
 ignore_missing_imports = True
+
+[mypy-auth0.*]
+ignore_missing_imports = True

--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -20,3 +20,4 @@ from . import batches
 from . import offline_results
 from . import offline_batch_results
 from . import reports
+from . import support

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -1,0 +1,171 @@
+import uuid
+import secrets
+from urllib.parse import urlparse
+from flask import jsonify, request, session, redirect
+from auth0.v3.authentication import GetToken
+from auth0.v3.management import Auth0
+from auth0.v3.exceptions import Auth0Error
+from werkzeug.exceptions import Conflict
+
+from . import api
+from ..models import *  # pylint: disable=wildcard-import
+from ..database import db_session
+from ..auth import (
+    restrict_access_superadmin,
+    set_loggedin_user,
+    UserType,
+)
+from ..config import (
+    AUDITADMIN_AUTH0_BASE_URL,
+    AUDITADMIN_AUTH0_CLIENT_ID,
+    AUDITADMIN_AUTH0_CLIENT_SECRET,
+)
+from ..util.jsonschema import validate
+
+AUTH0_DOMAIN = urlparse(AUDITADMIN_AUTH0_BASE_URL).hostname
+
+
+def auth0_get_token() -> str:
+    response = GetToken(AUTH0_DOMAIN).client_credentials(
+        AUDITADMIN_AUTH0_CLIENT_ID,
+        AUDITADMIN_AUTH0_CLIENT_SECRET,
+        f"https://{AUTH0_DOMAIN}/api/v2/",
+    )
+    return str(response["access_token"])
+
+
+def auth0_create_audit_admin(email: str):
+    token = auth0_get_token()
+    auth0 = Auth0(AUTH0_DOMAIN, token)
+    try:
+        auth0.users.create(
+            dict(
+                email=email,
+                password=secrets.token_urlsafe(),
+                connection="Username-Password-Authentication",
+            )
+        )
+    except Auth0Error as error:
+        # If user already exists in Auth0, no problem!
+        if error.status_code == 409:
+            return
+        raise error
+
+
+@api.route("/support/organizations", methods=["GET"])
+@restrict_access_superadmin
+def list_organizations():
+    organizations = Organization.query.order_by(Organization.name).all()
+    return jsonify(
+        [
+            dict(id=organization.id, name=organization.name)
+            for organization in organizations
+        ]
+    )
+
+
+@api.route("/support/organizations/<organization_id>", methods=["GET"])
+@restrict_access_superadmin
+def get_organization(organization_id: str):
+    organization = get_or_404(Organization, organization_id)
+    return jsonify(
+        id=organization.id,
+        name=organization.name,
+        elections=[
+            dict(
+                id=election.id,
+                auditName=election.audit_name,
+                auditType=election.audit_type,
+            )
+            for election in organization.elections
+        ],
+        auditAdmins=sorted(
+            [
+                dict(email=admin.user.email)
+                for admin in organization.audit_administrations
+            ],
+            key=lambda admin: str(admin["email"]),
+        ),
+    )
+
+
+@api.route("/support/elections/<election_id>", methods=["GET"])
+@restrict_access_superadmin
+def get_election(election_id: str):
+    election = get_or_404(Election, election_id)
+    return jsonify(
+        id=election.id,
+        auditName=election.audit_name,
+        auditType=election.audit_type,
+        jurisdictions=[
+            dict(
+                id=jurisdiction.id,
+                name=jurisdiction.name,
+                jurisdictionAdmins=sorted(
+                    [
+                        dict(email=admin.user.email)
+                        for admin in jurisdiction.jurisdiction_administrations
+                    ],
+                    key=lambda admin: str(admin["email"]),
+                ),
+            )
+            for jurisdiction in election.jurisdictions
+        ],
+    )
+
+
+AUDIT_ADMIN_SCHEMA = {
+    "type": "object",
+    "properties": {"email": {"type": "string", "format": "email"}},
+    "additionalProperties": False,
+    "required": ["email"],
+}
+
+
+@api.route("/support/organizations/<organization_id>/audit-admins", methods=["POST"])
+@restrict_access_superadmin
+def create_audit_admin(organization_id: str):
+    get_or_404(Organization, organization_id)
+    audit_admin = request.get_json()
+    validate(audit_admin, AUDIT_ADMIN_SCHEMA)
+
+    user = User.query.filter_by(email=audit_admin["email"]).one_or_none()
+    if not user:
+        user = User(
+            id=str(uuid.uuid4()),
+            email=audit_admin["email"],
+            external_id=audit_admin["email"],
+        )
+        db_session.add(user)
+
+    admin = AuditAdministration.query.filter_by(
+        user_id=user.id, organization_id=organization_id
+    ).one_or_none()
+    if admin:
+        raise Conflict("Audit admin already exists")
+    admin = AuditAdministration(user_id=user.id, organization_id=organization_id)
+    db_session.add(admin)
+
+    auth0_create_audit_admin(audit_admin["email"])
+
+    db_session.commit()
+
+    return jsonify(status="ok")
+
+
+@api.route(
+    "/support/audit-admins/<email>/login", methods=["GET"],
+)
+@restrict_access_superadmin
+def log_in_as_audit_admin(email: str):
+    set_loggedin_user(session, UserType.AUDIT_ADMIN, email, from_superadmin=True)
+    return redirect("/")
+
+
+@api.route(
+    "/support/jurisdiction-admins/<email>/login", methods=["GET"],
+)
+@restrict_access_superadmin
+def log_in_as_jurisdiction_admin(email: str):
+    set_loggedin_user(session, UserType.JURISDICTION_ADMIN, email, from_superadmin=True)
+    return redirect("/")

--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -157,7 +157,7 @@ def superadmin_login_callback():
         and userinfo["email"].split("@")[-1] == SUPERADMIN_EMAIL_DOMAIN
     ):
         set_superadmin_user(session, userinfo["email"])
-        return redirect("/superadmin/")
+        return redirect("/support")
     else:
         return redirect("/")
 

--- a/server/models.py
+++ b/server/models.py
@@ -58,7 +58,10 @@ class Organization(BaseModel):
     name = Column(String(200), nullable=False)
 
     elections = relationship(
-        "Election", back_populates="organization", passive_deletes=True
+        "Election",
+        back_populates="organization",
+        passive_deletes=True,
+        order_by="Election.audit_name",
     )
 
 

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -167,8 +167,10 @@ def test_support_create_audit_admin_already_in_auth0(  # pylint: disable=invalid
     )
 
 
-def test_support_create_audit_admin_already_exists(  # pylint: disable=invalid-name
-    client: FlaskClient, org_id: str
+@patch("server.api.support.GetToken")
+@patch("server.api.support.Auth0")
+def test_support_create_audit_admin_already_exists(  # pylint: disable=invalid-name,unused-argument
+    MockAuth0, MockGetToken, client: FlaskClient, org_id: str,
 ):
     # Start with an existing user that isn't already an audit admin for this org
     user = create_user(email="already-exists@example.org")
@@ -193,8 +195,10 @@ def test_support_create_audit_admin_already_exists(  # pylint: disable=invalid-n
     ]
 
 
-def test_support_create_audit_admin_already_admin(  # pylint: disable=invalid-name
-    client: FlaskClient, org_id: str
+@patch("server.api.support.GetToken")
+@patch("server.api.support.Auth0")
+def test_support_create_audit_admin_already_admin(  # pylint: disable=invalid-name,unused-argument
+    MockAuth0, MockGetToken, client: FlaskClient, org_id: str,
 ):
     set_superadmin_user(client, SUPPORT_EMAIL)
     rv = post_json(

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -1,0 +1,157 @@
+from unittest.mock import Mock, patch
+from urllib.parse import urlparse
+from flask.testing import FlaskClient
+
+from ..helpers import *  # pylint: disable=wildcard-import
+from ...api.support import (
+    AUTH0_DOMAIN,
+    AUDITADMIN_AUTH0_CLIENT_ID,
+    AUDITADMIN_AUTH0_CLIENT_SECRET,
+)
+
+SUPPORT_EMAIL = "support@example.org"
+
+
+def test_support_list_organizations(client: FlaskClient, org_id: str):
+    set_superadmin_user(client, SUPPORT_EMAIL)
+    rv = client.get("/api/support/organizations")
+    orgs = json.loads(rv.data)
+    # This will load orgs from all tests, so we can't check its exact length/value
+    assert len(orgs) > 1
+    org = next(org for org in orgs if org["id"] == org_id)
+    assert org == {"id": org_id, "name": "Test Org test_support_list_organizations"}
+
+
+def test_support_get_organization(client: FlaskClient, org_id: str, election_id: str):
+    set_superadmin_user(client, SUPPORT_EMAIL)
+    rv = client.get(f"/api/support/organizations/{org_id}")
+    compare_json(
+        json.loads(rv.data),
+        {
+            "id": org_id,
+            "name": "Test Org test_support_get_organization",
+            "elections": [
+                {
+                    "id": election_id,
+                    "auditName": "Test Audit test_support_get_organization",
+                    "auditType": "BALLOT_POLLING",
+                }
+            ],
+            "auditAdmins": [{"email": DEFAULT_AA_EMAIL}],
+        },
+    )
+
+
+def test_support_get_election(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
+    set_superadmin_user(client, SUPPORT_EMAIL)
+    rv = client.get(f"/api/support/elections/{election_id}")
+    compare_json(
+        json.loads(rv.data),
+        {
+            "id": election_id,
+            "auditName": "Test Audit test_support_get_election",
+            "auditType": "BALLOT_POLLING",
+            "jurisdictions": [
+                {
+                    "id": jurisdiction_ids[0],
+                    "name": "J1",
+                    "jurisdictionAdmins": [{"email": default_ja_email(election_id)}],
+                },
+                {
+                    "id": jurisdiction_ids[1],
+                    "name": "J2",
+                    "jurisdictionAdmins": [{"email": default_ja_email(election_id)}],
+                },
+                {
+                    "id": jurisdiction_ids[2],
+                    "name": "J3",
+                    "jurisdictionAdmins": [{"email": f"j3-{election_id}@example.com"}],
+                },
+            ],
+        },
+    )
+
+
+@patch("server.api.support.GetToken")
+@patch("server.api.support.Auth0")
+def test_support_create_audit_admin(  # pylint: disable=invalid-name
+    MockAuth0, MockGetToken, client: FlaskClient, org_id: str,
+):
+    MockGetToken.return_value = Mock()
+    MockGetToken.return_value.client_credentials = Mock(
+        return_value={"access_token": "test token"}
+    )
+    MockAuth0.return_value = Mock()
+    MockAuth0.return_value.users = Mock()
+    MockAuth0.return_value.users.create = Mock()
+
+    set_superadmin_user(client, SUPPORT_EMAIL)
+    rv = post_json(
+        client,
+        f"/api/support/organizations/{org_id}/audit-admins",
+        {"email": f"new-audit-admin-{org_id}@example.com"},
+    )
+    assert_ok(rv)
+
+    rv = client.get(f"/api/support/organizations/{org_id}")
+    assert json.loads(rv.data)["auditAdmins"] == [
+        {"email": DEFAULT_AA_EMAIL},
+        {"email": f"new-audit-admin-{org_id}@example.com"},
+    ]
+
+    MockGetToken.assert_called_with(AUTH0_DOMAIN)
+    MockGetToken.return_value.client_credentials.assert_called_with(
+        AUDITADMIN_AUTH0_CLIENT_ID,
+        AUDITADMIN_AUTH0_CLIENT_SECRET,
+        f"https://{AUTH0_DOMAIN}/api/v2/",
+    )
+    MockAuth0.assert_called_with(AUTH0_DOMAIN, "test token")
+    MockAuth0.return_value.users.create.assert_called()
+    create_spec = MockAuth0.return_value.users.create.call_args[0][0]
+    assert create_spec["email"] == f"new-audit-admin-{org_id}@example.com"
+    assert create_spec["password"]
+    assert create_spec["connection"] == "Username-Password-Authentication"
+
+
+def test_support_log_in_as_audit_admin(
+    client: FlaskClient, election_id: str,  # pylint: disable=unused-argument
+):
+    set_superadmin_user(client, SUPPORT_EMAIL)
+
+    with client.session_transaction() as session:  # type: ignore
+        original_created_at = session["_created_at"]
+        original_last_request_at = session["_last_request_at"]
+
+    rv = client.get(f"/api/support/audit-admins/{DEFAULT_AA_EMAIL}/login")
+    assert rv.status_code == 302
+    assert urlparse(rv.location).path == "/"
+
+    with client.session_transaction() as session:  # type: ignore
+        assert session["_user"]["type"] == UserType.AUDIT_ADMIN
+        assert session["_user"]["key"] == DEFAULT_AA_EMAIL
+        assert session["_created_at"] == original_created_at
+        assert session["_last_request_at"] != original_last_request_at
+
+
+def test_support_log_in_as_jurisdiction_admin(
+    client: FlaskClient, election_id: str,
+):
+    set_superadmin_user(client, SUPPORT_EMAIL)
+
+    with client.session_transaction() as session:  # type: ignore
+        original_created_at = session["_created_at"]
+        original_last_request_at = session["_last_request_at"]
+
+    rv = client.get(
+        f"/api/support/jurisdiction-admins/{default_ja_email(election_id)}/login"
+    )
+    assert rv.status_code == 302
+    assert urlparse(rv.location).path == "/"
+
+    with client.session_transaction() as session:  # type: ignore
+        assert session["_user"]["type"] == UserType.JURISDICTION_ADMIN
+        assert session["_user"]["key"] == default_ja_email(election_id)
+        assert session["_created_at"] == original_created_at
+        assert session["_last_request_at"] != original_last_request_at

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -117,7 +117,7 @@ def test_superadmin_callback(
 
             rv = client.get("/auth/superadmin/callback?code=foobar")
             assert rv.status_code == 302
-            assert urlparse(rv.location).path == "/superadmin/"
+            assert urlparse(rv.location).path == "/support"
 
             with client.session_transaction() as session:  # type: ignore
                 assert session["_superadmin"] == SA_EMAIL

--- a/server/util/jsonschema.py
+++ b/server/util/jsonschema.py
@@ -11,7 +11,11 @@ JSONSchema = JSONDict
 def validate(instance: Any, schema: JSONSchema):
     jsonschema.validators.validator_for(schema).check_schema(schema)
     validate_schema(schema)
-    jsonschema.validate(instance=instance, schema=schema)
+    jsonschema.validate(
+        instance=instance,
+        schema=schema,
+        format_checker=jsonschema.draft7_format_checker,
+    )
 
 
 def validate_schema(schema: JSONSchema):


### PR DESCRIPTION
Adds a new Support Tools interface (formerly known as the superadmin interface) built in React.

Features:
- Home screen with list of organizations
- Org screen with list of audits, list of audit admins (with login buttons), and form to create new audit admin (including integrating with Auth0)
- Audit screen with list of jurisdictions and list of jurisdiction admins (with login buttons)

I took this opportunity to test out two new libraries to help with data loading (react-query) and forms (react-hook-form).


https://user-images.githubusercontent.com/530106/103838547-31e3ac00-5042-11eb-9fb3-41588a7d9e26.mov

