### PR TITLE
Reprocess standardized contests on jurisdiction file change

### DIFF
--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -30,7 +30,7 @@ STANDARDIZED_CONTEST_COLUMNS = [
 def process_standardized_contests_file(
     session: Session, election: Election, file: File
 ):
-    def process():
+    def process() -> None:
         standardized_contests_csv = parse_csv(
             file.contents, STANDARDIZED_CONTEST_COLUMNS
         )

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -27,54 +27,52 @@ STANDARDIZED_CONTEST_COLUMNS = [
 ]
 
 
-def set_standardized_contests(election: Election, file: File):
-    standardized_contests_csv = parse_csv(file.contents, STANDARDIZED_CONTEST_COLUMNS)
-
-    standardized_contests = []
-    for row in standardized_contests_csv:
-        if row[JURISDICTIONS].strip() == "all":
-            jurisdictions = election.jurisdictions
-        else:
-            jurisdiction_names = {
-                name.strip() for name in row[JURISDICTIONS].split(",")
-            }
-            jurisdictions = list(
-                Jurisdiction.query.filter_by(election_id=election.id)
-                .filter(Jurisdiction.name.in_(jurisdiction_names))
-                .order_by(Jurisdiction.name)
-                .all()
-            )
-
-            if len(jurisdictions) < len(jurisdiction_names):
-                invalid_jurisdictions = jurisdiction_names - {
-                    jurisdiction.name for jurisdiction in jurisdictions
-                }
-                raise UserError(
-                    f"Invalid jurisdictions for contest {row[CONTEST_NAME]}: {', '.join(sorted(invalid_jurisdictions))}"
-                )
-
-        contest_name = " ".join(row[CONTEST_NAME].splitlines())
-        # Strip off Dominion's vote-for designation"
-        if "Vote For=" in contest_name:
-            match = re.match(r"^(.+) \(Vote For=(\d+)\)$", contest_name)
-            if match:
-                contest_name = match[1]
-
-        standardized_contests.append(
-            dict(
-                name=contest_name,
-                jurisdictionIds=[jurisdiction.id for jurisdiction in jurisdictions],
-            )
-        )
-
-    election.standardized_contests = standardized_contests
-
-
 def process_standardized_contests_file(
     session: Session, election: Election, file: File
 ):
     def process():
-        set_standardized_contests(election, file)
+        standardized_contests_csv = parse_csv(
+            file.contents, STANDARDIZED_CONTEST_COLUMNS
+        )
+
+        standardized_contests = []
+        for row in standardized_contests_csv:
+            if row[JURISDICTIONS].strip() == "all":
+                jurisdictions = election.jurisdictions
+            else:
+                jurisdiction_names = {
+                    name.strip() for name in row[JURISDICTIONS].split(",")
+                }
+                jurisdictions = list(
+                    Jurisdiction.query.filter_by(election_id=election.id)
+                    .filter(Jurisdiction.name.in_(jurisdiction_names))
+                    .order_by(Jurisdiction.name)
+                    .all()
+                )
+
+                if len(jurisdictions) < len(jurisdiction_names):
+                    invalid_jurisdictions = jurisdiction_names - {
+                        jurisdiction.name for jurisdiction in jurisdictions
+                    }
+                    raise UserError(
+                        f"Invalid jurisdictions for contest {row[CONTEST_NAME]}: {', '.join(sorted(invalid_jurisdictions))}"
+                    )
+
+            contest_name = " ".join(row[CONTEST_NAME].splitlines())
+            # Strip off Dominion's vote-for designation"
+            if "Vote For=" in contest_name:
+                match = re.match(r"^(.+) \(Vote For=(\d+)\)$", contest_name)
+                if match:
+                    contest_name = match[1]
+
+            standardized_contests.append(
+                dict(
+                    name=contest_name,
+                    jurisdictionIds=[jurisdiction.id for jurisdiction in jurisdictions],
+                )
+            )
+
+        election.standardized_contests = standardized_contests
 
     process_file(session, file, process)
 

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -428,5 +428,20 @@ def test_standardized_contests_change_jurisdictions_file(
     rv = client.get(f"/api/election/{election_id}/standardized-contests")
     assert json.loads(rv.data) is None
 
+    # Error should be recorded
     rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
-    assert json.loads(rv.data) == {"file": None, "processing": None}
+    compare_json(
+        json.loads(rv.data),
+        {
+            "file": {
+                "name": "standardized-contests.csv",
+                "uploadedAt": assert_is_date,
+            },
+            "processing": {
+                "status": ProcessingStatus.ERRORED,
+                "startedAt": assert_is_date,
+                "completedAt": assert_is_date,
+                "error": "Invalid jurisdictions for contest Contest 2: J3",
+            },
+        },
+    )

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -4,7 +4,10 @@ from flask.testing import FlaskClient
 
 from ...models import *  # pylint: disable=wildcard-import
 from ..helpers import *  # pylint: disable=wildcard-import
-from ...worker.bgcompute import bgcompute_update_standardized_contests_file
+from ...worker.bgcompute import (
+    bgcompute_update_standardized_contests_file,
+    bgcompute_update_election_jurisdictions_file,
+)
 
 
 def test_upload_standardized_contests(
@@ -343,3 +346,87 @@ def test_standardized_contests_dominion_vote_for(
         },
         {"name": "Contest 3", "jurisdictionIds": [jurisdiction_ids[1]]},
     ]
+
+
+def test_standardized_contests_change_jurisdictions_file(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
+    standardized_contests_file = (
+        "Contest Name,Jurisdictions\n"
+        "Contest 1,all\n"
+        'Contest 2,"J1, J3"\n'
+        "Contest 3,all \n"
+    )
+    rv = client.put(
+        f"/api/election/{election_id}/standardized-contests/file",
+        data={
+            "standardized-contests": (
+                io.BytesIO(standardized_contests_file.encode()),
+                "standardized-contests.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+
+    bgcompute_update_standardized_contests_file(election_id)
+
+    # Remove a jurisdiction that isn't referenced directly in standardized contests
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/file",
+        data={
+            "jurisdictions": (
+                io.BytesIO(
+                    (
+                        "Jurisdiction,Admin Email\n"
+                        f"J3,j3-{election_id}@example.com\n"
+                        f"J1,{default_ja_email(election_id)}\n"
+                    ).encode()
+                ),
+                "jurisdictions.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+    bgcompute_update_election_jurisdictions_file(election_id)
+
+    # Standardized contests should be automatically updated
+    rv = client.get(f"/api/election/{election_id}/standardized-contests")
+    assert json.loads(rv.data) == [
+        {
+            "name": "Contest 1",
+            "jurisdictionIds": [jurisdiction_ids[0], jurisdiction_ids[2]],
+        },
+        {
+            "name": "Contest 2",
+            "jurisdictionIds": [jurisdiction_ids[0], jurisdiction_ids[2]],
+        },
+        {
+            "name": "Contest 3",
+            "jurisdictionIds": [jurisdiction_ids[0], jurisdiction_ids[2]],
+        },
+    ]
+
+    # Now remove a jurisdiction that is referenced directly in standardized contests
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/file",
+        data={
+            "jurisdictions": (
+                io.BytesIO(
+                    (
+                        "Jurisdiction,Admin Email\n"
+                        f"J1,{default_ja_email(election_id)}\n"
+                    ).encode()
+                ),
+                "jurisdictions.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+    bgcompute_update_election_jurisdictions_file(election_id)
+
+    # Standardized contests should be cleared
+    rv = client.get(f"/api/election/{election_id}/standardized-contests")
+    assert json.loads(rv.data) is None
+
+    rv = client.get(f"/api/election/{election_id}/standardized-contests/file")
+    assert json.loads(rv.data) == {"file": None, "processing": None}

--- a/server/util/jurisdiction_bulk_update.py
+++ b/server/util/jurisdiction_bulk_update.py
@@ -2,9 +2,9 @@ import uuid
 import logging
 from typing import Tuple, List
 from ..models import *  # pylint: disable=wildcard-import
-from ..util.process_file import process_file, UserError
+from ..util.process_file import process_file
 from ..util.csv_parse import parse_csv, CSVValueType, CSVColumnType
-from ..api.standardized_contests import set_standardized_contests
+from ..api.standardized_contests import process_standardized_contests_file
 
 logger = logging.getLogger("arlo")
 
@@ -31,22 +31,26 @@ def process_jurisdictions_file(session, election: Election, file: File) -> None:
             [(row[JURISDICTION_NAME], row[ADMIN_EMAIL]) for row in jurisdictions_csv],
         )
 
-        # If standardized contests file already uploaded, try reprocessing the
-        # standardized contests file as well, since it depends on jurisdiction names.
-        # If it works, great! If it doesn't work, we delete standardized
-        # contests and any Contests created based on it to prevent inconsistencies.
-        if election.standardized_contests_file:
-            try:
-                set_standardized_contests(election, election.standardized_contests_file)
-            except UserError as exc:
-                logger.info(
-                    f"JURISDICTION_UPLOAD_CLEARED_CONTESTS {dict(election_id=election.id, error=str(exc))}"
-                )
-                election.standardized_contests = None
-                election.standardized_contests_file = None
-                election.contests = []
-
     process_file(session, file, process)
+
+    # If standardized contests file already uploaded, try reprocessing the
+    # standardized contests file as well, since it depends on jurisdiction names.
+    if election.standardized_contests_file:
+        logger.info(
+            f"START_REPROCESSING_STANDARDIZED_CONTESTS {dict(election_id=election.id)}"
+        )
+        # First, clear out the previously processed data.
+        election.standardized_contests = None
+        election.contests = []
+        election.standardized_contests_file.processing_started_at = None
+        election.standardized_contests_file.processing_completed_at = None
+        election.standardized_contests_file.processing_error = None
+        process_standardized_contests_file(
+            session, election, election.standardized_contests_file
+        )
+        logger.info(
+            f"DONE_REPROCESSING_STANDARDIZED_CONTESTS {dict(election_id=election.id)}"
+        )
 
 
 def bulk_update_jurisdictions(

--- a/server/util/jurisdiction_bulk_update.py
+++ b/server/util/jurisdiction_bulk_update.py
@@ -45,6 +45,7 @@ def process_jurisdictions_file(session, election: Election, file: File) -> None:
         election.standardized_contests_file.processing_started_at = None
         election.standardized_contests_file.processing_completed_at = None
         election.standardized_contests_file.processing_error = None
+        session.flush()  # Make sure process_file can read the changes we just made
         process_standardized_contests_file(
             session, election, election.standardized_contests_file
         )

--- a/server/util/process_file.py
+++ b/server/util/process_file.py
@@ -31,6 +31,7 @@ def process_file(session: Session, file: File, callback: Callable[[], None]) -> 
 
     # If we got this far, `file` is ours to process.
     try:
+        session.begin_nested()
         callback()
         file.processing_started_at = processing_started_at
         file.processing_completed_at = datetime.datetime.now(timezone.utc)
@@ -46,8 +47,6 @@ def process_file(session: Session, file: File, callback: Callable[[], None]) -> 
         file.processing_error = str(error) or str(
             traceback.format_exception(error.__class__, error, error.__traceback__)
         )
-        session.add(file)
-        session.commit()
         if not isinstance(error, UserError):
             raise error
         return True

--- a/server/worker/bgcompute.py
+++ b/server/worker/bgcompute.py
@@ -53,6 +53,8 @@ def bgcompute_update_election_jurisdictions_file(election_id: str = None):
                 f"ERROR updating jurisdictions file. election_id: {election_id}"
             )
 
+        db_session.commit()
+
 
 def bgcompute_update_standardized_contests_file(election_id: str = None):
     files = File.query.join(
@@ -85,6 +87,8 @@ def bgcompute_update_standardized_contests_file(election_id: str = None):
                 f"ERROR updating standardized contests file. election_id: {election_id}"
             )
 
+        db_session.commit()
+
 
 def bgcompute_update_ballot_manifest_file(election_id: str = None):
     files = File.query.join(
@@ -115,6 +119,8 @@ def bgcompute_update_ballot_manifest_file(election_id: str = None):
             app.logger.exception(
                 f"ERROR updating ballot manifest file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
             )
+
+        db_session.commit()
 
 
 def bgcompute_update_batch_tallies_file(election_id: str = None):
@@ -149,6 +155,8 @@ def bgcompute_update_batch_tallies_file(election_id: str = None):
                 f"ERROR updating batch tallies file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
             )
 
+        db_session.commit()
+
 
 def bgcompute_update_cvr_file(election_id: str = None):
     files = File.query.join(Jurisdiction, File.id == Jurisdiction.cvr_file_id).filter(
@@ -179,6 +187,8 @@ def bgcompute_update_cvr_file(election_id: str = None):
             app.logger.exception(
                 f"ERROR updating CVR file. election_id: {election_id}, jurisdiction_id: {jurisdiction_id}"
             )
+
+        db_session.commit()
 
 
 def bgcompute_forever():


### PR DESCRIPTION
Modifies process_file to use a nested transaction so that multiple files can be processed in the same transaction.