### PR TITLE
Simplify custom sample size validation

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
@@ -348,14 +348,14 @@ describe('Audit Setup > Review & Launch', () => {
       fireEvent.change(customSampleSizeInput, { target: { value: '40' } }) // userEvent has a problem with this field due to the lack of an explicit value field: https://github.com/testing-library/user-event/issues/356
       fireEvent.blur(customSampleSizeInput)
       await screen.findByText(
-        "Must be less than or equal to: 30 (the total number of ballots in the targeted contest: 'Contest Name')"
+        'Must be less than or equal to: 30 (the total number of ballots in the contest)'
       )
       userEvent.clear(customSampleSizeInput)
       fireEvent.change(customSampleSizeInput, { target: { value: '5' } })
       await waitFor(() =>
         expect(
           screen.queryByText(
-            "Must be less than or equal to: 30 (the total number of ballots in the targeted contest: 'Contest Name')"
+            'Must be less than or equal to: 30 (the total number of ballots in the contest)'
           )
         ).toBeNull()
       )
@@ -426,7 +426,7 @@ describe('Audit Setup > Review & Launch', () => {
       fireEvent.change(customSampleSizeInput, { target: { value: '40' } }) // userEvent has a problem with this field due to the lack of an explicit value field: https://github.com/testing-library/user-event/issues/356
       fireEvent.blur(customSampleSizeInput)
       await screen.findByText(
-        "Must be less than or equal to: 20 (the total number of batches in the targeted contest: 'Contest Name')"
+        'Must be less than or equal to: 20 (the total number of batches in the contest)'
       )
     })
   })
@@ -453,10 +453,10 @@ describe('Audit Setup > Review & Launch', () => {
       )
       userEvent.click(newSampleSize)
       const customSampleSizeInput = await screen.findByRole('spinbutton')
-      fireEvent.change(customSampleSizeInput, { target: { value: '5000' } }) // userEvent has a problem with this field due to the lack of an explicit value field: https://github.com/testing-library/user-event/issues/356
+      fireEvent.change(customSampleSizeInput, { target: { value: '50' } }) // userEvent has a problem with this field due to the lack of an explicit value field: https://github.com/testing-library/user-event/issues/356
       fireEvent.blur(customSampleSizeInput)
       await screen.findByText(
-        "Must be less than or equal to: 4234 (the total number of ballots in the targeted contest: 'Contest Name')"
+        'Must be less than or equal to: 30 (the total number of ballots in the contest)'
       )
     })
   })

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -140,53 +140,22 @@ const Review: React.FC<IProps> = ({
     isFileProcessed(j.ballotManifest)
   ).length
 
-  const getBatchTotal = () =>
-    participatingJurisdictions.reduce(
-      (a, { ballotManifest: { numBatches } }) =>
-        numBatches !== null ? a + numBatches : a,
-      0
-    )
-
-  const getBallotTotal = (jurisdictionIds: string[]) =>
-    jurisdictions
-      .filter(jurisdiction =>
-        jurisdictionIds.find(p => p === jurisdiction.name)
-      )
-      .reduce(
-        (a, { ballotManifest: { numBallots } }) =>
-          numBallots !== null ? a + numBallots : a,
+  const validateCustomSampleSize = (totalBallotsCast: string) => {
+    if (auditType === 'BATCH_COMPARISON') {
+      const totalBatches = participatingJurisdictions.reduce(
+        (a, { ballotManifest: { numBatches } }) =>
+          numBatches !== null ? a + numBatches : a,
         0
       )
-
-  const validateCustomSampleSize = (
-    totalBallotsCast: string,
-    jurisdictionIds: string[],
-    contestName: string
-  ) => {
-    if (auditType === 'BALLOT_POLLING') {
       return testNumber(
-        Number(totalBallotsCast),
-        `Must be less than or equal to: ${totalBallotsCast} (the total number of ballots in the targeted contest: '${contestName}')`
+        totalBatches,
+        `Must be less than or equal to: ${totalBatches} (the total number of batches in the contest)`
       )
     }
-    if (auditType === 'BATCH_COMPARISON') {
-      return testNumber(
-        Number(getBatchTotal()),
-        `Must be less than or equal to: ${Number(
-          getBatchTotal()
-        )} (the total number of batches in the targeted contest: '${contestName}')`
-      )
-    }
-    if (auditType === 'BALLOT_COMPARISON') {
-      return testNumber(
-        Number(getBallotTotal(jurisdictionIds)),
-        `Must be less than or equal to: ${Number(
-          getBallotTotal(jurisdictionIds)
-        )} (the total number of ballots in the targeted contest: '${contestName}')`
-      )
-    }
-    /* istanbul ignore next */
-    return Promise.resolve(undefined)
+    return testNumber(
+      Number(totalBallotsCast),
+      `Must be less than or equal to: ${totalBallotsCast} (the total number of ballots in the contest)`
+    )
   }
 
   return (
@@ -397,9 +366,7 @@ const Review: React.FC<IProps> = ({
                               }
                               type="number"
                               validate={validateCustomSampleSize(
-                                contest.totalBallotsCast,
-                                contest.jurisdictionIds,
-                                contest.name
+                                contest.totalBallotsCast
                               )}
                               disabled={locked}
                             />


### PR DESCRIPTION
After #1069, the contest metadata needed for sample size validation (total ballots cast) will be available on the contest object in ballot comparison audits, so we can simplify the custom sample size validation.