### PR TITLE
Fix ballot comparison round 2 sample sizes

### DIFF
--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -69,11 +69,9 @@ def sample_size_options(
             if round_one:
                 discrepancy_counts = None
             else:
-                num_previous_samples = (
-                    SampledBallotDraw.query.join(Round)
-                    .filter_by(election_id=election.id)
-                    .count()
-                )
+                num_previous_samples = SampledBallotDraw.query.filter_by(
+                    contest_id=contest.id
+                ).count()
                 discrepancies = supersimple.compute_discrepancies(
                     contest_for_sampler,
                     rounds.cvrs_for_contest(contest),

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -20,6 +20,11 @@ TABULATOR2,BATCH2,5,2-2-5,0.442956417641278897,N,Audit Board #1
 TABULATOR2,BATCH2,6,2-2-6,0.300053574780458718,N,Audit Board #1
 """
 
+snapshots["test_ballot_comparison_multiple_targeted_contests_sample_size 1"] = [
+    ({"key": "supersimple", "prob": None, "size": 30},),
+    ({"key": "supersimple", "prob": None, "size": 30},),
+]
+
 snapshots["test_ballot_comparison_two_rounds 1"] = {
     "key": "supersimple",
     "prob": None,


### PR DESCRIPTION
We were giving the math the number of previously sampled ballots across all
contests, instead of just for the given contest.
