### PR TITLE
Support Tools - clear audit boards

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,7 +17,6 @@ import AuthDataProvider, {
   useAuthDataContext,
 } from './components/UserContext'
 import SupportTools from './components/SupportTools'
-import { ConfirmProvider } from './components/Atoms/Confirm'
 
 const Main = styled.div`
   display: flex;
@@ -60,37 +59,35 @@ const App: React.FC = () => {
   return (
     <>
       <ToastContainer />
-      <ConfirmProvider>
-        <AuthDataProvider>
-          <Main>
-            <Route path="/" component={Header} />
-            <Switch>
-              <Route exact path="/" component={HomeScreen} />
-              <PrivateRoute
-                userType="audit_board"
-                path="/election/:electionId/audit-board/:auditBoardId"
-                component={DataEntry}
-              />
-              <PrivateRoute
-                userType="jurisdiction_admin"
-                path="/election/:electionId/jurisdiction/:jurisdictionId"
-                component={JurisdictionAdminView}
-              />
-              <PrivateRoute
-                userType="audit_admin"
-                path="/election/:electionId/:view?"
-                component={AuditAdminView}
-              />
-              <Route path="/support">
-                <SupportTools />
-              </Route>
-              <Route>
-                <Wrapper>404 Not Found</Wrapper>
-              </Route>
-            </Switch>
-          </Main>
-        </AuthDataProvider>
-      </ConfirmProvider>
+      <AuthDataProvider>
+        <Main>
+          <Route path="/" component={Header} />
+          <Switch>
+            <Route exact path="/" component={HomeScreen} />
+            <PrivateRoute
+              userType="audit_board"
+              path="/election/:electionId/audit-board/:auditBoardId"
+              component={DataEntry}
+            />
+            <PrivateRoute
+              userType="jurisdiction_admin"
+              path="/election/:electionId/jurisdiction/:jurisdictionId"
+              component={JurisdictionAdminView}
+            />
+            <PrivateRoute
+              userType="audit_admin"
+              path="/election/:electionId/:view?"
+              component={AuditAdminView}
+            />
+            <Route path="/support">
+              <SupportTools />
+            </Route>
+            <Route>
+              <Wrapper>404 Not Found</Wrapper>
+            </Route>
+          </Switch>
+        </Main>
+      </AuthDataProvider>
     </>
   )
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,7 @@ import AuthDataProvider, {
   useAuthDataContext,
 } from './components/UserContext'
 import SupportTools from './components/SupportTools'
+import { ConfirmProvider } from './components/Atoms/Confirm'
 
 const Main = styled.div`
   display: flex;
@@ -59,35 +60,37 @@ const App: React.FC = () => {
   return (
     <>
       <ToastContainer />
-      <AuthDataProvider>
-        <Main>
-          <Route path="/" component={Header} />
-          <Switch>
-            <Route exact path="/" component={HomeScreen} />
-            <PrivateRoute
-              userType="audit_board"
-              path="/election/:electionId/audit-board/:auditBoardId"
-              component={DataEntry}
-            />
-            <PrivateRoute
-              userType="jurisdiction_admin"
-              path="/election/:electionId/jurisdiction/:jurisdictionId"
-              component={JurisdictionAdminView}
-            />
-            <PrivateRoute
-              userType="audit_admin"
-              path="/election/:electionId/:view?"
-              component={AuditAdminView}
-            />
-            <Route path="/support">
-              <SupportTools />
-            </Route>
-            <Route>
-              <Wrapper>404 Not Found</Wrapper>
-            </Route>
-          </Switch>
-        </Main>
-      </AuthDataProvider>
+      <ConfirmProvider>
+        <AuthDataProvider>
+          <Main>
+            <Route path="/" component={Header} />
+            <Switch>
+              <Route exact path="/" component={HomeScreen} />
+              <PrivateRoute
+                userType="audit_board"
+                path="/election/:electionId/audit-board/:auditBoardId"
+                component={DataEntry}
+              />
+              <PrivateRoute
+                userType="jurisdiction_admin"
+                path="/election/:electionId/jurisdiction/:jurisdictionId"
+                component={JurisdictionAdminView}
+              />
+              <PrivateRoute
+                userType="audit_admin"
+                path="/election/:electionId/:view?"
+                component={AuditAdminView}
+              />
+              <Route path="/support">
+                <SupportTools />
+              </Route>
+              <Route>
+                <Wrapper>404 Not Found</Wrapper>
+              </Route>
+            </Switch>
+          </Main>
+        </AuthDataProvider>
+      </ConfirmProvider>
     </>
   )
 }

--- a/client/src/components/Atoms/Confirm.tsx
+++ b/client/src/components/Atoms/Confirm.tsx
@@ -29,8 +29,8 @@ export const useConfirm = () => {
 
   const confirmProps = {
     isOpen: !!options,
-    title: options ? options.title : undefined,
-    description: options ? options.description : undefined,
+    title: options ? options.title : '',
+    description: options ? options.description : '',
     yesButtonLabel: options ? options.yesButtonLabel : undefined,
     noButtonLabel: options ? options.noButtonLabel : undefined,
     onYesClick,

--- a/client/src/components/Atoms/Confirm.tsx
+++ b/client/src/components/Atoms/Confirm.tsx
@@ -1,13 +1,5 @@
-import React, {
-  createContext,
-  useContext,
-  useState,
-  ReactNode,
-  useEffect,
-  useCallback,
-} from 'react'
+import React, { useState, ReactNode } from 'react'
 import { Dialog, Classes, Button, Intent } from '@blueprintjs/core'
-import { useLocation } from 'react-router-dom'
 
 interface IConfirmOptions {
   title: ReactNode
@@ -17,77 +9,81 @@ interface IConfirmOptions {
   onYesClick: () => Promise<void>
 }
 
-const ConfirmContext = createContext<(options: IConfirmOptions) => void>(
-  async () => {}
-)
-
-export const ConfirmProvider = ({
-  children,
-}: {
-  children?: React.ReactNode
-}) => {
+export const useConfirm = () => {
   // We show the dialog whenever options are set.
   // On close, we set options to null.
   const [options, setOptions] = useState<IConfirmOptions | null>(null)
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
-  // Close the dialog whenever the location changes (e.g. user clicks the back
-  // button). Note: this means ConfirmProvider must be rendered inside Router.
-  const location = useLocation()
-  useEffect(() => setOptions(null), [location.key])
-
-  const confirm = useCallback((newOptions: IConfirmOptions) => {
-    setIsSubmitting(false)
+  const confirm = (newOptions: IConfirmOptions) => {
     setOptions(newOptions)
-  }, [])
+  }
+
+  const onYesClick = async () => {
+    await options!.onYesClick()
+    setOptions(null)
+  }
+
+  const onClose = () => {
+    setOptions(null)
+  }
+
+  const confirmProps = {
+    isOpen: !!options,
+    title: options ? options.title : undefined,
+    description: options ? options.description : undefined,
+    yesButtonLabel: options ? options.yesButtonLabel : undefined,
+    noButtonLabel: options ? options.noButtonLabel : undefined,
+    onYesClick,
+    onClose,
+  }
+
+  return { confirm, confirmProps }
+}
+
+interface IConfirmProps extends IConfirmOptions {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export const Confirm = ({
+  isOpen,
+  title,
+  description,
+  yesButtonLabel,
+  noButtonLabel,
+  onYesClick,
+  onClose,
+}: IConfirmProps) => {
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
   const handleYesClick = async () => {
     setIsSubmitting(true)
     try {
-      await options!.onYesClick()
-      setOptions(null)
+      await onYesClick()
     } catch (error) {
-      // Do nothing, error handling is the responsibility of the caller
+      // Do nothing, error handling should happen within onYesClick
     } finally {
       setIsSubmitting(false)
     }
   }
 
-  const handleClose = () => {
-    setOptions(null)
-  }
-
   return (
-    <>
-      <ConfirmContext.Provider value={confirm}>
-        {children}
-      </ConfirmContext.Provider>
-      <Dialog
-        icon="info-sign"
-        onClose={handleClose}
-        title={options && options.title}
-        isOpen={!!options}
-      >
-        <div className={Classes.DIALOG_BODY}>
-          {options && options.description}
+    <Dialog icon="info-sign" onClose={onClose} title={title} isOpen={isOpen}>
+      <div className={Classes.DIALOG_BODY}>{description}</div>
+      <div className={Classes.DIALOG_FOOTER}>
+        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <Button disabled={isSubmitting} onClick={onClose}>
+            {noButtonLabel || 'Cancel'}
+          </Button>
+          <Button
+            intent={Intent.PRIMARY}
+            onClick={handleYesClick}
+            loading={isSubmitting}
+          >
+            {yesButtonLabel || 'Ok'}
+          </Button>
         </div>
-        <div className={Classes.DIALOG_FOOTER}>
-          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-            <Button disabled={isSubmitting} onClick={handleClose}>
-              {(options && options.noButtonLabel) || 'Cancel'}
-            </Button>
-            <Button
-              intent={Intent.PRIMARY}
-              onClick={handleYesClick}
-              loading={isSubmitting}
-            >
-              {(options && options.yesButtonLabel) || 'Ok'}
-            </Button>
-          </div>
-        </div>
-      </Dialog>
-    </>
+      </div>
+    </Dialog>
   )
 }
-
-export const useConfirm = () => useContext(ConfirmContext)

--- a/client/src/components/Atoms/Confirm.tsx
+++ b/client/src/components/Atoms/Confirm.tsx
@@ -1,0 +1,93 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useEffect,
+  useCallback,
+} from 'react'
+import { Dialog, Classes, Button, Intent } from '@blueprintjs/core'
+import { useLocation } from 'react-router-dom'
+
+interface IConfirmOptions {
+  title: ReactNode
+  description: ReactNode
+  yesButtonLabel?: string
+  noButtonLabel?: string
+  onYesClick: () => Promise<void>
+}
+
+const ConfirmContext = createContext<(options: IConfirmOptions) => void>(
+  async () => {}
+)
+
+export const ConfirmProvider = ({
+  children,
+}: {
+  children?: React.ReactNode
+}) => {
+  // We show the dialog whenever options are set.
+  // On close, we set options to null.
+  const [options, setOptions] = useState<IConfirmOptions | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
+
+  // Close the dialog whenever the location changes (e.g. user clicks the back
+  // button). Note: this means ConfirmProvider must be rendered inside Router.
+  const location = useLocation()
+  useEffect(() => setOptions(null), [location.key])
+
+  const confirm = useCallback((newOptions: IConfirmOptions) => {
+    setIsSubmitting(false)
+    setOptions(newOptions)
+  }, [])
+
+  const handleYesClick = async () => {
+    setIsSubmitting(true)
+    try {
+      await options!.onYesClick()
+      setOptions(null)
+    } catch (error) {
+      // Do nothing, error handling is the responsibility of the caller
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleClose = () => {
+    setOptions(null)
+  }
+
+  return (
+    <>
+      <ConfirmContext.Provider value={confirm}>
+        {children}
+      </ConfirmContext.Provider>
+      <Dialog
+        icon="info-sign"
+        onClose={handleClose}
+        title={options && options.title}
+        isOpen={!!options}
+      >
+        <div className={Classes.DIALOG_BODY}>
+          {options && options.description}
+        </div>
+        <div className={Classes.DIALOG_FOOTER}>
+          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+            <Button disabled={isSubmitting} onClick={handleClose}>
+              {(options && options.noButtonLabel) || 'Cancel'}
+            </Button>
+            <Button
+              intent={Intent.PRIMARY}
+              onClick={handleYesClick}
+              loading={isSubmitting}
+            >
+              {(options && options.yesButtonLabel) || 'Ok'}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    </>
+  )
+}
+
+export const useConfirm = () => useContext(ConfirmContext)

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -33,7 +33,7 @@ import {
   useClearJurisdictionAuditBoards,
   IJurisdiction,
 } from './support-api'
-import { useConfirm } from '../Atoms/Confirm'
+import { useConfirm, Confirm } from '../Atoms/Confirm'
 
 const queryClient = new QueryClient(
   // Turn off query retries in test so we can mock effectively
@@ -276,7 +276,7 @@ const prettyAuditType = (auditType: IElection['auditType']) =>
 const Audit = ({ electionId }: { electionId: string }) => {
   const election = useElection(electionId)
   const clearAuditBoards = useClearJurisdictionAuditBoards()
-  const confirm = useConfirm()
+  const { confirm, confirmProps } = useConfirm()
 
   if (election.isLoading || election.isIdle) return null
   if (election.isError) {
@@ -294,6 +294,7 @@ const Audit = ({ electionId }: { electionId: string }) => {
       onYesClick: async () => {
         try {
           await clearAuditBoards.mutateAsync(jurisdiction.id)
+          toast.success(`Cleared audit boards for ${jurisdiction.name}`)
         } catch (error) {
           toast.error(error.message)
           throw error
@@ -335,6 +336,7 @@ const Audit = ({ electionId }: { electionId: string }) => {
           </Table>
         </div>
       ))}
+      <Confirm {...confirmProps} />
     </Column>
   )
 }

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -96,3 +96,13 @@ export const useElection = (electionId: string) =>
   useQuery<IElection, Error>(['election', electionId], () =>
     fetchApi(`/api/support/elections/${electionId}`)
   )
+
+export const useClearJurisdictionAuditBoards = () => {
+  const deleteAuditBoards = async (jurisdictionId: string) =>
+    fetchApi(`/api/support/jurisdictions/${jurisdictionId}/audit-boards`, {
+      method: 'DELETE',
+    })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return useMutation<any, Error, any>(deleteAuditBoards)
+}


### PR DESCRIPTION
- Backend endpoint to clear audit boards
- Button next to each jurisdiction in Support Tools to clear audit boards
- Reusable confirm dialog component + hook

Gonna come back and add unit tests for the Confirm component separately, because I want to get this feature out.


https://user-images.githubusercontent.com/530106/104634119-0d488f00-5655-11eb-866f-a5e48c9dd507.mov

