### PR TITLE
Show error drawing sample in the status bar

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
@@ -9,7 +9,7 @@ import { apiDownload } from '../../utilities'
 import { Inner } from '../../Atoms/Wrapper'
 import { IContest } from '../../../types'
 import { IAuditBoard } from '../useAuditBoards'
-import { IRound } from '../useRoundsAuditAdmin'
+import { IRound, drawSampleError } from '../useRoundsAuditAdmin'
 import { IAuditSettings } from '../useAuditSettings'
 
 const SpacedH3 = styled(H3)`
@@ -179,6 +179,21 @@ export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
       <StatusBox
         headline="The audit has not started."
         details={details}
+        auditName={auditSettings.auditName}
+      >
+        {children}
+      </StatusBox>
+    )
+  }
+
+  if (drawSampleError(rounds)) {
+    return (
+      <StatusBox
+        headline="Arlo could not draw the sample"
+        details={[
+          'Please contact our support team for help resolving this issue.',
+          `Error: ${drawSampleError(rounds)}`,
+        ]}
         auditName={auditSettings.auditName}
       >
         {children}

--- a/client/src/components/MultiJurisdictionAudit/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.test.tsx
@@ -354,6 +354,8 @@ describe('AA setup flow', () => {
       aaApiCalls.getUser,
       ...loadAfterLaunch,
       ...loadAfterLaunch,
+      aaApiCalls.getSettings(auditSettings.all),
+      aaApiCalls.getJurisdictionFile,
     ]
     await withMockFetch(expectedCalls, async () => {
       render(

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -30,7 +30,6 @@ import useAuditSettingsJurisdictionAdmin from './RoundManagement/useAuditSetting
 import H2Title from '../Atoms/H2Title'
 import CSVFile from './CSVForm'
 import { useInterval } from '../utilities'
-import { ErrorLabel } from '../Atoms/Form/_helpers'
 
 const VerticalInner = styled(Inner)`
   flex-direction: column;
@@ -107,30 +106,6 @@ export const AuditAdminView: React.FC = () => {
     )
   }
 
-  if (rounds.length > 0 && drawSampleError(rounds)) {
-    return (
-      <Wrapper>
-        <Inner>
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              width: '100%',
-              marginTop: '100px',
-            }}
-          >
-            <H3>Arlo could not draw the sample</H3>
-            <p>
-              Please contact our support team for help resolving this issue.
-            </p>
-            <ErrorLabel>Error: {drawSampleError(rounds)}</ErrorLabel>
-          </div>
-        </Inner>
-      </Wrapper>
-    )
-  }
-
   switch (view) {
     case 'setup':
       return (
@@ -168,13 +143,15 @@ export const AuditAdminView: React.FC = () => {
           >
             <RefreshTag refresh={refresh} />
           </AuditAdminStatusBox>
-          <Inner>
-            <Progress
-              jurisdictions={jurisdictions}
-              auditSettings={auditSettings}
-              round={rounds[rounds.length - 1]}
-            />
-          </Inner>
+          {!drawSampleError(rounds) && (
+            <Inner>
+              <Progress
+                jurisdictions={jurisdictions}
+                auditSettings={auditSettings}
+                round={rounds[rounds.length - 1]}
+              />
+            </Inner>
+          )}
         </Wrapper>
       )
     default:

--- a/client/src/components/MultiJurisdictionAudit/useRoundsAuditAdmin.ts
+++ b/client/src/components/MultiJurisdictionAudit/useRoundsAuditAdmin.ts
@@ -52,7 +52,7 @@ export const isDrawSampleComplete = (rounds: IRound[]) =>
   rounds[rounds.length - 1].drawSampleTask.completedAt !== null
 
 export const drawSampleError = (rounds: IRound[]) =>
-  rounds[rounds.length - 1].drawSampleTask.error
+  rounds.length > 0 && rounds[rounds.length - 1].drawSampleTask.error
 
 const useRoundsAuditAdmin = (
   electionId: string,


### PR DESCRIPTION
We want the review screen to still be viewable, so instead of blocking the whole screen with an error message, we move the error message to the status bar. We also hide the progress table, since it won't be accurate in this state.
