### PR TITLE
Don't clear contests on jurisdictions file reupload

### DIFF
--- a/server/util/jurisdiction_bulk_update.py
+++ b/server/util/jurisdiction_bulk_update.py
@@ -41,7 +41,6 @@ def process_jurisdictions_file(session, election: Election, file: File) -> None:
         )
         # First, clear out the previously processed data.
         election.standardized_contests = None
-        election.contests = []
         election.standardized_contests_file.processing_started_at = None
         election.standardized_contests_file.processing_completed_at = None
         election.standardized_contests_file.processing_error = None


### PR DESCRIPTION
Now that we are updating the contests when reprocessing the standardized contests file, we don't need to clear them beforehand.
