### PR TITLE
Reprocess batch tallies file when ballot manifest reuploaded

### DIFF
--- a/server/tests/batch_comparison/conftest.py
+++ b/server/tests/batch_comparison/conftest.py
@@ -24,6 +24,7 @@ def election_id(client: FlaskClient, org_id: str, request):
 
 @pytest.fixture
 def contest_ids(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     contests = [
         {
             "id": str(uuid.uuid4()),

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -8,15 +8,15 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots["test_batch_comparison_round_1 1"] = {
-    "numSamples": 14,
+    "numSamples": 10,
     "numSamplesAudited": 0,
-    "numUnique": 5,
+    "numUnique": 4,
     "numUniqueAudited": 0,
     "status": "NOT_STARTED",
 }
 
 snapshots["test_batch_comparison_round_1 2"] = {
-    "numSamples": 6,
+    "numSamples": 5,
     "numSamplesAudited": 0,
     "numUnique": 3,
     "numUniqueAudited": 0,

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -6,7 +6,6 @@ from ...models import *  # pylint: disable=wildcard-import
 from ..helpers import *  # pylint: disable=wildcard-import
 from ...util.group_by import group_by
 from ...worker.bgcompute import bgcompute_update_batch_tallies_file
-from ...worker.bgcompute import bgcompute_update_ballot_manifest_file
 
 
 def test_batch_comparison_only_one_contest_allowed(
@@ -160,6 +159,7 @@ def test_batch_comparison_round_1(
     jurisdiction_ids: List[str],
     contest_id: str,
     election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
     batch_tallies,  # pylint: disable=unused-argument
     snapshot,
 ):
@@ -170,61 +170,10 @@ def test_batch_comparison_round_1(
     assert jurisdictions[0]["currentRoundStatus"] is None
     assert jurisdictions[1]["currentRoundStatus"] is None
 
-    set_logged_in_user(
-        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
-    )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Batch Name,Number of Ballots\n"
-                    b"Batch 1,500\n"
-                    b"Batch 2,500\n"
-                    b"Batch 3,500\n"
-                    b"Batch 4,500\n"
-                    b"Batch 5,100\n"
-                    b"Batch 6,100\n"
-                    b"Batch 7,100\n"
-                    b"Batch 8,100\n"
-                    b"Batch 9,100\n"
-                    b"Batch 10,100\n"
-                    b"Batch 11,500\n"
-                    b"Batch 12,500\n"
-                ),
-                "manifest.csv",
-            )
-        },
-    )
-    assert_ok(rv)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Batch Name,Number of Ballots\n"
-                    b"Batch 1,500\n"
-                    b"Batch 2,500\n"
-                    b"Batch 3,500\n"
-                    b"Batch 4,500\n"
-                    b"Batch 5,250\n"
-                    b"Batch 6,250\n"
-                    b"Batch 7,250\n"
-                    b"Batch 8,250\n"
-                    b"Batch 9,250\n"
-                    b"Batch 10,500\n"
-                ),
-                "manifest.csv",
-            )
-        },
-    )
-    assert_ok(rv)
-    bgcompute_update_ballot_manifest_file(election_id)
-
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
 
     # Use an artificially large sample size in order to have enough samples to work with
-    sample_size = 20
+    sample_size = 15
     rv = post_json(
         client,
         f"/api/election/{election_id}/round",


### PR DESCRIPTION
Task: #1130 

Since the batch tallies file depends on the batches created from the manifest, if the manifest changes, we need to reprocess the batch tallies file.
