### PR TITLE
Update contests on standardized contests reupload

### DIFF
--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -74,6 +74,24 @@ def process_standardized_contests_file(
 
         election.standardized_contests = standardized_contests
 
+        # If any contests were already created based on an older version of the
+        # standardized contests file, update them based on this new file.
+        for contest in election.contests:
+            standardized_contest = next(
+                (
+                    standardized_contest
+                    for standardized_contest in standardized_contests
+                    if standardized_contest["name"] == contest.name
+                ),
+                None,
+            )
+            if standardized_contest is None:
+                session.delete(contest)
+            else:
+                contest.jurisdictions = Jurisdiction.query.filter(
+                    Jurisdiction.id.in_(standardized_contest["jurisdictionIds"])
+                ).all()
+
     process_file(session, file, process)
 
 


### PR DESCRIPTION
Task: #1125 

If any contests were created based on a previous version of the standardized contests, we need to update them based on the new standardized contests. We delete any contests that are no longer in the standardized contests, and update the contest universe for any that are still there.
