### PR TITLE
Fix progress screen flash when drawing sample

### DIFF
--- a/client/cypress/end-to-end/ballot-comparison-happy-path.spec.js
+++ b/client/cypress/end-to-end/ballot-comparison-happy-path.spec.js
@@ -82,8 +82,7 @@ describe('Ballot Comparison', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.get('table').should('be.visible')
-    cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
+    cy.contains('Audit Progress')
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)
     cy.findByText(`Jurisdictions - TestAudit${id}`).siblings('button').click()

--- a/client/cypress/end-to-end/ballot-comparison-happy-path.spec.js
+++ b/client/cypress/end-to-end/ballot-comparison-happy-path.spec.js
@@ -82,7 +82,6 @@ describe('Ballot Comparison', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.contains('Drawing a random sample of ballots...')
     cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)

--- a/client/cypress/end-to-end/ballot-comparison-happy-path.spec.js
+++ b/client/cypress/end-to-end/ballot-comparison-happy-path.spec.js
@@ -82,7 +82,7 @@ describe('Ballot Comparison', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.contains('Audit Progress')
+    cy.findByRole('heading', {name: "Audit Progress"})
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)
     cy.findByText(`Jurisdictions - TestAudit${id}`).siblings('button').click()

--- a/client/cypress/end-to-end/ballot-comparison-happy-path.spec.js
+++ b/client/cypress/end-to-end/ballot-comparison-happy-path.spec.js
@@ -82,6 +82,7 @@ describe('Ballot Comparison', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
+    cy.get('table').should('be.visible')
     cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)

--- a/client/cypress/end-to-end/ballot-polling-happy-path.spec.js
+++ b/client/cypress/end-to-end/ballot-polling-happy-path.spec.js
@@ -74,7 +74,6 @@ describe('Ballot Polling', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.contains('Drawing a random sample of ballots...')
     cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)
@@ -145,7 +144,6 @@ describe('Ballot Polling', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.contains('Drawing a random sample of ballots...')
     cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)

--- a/client/cypress/end-to-end/ballot-polling-happy-path.spec.js
+++ b/client/cypress/end-to-end/ballot-polling-happy-path.spec.js
@@ -74,6 +74,7 @@ describe('Ballot Polling', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
+    cy.get('table').should('be.visible')
     cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)
@@ -144,6 +145,7 @@ describe('Ballot Polling', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
+    cy.get('table').should('be.visible')
     cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)

--- a/client/cypress/end-to-end/ballot-polling-happy-path.spec.js
+++ b/client/cypress/end-to-end/ballot-polling-happy-path.spec.js
@@ -74,8 +74,7 @@ describe('Ballot Polling', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.get('table').should('be.visible')
-    cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
+    cy.contains('Audit Progress')
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)
     cy.findByText(`Jurisdictions - TestAudit${id}`).siblings('button').click()
@@ -145,8 +144,7 @@ describe('Ballot Polling', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.get('table').should('be.visible')
-    cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
+    cy.contains('Audit Progress')
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)
     cy.findByText(`Jurisdictions - TestAudit${id}`).siblings('button').click()

--- a/client/cypress/end-to-end/ballot-polling-happy-path.spec.js
+++ b/client/cypress/end-to-end/ballot-polling-happy-path.spec.js
@@ -74,7 +74,7 @@ describe('Ballot Polling', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.contains('Audit Progress')
+    cy.findByRole('heading', {name: "Audit Progress"})
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)
     cy.findByText(`Jurisdictions - TestAudit${id}`).siblings('button').click()
@@ -144,7 +144,7 @@ describe('Ballot Polling', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.contains('Audit Progress')
+    cy.findByRole('heading', {name: "Audit Progress"})
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)
     cy.findByText(`Jurisdictions - TestAudit${id}`).siblings('button').click()

--- a/client/cypress/end-to-end/batch-comparison-happy-path.spec.js
+++ b/client/cypress/end-to-end/batch-comparison-happy-path.spec.js
@@ -79,7 +79,6 @@ describe('Batch Comparison', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.contains('Drawing a random sample of ballots...')
     cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)

--- a/client/cypress/end-to-end/batch-comparison-happy-path.spec.js
+++ b/client/cypress/end-to-end/batch-comparison-happy-path.spec.js
@@ -78,8 +78,7 @@ describe('Batch Comparison', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.get('table').should('be.visible')
-    cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
+    cy.contains('Audit Progress')
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)
     cy.findByText(`Jurisdictions - TestAudit${id}`).siblings('button').click()

--- a/client/cypress/end-to-end/batch-comparison-happy-path.spec.js
+++ b/client/cypress/end-to-end/batch-comparison-happy-path.spec.js
@@ -78,7 +78,7 @@ describe('Batch Comparison', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
-    cy.contains('Audit Progress')
+    cy.findByRole('heading', {name: "Audit Progress"})
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)
     cy.findByText(`Jurisdictions - TestAudit${id}`).siblings('button').click()

--- a/client/cypress/end-to-end/batch-comparison-happy-path.spec.js
+++ b/client/cypress/end-to-end/batch-comparison-happy-path.spec.js
@@ -7,7 +7,6 @@ describe('Batch Comparison', () => {
   const jurisdictionAdmin = 'wtarkin@empire.gov'
   const uuid = () => Cypress._.random(0, 1e6)
   let id = 0
-  let board_credentials_url = ''
 
   it('Creates, launches, and audits', () => {
     id = uuid()
@@ -79,6 +78,7 @@ describe('Batch Comparison', () => {
     cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
       secondButton.click()
     })
+    cy.get('table').should('be.visible')
     cy.get('tbody').children('tr').its('length').should('be.gt', 0) // ensures ballot drawing is done
     cy.logout(auditAdmin)
     cy.loginJurisdictionAdmin(jurisdictionAdmin)

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
@@ -88,10 +88,16 @@ routeMock.mockReturnValue({
 const { prevStage } = relativeStages('review')
 
 const refreshMock = jest.fn()
+const startNextRoundMock = jest.fn().mockResolvedValue(true)
 
 const renderView = () =>
   renderWithRouter(
-    <Review locked={false} prevStage={prevStage} refresh={refreshMock} />,
+    <Review
+      locked={false}
+      prevStage={prevStage}
+      refresh={refreshMock}
+      startNextRound={startNextRoundMock}
+    />,
     {
       route: '/election/1/setup',
     }
@@ -99,6 +105,7 @@ const renderView = () =>
 
 beforeEach(() => {
   refreshMock.mockClear()
+  startNextRoundMock.mockClear()
   toastSpy.mockClear()
   checkAndToastMock.mockClear()
   routeMock.mockClear()
@@ -114,7 +121,6 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getRounds,
       apiCalls.getSampleSizeOptions,
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -132,7 +138,6 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getRounds,
       apiCalls.getSampleSizeOptions,
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -150,7 +155,6 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getRounds,
       apiCalls.getSampleSizeOptions,
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -168,7 +172,6 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getRounds,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -185,7 +188,6 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getRounds,
       apiCalls.getSampleSizeOptions,
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -205,7 +207,6 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
-      apiCalls.getRounds,
       apiCalls.getSampleSizeOptions,
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -221,7 +222,6 @@ describe('Audit Setup > Review & Launch', () => {
       apiCalls.getJurisdictions({ jurisdictions: [] }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getRounds,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -236,7 +236,6 @@ describe('Audit Setup > Review & Launch', () => {
       apiCalls.getJurisdictions({ jurisdictions: [] }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledOpportunisticWithJurisdictionId),
-      apiCalls.getRounds,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -253,10 +252,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getRounds,
       apiCalls.getSampleSizeOptions,
-      apiCalls.postRound({ 'contest-id': 46 }),
-      apiCalls.getRounds,
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -266,7 +262,10 @@ describe('Audit Setup > Review & Launch', () => {
       await screen.findByText('Are you sure you want to launch the audit?')
       const confirmLaunchButton = screen.getAllByText('Launch Audit')[1]
       userEvent.click(confirmLaunchButton)
-      await waitFor(() => expect(refreshMock).toHaveBeenCalled())
+      await waitFor(() => {
+        expect(startNextRoundMock).toHaveBeenCalledWith({ 'contest-id': 46 })
+        expect(refreshMock).toHaveBeenCalled()
+      })
     })
   })
 
@@ -278,7 +277,6 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getRounds,
       apiCalls.getSampleSizeOptions,
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -289,7 +287,11 @@ describe('Audit Setup > Review & Launch', () => {
       await screen.findByText('Are you sure you want to launch the audit?')
       const cancelLaunchButton = screen.getByText('Cancel')
       userEvent.click(cancelLaunchButton)
-      await waitFor(() => expect(refreshMock).not.toHaveBeenCalled())
+      await waitFor(() =>
+        expect(
+          screen.queryByText('Are you sure you want to launch the audit?')
+        ).not.toBeInTheDocument()
+      )
     })
   })
 
@@ -301,10 +303,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getRounds,
       apiCalls.getSampleSizeOptions,
-      apiCalls.postRound({ 'contest-id': 67 }),
-      apiCalls.getRounds,
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -317,7 +316,10 @@ describe('Audit Setup > Review & Launch', () => {
       await screen.findByText('Are you sure you want to launch the audit?')
       const confirmLaunchButton = screen.getAllByText('Launch Audit')[1]
       userEvent.click(confirmLaunchButton)
-      await waitFor(() => expect(refreshMock).toHaveBeenCalled())
+      await waitFor(() => {
+        expect(startNextRoundMock).toHaveBeenCalledWith({ 'contest-id': 67 })
+        expect(refreshMock).toHaveBeenCalled()
+      })
     })
   })
 
@@ -329,10 +331,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getRounds,
       apiCalls.getSampleSizeOptions,
-      apiCalls.postRound({ 'contest-id': 5 }),
-      apiCalls.getRounds,
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -360,7 +359,10 @@ describe('Audit Setup > Review & Launch', () => {
       await screen.findByText('Are you sure you want to launch the audit?')
       const confirmLaunchButton = screen.getAllByText('Launch Audit')[1]
       userEvent.click(confirmLaunchButton)
-      await waitFor(() => expect(refreshMock).toHaveBeenCalled())
+      await waitFor(() => {
+        expect(startNextRoundMock).toHaveBeenCalledWith({ 'contest-id': 5 })
+        expect(refreshMock).toHaveBeenCalled()
+      })
     })
   })
 
@@ -372,7 +374,6 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getRounds,
       apiCalls.getStandardizedContestsFile,
     ]
     await withMockFetch(expectedCalls, async () => {

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -26,7 +26,7 @@ import {
   isFileProcessed,
   useStandardizedContestsFile,
 } from '../../useCSV'
-import useRoundsAuditAdmin from '../../useRoundsAuditAdmin'
+import { ISampleSizes } from '../../useRoundsAuditAdmin'
 import { mapValues } from '../../../../utils/objects'
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
@@ -41,9 +41,15 @@ interface IProps {
   locked: boolean
   prevStage: ISidebarMenuItem
   refresh: () => void
+  startNextRound: (sampleSizes: ISampleSizes) => Promise<boolean>
 }
 
-const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
+const Review: React.FC<IProps> = ({
+  prevStage,
+  locked,
+  refresh,
+  startNextRound,
+}: IProps) => {
   const { electionId } = useParams<{ electionId: string }>()
   const [auditSettings] = useAuditSettings(electionId)
   const jurisdictions = useJurisdictions(electionId)
@@ -62,7 +68,6 @@ const Review: React.FC<IProps> = ({ prevStage, locked, refresh }: IProps) => {
     !!auditSettings &&
     isSetupComplete(jurisdictions, contests, auditSettings)
   let sampleSizeOptions = useSampleSizes(electionId, shouldShowSampleSizes)
-  const [, startNextRound] = useRoundsAuditAdmin(electionId)
 
   if (
     !jurisdictions ||

--- a/client/src/components/MultiJurisdictionAudit/AASetup/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/index.test.tsx
@@ -67,6 +67,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="participants"
           menuItems={relativeStages('participants').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -84,6 +85,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="participants"
           menuItems={relativeStages('participants', 'locked').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -101,6 +103,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="participants"
           menuItems={relativeStages('participants', 'processing').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -117,6 +120,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="target-contests"
           menuItems={relativeStages('target-contests').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -132,6 +136,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="target-contests"
           menuItems={relativeStages('target-contests', 'locked').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -147,6 +152,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="target-contests"
           menuItems={relativeStages('target-contests', 'processing').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -166,6 +172,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="opportunistic-contests"
           menuItems={relativeStages('opportunistic-contests').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -187,6 +194,7 @@ describe('Setup', () => {
           menuItems={
             relativeStages('opportunistic-contests', 'locked').menuItems
           }
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -208,6 +216,7 @@ describe('Setup', () => {
           menuItems={
             relativeStages('opportunistic-contests', 'processing').menuItems
           }
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -223,6 +232,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="settings"
           menuItems={relativeStages('settings').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -237,6 +247,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="settings"
           menuItems={relativeStages('settings', 'locked').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -251,6 +262,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="settings"
           menuItems={relativeStages('settings', 'processing').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -265,6 +277,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="review"
           menuItems={relativeStages('review').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -281,6 +294,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="review"
           menuItems={relativeStages('review', 'locked').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )
@@ -297,6 +311,7 @@ describe('Setup', () => {
           refresh={jest.fn()}
           stage="review"
           menuItems={relativeStages('review', 'processing').menuItems}
+          startNextRound={jest.fn()}
         />
       </MemoryRouter>
     )

--- a/client/src/components/MultiJurisdictionAudit/AASetup/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/index.tsx
@@ -7,6 +7,7 @@ import Settings from './Settings'
 import Review from './Review'
 import { ISidebarMenuItem } from '../../Atoms/Sidebar'
 import { IAuditSettings } from '../useAuditSettings'
+import { ISampleSizes } from '../useRoundsAuditAdmin'
 
 export const setupStages = [
   'participants',
@@ -29,6 +30,7 @@ interface IProps {
   menuItems: ISidebarMenuItem[]
   refresh: () => void
   auditType: IAuditSettings['auditType']
+  startNextRound: (sampleSizes: ISampleSizes) => Promise<boolean>
 }
 
 const AASetup: React.FC<IProps> = ({
@@ -36,6 +38,7 @@ const AASetup: React.FC<IProps> = ({
   menuItems,
   refresh,
   auditType,
+  startNextRound,
 }) => {
   const activeStage = menuItems.find(m => m.id === stage)
   const nextStage: ISidebarMenuItem | undefined =
@@ -89,6 +92,7 @@ const AASetup: React.FC<IProps> = ({
           prevStage={prevStage!}
           locked={activeStage!.state === 'locked'}
           refresh={refresh}
+          startNextRound={startNextRound}
         />
       )
     /* istanbul ignore next */

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -122,6 +122,7 @@ export const AuditAdminView: React.FC = () => {
               refresh={refresh}
               menuItems={menuItems}
               auditType={auditSettings.auditType}
+              startNextRound={startNextRound}
             />
           </Inner>
         </Wrapper>


### PR DESCRIPTION
Previously, the progress screen would render briefly after launching the audit before the spinner would get rendered. This happened because the old round data (an empty array) hadn't been updated from the backend yet. To fix this, we use the `startNextRound` function from the same hook that loaded that data, so that it will invalidate and reload the data automatically before resolving the `startNextRound` promise.