### PR TITLE
JA audit board status improvements

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import RoundProgress from './RoundProgress'
 import { auditBoardMocks } from '../useSetupMenuItems/_mocks'
 
 describe('RoundProgress', () => {
-  it('renders incomplete round with no audit boards', () => {
+  it('renders nothing with no audit boards', () => {
     const { container } = render(
       <RoundProgress auditBoards={auditBoardMocks.empty} />
     )
@@ -35,6 +35,13 @@ describe('RoundProgress', () => {
   it('renders incomplete round with an audit board with no ballots sampled', () => {
     const { container } = render(
       <RoundProgress auditBoards={auditBoardMocks.noBallots} />
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders an audit board with auditing complete that has not signed off', () => {
+    const { container } = render(
+      <RoundProgress auditBoards={auditBoardMocks.finished} />
     )
     expect(container).toMatchSnapshot()
   })

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.tsx
@@ -45,8 +45,8 @@ const RoundProgress = ({ auditBoards }: { auditBoards: IAuditBoard[] }) => {
         </p>
         <ProgressBar
           value={auditedBallots / sampledBallots}
-          animate={false}
           intent={progressIntent}
+          stripes={false}
         />
       </MainBarWrapper>
       {auditBoards.map(
@@ -73,8 +73,8 @@ const RoundProgress = ({ auditBoards }: { auditBoards: IAuditBoard[] }) => {
                   </div>
                   <ProgressBar
                     value={numAuditedBallots / numSampledBallots}
-                    animate={false}
                     intent={intent}
+                    stripes={false}
                   />
                 </>
               ) : (

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.tsx
@@ -7,6 +7,9 @@ const MainBarWrapper = styled.div`
   margin-bottom: 30px;
   width: 500px;
   font-size: 16px;
+  .bp3-progress-bar {
+    height: 12px;
+  }
 `
 
 const SmallBarWrapper = styled.div`

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.tsx
@@ -14,7 +14,7 @@ const MainBarWrapper = styled.div`
 
 const SmallBarWrapper = styled.div`
   margin-bottom: 30px;
-  width: 400px;
+  width: 500px;
   > div:first-child {
     display: flex;
     justify-content: space-between;

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/RoundProgress.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/RoundProgress.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`RoundProgress renders an audit board with auditing complete that has no
     </div>
   </div>
   <div
-    class="sc-bwzfXH bkrlja"
+    class="sc-bwzfXH eCcuoP"
   >
     <div>
       <span>
@@ -82,7 +82,7 @@ exports[`RoundProgress renders complete round 1`] = `
     </div>
   </div>
   <div
-    class="sc-bwzfXH bkrlja"
+    class="sc-bwzfXH eCcuoP"
   >
     <div>
       <span>
@@ -137,7 +137,7 @@ exports[`RoundProgress renders incomplete round with an audit board 1`] = `
     </div>
   </div>
   <div
-    class="sc-bwzfXH bkrlja"
+    class="sc-bwzfXH eCcuoP"
   >
     <div>
       <span>
@@ -192,13 +192,13 @@ exports[`RoundProgress renders incomplete round with an audit board with no ball
     </div>
   </div>
   <div
-    class="sc-bwzfXH bkrlja"
+    class="sc-bwzfXH eCcuoP"
   >
     Audit Board #01
     : no ballots to audit
   </div>
   <div
-    class="sc-bwzfXH bkrlja"
+    class="sc-bwzfXH eCcuoP"
   >
     <div>
       <span>
@@ -253,7 +253,7 @@ exports[`RoundProgress renders incomplete round with auditing in progress 1`] = 
     </div>
   </div>
   <div
-    class="sc-bwzfXH bkrlja"
+    class="sc-bwzfXH eCcuoP"
   >
     <div>
       <span>
@@ -308,7 +308,7 @@ exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
     </div>
   </div>
   <div
-    class="sc-bwzfXH bkrlja"
+    class="sc-bwzfXH eCcuoP"
   >
     <div>
       <span>
@@ -334,7 +334,7 @@ exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
     </div>
   </div>
   <div
-    class="sc-bwzfXH bkrlja"
+    class="sc-bwzfXH eCcuoP"
   >
     <div>
       <span>

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/RoundProgress.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/RoundProgress.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`RoundProgress renders an audit board with auditing complete that has not signed off 1`] = `
 <div>
   <div
-    class="sc-bdVaJa cpJoSX"
+    class="sc-bdVaJa fHQGtV"
   >
     <h4
       class="bp3-heading"
@@ -18,7 +18,7 @@ exports[`RoundProgress renders an audit board with auditing complete that has no
        
     </p>
     <div
-      class="bp3-progress-bar bp3-intent-success bp3-no-animation"
+      class="bp3-progress-bar bp3-intent-success bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -44,7 +44,7 @@ exports[`RoundProgress renders an audit board with auditing complete that has no
       </span>
     </div>
     <div
-      class="bp3-progress-bar bp3-intent-warning bp3-no-animation"
+      class="bp3-progress-bar bp3-intent-warning bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -58,7 +58,7 @@ exports[`RoundProgress renders an audit board with auditing complete that has no
 exports[`RoundProgress renders complete round 1`] = `
 <div>
   <div
-    class="sc-bdVaJa cpJoSX"
+    class="sc-bdVaJa fHQGtV"
   >
     <h4
       class="bp3-heading"
@@ -73,7 +73,7 @@ exports[`RoundProgress renders complete round 1`] = `
        
     </p>
     <div
-      class="bp3-progress-bar bp3-intent-success bp3-no-animation"
+      class="bp3-progress-bar bp3-intent-success bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -99,7 +99,7 @@ exports[`RoundProgress renders complete round 1`] = `
       </span>
     </div>
     <div
-      class="bp3-progress-bar bp3-intent-success bp3-no-animation"
+      class="bp3-progress-bar bp3-intent-success bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -113,7 +113,7 @@ exports[`RoundProgress renders complete round 1`] = `
 exports[`RoundProgress renders incomplete round with an audit board 1`] = `
 <div>
   <div
-    class="sc-bdVaJa cpJoSX"
+    class="sc-bdVaJa fHQGtV"
   >
     <h4
       class="bp3-heading"
@@ -128,7 +128,7 @@ exports[`RoundProgress renders incomplete round with an audit board 1`] = `
        
     </p>
     <div
-      class="bp3-progress-bar bp3-no-animation"
+      class="bp3-progress-bar bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -154,7 +154,7 @@ exports[`RoundProgress renders incomplete round with an audit board 1`] = `
       </span>
     </div>
     <div
-      class="bp3-progress-bar bp3-no-animation"
+      class="bp3-progress-bar bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -168,7 +168,7 @@ exports[`RoundProgress renders incomplete round with an audit board 1`] = `
 exports[`RoundProgress renders incomplete round with an audit board with no ballots sampled 1`] = `
 <div>
   <div
-    class="sc-bdVaJa cpJoSX"
+    class="sc-bdVaJa fHQGtV"
   >
     <h4
       class="bp3-heading"
@@ -183,7 +183,7 @@ exports[`RoundProgress renders incomplete round with an audit board with no ball
        
     </p>
     <div
-      class="bp3-progress-bar bp3-no-animation"
+      class="bp3-progress-bar bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -215,7 +215,7 @@ exports[`RoundProgress renders incomplete round with an audit board with no ball
       </span>
     </div>
     <div
-      class="bp3-progress-bar bp3-no-animation"
+      class="bp3-progress-bar bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -229,7 +229,7 @@ exports[`RoundProgress renders incomplete round with an audit board with no ball
 exports[`RoundProgress renders incomplete round with auditing in progress 1`] = `
 <div>
   <div
-    class="sc-bdVaJa cpJoSX"
+    class="sc-bdVaJa fHQGtV"
   >
     <h4
       class="bp3-heading"
@@ -244,7 +244,7 @@ exports[`RoundProgress renders incomplete round with auditing in progress 1`] = 
        
     </p>
     <div
-      class="bp3-progress-bar bp3-intent-primary bp3-no-animation"
+      class="bp3-progress-bar bp3-intent-primary bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -270,7 +270,7 @@ exports[`RoundProgress renders incomplete round with auditing in progress 1`] = 
       </span>
     </div>
     <div
-      class="bp3-progress-bar bp3-intent-primary bp3-no-animation"
+      class="bp3-progress-bar bp3-intent-primary bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -284,7 +284,7 @@ exports[`RoundProgress renders incomplete round with auditing in progress 1`] = 
 exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
 <div>
   <div
-    class="sc-bdVaJa cpJoSX"
+    class="sc-bdVaJa fHQGtV"
   >
     <h4
       class="bp3-heading"
@@ -299,7 +299,7 @@ exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
        
     </p>
     <div
-      class="bp3-progress-bar bp3-no-animation"
+      class="bp3-progress-bar bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -325,7 +325,7 @@ exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
       </span>
     </div>
     <div
-      class="bp3-progress-bar bp3-no-animation"
+      class="bp3-progress-bar bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"
@@ -351,7 +351,7 @@ exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
       </span>
     </div>
     <div
-      class="bp3-progress-bar bp3-no-animation"
+      class="bp3-progress-bar bp3-no-stripes"
     >
       <div
         class="bp3-progress-meter"

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/RoundProgress.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/RoundProgress.test.tsx.snap
@@ -1,24 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RoundProgress renders complete round 1`] = `
+exports[`RoundProgress renders an audit board with auditing complete that has not signed off 1`] = `
 <div>
   <div
-    class="sc-bdVaJa dXfzyv"
+    class="sc-bdVaJa cpJoSX"
   >
     <h4
       class="bp3-heading"
     >
       Audit Board Progress
     </h4>
-    <span>
+    <p>
       30
        of 
       30
        ballots audited
        
-    </span>
+    </p>
     <div
-      class="bp3-progress-bar bp3-intent-primary bp3-no-animation"
+      class="bp3-progress-bar bp3-intent-success bp3-no-animation"
     >
       <div
         class="bp3-progress-meter"
@@ -27,13 +27,79 @@ exports[`RoundProgress renders complete round 1`] = `
     </div>
   </div>
   <div
-    class="sc-bwzfXH jGjlAC"
+    class="sc-bwzfXH bkrlja"
   >
-    <span>
-      Audit Board #01: 30 of 30 ballots audited 
-    </span>
+    <div>
+      <span>
+        Audit Board #01: 30 of 30 ballots audited 
+      </span>
+      <span
+        class="bp3-tag bp3-intent-warning"
+      >
+        <span
+          class="bp3-text-overflow-ellipsis bp3-fill"
+        >
+          Not signed off
+        </span>
+      </span>
+    </div>
     <div
-      class="bp3-progress-bar bp3-intent-primary bp3-no-animation"
+      class="bp3-progress-bar bp3-intent-warning bp3-no-animation"
+    >
+      <div
+        class="bp3-progress-meter"
+        style="width: 100%;"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RoundProgress renders complete round 1`] = `
+<div>
+  <div
+    class="sc-bdVaJa cpJoSX"
+  >
+    <h4
+      class="bp3-heading"
+    >
+      Audit Board Progress
+    </h4>
+    <p>
+      30
+       of 
+      30
+       ballots audited
+       
+    </p>
+    <div
+      class="bp3-progress-bar bp3-intent-success bp3-no-animation"
+    >
+      <div
+        class="bp3-progress-meter"
+        style="width: 100%;"
+      />
+    </div>
+  </div>
+  <div
+    class="sc-bwzfXH bkrlja"
+  >
+    <div>
+      <span>
+        Audit Board #01: 30 of 30 ballots audited 
+      </span>
+      <span
+        class="bp3-tag bp3-intent-success"
+      >
+        <span
+          class="bp3-text-overflow-ellipsis bp3-fill"
+        >
+          Signed off
+        </span>
+      </span>
+    </div>
+    <div
+      class="bp3-progress-bar bp3-intent-success bp3-no-animation"
     >
       <div
         class="bp3-progress-meter"
@@ -47,22 +113,22 @@ exports[`RoundProgress renders complete round 1`] = `
 exports[`RoundProgress renders incomplete round with an audit board 1`] = `
 <div>
   <div
-    class="sc-bdVaJa dXfzyv"
+    class="sc-bdVaJa cpJoSX"
   >
     <h4
       class="bp3-heading"
     >
       Audit Board Progress
     </h4>
-    <span>
+    <p>
       0
        of 
       30
        ballots audited
        
-    </span>
+    </p>
     <div
-      class="bp3-progress-bar bp3-intent-primary"
+      class="bp3-progress-bar bp3-no-animation"
     >
       <div
         class="bp3-progress-meter"
@@ -71,13 +137,24 @@ exports[`RoundProgress renders incomplete round with an audit board 1`] = `
     </div>
   </div>
   <div
-    class="sc-bwzfXH jGjlAC"
+    class="sc-bwzfXH bkrlja"
   >
-    <span>
-      Audit Board #01: 0 of 30 ballots audited 
-    </span>
+    <div>
+      <span>
+        Audit Board #01: 0 of 30 ballots audited 
+      </span>
+      <span
+        class="bp3-tag"
+      >
+        <span
+          class="bp3-text-overflow-ellipsis bp3-fill"
+        >
+          Not started
+        </span>
+      </span>
+    </div>
     <div
-      class="bp3-progress-bar bp3-intent-primary"
+      class="bp3-progress-bar bp3-no-animation"
     >
       <div
         class="bp3-progress-meter"
@@ -91,22 +168,22 @@ exports[`RoundProgress renders incomplete round with an audit board 1`] = `
 exports[`RoundProgress renders incomplete round with an audit board with no ballots sampled 1`] = `
 <div>
   <div
-    class="sc-bdVaJa dXfzyv"
+    class="sc-bdVaJa cpJoSX"
   >
     <h4
       class="bp3-heading"
     >
       Audit Board Progress
     </h4>
-    <span>
+    <p>
       0
        of 
       30
        ballots audited
        
-    </span>
+    </p>
     <div
-      class="bp3-progress-bar bp3-intent-primary"
+      class="bp3-progress-bar bp3-no-animation"
     >
       <div
         class="bp3-progress-meter"
@@ -115,21 +192,30 @@ exports[`RoundProgress renders incomplete round with an audit board with no ball
     </div>
   </div>
   <div
-    class="sc-bwzfXH jGjlAC"
+    class="sc-bwzfXH bkrlja"
   >
-    <span>
-      Audit Board #01
-      : no ballots to audit
-    </span>
+    Audit Board #01
+    : no ballots to audit
   </div>
   <div
-    class="sc-bwzfXH jGjlAC"
+    class="sc-bwzfXH bkrlja"
   >
-    <span>
-      Audit Board #02: 0 of 30 ballots audited 
-    </span>
+    <div>
+      <span>
+        Audit Board #02: 0 of 30 ballots audited 
+      </span>
+      <span
+        class="bp3-tag"
+      >
+        <span
+          class="bp3-text-overflow-ellipsis bp3-fill"
+        >
+          Not started
+        </span>
+      </span>
+    </div>
     <div
-      class="bp3-progress-bar bp3-intent-primary"
+      class="bp3-progress-bar bp3-no-animation"
     >
       <div
         class="bp3-progress-meter"
@@ -143,22 +229,22 @@ exports[`RoundProgress renders incomplete round with an audit board with no ball
 exports[`RoundProgress renders incomplete round with auditing in progress 1`] = `
 <div>
   <div
-    class="sc-bdVaJa dXfzyv"
+    class="sc-bdVaJa cpJoSX"
   >
     <h4
       class="bp3-heading"
     >
       Audit Board Progress
     </h4>
-    <span>
+    <p>
       15
        of 
       30
        ballots audited
        
-    </span>
+    </p>
     <div
-      class="bp3-progress-bar bp3-intent-primary"
+      class="bp3-progress-bar bp3-intent-primary bp3-no-animation"
     >
       <div
         class="bp3-progress-meter"
@@ -167,13 +253,24 @@ exports[`RoundProgress renders incomplete round with auditing in progress 1`] = 
     </div>
   </div>
   <div
-    class="sc-bwzfXH jGjlAC"
+    class="sc-bwzfXH bkrlja"
   >
-    <span>
-      Audit Board #01: 15 of 30 ballots audited 
-    </span>
+    <div>
+      <span>
+        Audit Board #01: 15 of 30 ballots audited 
+      </span>
+      <span
+        class="bp3-tag bp3-intent-primary"
+      >
+        <span
+          class="bp3-text-overflow-ellipsis bp3-fill"
+        >
+          In progress
+        </span>
+      </span>
+    </div>
     <div
-      class="bp3-progress-bar bp3-intent-primary"
+      class="bp3-progress-bar bp3-intent-primary bp3-no-animation"
     >
       <div
         class="bp3-progress-meter"
@@ -184,27 +281,25 @@ exports[`RoundProgress renders incomplete round with auditing in progress 1`] = 
 </div>
 `;
 
-exports[`RoundProgress renders incomplete round with no audit boards 1`] = `<div />`;
-
 exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
 <div>
   <div
-    class="sc-bdVaJa dXfzyv"
+    class="sc-bdVaJa cpJoSX"
   >
     <h4
       class="bp3-heading"
     >
       Audit Board Progress
     </h4>
-    <span>
+    <p>
       0
        of 
       60
        ballots audited
        
-    </span>
+    </p>
     <div
-      class="bp3-progress-bar bp3-intent-primary"
+      class="bp3-progress-bar bp3-no-animation"
     >
       <div
         class="bp3-progress-meter"
@@ -213,13 +308,24 @@ exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
     </div>
   </div>
   <div
-    class="sc-bwzfXH jGjlAC"
+    class="sc-bwzfXH bkrlja"
   >
-    <span>
-      Audit Board #01: 0 of 30 ballots audited 
-    </span>
+    <div>
+      <span>
+        Audit Board #01: 0 of 30 ballots audited 
+      </span>
+      <span
+        class="bp3-tag"
+      >
+        <span
+          class="bp3-text-overflow-ellipsis bp3-fill"
+        >
+          Not started
+        </span>
+      </span>
+    </div>
     <div
-      class="bp3-progress-bar bp3-intent-primary"
+      class="bp3-progress-bar bp3-no-animation"
     >
       <div
         class="bp3-progress-meter"
@@ -228,13 +334,24 @@ exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
     </div>
   </div>
   <div
-    class="sc-bwzfXH jGjlAC"
+    class="sc-bwzfXH bkrlja"
   >
-    <span>
-      Audit Board #02: 0 of 30 ballots audited 
-    </span>
+    <div>
+      <span>
+        Audit Board #02: 0 of 30 ballots audited 
+      </span>
+      <span
+        class="bp3-tag"
+      >
+        <span
+          class="bp3-text-overflow-ellipsis bp3-fill"
+        >
+          Not started
+        </span>
+      </span>
+    </div>
     <div
-      class="bp3-progress-bar bp3-intent-primary"
+      class="bp3-progress-bar bp3-no-animation"
     >
       <div
         class="bp3-progress-meter"
@@ -244,3 +361,5 @@ exports[`RoundProgress renders incomplete round with two audit boards 1`] = `
   </div>
 </div>
 `;
+
+exports[`RoundProgress renders nothing with no audit boards 1`] = `<div />`;

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
@@ -2118,7 +2118,7 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
         </div>
       </div>
       <div
-        class="sc-gqjmRU ddNDMP"
+        class="sc-gqjmRU cknesl"
       >
         <div>
           <span>

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
@@ -2094,22 +2094,22 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
       class="sc-hMqMXs kBeHNE"
     >
       <div
-        class="sc-gZMcBi hUnsTv"
+        class="sc-gZMcBi fIaHlv"
       >
         <h4
           class="bp3-heading"
         >
           Audit Board Progress
         </h4>
-        <span>
+        <p>
           0
            of 
           30
            ballots audited
            
-        </span>
+        </p>
         <div
-          class="bp3-progress-bar bp3-intent-primary"
+          class="bp3-progress-bar bp3-no-animation"
         >
           <div
             class="bp3-progress-meter"
@@ -2118,13 +2118,24 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
         </div>
       </div>
       <div
-        class="sc-gqjmRU fWgawt"
+        class="sc-gqjmRU ddNDMP"
       >
-        <span>
-          Audit Board #01: 0 of 30 ballots audited 
-        </span>
+        <div>
+          <span>
+            Audit Board #01: 0 of 30 ballots audited 
+          </span>
+          <span
+            class="bp3-tag"
+          >
+            <span
+              class="bp3-text-overflow-ellipsis bp3-fill"
+            >
+              Not started
+            </span>
+          </span>
+        </div>
         <div
-          class="bp3-progress-bar bp3-intent-primary"
+          class="bp3-progress-bar bp3-no-animation"
         >
           <div
             class="bp3-progress-meter"

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
@@ -2094,7 +2094,7 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
       class="sc-hMqMXs kBeHNE"
     >
       <div
-        class="sc-gZMcBi fIaHlv"
+        class="sc-gZMcBi cPjbpf"
       >
         <h4
           class="bp3-heading"
@@ -2109,7 +2109,7 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
            
         </p>
         <div
-          class="bp3-progress-bar bp3-no-animation"
+          class="bp3-progress-bar bp3-no-stripes"
         >
           <div
             class="bp3-progress-meter"
@@ -2135,7 +2135,7 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
           </span>
         </div>
         <div
-          class="bp3-progress-bar bp3-no-animation"
+          class="bp3-progress-bar bp3-no-stripes"
         >
           <div
             class="bp3-progress-meter"

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
@@ -302,12 +302,32 @@ describe('StatusBox', () => {
       screen.getByText('0 of 1 audit boards complete.')
     })
 
-    it('renders 1st round finished, incomplete audit state', () => {
+    it('renders 1st round auditing complete, audit board not signed off, incomplete audit state', () => {
       render(
         <Router>
           <JurisdictionAdminStatusBox
             rounds={roundMocks.singleIncomplete}
             auditBoards={auditBoardMocks.finished}
+            ballotManifest={{
+              file: null,
+              processing: fileProcessingMocks.processed,
+            }}
+            batchTallies={{ file: null, processing: null }}
+            cvrs={{ file: null, processing: null }}
+            auditType="BALLOT_POLLING"
+          />
+        </Router>
+      )
+      screen.getByText('Round 1 of the audit is in progress.')
+      screen.getByText('0 of 1 audit boards complete.')
+    })
+
+    it('renders 1st round finished, incomplete audit state', () => {
+      render(
+        <Router>
+          <JurisdictionAdminStatusBox
+            rounds={roundMocks.singleIncomplete}
+            auditBoards={auditBoardMocks.signedOff}
             ballotManifest={{
               file: null,
               processing: fileProcessingMocks.processed,

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
@@ -309,9 +309,8 @@ export const JurisdictionAdminStatusBox = ({
       )
 
     const numCompleted = auditBoards.filter(
-      ({ currentRoundStatus }) =>
-        currentRoundStatus.numAuditedBallots ===
-        currentRoundStatus.numSampledBallots
+      ({ currentRoundStatus, signedOffAt }) =>
+        currentRoundStatus.numSampledBallots === 0 || signedOffAt
     ).length
     const details = [
       `${numCompleted} of ${auditBoards.length} audit boards complete.`,


### PR DESCRIPTION
- Fix the status box to only show audit boards complete once they're
signed off
- Add tags/intent to the progress bars for individual audit boards in
order to differentiate which boards have signed off

<img width="560" alt="Screen Shot 2021-01-20 at 12 49 13 PM" src="https://user-images.githubusercontent.com/530106/105232883-eb9c4b80-5b1d-11eb-993d-04dba8e4e579.png">
