### PR TITLE
Fix bug with CVR contest choice metadata

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -41,13 +41,14 @@ def set_contest_metadata_from_cvrs(contest: Contest):
         return
 
     contest.total_ballots_cast = 0
+    contest.choices = []
 
     for jurisdiction in contest.jurisdictions:
         contest_metadata = typing.cast(JSONDict, jurisdiction.cvr_contests_metadata)[
             contest.name
         ]
 
-        if not contest.choices:
+        if len(contest.choices) == 0:
             contest.choices = [
                 ContestChoice(
                     id=str(uuid.uuid4()),

--- a/server/models.py
+++ b/server/models.py
@@ -350,6 +350,7 @@ class Contest(BaseModel):
         "ContestChoice",
         back_populates="contest",
         uselist=True,
+        cascade="all, delete-orphan",
         passive_deletes=True,
         order_by="ContestChoice.created_at",
     )

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -157,3 +157,13 @@ snapshots["test_set_contest_metadata_on_cvr_upload 1"] = {
     "total_ballots_cast": 30,
     "votes_allowed": 2,
 }
+
+snapshots["test_set_contest_metadata_on_cvr_upload 2"] = {
+    "choices": [
+        {"name": "Choice 2-1", "num_votes": 17},
+        {"name": "Choice 2-2", "num_votes": 8},
+        {"name": "Choice 2-3", "num_votes": 9},
+    ],
+    "total_ballots_cast": 18,
+    "votes_allowed": 2,
+}


### PR DESCRIPTION
Now that we're computing the contest metadata from the CVRs on write, it's possible that it will need to be updated after a CVR is changed. The previous code didn't account for that case.