### PR TITLE
Hide CVR/non-CVR vote counts when CVRs invalid

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -292,8 +292,14 @@ const Review: React.FC<IProps> = ({
                         <td>{choice.numVotes.toLocaleString()}</td>
                         {auditType === 'HYBRID' && (
                           <>
-                            <td>{choice.numVotesCvr!.toLocaleString()}</td>
-                            <td>{choice.numVotesNonCvr!.toLocaleString()}</td>
+                            <td>
+                              {choice.numVotesCvr != null &&
+                                choice.numVotesCvr.toLocaleString()}
+                            </td>
+                            <td>
+                              {choice.numVotesNonCvr != null &&
+                                choice.numVotesNonCvr.toLocaleString()}
+                            </td>
                           </>
                         )}
                       </tr>


### PR DESCRIPTION
If there's a CVR validation error (which is returned by the sample size endpoint), the CVR/non-CVR vote totals returned by the contests endpoint will be null, which was causing an error. In that case, we just show empty cells in the vote counts table until the validation error is resolved.
