### PR TITLE
Separate logout for superadmins

### DIFF
--- a/client/src/components/Header.test.tsx
+++ b/client/src/components/Header.test.tsx
@@ -178,7 +178,7 @@ describe('Header', () => {
 
       // Log out button
       const logOutButton = screen.getByRole('link', { name: 'Log out' })
-      expect(logOutButton).toHaveAttribute('href', '/auth/logout')
+      expect(logOutButton).toHaveAttribute('href', '/auth/superadmin/logout')
 
       // No regular navbar
       // TODO once we actually move the Support Tools interface to the React App
@@ -209,7 +209,7 @@ describe('Header', () => {
 
       // Log out button
       const logOutButton = screen.getByRole('link', { name: 'Log out' })
-      expect(logOutButton).toHaveAttribute('href', '/auth/logout')
+      expect(logOutButton).toHaveAttribute('href', '/auth/superadmin/logout')
 
       // Audit admin navbar
 
@@ -250,7 +250,7 @@ describe('Header', () => {
 
       // Log out button
       const logOutButton = screen.getByRole('link', { name: 'Log out' })
-      expect(logOutButton).toHaveAttribute('href', '/auth/logout')
+      expect(logOutButton).toHaveAttribute('href', '/auth/superadmin/logout')
 
       // Jurisdiction admin navbar
 

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -108,7 +108,7 @@ const Header: React.FC<{}> = () => {
             <NavbarGroup align={Alignment.RIGHT}>
               <span>{auth.superadminUser.email}</span>
               <NavbarDivider />
-              <a href="/auth/logout">Log out</a>
+              <a href="/auth/superadmin/logout">Log out</a>
             </NavbarGroup>
           </InnerBar>
         </SupportBar>

--- a/server/auth/lib.py
+++ b/server/auth/lib.py
@@ -88,8 +88,7 @@ def set_superadmin_user(session, email: str):
 
 
 def clear_superadmin_user(session):
-    if _SUPERADMIN in session:
-        del session[_SUPERADMIN]
+    session[_SUPERADMIN] = None
 
 
 def get_superadmin_user(session) -> Optional[str]:

--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -125,16 +125,16 @@ def auth_me():
 
 @auth.route("/auth/logout")
 def logout():
-    clear_superadmin_user(session)
-
-    user_type, _user_email = get_loggedin_user(session)
-    if not user_type:
-        return redirect("/")
-
+    # Because we have max_age on the oauth requests, we don't need to log out
+    # of Auth0.
     clear_loggedin_user(session)
+    return redirect("/support" if get_superadmin_user(session) else "/")
 
-    # because we have max_age on the oauth requests,
-    # we don't need to log out of Auth0.
+
+@auth.route("/auth/superadmin/logout")
+def superadmin_logout():
+    clear_superadmin_user(session)
+    clear_loggedin_user(session)
     return redirect("/")
 
 


### PR DESCRIPTION
Adds a separate logout endpoint for superadmins that logs out both the superadmin and AA/JA (if the superadmin has logged in as an AA/JA). Modifies the existing logout endpoint to not log out the superadmin.