### PR TITLE
Support Tools: Reopen audit board

### DIFF
--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`App / renders aa logged in properly 1`] = `
           class="bp3-navbar-group bp3-align-right"
         >
           <div
-            class="sc-ifAKCX jAFEAy"
+            class="sc-ifAKCX fWzXiF"
           >
             <div
               class="bp3-popover-wrapper bp3-fill"
@@ -285,7 +285,7 @@ exports[`App / renders ja logged in properly 1`] = `
           class="bp3-navbar-group bp3-align-right"
         >
           <div
-            class="sc-ifAKCX jAFEAy"
+            class="sc-ifAKCX fWzXiF"
           >
             <div
               class="bp3-popover-wrapper bp3-fill"
@@ -503,7 +503,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders aa logged i
           class="bp3-navbar-group bp3-align-right"
         >
           <div
-            class="sc-ifAKCX jAFEAy"
+            class="sc-ifAKCX fWzXiF"
           >
             <div
               class="bp3-popover-wrapper bp3-fill"
@@ -754,7 +754,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ab logged i
           class="bp3-navbar-group bp3-align-right"
         >
           <div
-            class="sc-ifAKCX jAFEAy"
+            class="sc-ifAKCX fWzXiF"
           >
             <div
               class="bp3-popover-wrapper bp3-fill"
@@ -1094,7 +1094,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ja logged i
           class="bp3-navbar-group bp3-align-right"
         >
           <div
-            class="sc-ifAKCX jAFEAy"
+            class="sc-ifAKCX fWzXiF"
           >
             <div
               class="bp3-popover-wrapper bp3-fill"
@@ -1312,7 +1312,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders aa logge
           class="bp3-navbar-group bp3-align-right"
         >
           <div
-            class="sc-ifAKCX jAFEAy"
+            class="sc-ifAKCX fWzXiF"
           >
             <div
               class="bp3-popover-wrapper bp3-fill"
@@ -1569,7 +1569,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders ja logge
           class="bp3-navbar-group bp3-align-right"
         >
           <div
-            class="sc-ifAKCX jAFEAy"
+            class="sc-ifAKCX fWzXiF"
           >
             <div
               class="bp3-popover-wrapper bp3-fill"

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -61,6 +61,7 @@ const UserMenu = styled.div`
   .bp3-button-text {
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .bp3-menu {
     width: 200px;

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -272,6 +272,24 @@ describe('Support Tools', () => {
       supportApiCalls.getUser,
       apiCalls.getJurisdiction,
       apiCalls.reopenAuditBoard,
+      {
+        ...apiCalls.getJurisdiction,
+        response: {
+          ...apiCalls.getJurisdiction.response,
+          auditBoards: [
+            {
+              id: 'audit-board-id-1',
+              name: 'Audit Board #1',
+              signedOffAt: null,
+            },
+            {
+              id: 'audit-board-id-2',
+              name: 'Audit Board #2',
+              signedOffAt: null,
+            },
+          ],
+        },
+      },
     ]
     await withMockFetch(expectedCalls, async () => {
       renderRoute('/support/jurisdictions/jurisdiction-id-1')
@@ -338,6 +356,13 @@ describe('Support Tools', () => {
       supportApiCalls.getUser,
       apiCalls.getJurisdiction,
       apiCalls.deleteAuditBoards,
+      {
+        ...apiCalls.getJurisdiction,
+        response: {
+          ...apiCalls.getJurisdiction.response,
+          auditBoards: [],
+        },
+      },
     ]
     await withMockFetch(expectedCalls, async () => {
       renderRoute('/support/jurisdictions/jurisdiction-id-1')
@@ -364,6 +389,8 @@ describe('Support Tools', () => {
 
       const toast = await screen.findByRole('alert')
       expect(toast).toHaveTextContent('Cleared audit boards for Jurisdiction 1')
+
+      screen.getByText("The jurisdiction hasn't created audit boards yet.")
     })
   })
 
@@ -464,7 +491,7 @@ describe('Support Tools', () => {
     })
   })
 
-  it('jurisdictino screen handles error on clear audit boards', async () => {
+  it('jurisdiction screen handles error on clear audit boards', async () => {
     const expectedCalls = [
       supportApiCalls.getUser,
       apiCalls.getJurisdiction,

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -303,6 +303,13 @@ describe('Support Tools', () => {
 
       const toast = await screen.findByRole('alert')
       expect(toast).toHaveTextContent('Reopened Audit Board #1')
+
+      expect(
+        within(screen.getByText('Audit Board #1').closest('tr')!).getByRole(
+          'button',
+          { name: 'Reopen' }
+        )
+      ).toBeDisabled()
     })
   })
 

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -12,7 +12,6 @@ import {
   H2,
   AnchorButton,
   Tag,
-  H4,
   ButtonGroup,
   Alignment,
   Colors,
@@ -30,8 +29,10 @@ import {
   IAuditAdmin,
   IElection,
   useCreateOrganization,
-  useClearJurisdictionAuditBoards,
-  IJurisdiction,
+  useJurisdiction,
+  IAuditBoard,
+  useClearAuditBoards,
+  useReopenAuditBoard,
 } from './support-api'
 import { useConfirm, Confirm } from '../Atoms/Confirm'
 
@@ -65,6 +66,11 @@ const SupportTools = () => {
               </Route>
               <Route path="/support/audits/:electionId">
                 {({ match }) => <Audit electionId={match!.params.electionId} />}
+              </Route>
+              <Route path="/support/jurisdictions/:jurisdictionId">
+                {({ match }) => (
+                  <Jurisdiction jurisdictionId={match!.params.jurisdictionId} />
+                )}
               </Route>
             </Switch>
           </div>
@@ -171,7 +177,8 @@ const Table = styled(HTMLTable)`
     text-overflow: ellipsis;
   }
   td:last-child {
-    width: 150px;
+    padding-right: 15px;
+    text-align: right;
   }
   tr td {
     vertical-align: baseline;
@@ -250,7 +257,6 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
                   <td>
                     <AnchorButton
                       icon="log-in"
-                      style={{ marginLeft: '20px' }}
                       href={`/api/support/audit-admins/${auditAdmin.email}/login`}
                     >
                       Log in as
@@ -275,8 +281,6 @@ const prettyAuditType = (auditType: IElection['auditType']) =>
 
 const Audit = ({ electionId }: { electionId: string }) => {
   const election = useElection(electionId)
-  const clearAuditBoards = useClearJurisdictionAuditBoards()
-  const { confirm, confirmProps } = useConfirm()
 
   if (election.isLoading || election.isIdle) return null
   if (election.isError) {
@@ -286,15 +290,72 @@ const Audit = ({ electionId }: { electionId: string }) => {
 
   const { auditName, auditType, jurisdictions } = election.data
 
-  const onClickClearAuditBoards = (jurisdiction: IJurisdiction) => {
+  return (
+    <Column>
+      <H2>{auditName}</H2>
+      <Tag large style={{ marginBottom: '15px' }}>
+        {prettyAuditType(auditType)}
+      </Tag>
+      <H3>Jurisdictions</H3>
+      <ButtonList>
+        {jurisdictions.map(jurisdiction => (
+          <LinkButton
+            key={jurisdiction.id}
+            to={`/support/jurisdictions/${jurisdiction.id}`}
+            intent={Intent.PRIMARY}
+          >
+            {jurisdiction.name}
+          </LinkButton>
+        ))}
+      </ButtonList>
+      {/* {jurisdictions.map(jurisdiction => (
+        <div key={jurisdiction.id} style={{ marginTop: '15px' }}>
+        </div>
+      ))} */}
+    </Column>
+  )
+}
+
+const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
+  const jurisdiction = useJurisdiction(jurisdictionId)
+  const clearAuditBoards = useClearAuditBoards()
+  const reopenAuditBoard = useReopenAuditBoard()
+  const { confirm, confirmProps } = useConfirm()
+
+  if (jurisdiction.isLoading || jurisdiction.isIdle) return null
+  if (jurisdiction.isError) {
+    toast.error(jurisdiction.error.message)
+    return null
+  }
+
+  const { name, jurisdictionAdmins, auditBoards } = jurisdiction.data
+
+  const onClickClearAuditBoards = () => {
     confirm({
       title: 'Confirm',
-      description: `Are you sure you want to clear the audit boards for ${jurisdiction.name}?`,
+      description: `Are you sure you want to clear the audit boards for ${name}?`,
       yesButtonLabel: 'Clear audit boards',
       onYesClick: async () => {
         try {
-          await clearAuditBoards.mutateAsync(jurisdiction.id)
-          toast.success(`Cleared audit boards for ${jurisdiction.name}`)
+          await clearAuditBoards.mutateAsync(jurisdictionId)
+          toast.success(`Cleared audit boards for ${name}`)
+        } catch (error) {
+          toast.error(error.message)
+          throw error
+        }
+      },
+    })
+  }
+
+  const onClickReopenAuditBoard = (auditBoard: IAuditBoard) => {
+    confirm({
+      title: 'Confirm',
+      description: `Are you sure you want to reopen ${auditBoard.name}?`,
+      yesButtonLabel: 'Reopen',
+      onYesClick: async () => {
+        try {
+          await reopenAuditBoard.mutateAsync(auditBoard.id)
+          toast.success(`Reopened ${auditBoard.name}`)
         } catch (error) {
           toast.error(error.message)
           throw error
@@ -304,27 +365,49 @@ const Audit = ({ electionId }: { electionId: string }) => {
   }
 
   return (
-    <Column>
-      <H2>{auditName}</H2>
-      <Tag large style={{ marginBottom: '15px' }}>
-        {prettyAuditType(auditType)}
-      </Tag>
-      <H3>Jurisdictions</H3>
-      {jurisdictions.map(jurisdiction => (
-        <div key={jurisdiction.id} style={{ marginTop: '15px' }}>
-          <H4>{jurisdiction.name}</H4>
-          <Button onClick={() => onClickClearAuditBoards(jurisdiction)}>
-            Clear audit boards
-          </Button>
+    <div style={{ width: '100%' }}>
+      <H2>{name}</H2>
+      <div style={{ display: 'flex', width: '100%' }}>
+        <Column>
+          <H3>Current Round Audit Boards</H3>
+          {auditBoards.length === 0 ? (
+            "The jurisdiction hasn't created audit boards yet."
+          ) : (
+            <>
+              <Button intent="danger" onClick={onClickClearAuditBoards}>
+                Clear audit boards
+              </Button>
+              <Table striped>
+                <tbody>
+                  {auditBoards.map(auditBoard => (
+                    <tr key={auditBoard.id}>
+                      <td>{auditBoard.name}</td>
+                      <td>
+                        <Button
+                          onClick={() => onClickReopenAuditBoard(auditBoard)}
+                          disabled={!auditBoard.signedOffAt}
+                        >
+                          Reopen
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+              <Confirm {...confirmProps} />
+            </>
+          )}
+        </Column>
+        <Column>
+          <H3>Jurisdiction Admins</H3>
           <Table striped>
             <tbody>
-              {jurisdiction.jurisdictionAdmins.map(jurisdictionAdmin => (
+              {jurisdictionAdmins.map(jurisdictionAdmin => (
                 <tr key={jurisdictionAdmin.email}>
                   <td>{jurisdictionAdmin.email}</td>
                   <td>
                     <AnchorButton
                       icon="log-in"
-                      style={{ marginLeft: '20px' }}
                       href={`/api/support/jurisdiction-admins/${jurisdictionAdmin.email}/login`}
                     >
                       Log in as
@@ -334,10 +417,9 @@ const Audit = ({ electionId }: { electionId: string }) => {
               ))}
             </tbody>
           </Table>
-        </div>
-      ))}
-      <Confirm {...confirmProps} />
-    </Column>
+        </Column>
+      </div>
+    </div>
   )
 }
 

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -337,7 +337,7 @@ const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
       yesButtonLabel: 'Clear audit boards',
       onYesClick: async () => {
         try {
-          await clearAuditBoards.mutateAsync(jurisdictionId)
+          await clearAuditBoards.mutateAsync({ jurisdictionId })
           toast.success(`Cleared audit boards for ${name}`)
         } catch (error) {
           toast.error(error.message)
@@ -354,7 +354,10 @@ const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
       yesButtonLabel: 'Reopen',
       onYesClick: async () => {
         try {
-          await reopenAuditBoard.mutateAsync(auditBoard.id)
+          await reopenAuditBoard.mutateAsync({
+            jurisdictionId,
+            auditBoardId: auditBoard.id,
+          })
           toast.success(`Reopened ${auditBoard.name}`)
         } catch (error) {
           toast.error(error.message)

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -308,10 +308,6 @@ const Audit = ({ electionId }: { electionId: string }) => {
           </LinkButton>
         ))}
       </ButtonList>
-      {/* {jurisdictions.map(jurisdiction => (
-        <div key={jurisdiction.id} style={{ marginTop: '15px' }}>
-        </div>
-      ))} */}
     </Column>
   )
 }

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -117,7 +117,11 @@ export const useJurisdiction = (jurisdictionId: string) =>
   )
 
 export const useClearAuditBoards = () => {
-  const deleteAuditBoards = async (jurisdictionId: string) =>
+  const deleteAuditBoards = async ({
+    jurisdictionId,
+  }: {
+    jurisdictionId: string
+  }) =>
     fetchApi(`/api/support/jurisdictions/${jurisdictionId}/audit-boards`, {
       method: 'DELETE',
     })
@@ -135,7 +139,12 @@ export const useClearAuditBoards = () => {
 }
 
 export const useReopenAuditBoard = () => {
-  const reopenAuditBoard = async (auditBoardId: string) =>
+  const reopenAuditBoard = async ({
+    auditBoardId,
+  }: {
+    jurisdictionId: string
+    auditBoardId: string
+  }) =>
     fetchApi(`/api/support/audit-boards/${auditBoardId}/sign-off`, {
       method: 'DELETE',
     })

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -130,17 +130,7 @@ def get_election(election_id: str):
         auditName=election.audit_name,
         auditType=election.audit_type,
         jurisdictions=[
-            dict(
-                id=jurisdiction.id,
-                name=jurisdiction.name,
-                jurisdictionAdmins=sorted(
-                    [
-                        dict(email=admin.user.email)
-                        for admin in jurisdiction.jurisdiction_administrations
-                    ],
-                    key=lambda admin: str(admin["email"]),
-                ),
-            )
+            dict(id=jurisdiction.id, name=jurisdiction.name,)
             for jurisdiction in election.jurisdictions
         ],
     )
@@ -184,6 +174,31 @@ def create_audit_admin(organization_id: str):
     db_session.commit()
 
     return jsonify(status="ok")
+
+
+@api.route("/support/jurisdictions/<jurisdiction_id>", methods=["GET"])
+@restrict_access_support
+def get_jurisdiction(jurisdiction_id: str):
+    jurisdiction = get_or_404(Jurisdiction, jurisdiction_id)
+    return jsonify(
+        id=jurisdiction.id,
+        name=jurisdiction.name,
+        jurisdictionAdmins=sorted(
+            [
+                dict(email=admin.user.email)
+                for admin in jurisdiction.jurisdiction_administrations
+            ],
+            key=lambda admin: str(admin["email"]),
+        ),
+        auditBoards=[
+            dict(
+                id=audit_board.id,
+                name=audit_board.name,
+                signedOffAt=audit_board.signed_off_at,
+            )
+            for audit_board in jurisdiction.audit_boards
+        ],
+    )
 
 
 @api.route("/support/jurisdictions/<jurisdiction_id>/audit-boards", methods=["DELETE"])

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -319,3 +319,101 @@ def test_support_clear_audit_boards(
     assert_ok(rv)
 
     assert Jurisdiction.query.get(jurisdiction_ids[0]).audit_boards == []
+
+
+def test_support_reopen_audit_board(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_ids: List[str],
+    round_1_id: str,
+    audit_board_round_1_ids: List[str],
+):
+    set_support_user(client, SUPPORT_EMAIL)
+
+    # Can't reopen if audit board hasn't signed off
+    rv = client.delete(
+        f"/api/support/audit-boards/{audit_board_round_1_ids[0]}/sign-off"
+    )
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {"errorType": "Conflict", "message": "Audit board has not signed off."}
+        ]
+    }
+
+    run_audit_round(round_1_id, contest_ids[0], contest_ids, 0.55)
+
+    # Can't reopen after round ends before starting next round
+    rv = client.delete(
+        f"/api/support/audit-boards/{audit_board_round_1_ids[0]}/sign-off"
+    )
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Conflict",
+                "message": "Can't reopen audit board after round ends.",
+            }
+        ]
+    }
+
+    # Start round 2
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2},)
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/round",)
+    rounds = json.loads(rv.data)["rounds"]
+    round_2_id = str(rounds[1]["id"])
+
+    # Can't reopen audit boards from previous rounds
+    set_support_user(client, SUPPORT_EMAIL)
+    rv = client.delete(
+        f"/api/support/audit-boards/{audit_board_round_1_ids[0]}/sign-off"
+    )
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Conflict",
+                "message": "Audit board is not part of the current round.",
+            }
+        ]
+    }
+
+    # Create audit boards
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/audit-board",
+        [{"name": "Audit Board #1"}, {"name": "Audit Board #2"},],
+    )
+    assert_ok(rv)
+
+    # Audit ballots
+    audit_board = AuditBoard.query.filter_by(
+        jurisdiction_id=jurisdiction_ids[0], round_id=round_2_id
+    ).first()
+    audit_board.member_1 = "A"
+    audit_board.member_2 = "B"
+    for ballot in audit_board.sampled_ballots:
+        audit_ballot(ballot, contest_ids[0], Interpretation.BLANK)
+    db_session.commit()
+
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board.id)
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/audit-board/{audit_board.id}/sign-off",
+        {"memberName1": audit_board.member_1, "memberName2": audit_board.member_2},
+    )
+    assert_ok(rv)
+
+    # Happy path
+    set_support_user(client, SUPPORT_EMAIL)
+    rv = client.delete(f"/api/support/audit-boards/{audit_board.id}/sign-off")
+    assert_ok(rv)
+
+    assert AuditBoard.query.get(audit_board.id).signed_off_at is None

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -73,21 +73,9 @@ def test_support_get_election(
             "auditName": "Test Audit test_support_get_election",
             "auditType": "BALLOT_POLLING",
             "jurisdictions": [
-                {
-                    "id": jurisdiction_ids[0],
-                    "name": "J1",
-                    "jurisdictionAdmins": [{"email": default_ja_email(election_id)}],
-                },
-                {
-                    "id": jurisdiction_ids[1],
-                    "name": "J2",
-                    "jurisdictionAdmins": [{"email": default_ja_email(election_id)}],
-                },
-                {
-                    "id": jurisdiction_ids[2],
-                    "name": "J3",
-                    "jurisdictionAdmins": [{"email": f"j3-{election_id}@example.com"}],
-                },
+                {"id": jurisdiction_ids[0], "name": "J1",},
+                {"id": jurisdiction_ids[1], "name": "J2",},
+                {"id": jurisdiction_ids[2], "name": "J3",},
             ],
         },
     )
@@ -228,6 +216,28 @@ def test_support_create_audit_admin_already_admin(  # pylint: disable=invalid-na
     assert json.loads(rv.data) == {
         "errors": [{"errorType": "Conflict", "message": "Audit admin already exists"}]
     }
+
+
+def test_support_get_jurisdiction(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    audit_board_round_1_ids: List[str],
+):
+    set_support_user(client, SUPPORT_EMAIL)
+    rv = client.get(f"/api/support/jurisdictions/{jurisdiction_ids[0]}")
+    compare_json(
+        json.loads(rv.data),
+        {
+            "id": jurisdiction_ids[0],
+            "name": "J1",
+            "jurisdictionAdmins": [{"email": default_ja_email(election_id)}],
+            "auditBoards": [
+                {"id": id, "name": f"Audit Board #{i+1}", "signedOffAt": None}
+                for i, id in enumerate(audit_board_round_1_ids)
+            ],
+        },
+    )
 
 
 def test_support_log_in_as_audit_admin(


### PR DESCRIPTION
- Reorganize support tools to have a separate screen for each jurisdiction with a list of audit boards and JAs
- Add a button to reopen an audit board after it has signed off


https://user-images.githubusercontent.com/530106/105403986-485f3b00-5bde-11eb-8b2a-1e9b7d050d2f.mov

