### PR TITLE
Set total ballots cast from manifest

### DIFF
--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -8,6 +8,7 @@ from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from ..util.jsonschema import validate, JSONDict
 from .cvrs import hybrid_contest_choice_vote_counts, set_contest_metadata_from_cvrs
+from .ballot_manifest import set_total_ballots_from_manifests
 
 
 CONTEST_CHOICE_SCHEMA = {
@@ -170,6 +171,10 @@ def create_or_update_all_contests(election: Election):
         deserialize_contest(json_contest, election.id) for json_contest in json_contests
     ]
     db_session.add_all(contests)
+
+    if election.audit_type != AuditType.BALLOT_POLLING:
+        for contest in contests:
+            set_total_ballots_from_manifests(contest)
 
     if election.audit_type == AuditType.BALLOT_COMPARISON:
         for contest in contests:

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -41,7 +41,6 @@ def set_contest_metadata_from_cvrs(contest: Contest):
     if not all_cvrs_uploaded(contest):
         return
 
-    contest.total_ballots_cast = 0
     contest.choices = []
 
     for jurisdiction in contest.jurisdictions:
@@ -60,7 +59,6 @@ def set_contest_metadata_from_cvrs(contest: Contest):
                 for choice_name in contest_metadata["choices"]
             ]
 
-        contest.total_ballots_cast += contest_metadata["total_ballots_cast"]
         contest.votes_allowed = contest_metadata["votes_allowed"]
         for choice_name, choice_metadata in contest_metadata["choices"].items():
             choice = next(c for c in contest.choices if c.name == choice_name)

--- a/server/tests/api/test_elections.py
+++ b/server/tests/api/test_elections.py
@@ -19,7 +19,6 @@ def test_create_election_missing_fields(client: FlaskClient, org_id: str):
         del new_election[field]
 
         rv = post_json(client, "/api/election", new_election)
-        print(rv.data)
         assert rv.status_code == 400
         assert json.loads(rv.data) == {
             "errors": [

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -23,21 +23,21 @@ TABULATOR2,BATCH2,6,2-2-6,0.300053574780458718,N,Audit Board #1
 snapshots["test_ballot_comparison_two_rounds 1"] = {
     "key": "supersimple",
     "prob": None,
-    "size": 30,
+    "size": 40,
 }
 
 snapshots["test_ballot_comparison_two_rounds 2"] = {
-    "numSamples": 13,
+    "numSamples": 18,
     "numSamplesAudited": 0,
-    "numUnique": 8,
+    "numUnique": 11,
     "numUniqueAudited": 0,
     "status": "NOT_STARTED",
 }
 
 snapshots["test_ballot_comparison_two_rounds 3"] = {
-    "numSamples": 17,
+    "numSamples": 22,
     "numSamplesAudited": 0,
-    "numUnique": 12,
+    "numUnique": 13,
     "numUniqueAudited": 0,
     "status": "NOT_STARTED",
 }
@@ -50,8 +50,8 @@ Test Org test_ballot_comparison_two_rounds,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
 Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,1,22,Choice 1-1: 12; Choice 1-2: 8\r
-Contest 2,Opportunistic,1,2,28,Choice 2-1: 26; Choice 2-2: 12; Choice 2-3: 14\r
+Contest 1,Targeted,1,1,30,Choice 1-1: 12; Choice 1-2: 8\r
+Contest 2,Opportunistic,1,2,30,Choice 2-1: 26; Choice 2-2: 12; Choice 2-3: 14\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
@@ -64,30 +64,34 @@ J2,Audit Board #1,,,,\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,30,No,163007579.5813730061,DATETIME,DATETIME,Choice 1-1: 13; Choice 1-2: 10\r
-1,Contest 2,Opportunistic,,No,3073.4982074829,DATETIME,DATETIME,Choice 2-1: 15; Choice 2-2: 9; Choice 2-3: 9\r
+1,Contest 1,Targeted,40,No,179125340.4921900034,DATETIME,DATETIME,Choice 1-1: 17; Choice 1-2: 12\r
+1,Contest 2,Opportunistic,,No,1842.4616004052,DATETIME,DATETIME,Choice 2-1: 19; Choice 2-2: 9; Choice 2-3: 13\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Discrepancy: Contest 2\r
 J1,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.243550726331576894,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J1,TABULATOR1,BATCH1,2,1-1-2,Round 1: 0.658361514845611561,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J1,TABULATOR1,BATCH2,2,1-2-2,Round 1: 0.125871889047705889,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J1,TABULATOR1,BATCH2,3,1-2-3,"Round 1: 0.126622033568908859, 0.570682515619614792",AUDITED,"Choice 1-1, Choice 1-2",Choice 1-1,1,"Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-3",2\r
+J1,TABULATOR2,BATCH1,2,2-1-2,Round 1: 0.651118570553261125,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.607927957276839128,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J1,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.053992217600758631, 0.528652598036440834",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",\r
 J1,TABULATOR2,BATCH2,3,,Round 1: 0.255119157791673311,NOT_FOUND,,,2,,,2\r
-J1,TABULATOR2,BATCH2,4,2-2-4,"Round 1: 0.064984443990590400, 0.069414660569975443",AUDITED,BLANK,,,BLANK,"Choice 2-1, Choice 2-3",1\r
+J1,TABULATOR2,BATCH2,4,2-2-4,"Round 1: 0.064984443990590400, 0.069414660569975443, 0.662654312843285447",AUDITED,BLANK,,,BLANK,"Choice 2-1, Choice 2-3",1\r
 J1,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.442956417641278897, 0.492638838970333256",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
-J1,TABULATOR2,BATCH2,6,2-2-6,"Round 1: 0.300053574780458718, 0.539920212714138536",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,6,2-2-6,"Round 1: 0.300053574780458718, 0.539920212714138536, 0.614239889448737812",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.476019554092109137,AUDITED,Choice 1-1,Choice 1-2,0,Choice 2-1,"Choice 2-1, Choice 2-2",0\r
 J2,TABULATOR1,BATCH1,2,1-1-2,"Round 1: 0.511105635717372621, 0.583472201399663519",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR1,BATCH1,3,1-1-3,Round 1: 0.242392535590495322,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J2,TABULATOR1,BATCH2,1,1-2-1,"Round 1: 0.200269401620671924, 0.588219390083415326",NOT_FOUND,,Choice 1-1,2,,"Choice 2-1, Choice 2-3",2\r
 J2,TABULATOR1,BATCH2,3,1-2-3,Round 1: 0.556310137163677574,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR2,BATCH1,1,2-1-1,Round 1: 0.174827909206366766,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH1,1,2-1-1,"Round 1: 0.174827909206366766, 0.638759896009674755, 0.666161104573622944",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH1,2,2-1-2,Round 1: 0.677864268646804078,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.185417954749015145,AUDITED,CONTEST_NOT_ON_BALLOT,Choice 1-1,1,CONTEST_NOT_ON_BALLOT,"Choice 2-1, Choice 2-3",1\r
 J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",\r
 J2,TABULATOR2,BATCH2,3,,"Round 1: 0.179114059650472941, 0.443867094961314498, 0.553767880261132538",AUDITED,Choice 1-1,,2,"Choice 2-1, Choice 2-3",,2\r
-J2,TABULATOR2,BATCH2,4,2-2-4,Round 1: 0.583133559190710795,AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR2,BATCH2,5,2-2-5,Round 1: 0.462119987445142117,AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH2,4,2-2-4,"Round 1: 0.583133559190710795, 0.685610948371080498",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J2,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.462119987445142117, 0.593645562906652185",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J2,TABULATOR2,BATCH2,6,2-2-6,Round 1: 0.414184312862040881,AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 """
 
@@ -99,8 +103,8 @@ Test Org test_ballot_comparison_two_rounds,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
 Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,1,22,Choice 1-1: 12; Choice 1-2: 8\r
-Contest 2,Opportunistic,1,2,28,Choice 2-1: 26; Choice 2-2: 12; Choice 2-3: 14\r
+Contest 1,Targeted,1,1,30,Choice 1-1: 12; Choice 1-2: 8\r
+Contest 2,Opportunistic,1,2,30,Choice 2-1: 26; Choice 2-2: 12; Choice 2-3: 14\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
@@ -113,37 +117,41 @@ J2,Audit Board #1,,,,\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,30,No,163007579.5813730061,DATETIME,DATETIME,Choice 1-1: 13; Choice 1-2: 10\r
-1,Contest 2,Opportunistic,,No,3073.4982074829,DATETIME,DATETIME,Choice 2-1: 15; Choice 2-2: 9; Choice 2-3: 9\r
-2,Contest 1,Targeted,22,Yes,0,DATETIME,DATETIME,Choice 1-1: 8; Choice 1-2: 10\r
-2,Contest 2,Opportunistic,,No,1220.1312885251,DATETIME,DATETIME,Choice 2-1: 14; Choice 2-2: 7; Choice 2-3: 8\r
+1,Contest 1,Targeted,40,No,179125340.4921900034,DATETIME,DATETIME,Choice 1-1: 17; Choice 1-2: 12\r
+1,Contest 2,Opportunistic,,No,1842.4616004052,DATETIME,DATETIME,Choice 2-1: 19; Choice 2-2: 9; Choice 2-3: 13\r
+2,Contest 1,Targeted,30,No,2422250319.638420105,DATETIME,DATETIME,Choice 1-1: 17; Choice 1-2: 16\r
+2,Contest 2,Opportunistic,,No,783.4369043583,DATETIME,DATETIME,Choice 2-1: 16; Choice 2-2: 12; Choice 2-3: 7\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Discrepancy: Contest 2\r
 J1,TABULATOR1,BATCH1,1,1-1-1,"Round 1: 0.243550726331576894, Round 2: 0.686337915847173217, 0.780585292625102279",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
-J1,TABULATOR1,BATCH2,2,1-2-2,"Round 1: 0.125871889047705889, Round 2: 0.752068917437552786",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
-J1,TABULATOR1,BATCH2,3,1-2-3,"Round 1: 0.126622033568908859, 0.570682515619614792",AUDITED,"Choice 1-1, Choice 1-2",Choice 1-1,1,"Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-3",2\r
-J1,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.053992217600758631, 0.528652598036440834, Round 2: 0.764288236446565653",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",\r
+J1,TABULATOR1,BATCH1,2,1-1-2,Round 1: 0.658361514845611561,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR1,BATCH2,2,1-2-2,"Round 1: 0.125871889047705889, Round 2: 0.752068917437552786, 0.861487366858738482",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J1,TABULATOR1,BATCH2,3,1-2-3,"Round 1: 0.126622033568908859, 0.570682515619614792, Round 2: 0.834196264967811357, 0.865330875569241072",AUDITED,"Choice 1-1, Choice 1-2",Choice 1-1,1,"Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-3",2\r
+J1,TABULATOR2,BATCH1,2,2-1-2,Round 1: 0.651118570553261125,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,1,2-2-1,"Round 1: 0.607927957276839128, Round 2: 0.787278086653253195",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.053992217600758631, 0.528652598036440834, Round 2: 0.764288236446565653, 0.820175995974143805",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",\r
 J1,TABULATOR2,BATCH2,3,,Round 1: 0.255119157791673311,NOT_FOUND,,,2,,,2\r
-J1,TABULATOR2,BATCH2,4,2-2-4,"Round 1: 0.064984443990590400, 0.069414660569975443, Round 2: 0.662654312843285447, 0.739178008942093721",AUDITED,BLANK,,,BLANK,"Choice 2-1, Choice 2-3",1\r
-J1,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.442956417641278897, 0.492638838970333256",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
-J1,TABULATOR2,BATCH2,6,2-2-6,"Round 1: 0.300053574780458718, 0.539920212714138536, Round 2: 0.614239889448737812",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,4,2-2-4,"Round 1: 0.064984443990590400, 0.069414660569975443, 0.662654312843285447, Round 2: 0.739178008942093721",AUDITED,BLANK,,,BLANK,"Choice 2-1, Choice 2-3",1\r
+J1,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.442956417641278897, 0.492638838970333256, Round 2: 0.865476992385430338",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J1,TABULATOR2,BATCH2,6,2-2-6,"Round 1: 0.300053574780458718, 0.539920212714138536, 0.614239889448737812",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR1,BATCH1,1,1-1-1,"Round 1: 0.476019554092109137, Round 2: 0.762943953776491170",AUDITED,Choice 1-1,Choice 1-2,0,Choice 2-1,"Choice 2-1, Choice 2-2",0\r
 J2,TABULATOR1,BATCH1,2,1-1-2,"Round 1: 0.511105635717372621, 0.583472201399663519",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR1,BATCH1,3,1-1-3,"Round 1: 0.242392535590495322, Round 2: 0.705264140168043487",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J2,TABULATOR1,BATCH2,1,1-2-1,"Round 1: 0.200269401620671924, 0.588219390083415326",NOT_FOUND,,Choice 1-1,2,,"Choice 2-1, Choice 2-3",2\r
 J2,TABULATOR1,BATCH2,3,1-2-3,Round 1: 0.556310137163677574,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR2,BATCH1,1,2-1-1,"Round 1: 0.174827909206366766, Round 2: 0.638759896009674755, 0.666161104573622944, 0.688295361956370024, 0.773068356532987654",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH1,1,2-1-1,"Round 1: 0.174827909206366766, 0.638759896009674755, 0.666161104573622944, Round 2: 0.688295361956370024, 0.773068356532987654",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH1,2,2-1-2,"Round 1: 0.677864268646804078, Round 2: 0.852896835996908532, 0.856103819529989087, 0.857728105355769040",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
 J2,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.185417954749015145,AUDITED,CONTEST_NOT_ON_BALLOT,Choice 1-1,1,CONTEST_NOT_ON_BALLOT,"Choice 2-1, Choice 2-3",1\r
-J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438, Round 2: 0.770913121904276479",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",\r
-J2,TABULATOR2,BATCH2,3,,"Round 1: 0.179114059650472941, 0.443867094961314498, 0.553767880261132538",AUDITED,Choice 1-1,,2,"Choice 2-1, Choice 2-3",,2\r
-J2,TABULATOR2,BATCH2,4,2-2-4,"Round 1: 0.583133559190710795, Round 2: 0.685610948371080498",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.462119987445142117, Round 2: 0.593645562906652185, 0.727818415897312844",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438, Round 2: 0.770913121904276479, 0.858710774003854808",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",\r
+J2,TABULATOR2,BATCH2,3,,"Round 1: 0.179114059650472941, 0.443867094961314498, 0.553767880261132538, Round 2: 0.864886825414213315",AUDITED,Choice 1-1,,2,"Choice 2-1, Choice 2-3",,2\r
+J2,TABULATOR2,BATCH2,4,2-2-4,"Round 1: 0.583133559190710795, 0.685610948371080498",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J2,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.462119987445142117, 0.593645562906652185, Round 2: 0.727818415897312844",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 J2,TABULATOR2,BATCH2,6,2-2-6,Round 1: 0.414184312862040881,AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J1,TABULATOR1,BATCH1,2,1-1-2,Round 2: 0.658361514845611561,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J1,TABULATOR2,BATCH1,2,2-1-2,Round 2: 0.651118570553261125,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J1,TABULATOR2,BATCH2,1,2-2-1,"Round 2: 0.607927957276839128, 0.787278086653253195",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
-J2,TABULATOR2,BATCH1,2,2-1-2,Round 2: 0.677864268646804078,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR1,BATCH2,1,1-2-1,"Round 2: 0.789999110379954007, 0.795280178707820266, 0.860992097951906207",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH1,1,2-1-1,Round 2: 0.866942401925500729,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR1,BATCH2,2,1-2-2,"Round 2: 0.802360074986437243, 0.820653389137078523",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH1,3,2-1-3,"Round 2: 0.803716379074313244, 0.853400178985340640",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
 """
 
 snapshots["test_set_contest_metadata_on_contest_creation 1"] = {
@@ -152,26 +160,26 @@ snapshots["test_set_contest_metadata_on_contest_creation 1"] = {
         {"name": "Choice 2-2", "num_votes": 12},
         {"name": "Choice 2-3", "num_votes": 14},
     ],
-    "total_ballots_cast": 28,
+    "total_ballots_cast": 30,
     "votes_allowed": 2,
 }
 
-snapshots["test_set_contest_metadata_on_cvr_upload 1"] = {
+snapshots["test_set_contest_metadata_on_manifest_and_cvr_upload 1"] = {
     "choices": [
         {"name": "Choice 2-1", "num_votes": 26},
         {"name": "Choice 2-2", "num_votes": 12},
         {"name": "Choice 2-3", "num_votes": 14},
     ],
-    "total_ballots_cast": 28,
+    "total_ballots_cast": 30,
     "votes_allowed": 2,
 }
 
-snapshots["test_set_contest_metadata_on_cvr_upload 2"] = {
+snapshots["test_set_contest_metadata_on_manifest_and_cvr_upload 2"] = {
     "choices": [
         {"name": "Choice 2-1", "num_votes": 16},
         {"name": "Choice 2-2", "num_votes": 8},
         {"name": "Choice 2-3", "num_votes": 8},
     ],
-    "total_ballots_cast": 17,
+    "total_ballots_cast": 21,
     "votes_allowed": 2,
 }


### PR DESCRIPTION
In all audit types except ballot polling, we want the total ballots cast to be independent of the results being audited. This mainly matters in ballot comparison/hybrid, where we were previously computing total ballots cast from the CVR.

Future work:
- Remove the total ballots cast field from the contest setup screen (except in ballot polling)
- In ballot polling, validate the total ballots cast set on the contest setup screen