### PR TITLE
bgcompute: commit before sleeping

### DIFF
--- a/server/worker/bgcompute.py
+++ b/server/worker/bgcompute.py
@@ -185,6 +185,10 @@ def bgcompute_forever():
     while True:
         bgcompute()
         run_new_tasks()
+        # Before sleeping, we need to commit the curren transaction, otherwise
+        # we will have "idle in transaction" queries that will lock the
+        # database, which gets in the way of migrations.
+        db_session.commit()
         time.sleep(2)
 
 


### PR DESCRIPTION
Migrations would often hang when the worker was running. The `pg_stat_activity` table would show an "idle in transaction" query coming from bgcompute. Committing the transaction before sleeping seems to solve it!