### PR TITLE
Fix bug for standardized contests with a dot in their name

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.test.tsx
@@ -29,7 +29,7 @@ const apiCalls = {
     url: '/api/election/1/standardized-contests',
     response: [
       {
-        name: 'Contest 1',
+        name: 'Contest 1.\'"', // Make sure dots and quotes in the name work
         jurisdictionIds: ['jurisdiction-id-1', 'jurisdiction-id-2'],
       },
       {
@@ -65,7 +65,7 @@ jest.mock('uuidv4', () => {
 describe('Audit Setup > Contests (Ballot Comparison)', () => {
   const expectedNewContestsRequest = [
     {
-      name: 'Contest 1',
+      name: 'Contest 1.\'"',
       id: '1',
       isTargeted: true,
       numWinners: 2,
@@ -109,7 +109,7 @@ describe('Audit Setup > Contests (Ballot Comparison)', () => {
       expect(rows).toHaveLength(3 + 1) // Includes headers
       expect(within(rows[1]).getByRole('checkbox')).not.toBeChecked()
       expect(within(rows[1]).getAllByRole('cell')[1]).toHaveTextContent(
-        'Contest 1'
+        'Contest 1.\'"'
       )
       expect(within(rows[1]).getAllByRole('cell')[2]).toHaveTextContent('All')
       expect(within(rows[1]).getByRole('spinbutton')).toBeDisabled()
@@ -203,7 +203,7 @@ describe('Audit Setup > Contests (Ballot Comparison)', () => {
       expect(within(rows[1]).getByRole('checkbox')).toBeChecked()
       expect(within(rows[1]).getByRole('checkbox')).toBeDisabled()
       expect(within(rows[1]).getAllByRole('cell')[1]).toHaveTextContent(
-        'Contest 1'
+        'Contest 1.\'"'
       )
       expect(within(rows[1]).getByRole('spinbutton')).toBeDisabled()
 
@@ -250,7 +250,7 @@ describe('Audit Setup > Contests (Ballot Comparison)', () => {
       let rows = screen.getAllByRole('row')
       within(rows[1]).getByText('Contest 3')
       within(rows[2]).getByText('Contest 2')
-      within(rows[3]).getByText('Contest 1')
+      within(rows[3]).getByText('Contest 1.\'"')
 
       // Select Contest 1
       userEvent.click(within(rows[3]).getByRole('checkbox'))
@@ -258,7 +258,7 @@ describe('Audit Setup > Contests (Ballot Comparison)', () => {
       // Now reset sorting and confirmed it's still checked
       userEvent.click(contestNameHeader)
       rows = screen.getAllByRole('row')
-      within(rows[1]).getByText('Contest 1')
+      within(rows[1]).getByText('Contest 1.\'"')
       expect(within(rows[1]).getByRole('checkbox')).toBeChecked()
       expect(within(rows[2]).getByRole('checkbox')).not.toBeChecked()
       expect(within(rows[3]).getByRole('checkbox')).not.toBeChecked()
@@ -284,7 +284,7 @@ describe('Audit Setup > Contests (Ballot Comparison)', () => {
       userEvent.type(screen.getByRole('textbox'), 'one')
       rows = screen.getAllByRole('row')
       expect(rows).toHaveLength(2 + 1) // Includes headers
-      within(rows[1]).getByText('Contest 1')
+      within(rows[1]).getByText('Contest 1.\'"')
       within(rows[2]).getByText('Contest 2')
 
       // Deselect Contest 1

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/ContestSelect.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import React, { useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { Formik, FormikProps, Field } from 'formik'
-import { Checkbox, Spinner } from '@blueprintjs/core'
+import { Formik, FormikProps } from 'formik'
+import { Checkbox, Spinner, NumericInput } from '@blueprintjs/core'
 import { Cell } from 'react-table'
 import uuidv4 from 'uuidv4'
 import FormWrapper from '../../../Atoms/Form/FormWrapper'
@@ -16,7 +16,6 @@ import { IAuditSettings } from '../../useAuditSettings'
 import useContestsBallotComparison, {
   INewContest,
 } from '../../useContestsBallotComparison'
-import FormField from '../../../Atoms/Form/FormField'
 
 interface IProps {
   isTargeted: boolean
@@ -100,7 +99,7 @@ const ContestSelect: React.FC<IProps> = ({
 
   return (
     <Formik initialValues={initialValues} onSubmit={submit}>
-      {({ values, handleSubmit, setFieldValue }: FormikProps<IFormValues>) => (
+      {({ values, handleSubmit, setValues }: FormikProps<IFormValues>) => (
         <form>
           <FormWrapper
             title={isTargeted ? 'Target Contests' : 'Opportunistic Contests'}
@@ -129,10 +128,16 @@ const ContestSelect: React.FC<IProps> = ({
                       inline
                       checked={values[contestName].checked}
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                        setFieldValue(
-                          `${contestName}.checked`,
-                          e.currentTarget.checked
-                        )
+                        // We have to use setValues because the contest name
+                        // might have a dot or apostrophe in it, so
+                        // setFieldValue won't work.
+                        setValues({
+                          ...values,
+                          [contestName]: {
+                            ...values[contestName],
+                            checked: e.currentTarget.checked,
+                          },
+                        })
                       }
                       disabled={values[contestName].isTargeted !== isTargeted}
                     />
@@ -165,15 +170,28 @@ const ContestSelect: React.FC<IProps> = ({
                   disableSortBy: true,
                   // eslint-disable-next-line react/display-name
                   Cell: ({ value: contestName }: Cell) => (
-                    <Field
+                    <NumericInput
                       type="number"
-                      name={`${contestName}.numWinners`}
+                      value={values[contestName].numWinners}
+                      onValueChange={(value: number) =>
+                        // We have to use setValues because the contest name
+                        // might have a dot or apostrophe in it, so
+                        // setFieldValue won't work.
+                        setValues({
+                          ...values,
+                          [contestName]: {
+                            ...values[contestName],
+                            numWinners: value,
+                          },
+                        })
+                      }
                       disabled={
                         !values[contestName].checked ||
                         values[contestName].isTargeted !== isTargeted
                       }
                       min={1}
-                      component={FormField}
+                      minorStepSize={null} // Only allow integers
+                      style={{ width: '60px' }}
                     />
                   ),
                 },


### PR DESCRIPTION
Task: #978 

The standardized contests selection form was breaking when a contest had a dot in its name. This is because Formik uses dot notation field names to access fields, both in the Field `name` prop and in `setFieldValue`.

The recommended fix in the Formik docs is to use the bracket notation: `['field']`, but this won't work if the field name has apostrophes in it.

This fix removes uses of the `name` prop and replaces `setFieldValue` with `setValues`.