### PR TITLE
Allow deleting contests through election.contests relationship

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -115,6 +115,7 @@ class Election(BaseModel):
         "Contest",
         back_populates="election",
         uselist=True,
+        cascade="all, delete-orphan",
         passive_deletes=True,
         order_by="Contest.created_at",
     )

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -370,6 +370,21 @@ def test_standardized_contests_change_jurisdictions_file(
 
     bgcompute_update_standardized_contests_file(election_id)
 
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/contest",
+        [
+            {
+                "id": str(uuid.uuid4()),
+                "name": "Contest 1",
+                "numWinners": 1,
+                "jurisdictionIds": jurisdiction_ids,
+                "isTargeted": True,
+            }
+        ],
+    )
+    assert_ok(rv)
+
     # Remove a jurisdiction that isn't referenced directly in standardized contests
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/file",


### PR DESCRIPTION
Without the cascade delete-orphan setting, a contest that is removed from the election.contests relationship will have a null election_id, which violates the not null constraint. This setting will cause that orphan contest to get deleted, which is what we want.
