### PR TITLE
Bugfix: show sample sizes error

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
@@ -346,6 +346,7 @@ describe('Audit Setup > Review & Launch', () => {
       apiCalls.getStandardizedContestsFile,
       apiCalls.getSampleSizeOptions({
         ...sampleSizeMock,
+        sampleSizes: null,
         task: {
           ...sampleSizeMock.task,
           status: FileProcessingStatus.ERRORED,

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -329,6 +329,9 @@ const Review: React.FC<IProps> = ({
             </p>
           )
 
+        if (sampleSizesResponse && sampleSizesResponse.task.error !== null)
+          return <ErrorLabel>{sampleSizesResponse.task.error}</ErrorLabel>
+
         if (
           sampleSizesResponse === null ||
           sampleSizesResponse.sampleSizes === null
@@ -341,9 +344,6 @@ const Review: React.FC<IProps> = ({
               </span>
             </div>
           )
-
-        if (sampleSizesResponse.task.error !== null)
-          return <ErrorLabel>{sampleSizesResponse.task.error}</ErrorLabel>
 
         // Add custom option to sample size options from backend
         const sampleSizeOptions = mapValues(


### PR DESCRIPTION
The conditions here were in the wrong order, causing a loading spinner to be shown instead of the error.