### PR TITLE
Wrap header on narrow screens

### DIFF
--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`App / renders aa logged in properly 1`] = `
     class="sc-lhVmIH daMHBT"
   >
     <div
-      class="bp3-navbar sc-bxivhb jDnGce"
+      class="bp3-navbar sc-bxivhb fJOOqK"
     >
       <div
         class="sc-bwzfXH sc-EHOje bgNFlR"
@@ -273,7 +273,7 @@ exports[`App / renders ja logged in properly 1`] = `
     class="sc-lhVmIH daMHBT"
   >
     <div
-      class="bp3-navbar sc-bxivhb jDnGce"
+      class="bp3-navbar sc-bxivhb fJOOqK"
     >
       <div
         class="sc-bwzfXH sc-EHOje bgNFlR"
@@ -415,7 +415,7 @@ exports[`App / renders unauthenticated properly 1`] = `
     class="sc-lhVmIH daMHBT"
   >
     <div
-      class="bp3-navbar sc-bxivhb jDnGce"
+      class="bp3-navbar sc-bxivhb fJOOqK"
     >
       <div
         class="sc-bwzfXH sc-EHOje bgNFlR"
@@ -491,7 +491,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders aa logged i
     class="sc-lhVmIH daMHBT"
   >
     <div
-      class="bp3-navbar sc-bxivhb jDnGce"
+      class="bp3-navbar sc-bxivhb fJOOqK"
     >
       <div
         class="sc-bwzfXH sc-EHOje bgNFlR"
@@ -755,7 +755,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ab logged i
     class="sc-lhVmIH daMHBT"
   >
     <div
-      class="bp3-navbar sc-bxivhb jDnGce"
+      class="bp3-navbar sc-bxivhb fJOOqK"
     >
       <div
         class="sc-bwzfXH sc-EHOje bgNFlR"
@@ -1095,7 +1095,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders ja logged i
     class="sc-lhVmIH daMHBT"
   >
     <div
-      class="bp3-navbar sc-bxivhb jDnGce"
+      class="bp3-navbar sc-bxivhb fJOOqK"
     >
       <div
         class="sc-bwzfXH sc-EHOje bgNFlR"
@@ -1237,7 +1237,7 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders unauthentic
     class="sc-lhVmIH daMHBT"
   >
     <div
-      class="bp3-navbar sc-bxivhb jDnGce"
+      class="bp3-navbar sc-bxivhb fJOOqK"
     >
       <div
         class="sc-bwzfXH sc-EHOje bgNFlR"
@@ -1313,7 +1313,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders aa logge
     class="sc-lhVmIH daMHBT"
   >
     <div
-      class="bp3-navbar sc-bxivhb jDnGce"
+      class="bp3-navbar sc-bxivhb fJOOqK"
     >
       <div
         class="sc-bwzfXH sc-EHOje bgNFlR"
@@ -1577,7 +1577,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders ja logge
     class="sc-lhVmIH daMHBT"
   >
     <div
-      class="bp3-navbar sc-bxivhb jDnGce"
+      class="bp3-navbar sc-bxivhb fJOOqK"
     >
       <div
         class="sc-bwzfXH sc-EHOje bgNFlR"
@@ -1824,7 +1824,7 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders unauthen
     class="sc-lhVmIH daMHBT"
   >
     <div
-      class="bp3-navbar sc-bxivhb jDnGce"
+      class="bp3-navbar sc-bxivhb fJOOqK"
     >
       <div
         class="sc-bwzfXH sc-EHOje bgNFlR"

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -45,6 +45,7 @@ const SupportBar = styled(Navbar)`
 
 const Nav = styled(Navbar)`
   width: 100%;
+  height: auto;
   padding: 0;
 
   .bp3-navbar-heading img {


### PR DESCRIPTION
Previously the header would overflow if you resized the screen to a narrow width.

Before:
<img width="823" alt="Screen Shot 2021-02-22 at 1 56 36 PM" src="https://user-images.githubusercontent.com/530106/108775441-ee6fcf00-7515-11eb-8905-e5591d4e8f35.png">

After:
<img width="832" alt="Screen Shot 2021-02-22 at 1 57 17 PM" src="https://user-images.githubusercontent.com/530106/108775457-f29bec80-7515-11eb-8341-82f91ea1b684.png">

