### PR TITLE
Set contest metadata from CVRs on write

### DIFF
--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -25,7 +25,6 @@ from ..util.isoformat import isoformat
 from ..util.group_by import group_by
 from ..util.jsonschema import JSONDict
 from ..audit_math import sampler, ballot_polling, macro, supersimple, sampler_contest
-from .cvrs import set_contest_metadata_from_cvrs
 from ..worker.tasks import (
     background_task,
     create_background_task,
@@ -811,14 +810,7 @@ def create_round(election: Election):
 
     # For round 1, use the given sample size for each contest.
     if json_round["roundNum"] == 1:
-        # For ballot comparison audits, we need to lock in the contest metadata we
-        # parse from the CVRs when we launch the audit.
-        if election.audit_type == AuditType.BALLOT_COMPARISON:
-            for contest in election.contests:
-                set_contest_metadata_from_cvrs(contest)
-
         validate_sample_size(json_round, election)
-
         sample_sizes = json_round["sampleSizes"]
     # In later rounds, select a sample size automatically.
     else:

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -138,7 +138,17 @@ J2,TABULATOR2,BATCH1,2,2-1-2,"Round 2: 0.677864268646804078, 0.85289683599690853
 J2,TABULATOR2,BATCH1,3,2-1-3,"Round 2: 0.803716379074313244, 0.853400178985340640",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 """
 
-snapshots["test_set_contest_metadata_from_cvrs 1"] = {
+snapshots["test_set_contest_metadata_on_contest_creation 1"] = {
+    "choices": [
+        {"name": "Choice 2-1", "num_votes": 28},
+        {"name": "Choice 2-2", "num_votes": 12},
+        {"name": "Choice 2-3", "num_votes": 16},
+    ],
+    "total_ballots_cast": 30,
+    "votes_allowed": 2,
+}
+
+snapshots["test_set_contest_metadata_on_cvr_upload 1"] = {
     "choices": [
         {"name": "Choice 2-1", "num_votes": 28},
         {"name": "Choice 2-2", "num_votes": 12},


### PR DESCRIPTION
Previously, we computed contest metadata (e.g. total votes, votes for each
choice) based on the CVRs at read time: either when computing the sample size
options or finally when starting the round.

Two issues with this:
1. A bug! There was a guard to make sure we only computed the contest metadata once, which meant that if a jurisdiction changed their CVR after the first time sample sizes were computed, it wouldn't be taken into account.
2. The upcoming redesign to the Review screen shows this computed contest metadata via the /contests endpoint. That meant that both the sample sizes endpoint and the contests endpoint, which both get called by the review screen, were going to need to invoke this computation, so it seemed simpler to just move it to be computed on write so that we didn't have multiple different readers trying to lazily compute the same data. Especially since the contests endpoint is called in a variety of other circumstances besides the Review screen.

This change also factors out the validation of whether we are ready to compute the contest metadata (i.e. whether all the CVRs have been uploaded) so that the sample sizes endpoint can continue to raise that error.