### PR TITLE
Better CVR parsing error messages

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -18,6 +18,7 @@ from ..util.process_file import (
     process_file,
     serialize_file,
     serialize_file_processing,
+    UserError,
 )
 from ..util.csv_download import csv_response
 from ..util.csv_parse import decode_csv_file
@@ -63,6 +64,9 @@ def process_cvr_file(session: Session, jurisdiction: Jurisdiction, file: File):
     assert jurisdiction.cvr_file_id == file.id
 
     def process():
+        if jurisdiction.cvr_file.contents == "":
+            raise UserError("CVR file cannot be empty.")
+
         cvrs = csv.reader(
             io.StringIO(jurisdiction.cvr_file.contents, newline=None), delimiter=","
         )
@@ -206,6 +210,8 @@ def process_cvr_file(session: Session, jurisdiction: Jurisdiction, file: File):
         try:
             process()
         except Exception as exc:
+            if isinstance(exc, UserError):
+                raise exc
             raise Exception("Could not parse CVR file") from exc
 
     process_file(session, file, process_catch_exceptions)

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -474,7 +474,48 @@ def test_invalid_cvrs(
     # CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
     # 1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1
     # """
-    invalid_cvrs = [("", "CVR file cannot be empty.",)]
+    invalid_cvrs = [
+        ("", "CVR file cannot be empty.",),
+        (
+            """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
+,,,,,,,,"Contest 1 (Vote For=1)","Contest 1 (123)"
+,,,,,,,,Choice 1-1,Choice 1-2
+CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
+1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1
+""",
+            "Invalid contest name: Contest 1 (123). Contest names should have this format: Contest Name (Vote For=1).",
+        ),
+        (
+            """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
+,,,,,,,,"Contest 1 (Vote For=1)","Contest 1 (Vote For=1)"
+,,,,,,,,Choice 1-1,Choice 1-2
+CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
+1,TABULATOR1,BATCH001,1,1-1-1,Election Day,12345,COUNTY,0,1
+""",
+            (
+                "Invalid TabulatorNum/BatchId for row with CvrNumber 1: TABULATOR1, BATCH001."
+                " The TabulatorNum and BatchId fields in the CVR file must match the Tabulator and Batch Name"
+                " fields in the ballot manifest. The closest match we found in the ballot manifest was:"
+                " TABULATOR1, BATCH1. Please check your CVR file and ballot manifest thoroughly to make"
+                " sure these values match - there may be a similar inconsistency in other rows in the CVR file."
+            ),
+        ),
+        (
+            """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
+,,,,,,,,"Contest 1 (Vote For=1)","Contest 1 (Vote For=1)"
+,,,,,,,,Choice 1-1,Choice 1-2
+CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
+1,abc,123,1,1-1-1,Election Day,12345,COUNTY,0,1
+""",
+            (
+                "Invalid TabulatorNum/BatchId for row with CvrNumber 1: abc, 123."
+                " The TabulatorNum and BatchId fields in the CVR file must match the Tabulator and Batch Name"
+                " fields in the ballot manifest."
+                " Please check your CVR file and ballot manifest thoroughly to make"
+                " sure these values match - there may be a similar inconsistency in other rows in the CVR file."
+            ),
+        ),
+    ]
 
     for invalid_cvr, expected_error in invalid_cvrs:
         rv = client.put(

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -505,6 +505,21 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortio
 ,,,,,,,,"Contest 1 (Vote For=1)","Contest 1 (Vote For=1)"
 ,,,,,,,,Choice 1-1,Choice 1-2
 CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
+1,TABULATO1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1
+""",
+            (
+                "Invalid TabulatorNum/BatchId for row with CvrNumber 1: TABULATO1, BATCH1."
+                " The TabulatorNum and BatchId fields in the CVR file must match the Tabulator and Batch Name"
+                " fields in the ballot manifest. The closest match we found in the ballot manifest was:"
+                " TABULATOR1, BATCH1. Please check your CVR file and ballot manifest thoroughly to make"
+                " sure these values match - there may be a similar inconsistency in other rows in the CVR file."
+            ),
+        ),
+        (
+            """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
+,,,,,,,,"Contest 1 (Vote For=1)","Contest 1 (Vote For=1)"
+,,,,,,,,Choice 1-1,Choice 1-2
+CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
 1,abc,123,1,1-1-1,Election Day,12345,COUNTY,0,1
 """,
             (

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -8,8 +8,6 @@ from ...bgcompute import bgcompute_update_cvr_file
 from ...util.process_file import ProcessingStatus
 from .conftest import TEST_CVRS
 
-# TODO test a bunch of CVR parse errors
-
 
 def test_cvr_upload(
     client: FlaskClient,
@@ -459,3 +457,53 @@ def test_cvrs_newlines(
     snapshot.assert_match(
         Jurisdiction.query.get(jurisdiction_ids[0]).cvr_contests_metadata
     )
+
+
+def test_invalid_cvrs(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    manifests,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    #             """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
+    # ,,,,,,,,"Contest 1 (Vote For=1)","Contest 1 (Vote For=1)"
+    # ,,,,,,,,Choice 1-1,Choice 1-2
+    # CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
+    # 1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1
+    # """
+    invalid_cvrs = [("", "CVR file cannot be empty.",)]
+
+    for invalid_cvr, expected_error in invalid_cvrs:
+        rv = client.put(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
+            data={"cvrs": (io.BytesIO(invalid_cvr.encode()), "cvrs.csv",)},
+        )
+        assert_ok(rv)
+
+        bgcompute_update_cvr_file(election_id)
+
+        rv = client.get(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs"
+        )
+        compare_json(
+            json.loads(rv.data),
+            {
+                "file": {"name": "cvrs.csv", "uploadedAt": assert_is_date,},
+                "processing": {
+                    "status": ProcessingStatus.ERRORED,
+                    "startedAt": assert_is_date,
+                    "completedAt": assert_is_date,
+                    "error": expected_error,
+                },
+            },
+        )
+        cvr_ballots = (
+            CvrBallot.query.join(Batch)
+            .filter_by(jurisdiction_id=jurisdiction_ids[0])
+            .all()
+        )
+        assert len(cvr_ballots) == 0
+        assert Jurisdiction.query.get(jurisdiction_ids[0]).cvr_contests_metadata is None


### PR DESCRIPTION
Task: #986 

Adds user-facing error messages for three issues we've seen so far:
- Empty CVR file
- Invalid contest name format (missing the "(Vote For=1)" suffix)
- Tabulator/batch name that doesn't match manifest