### PR TITLE
Now throwing an error if we need to do a full recout before we do it

### DIFF
--- a/server/audit_math/suite.py
+++ b/server/audit_math/suite.py
@@ -658,6 +658,12 @@ def get_sample_size(
 
         sample_size = sorted(sample_sizes, key=sum, reverse=True)[0]
 
+    if (
+        sample_size[0] == cvr_stratum.num_ballots
+        or sample_size[1] == bp_stratum.num_ballots
+    ):
+        raise ValueError("One or both strata need to be recouted.")
+
     return HybridPair(cvr=sample_size[0], non_cvr=sample_size[1])
 
 

--- a/server/audit_math/suite.py
+++ b/server/audit_math/suite.py
@@ -662,7 +662,7 @@ def get_sample_size(
         sample_size[0] == cvr_stratum.num_ballots
         or sample_size[1] == bp_stratum.num_ballots
     ):
-        raise ValueError("One or both strata need to be recouted.")
+        raise ValueError("One or both strata need to be recounted.")
 
     return HybridPair(cvr=sample_size[0], non_cvr=sample_size[1])
 

--- a/server/tests/audit_math/test_suite.py
+++ b/server/tests/audit_math/test_suite.py
@@ -689,7 +689,7 @@ def test_really_close_race():
         no_cvr_stratum_ballots, no_cvr_stratum_vote_totals, {}, sample_size=0,
     )
 
-    with pytest.raises(ValueError, match=r"One or both strata need to be recouted"):
+    with pytest.raises(ValueError, match=r"One or both strata need to be recounted"):
         get_sample_size(5, contest, no_cvr_stratum, cvr_stratum)
 
     # Take some silly samples
@@ -913,7 +913,7 @@ def test_tie():
         no_cvr_stratum_ballots, no_cvr_stratum_vote_totals, {}, sample_size=0,
     )
 
-    with pytest.raises(ValueError, match=r"One or both strata need to be recouted"):
+    with pytest.raises(ValueError, match=r"One or both strata need to be recounted"):
         get_sample_size(5, contest, no_cvr_stratum, cvr_stratum)
 
     # Take some silly samples

--- a/server/tests/audit_math/test_suite.py
+++ b/server/tests/audit_math/test_suite.py
@@ -689,11 +689,8 @@ def test_really_close_race():
         no_cvr_stratum_ballots, no_cvr_stratum_vote_totals, {}, sample_size=0,
     )
 
-    expected_sample_size = HybridPair(cvr=700, non_cvr=300)
-
-    assert expected_sample_size == get_sample_size(
-        5, contest, no_cvr_stratum, cvr_stratum
-    )
+    with pytest.raises(ValueError, match=r"One or both strata need to be recouted"):
+        get_sample_size(5, contest, no_cvr_stratum, cvr_stratum)
 
     # Take some silly samples
 
@@ -916,11 +913,8 @@ def test_tie():
         no_cvr_stratum_ballots, no_cvr_stratum_vote_totals, {}, sample_size=0,
     )
 
-    expected_sample_size = HybridPair(cvr=700, non_cvr=300)
-
-    assert expected_sample_size == get_sample_size(
-        5, contest, no_cvr_stratum, cvr_stratum
-    )
+    with pytest.raises(ValueError, match=r"One or both strata need to be recouted"):
+        get_sample_size(5, contest, no_cvr_stratum, cvr_stratum)
 
     # Take some silly samples
 


### PR DESCRIPTION
**Description**

`suite.get_sample_size` now errors if a recount of either strata is expected. 

**Testing**

Modified test cases accordingly. 

**Progress**

Ready. 