### PR TITLE
Fix migration order

### DIFF
--- a/server/migrations/versions/f44bbbb8b076_cvrballot_ballot_position_and_record_id.py
+++ b/server/migrations/versions/f44bbbb8b076_cvrballot_ballot_position_and_record_id.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "f44bbbb8b076"
-down_revision = "f8e901e92f0a"
+down_revision = "df1334fc5fe9"
 branch_labels = None
 depends_on = None
 

--- a/server/migrations/versions/f8e901e92f0a_background_sample_size_options.py
+++ b/server/migrations/versions/f8e901e92f0a_background_sample_size_options.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "f8e901e92f0a"
-down_revision = "df1334fc5fe9"
+down_revision = "b91b345bf0a9"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
I messed up when rebasing the background sample sizes pull request and put its migration before the CVR ballot migrations in the migration ordering. That meant that it didn't get run automatically on deploy to staging. This should put the background sample sizes migration at the end of the ordering, so it should get run.
