### PR TITLE
Batch data entry fixes

### DIFF
--- a/client/cypress/end-to-end/offline-batch-data-entry-tests.spec.js
+++ b/client/cypress/end-to-end/offline-batch-data-entry-tests.spec.js
@@ -1,0 +1,296 @@
+import 'cypress-file-upload'
+
+before(() => cy.exec('./cypress/seed-test-db.sh'))
+
+describe('Offline Batch Data Entry', () => {
+  const auditAdmin = 'audit-admin-cypress@example.com'
+  const jurisdictionAdmin = 'wtarkin@empire.gov'
+  const uuid = () => Cypress._.random(0, 1e6)
+  let id = 0
+
+  beforeEach(() => {
+    id = uuid()
+    cy.visit('/')
+    cy.loginAuditAdmin(auditAdmin)
+    cy.get('input[name=auditName]').type(`TestAudit${id}`)
+    cy.get('input[value="BALLOT_POLLING"]').check({ force: true })
+    cy.get('input[value="BRAVO"]').check({ force: true })
+    cy.findByText('Create Audit').click()
+    cy.viewport(1000, 2000)
+    cy.contains('Audit Setup')
+  })
+
+  it('happy path', () => {
+    cy.fixture('CSVs/jurisdiction/sample_jurisdiction_filesheet.csv').then(
+      fileContent => {
+        cy.get('input[type="file"]')
+          .first()
+          .attachFile({
+            fileContent: fileContent.toString(),
+            fileName: 'sample_jurisdiction_filesheet.csv',
+            mimeType: 'csv',
+          })
+      }
+    )
+    cy.findAllByText('Upload File').spread((firstButton, secondButton) => {
+      firstButton.click()
+    })
+    cy.contains('Upload successfully completed')
+
+    cy.wait(100) // gets stuck in an infinite loop without a 100ms wait here
+    cy.findByText('Next').click()
+    cy.get('input[name="contests[0].name"]').type('Contest')
+    cy.get('input[name="contests[0].choices[0].name"]').type('A')
+    cy.get('input[name="contests[0].choices[0].numVotes"]').type('300')
+    cy.get('input[name="contests[0].choices[1].name"]').type('B')
+    cy.get('input[name="contests[0].choices[1].numVotes"]').type('100')
+    cy.get('input[name="contests[0].totalBallotsCast"]').type('400')
+    cy.findByText('Select Jurisdictions').click()
+    cy.findByLabelText('Death Star').check({ force: true })
+    cy.findByText('Save & Next').click()
+    cy.findAllByText('Opportunistic Contests').should('have.length', 2)
+    cy.findByText('Save & Next').click()
+    cy.get('#state').select('AL')
+    cy.get('input[name=electionName]').type(`Test Election`)
+    cy.get('#risk-limit').select('10')
+    cy.get('input[name=randomSeed]').type('543210')
+    cy.findByText('Save & Next').click()
+    cy.findAllByText('Review & Launch').should('have.length', 2)
+    cy.logout(auditAdmin)
+    cy.loginJurisdictionAdmin(jurisdictionAdmin)
+    cy.findByText(`Jurisdictions - TestAudit${id}`)
+      .siblings('button')
+      .click()
+    cy.fixture('CSVs/manifest/ballot_polling_manifest.csv').then(
+      fileContent => {
+        cy.get('input[type="file"]')
+          .first()
+          .attachFile({
+            fileContent: fileContent.toString(),
+            fileName: 'ballot_polling_manifest.csv',
+            mimeType: 'csv',
+          })
+      }
+    )
+    cy.findByText('Upload File').click()
+    cy.contains('Upload successfully completed')
+    cy.logout(jurisdictionAdmin)
+    cy.loginAuditAdmin(auditAdmin)
+    cy.findByText(`TestAudit${id}`).click()
+    cy.findByText('Review & Launch').click()
+    cy.findAllByText('Review & Launch').should('have.length', 2)
+
+    // add custom sample size to be same as total ballots cast
+    cy.findByText('Enter your own sample size (not recommended)').click()
+    cy.findByRole('spinbutton').type('400').blur()
+
+    cy.findByRole('button', { name: 'Launch Audit' })
+      .should('be.enabled')
+      .click()
+    cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
+      secondButton.click()
+    })
+    cy.findByRole('heading', { name: 'Audit Progress' })
+    cy.logout(auditAdmin)
+    cy.loginJurisdictionAdmin(jurisdictionAdmin)
+    cy.findByText(`Jurisdictions - TestAudit${id}`)
+      .siblings('button')
+      .click()
+    cy.contains('Number of Audit Boards')
+    cy.findByText('Save & Next').click()
+
+    // renders properly
+    cy.contains('No batches added. Add your first batch below.')
+
+    // adding batch
+    cy.findByRole('button', { name: /Add batch/ }).click()
+    cy.findByLabelText('Batch Name').type('Batch 1')
+    cy.findByLabelText('Batch Type').select('Other')
+    cy.findByLabelText('A').type('200')
+    cy.findByLabelText('B').type('50')
+    cy.findByRole('button', {name: 'Save Batch'}).click()
+    cy.contains('Batch 1')
+
+    cy.findByRole('button', { name: /Add batch/ }).click()
+    cy.findByLabelText('Batch Name').type('Batch 2')
+    cy.findByLabelText('Batch Type').select('Provisional')
+    cy.findByLabelText('A').type('100')
+    cy.findByLabelText('B').type('50')
+    cy.findByRole('button', {name: 'Save Batch'}).click()
+    cy.contains('Batch 2')
+
+    // editing batch
+    cy.findByText('Batch 1').closest('tr').findByRole('button', /Edit/).click()
+    cy.findByLabelText('Batch Type').select('Election Day')
+    cy.findByRole('button', {name: 'Save Batch'}).click()
+    cy.findAllByText('Batch 1').closest('tr').contains('Election Day')
+
+    // deleting batch
+    cy.findByText('Batch 2').closest('tr').findByRole('button', /Edit/).click()
+    cy.findByRole('button', {name: 'Remove Batch'}).click()
+    cy.findByText('Batch 2').should('not.exist')
+
+    // adding batch again
+    cy.findByRole('button', { name: /Add batch/ }).click()
+    cy.findByLabelText('Batch Name').type('Batch 2')
+    cy.findByLabelText('Batch Type').select('Provisional')
+    cy.findByLabelText('A').type('100')
+    cy.findByLabelText('B').type('50')
+    cy.findByRole('button', {name: 'Save Batch'}).click()
+    cy.contains('Batch 2')
+
+    //verify total
+    cy.findAllByText('Total').closest('tr').last().contains('400')
+
+    // finalize results
+    cy.findByRole('button', {name: 'Finalize Results'}).click()
+    cy.contains('Are you sure you want to finalize your results?')
+    cy.findAllByText('Finalize Results').spread((firstButton, secondButton) => {
+        secondButton.click()
+    })
+    cy.findByRole('button', {name: 'Finalize Results'}).should('be.disabled')
+
+    // unfinalize results
+    cy.logout(jurisdictionAdmin)
+    cy.loginAuditAdmin(auditAdmin)
+    cy.findByText(`TestAudit${id}`).click()
+    cy.findByText('Death Star').closest('tr').findByText('Complete').click({force: true})
+    cy.findByRole('button', {name: 'Unfinalize Results'}).click()
+    cy.findByText('Death Star').closest('tr').contains('In progress')
+    cy.logout(auditAdmin)
+    cy.loginJurisdictionAdmin(jurisdictionAdmin)
+    cy.findByText(`Jurisdictions - TestAudit${id}`)
+      .siblings('button')
+      .click()
+
+    // finalize results again
+    cy.findByRole('button', {name: 'Finalize Results'}).click()
+    cy.contains('Are you sure you want to finalize your results?')
+    cy.findAllByText('Finalize Results').spread((firstButton, secondButton) => {
+        secondButton.click()
+    })
+    cy.findByRole('button', {name: 'Finalize Results'}).should('be.disabled')
+  })
+
+  it('failure cases', () => {
+    cy.fixture('CSVs/jurisdiction/sample_jurisdiction_filesheet.csv').then(
+      fileContent => {
+        cy.get('input[type="file"]')
+          .first()
+          .attachFile({
+            fileContent: fileContent.toString(),
+            fileName: 'sample_jurisdiction_filesheet.csv',
+            mimeType: 'csv',
+          })
+      }
+    )
+    cy.findAllByText('Upload File').spread((firstButton, secondButton) => {
+      firstButton.click()
+    })
+    cy.contains('Upload successfully completed')
+
+    cy.wait(100) // gets stuck in an infinite loop without a 100ms wait here
+    cy.findByText('Next').click()
+    cy.get('input[name="contests[0].name"]').type('Contest')
+    cy.get('input[name="contests[0].choices[0].name"]').type('A')
+    cy.get('input[name="contests[0].choices[0].numVotes"]').type('300')
+    cy.get('input[name="contests[0].choices[1].name"]').type('B')
+    cy.get('input[name="contests[0].choices[1].numVotes"]').type('100')
+    cy.get('input[name="contests[0].totalBallotsCast"]').type('400')
+    cy.findByText('Select Jurisdictions').click()
+    cy.findByLabelText('Death Star').check({ force: true })
+    cy.findByText('Save & Next').click()
+    cy.findAllByText('Opportunistic Contests').should('have.length', 2)
+    cy.findByText('Save & Next').click()
+    cy.get('#state').select('AL')
+    cy.get('input[name=electionName]').type(`Test Election`)
+    cy.get('#risk-limit').select('10')
+    cy.get('input[name=randomSeed]').type('543210')
+    cy.findByText('Save & Next').click()
+    cy.findAllByText('Review & Launch').should('have.length', 2)
+    cy.logout(auditAdmin)
+    cy.loginJurisdictionAdmin(jurisdictionAdmin)
+    cy.findByText(`Jurisdictions - TestAudit${id}`)
+      .siblings('button')
+      .click()
+    cy.fixture('CSVs/manifest/ballot_polling_manifest.csv').then(
+      fileContent => {
+        cy.get('input[type="file"]')
+          .first()
+          .attachFile({
+            fileContent: fileContent.toString(),
+            fileName: 'ballot_polling_manifest.csv',
+            mimeType: 'csv',
+          })
+      }
+    )
+    cy.findByText('Upload File').click()
+    cy.contains('Upload successfully completed')
+    cy.logout(jurisdictionAdmin)
+    cy.loginAuditAdmin(auditAdmin)
+    cy.findByText(`TestAudit${id}`).click()
+    cy.findByText('Review & Launch').click()
+    cy.findAllByText('Review & Launch').should('have.length', 2)
+
+    // add custom sample size to be same as total ballots cast
+    cy.findByText('Enter your own sample size (not recommended)').click()
+    cy.findByRole('spinbutton').type('400').blur()
+
+    cy.findByRole('button', { name: 'Launch Audit' })
+      .should('be.enabled')
+      .click()
+    cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
+      secondButton.click()
+    })
+    cy.findByRole('heading', { name: 'Audit Progress' })
+    cy.logout(auditAdmin)
+    cy.loginJurisdictionAdmin(jurisdictionAdmin)
+    cy.findByText(`Jurisdictions - TestAudit${id}`)
+      .siblings('button')
+      .click()
+    cy.contains('Number of Audit Boards')
+    cy.findByText('Save & Next').click()
+    cy.contains('No batches added. Add your first batch below.')
+
+    // check validation message when no fields are filled up
+    cy.findByRole('button', { name: /Add batch/ }).click()
+    cy.findByRole('button', {name: 'Save Batch'}).click()
+    cy.contains('Please fill in the empty fields above before saving this batch.')
+
+    cy.findByLabelText('Batch Name').type('Batch 1')
+    cy.findByLabelText('Batch Type').select('Other')
+    cy.findByLabelText('A').type('300')
+    cy.findByLabelText('B').type('100')
+    cy.findByRole('button', {name: 'Save Batch'}).click()
+    cy.contains('Batch 1')
+
+    // shouldn't allow same batch name to be used.
+    cy.findByRole('button', { name: /Add batch/ }).click()
+    cy.findByLabelText('Batch Name').type('Batch 1')
+    cy.findByLabelText('Batch Type').select('Other')
+    cy.findByLabelText('A').type('300')
+    cy.findByLabelText('B').type('100')
+    cy.findByRole('button', {name: 'Save Batch'}).click()
+    cy.get('.Toastify')
+    .find('div')
+    .find('div')
+    .contains('Batch names must be unique')
+    .invoke('text')
+    .then(text =>
+      expect(text).to.equal('Batch names must be unique')
+    )
+    cy.get('.Toastify')
+      .find('div')
+      .should('not.have.class', 'Toastify__bounce-exit--top-right')
+      .get('.Toastify__close-button')
+      .click()
+
+    cy.findByRole('button', {name: 'Cancel'}).click()
+    cy.findByRole('button', {name: 'Finalize Results'}).click()
+    cy.contains('Are you sure you want to finalize your results?')
+    cy.findAllByText('Finalize Results').spread((firstButton, secondButton) => {
+        secondButton.click()
+    })
+    cy.findByRole('button', {name: 'Finalize Results'}).should('be.disabled')
+  })
+})

--- a/client/cypress/end-to-end/offline-batch-data-entry-tests.spec.js
+++ b/client/cypress/end-to-end/offline-batch-data-entry-tests.spec.js
@@ -20,7 +20,7 @@ describe('Offline Batch Data Entry', () => {
     cy.contains('Audit Setup')
   })
 
-  it('happy path', () => {
+  it('success & failure cases', () => {
     cy.fixture('CSVs/jurisdiction/sample_jurisdiction_filesheet.csv').then(
       fileContent => {
         cy.get('input[type="file"]')
@@ -119,6 +119,28 @@ describe('Offline Batch Data Entry', () => {
     cy.findByRole('button', {name: 'Save Batch'}).click()
     cy.contains('Batch 2')
 
+    // shouldn't allow same batch name to be used
+    cy.findByRole('button', { name: /Add batch/ }).click()
+    cy.findByLabelText('Batch Name').type('Batch 1')
+    cy.findByLabelText('Batch Type').select('Other')
+    cy.findByLabelText('A').type('300')
+    cy.findByLabelText('B').type('100')
+    cy.findByRole('button', {name: 'Save Batch'}).click()
+    cy.get('.Toastify')
+    .find('div')
+    .find('div')
+    .contains('Batch names must be unique')
+    .invoke('text')
+    .then(text =>
+      expect(text).to.equal('Batch names must be unique')
+    )
+    cy.get('.Toastify')
+      .find('div')
+      .should('not.have.class', 'Toastify__bounce-exit--top-right')
+      .get('.Toastify__close-button')
+      .click()
+    cy.findByRole('button', {name: 'Cancel'}).click()
+
     // editing batch
     cy.findByText('Batch 1').closest('tr').findByRole('button', /Edit/).click()
     cy.findByLabelText('Batch Type').select('Election Day')
@@ -164,128 +186,6 @@ describe('Offline Batch Data Entry', () => {
       .click()
 
     // finalize results again
-    cy.findByRole('button', {name: 'Finalize Results'}).click()
-    cy.contains('Are you sure you want to finalize your results?')
-    cy.findAllByText('Finalize Results').spread((firstButton, secondButton) => {
-        secondButton.click()
-    })
-    cy.findByRole('button', {name: 'Finalize Results'}).should('be.disabled')
-  })
-
-  it('failure cases', () => {
-    cy.fixture('CSVs/jurisdiction/sample_jurisdiction_filesheet.csv').then(
-      fileContent => {
-        cy.get('input[type="file"]')
-          .first()
-          .attachFile({
-            fileContent: fileContent.toString(),
-            fileName: 'sample_jurisdiction_filesheet.csv',
-            mimeType: 'csv',
-          })
-      }
-    )
-    cy.findAllByText('Upload File').spread((firstButton, secondButton) => {
-      firstButton.click()
-    })
-    cy.contains('Upload successfully completed')
-
-    cy.wait(100) // gets stuck in an infinite loop without a 100ms wait here
-    cy.findByText('Next').click()
-    cy.get('input[name="contests[0].name"]').type('Contest')
-    cy.get('input[name="contests[0].choices[0].name"]').type('A')
-    cy.get('input[name="contests[0].choices[0].numVotes"]').type('300')
-    cy.get('input[name="contests[0].choices[1].name"]').type('B')
-    cy.get('input[name="contests[0].choices[1].numVotes"]').type('100')
-    cy.get('input[name="contests[0].totalBallotsCast"]').type('400')
-    cy.findByText('Select Jurisdictions').click()
-    cy.findByLabelText('Death Star').check({ force: true })
-    cy.findByText('Save & Next').click()
-    cy.findAllByText('Opportunistic Contests').should('have.length', 2)
-    cy.findByText('Save & Next').click()
-    cy.get('#state').select('AL')
-    cy.get('input[name=electionName]').type(`Test Election`)
-    cy.get('#risk-limit').select('10')
-    cy.get('input[name=randomSeed]').type('543210')
-    cy.findByText('Save & Next').click()
-    cy.findAllByText('Review & Launch').should('have.length', 2)
-    cy.logout(auditAdmin)
-    cy.loginJurisdictionAdmin(jurisdictionAdmin)
-    cy.findByText(`Jurisdictions - TestAudit${id}`)
-      .siblings('button')
-      .click()
-    cy.fixture('CSVs/manifest/ballot_polling_manifest.csv').then(
-      fileContent => {
-        cy.get('input[type="file"]')
-          .first()
-          .attachFile({
-            fileContent: fileContent.toString(),
-            fileName: 'ballot_polling_manifest.csv',
-            mimeType: 'csv',
-          })
-      }
-    )
-    cy.findByText('Upload File').click()
-    cy.contains('Upload successfully completed')
-    cy.logout(jurisdictionAdmin)
-    cy.loginAuditAdmin(auditAdmin)
-    cy.findByText(`TestAudit${id}`).click()
-    cy.findByText('Review & Launch').click()
-    cy.findAllByText('Review & Launch').should('have.length', 2)
-
-    // add custom sample size to be same as total ballots cast
-    cy.findByText('Enter your own sample size (not recommended)').click()
-    cy.findByRole('spinbutton').type('400').blur()
-
-    cy.findByRole('button', { name: 'Launch Audit' })
-      .should('be.enabled')
-      .click()
-    cy.findAllByText('Launch Audit').spread((firstButton, secondButton) => {
-      secondButton.click()
-    })
-    cy.findByRole('heading', { name: 'Audit Progress' })
-    cy.logout(auditAdmin)
-    cy.loginJurisdictionAdmin(jurisdictionAdmin)
-    cy.findByText(`Jurisdictions - TestAudit${id}`)
-      .siblings('button')
-      .click()
-    cy.contains('Number of Audit Boards')
-    cy.findByText('Save & Next').click()
-    cy.contains('No batches added. Add your first batch below.')
-
-    // check validation message when no fields are filled up
-    cy.findByRole('button', { name: /Add batch/ }).click()
-    cy.findByRole('button', {name: 'Save Batch'}).click()
-    cy.contains('Please fill in the empty fields above before saving this batch.')
-
-    cy.findByLabelText('Batch Name').type('Batch 1')
-    cy.findByLabelText('Batch Type').select('Other')
-    cy.findByLabelText('A').type('300')
-    cy.findByLabelText('B').type('100')
-    cy.findByRole('button', {name: 'Save Batch'}).click()
-    cy.contains('Batch 1')
-
-    // shouldn't allow same batch name to be used.
-    cy.findByRole('button', { name: /Add batch/ }).click()
-    cy.findByLabelText('Batch Name').type('Batch 1')
-    cy.findByLabelText('Batch Type').select('Other')
-    cy.findByLabelText('A').type('300')
-    cy.findByLabelText('B').type('100')
-    cy.findByRole('button', {name: 'Save Batch'}).click()
-    cy.get('.Toastify')
-    .find('div')
-    .find('div')
-    .contains('Batch names must be unique')
-    .invoke('text')
-    .then(text =>
-      expect(text).to.equal('Batch names must be unique')
-    )
-    cy.get('.Toastify')
-      .find('div')
-      .should('not.have.class', 'Toastify__bounce-exit--top-right')
-      .get('.Toastify__close-button')
-      .click()
-
-    cy.findByRole('button', {name: 'Cancel'}).click()
     cy.findByRole('button', {name: 'Finalize Results'}).click()
     cy.contains('Are you sure you want to finalize your results?')
     cy.findAllByText('Finalize Results').spread((firstButton, secondButton) => {

--- a/client/cypress/end-to-end/offline-batch-data-entry-tests.spec.js
+++ b/client/cypress/end-to-end/offline-batch-data-entry-tests.spec.js
@@ -126,19 +126,7 @@ describe('Offline Batch Data Entry', () => {
     cy.findByLabelText('A').type('300')
     cy.findByLabelText('B').type('100')
     cy.findByRole('button', {name: 'Save Batch'}).click()
-    cy.get('.Toastify')
-    .find('div')
-    .find('div')
-    .contains('Batch names must be unique')
-    .invoke('text')
-    .then(text =>
-      expect(text).to.equal('Batch names must be unique')
-    )
-    cy.get('.Toastify')
-      .find('div')
-      .should('not.have.class', 'Toastify__bounce-exit--top-right')
-      .get('.Toastify__close-button')
-      .click()
+    cy.findAndCloseToast('Batch names must be unique')
     cy.findByRole('button', {name: 'Cancel'}).click()
 
     // editing batch

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.test.tsx
@@ -132,7 +132,7 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it.skip('submits offline batch', async () => {
+  it('submits offline batch', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
       apiCalls.getResults(offlineBatchMocks.empty),
@@ -226,7 +226,7 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it.skip('edits offline batch', async () => {
+  it('edits offline batch', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
       apiCalls.getResults(offlineBatchMocks.complete),

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.test.tsx
@@ -1,0 +1,335 @@
+import React from 'react'
+import { screen, fireEvent, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useParams } from 'react-router-dom'
+import { contestMocks } from '../useSetupMenuItems/_mocks'
+import {
+  offlineBatchMocks,
+  offlineBatchResultsMocks,
+  roundMocks,
+} from './_mocks'
+import { renderWithRouter, withMockFetch } from '../../testUtilities'
+import { IContest } from '../../../types'
+import { IBatch } from './useBatchResults'
+import OfflineBatchRoundDataEntry from './OfflineBatchRoundDataEntry'
+import {
+  IOfflineBatchResult,
+  IOfflineBatchResults,
+} from './useOfflineBatchResults'
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
+  useRouteMatch: jest.fn(),
+  useParams: jest.fn(),
+}))
+const paramsMock = useParams as jest.Mock
+paramsMock.mockReturnValue({
+  electionId: '1',
+  jurisdictionId: '1',
+})
+
+const apiCalls = {
+  getJAContests: (response: { contests: IContest[] }) => ({
+    url: `/api/election/1/jurisdiction/1/contest`,
+    response,
+  }),
+  getBatches: (response: { batches: IBatch[] }) => ({
+    url: '/api/election/1/jurisdiction/1/round/round-1/batches',
+    response,
+  }),
+  getResults: (response: IOfflineBatchResults) => ({
+    url: '/api/election/1/jurisdiction/1/round/round-1/results/batch',
+    response,
+  }),
+  postResults: (results: IOfflineBatchResult) => ({
+    url: '/api/election/1/jurisdiction/1/round/round-1/results/batch/',
+    options: {
+      method: 'POST',
+      body: JSON.stringify(results),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+    response: { status: 'ok' },
+  }),
+  putResults: (results: IOfflineBatchResult, previousBatchName: string) => ({
+    url: `/api/election/1/jurisdiction/1/round/round-1/results/batch/${previousBatchName}`,
+    options: {
+      method: 'PUT',
+      body: JSON.stringify(results),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+    response: { status: 'ok' },
+  }),
+  deleteResults: (batchName: string) => ({
+    url: `/api/election/1/jurisdiction/1/round/round-1/results/batch/${batchName}`,
+    options: {
+      method: 'DELETE',
+    },
+    response: { status: 'ok' },
+  }),
+  finalizeResults: {
+    url: '/api/election/1/jurisdiction/1/round/round-1/results/batch/finalize',
+    options: {
+      method: 'POST',
+    },
+    response: { status: 'ok' },
+  },
+}
+
+describe('offline batch round data entry', () => {
+  it('renders', async () => {
+    const expectedCalls = [
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getResults(offlineBatchMocks.empty),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderWithRouter(
+        <OfflineBatchRoundDataEntry
+          round={roundMocks.singleIncompleteOffline}
+        />,
+        {
+          route: '/election/1/jurisdiction/1',
+        }
+      )
+      await screen.findByText('No batches added. Add your first batch below.')
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  it('validation error for blank submission', async () => {
+    const expectedCalls = [
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getResults(offlineBatchMocks.empty),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderWithRouter(
+        <OfflineBatchRoundDataEntry
+          round={roundMocks.singleIncompleteOffline}
+        />,
+        {
+          route: '/election/1/jurisdiction/1',
+        }
+      )
+      await screen.findByText('No batches added. Add your first batch below.')
+      const addButton = screen.getByRole('button', { name: /Add batch/ })
+      await userEvent.click(addButton)
+
+      const dialog = (await screen.findByRole('heading', {
+        name: /Add Batch/,
+      })).closest('.bp3-dialog')! as HTMLElement
+      within(dialog).getByText('Batch Info')
+      userEvent.click(
+        within(dialog).getByRole('button', { name: 'Save Batch' })
+      )
+
+      await screen.findByText(
+        'Please fill in the empty fields above before saving this batch.'
+      )
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  it.skip('submits offline batch', async () => {
+    const expectedCalls = [
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getResults(offlineBatchMocks.empty),
+      apiCalls.postResults(offlineBatchResultsMocks.complete),
+      apiCalls.getResults(offlineBatchMocks.complete),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderWithRouter(
+        <OfflineBatchRoundDataEntry
+          round={roundMocks.singleIncompleteOffline}
+        />,
+        {
+          route: '/election/1/jurisdiction/1',
+        }
+      )
+      await screen.findByText('No batches added. Add your first batch below.')
+      const addButton = screen.getByRole('button', { name: /Add batch/ })
+      userEvent.click(addButton)
+
+      const dialog = (await screen.findByRole('heading', {
+        name: /Add Batch/,
+      })).closest('.bp3-dialog')! as HTMLElement
+      within(dialog).getByText('Batch Info')
+
+      const batchNameInput = within(dialog).getByLabelText('Batch Name')
+      userEvent.type(batchNameInput, 'Batch1')
+
+      const choiceOneInput = within(dialog).getByLabelText('Choice One')
+      fireEvent.change(choiceOneInput, { target: { value: 10 } })
+
+      const choiceTwoInput = within(dialog).getByLabelText('Choice Two')
+      fireEvent.change(choiceTwoInput, { target: { value: 20 } })
+
+      userEvent.selectOptions(
+        within(dialog).getByLabelText('Batch Type'),
+        'Other'
+      )
+
+      fireEvent.click(
+        within(dialog).getByRole('button', { name: 'Save Batch' })
+      )
+      await screen.findByText('Batch1')
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  it('renders with offline batches', async () => {
+    const expectedCalls = [
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getResults(offlineBatchMocks.complete),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderWithRouter(
+        <OfflineBatchRoundDataEntry
+          round={roundMocks.singleIncompleteOffline}
+        />,
+        {
+          route: '/election/1/jurisdiction/1',
+        }
+      )
+      await screen.findByText('Batch1')
+
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  it('renders with proper totals', async () => {
+    const expectedCalls = [
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getResults(offlineBatchMocks.completeWithMultipleBatch),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderWithRouter(
+        <OfflineBatchRoundDataEntry
+          round={roundMocks.singleIncompleteOffline}
+        />,
+        {
+          route: '/election/1/jurisdiction/1',
+        }
+      )
+      await screen.findByText('Batch1')
+
+      const totalRow = screen
+        .getAllByText('Total')[1]
+        .closest('tr')! as HTMLElement
+
+      // checking if total is proper
+      within(totalRow).getByText('30')
+
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  it.skip('edits offline batch', async () => {
+    const expectedCalls = [
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getResults(offlineBatchMocks.complete),
+      apiCalls.putResults(offlineBatchResultsMocks.updated, 'Batch1'),
+      apiCalls.getResults(offlineBatchMocks.updated),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderWithRouter(
+        <OfflineBatchRoundDataEntry
+          round={roundMocks.singleIncompleteOffline}
+        />,
+        {
+          route: '/election/1/jurisdiction/1',
+        }
+      )
+
+      await screen.findByText('Batch1')
+      userEvent.click(screen.getByText(/Edit/))
+
+      const dialog = (await screen.findByRole('heading', {
+        name: /Edit Batch/,
+      })).closest('.bp3-dialog')! as HTMLElement
+      within(dialog).getByText('Batch Info')
+
+      const batchNameInput = within(dialog).getByLabelText('Batch Name')
+      userEvent.type(batchNameInput, '2')
+
+      fireEvent.click(
+        within(dialog).getByRole('button', { name: 'Save Batch' })
+      )
+      await screen.findByText('Batch12')
+
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  it('deletes offline batch', async () => {
+    const expectedCalls = [
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getResults(offlineBatchMocks.complete),
+      apiCalls.deleteResults(offlineBatchResultsMocks.complete.batchName),
+      apiCalls.getResults(offlineBatchMocks.empty),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderWithRouter(
+        <OfflineBatchRoundDataEntry
+          round={roundMocks.singleIncompleteOffline}
+        />,
+        {
+          route: '/election/1/jurisdiction/1',
+        }
+      )
+
+      await screen.findByText('Batch1')
+      userEvent.click(screen.getByText(/Edit/))
+
+      const dialog = (await screen.findByRole('heading', {
+        name: /Edit Batch/,
+      })).closest('.bp3-dialog')! as HTMLElement
+      within(dialog).getByText('Batch Info')
+
+      fireEvent.click(
+        within(dialog).getByRole('button', { name: 'Remove Batch' })
+      )
+      await screen.findByText('No batches added. Add your first batch below.')
+
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  it('finalizes offline batches', async () => {
+    const expectedCalls = [
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getResults(offlineBatchMocks.complete),
+      apiCalls.finalizeResults,
+      apiCalls.getResults(offlineBatchMocks.finalized),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = renderWithRouter(
+        <OfflineBatchRoundDataEntry
+          round={roundMocks.singleIncompleteOffline}
+        />,
+        {
+          route: '/election/1/jurisdiction/1',
+        }
+      )
+      await screen.findByText('Batch1')
+
+      fireEvent.click(screen.getByRole('button', { name: 'Finalize Results' }))
+
+      const dialog = (await screen.findByRole('heading', {
+        name: /Are you sure you want to finalize your results?/,
+      })).closest('.bp3-dialog')! as HTMLElement
+
+      within(dialog).getByText('This action cannot be undone.')
+
+      fireEvent.click(
+        within(dialog).getByRole('button', { name: 'Finalize Results' })
+      )
+
+      await screen.findByText(/Results finalized at/)
+
+      expect(container).toMatchSnapshot()
+    })
+  })
+})

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
@@ -129,7 +129,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
   const { results, finalizedAt } = batchResults
 
   const total = (choiceId: string) =>
-    sum(results.map(batch => Number(batch.choiceResults[choiceId])))
+    sum(results.map(batch => batch.choiceResults[choiceId]))
 
   const emptyBatch = (): IOfflineBatchResult => ({
     batchName: '',
@@ -247,9 +247,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                       ))}
                       <td style={totalStyle}>
                         {sum(
-                          Object.values(batch.choiceResults).map(choice =>
-                            Number(choice)
-                          )
+                          Object.values(batch.choiceResults)
                         ).toLocaleString()}
                       </td>
                     </tr>

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
@@ -83,6 +83,7 @@ const InputWithValidation = ({ field, form, ...props }: FieldProps) => {
         className={`bp3-input bp3-fill ${error ? 'bp3-intent-danger' : ''}`}
         {...field}
         {...props}
+        value={field.value || ''}
       />
     </div>
   )
@@ -130,16 +131,10 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
   const total = (choiceId: string) =>
     sum(results.map(batch => Number(batch.choiceResults[choiceId])))
 
-  // set default choiceResults to blank for controlled input
-  const defaultChoiceArr: { [key: string]: string } = {}
-  contest.choices.forEach(choice => {
-    defaultChoiceArr[choice.id] = ''
-  })
-
   const emptyBatch = (): IOfflineBatchResult => ({
     batchName: '',
     batchType: '',
-    choiceResults: defaultChoiceArr,
+    choiceResults: {},
   })
 
   interface FormValues {
@@ -332,10 +327,14 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                     >
                       <div style={{ flexGrow: 1 }}>
                         <H4>Batch Info</H4>
-                        <FormGroup label="Batch Name">
+                        <FormGroup
+                          label="Batch Name"
+                          labelFor="editingBatch-batchName"
+                        >
                           <Field
                             type="text"
                             name="editingBatch.batchName"
+                            id="editingBatch-batchName"
                             component={InputWithValidation}
                             validate={(value: string) =>
                               !value ? 'Required' : null
@@ -343,9 +342,13 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                             autoFocus
                           />
                         </FormGroup>
-                        <FormGroup label="Batch Type">
+                        <FormGroup
+                          label="Batch Type"
+                          labelFor="editingBatch-batchType"
+                        >
                           <Field
                             name="editingBatch.batchType"
+                            id="editingBatch-batchType"
                             component={SelectWithValidation}
                             validate={(value: string) =>
                               !value ? 'Required' : null
@@ -364,10 +367,14 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                         <H4>Audited Votes</H4>
                         {contest.choices.map(choice => (
                           <div key={`editing-${choice.id}`}>
-                            <FormGroup label={choice.name}>
+                            <FormGroup
+                              label={choice.name}
+                              labelFor={`editingBatch-choiceResults-${choice.id}`}
+                            >
                               <Field
                                 type="number"
                                 name={`editingBatch.choiceResults.${choice.id}`}
+                                id={`editingBatch-choiceResults-${choice.id}`}
                                 component={InputWithValidation}
                                 validate={testNumber()}
                               />

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
@@ -128,12 +128,18 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
   const { results, finalizedAt } = batchResults
 
   const total = (choiceId: string) =>
-    sum(results.map(batch => batch.choiceResults[choiceId]))
+    sum(results.map(batch => Number(batch.choiceResults[choiceId])))
+
+  // set default choiceResults to blank for controlled input
+  const defaultChoiceArr: { [key: string]: string } = {}
+  contest.choices.forEach(choice => {
+    defaultChoiceArr[choice.id] = ''
+  })
 
   const emptyBatch = (): IOfflineBatchResult => ({
     batchName: '',
     batchType: '',
-    choiceResults: {},
+    choiceResults: defaultChoiceArr,
   })
 
   interface FormValues {
@@ -246,7 +252,9 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                       ))}
                       <td style={totalStyle}>
                         {sum(
-                          Object.values(batch.choiceResults)
+                          Object.values(batch.choiceResults).map(choice =>
+                            Number(choice)
+                          )
                         ).toLocaleString()}
                       </td>
                     </tr>
@@ -284,6 +292,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                     })
                   }
                   intent="primary"
+                  disabled={!!finalizedAt}
                 >
                   Add batch
                 </Button>
@@ -292,7 +301,10 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                     document.getElementById('results-table')!.outerHTML
                   }
                 />
-                <Button onClick={() => setIsConfirmOpen(true)}>
+                <Button
+                  onClick={() => setIsConfirmOpen(true)}
+                  disabled={!!finalizedAt}
+                >
                   Finalize Results
                 </Button>
               </div>

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/OfflineBatchRoundDataEntry.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/OfflineBatchRoundDataEntry.test.tsx.snap
@@ -156,6 +156,207 @@ exports[`offline batch round data entry deletes offline batch 1`] = `
 </div>
 `;
 
+exports[`offline batch round data entry edits offline batch 1`] = `
+<div>
+  <form
+    class="sc-bdVaJa hazmWT"
+  >
+    <div
+      style="width: 510px; margin-bottom: 20px;"
+    >
+      <p>
+        When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice for each batch of audited ballots.
+      </p>
+      
+    </div>
+    <fieldset>
+      <table
+        class="bp3-html-table bp3-html-table-bordered bp3-html-table-striped"
+        id="results-table"
+      >
+        <thead>
+          <tr>
+            <th />
+            <th>
+              Batch Name
+            </th>
+            <th>
+              Batch Type
+            </th>
+            <th>
+              Choice One
+            </th>
+            <th>
+              Choice Two
+            </th>
+            <th
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <button
+                class="bp3-button"
+                type="button"
+              >
+                <span
+                  class="bp3-icon bp3-icon-edit"
+                  icon="edit"
+                >
+                  <svg
+                    data-icon="edit"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      edit
+                    </desc>
+                    <path
+                      d="M3.25 10.26l2.47 2.47 6.69-6.69-2.46-2.48-6.7 6.7zM.99 14.99l3.86-1.39-2.46-2.44-1.4 3.83zm12.25-14c-.48 0-.92.2-1.24.51l-1.44 1.44 2.47 2.47 1.44-1.44c.32-.32.51-.75.51-1.24.01-.95-.77-1.74-1.74-1.74z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="bp3-button-text"
+                >
+                  Edit
+                </span>
+              </button>
+            </td>
+            <td>
+              Batch12
+            </td>
+            <td>
+              Other
+            </td>
+            <td>
+              10
+            </td>
+            <td>
+              20
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              30
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              10
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              20
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              30
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        style="display: flex; justify-content: space-between; margin-top: 20px;"
+      >
+        <button
+          class="bp3-button bp3-intent-primary"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-plus"
+            icon="plus"
+          >
+            <svg
+              data-icon="plus"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                plus
+              </desc>
+              <path
+                d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Add batch
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          style="width: 160px;"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-clipboard"
+            icon="clipboard"
+          >
+            <svg
+              data-icon="clipboard"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                clipboard
+              </desc>
+              <path
+                d="M11 2c0-.55-.45-1-1-1h.22C9.88.4 9.24 0 8.5 0S7.12.4 6.78 1H7c-.55 0-1 .45-1 1v1h5V2zm2 0h-1v2H5V2H4c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h9c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Copy to clipboard
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Finalize Results
+          </span>
+        </button>
+      </div>
+    </fieldset>
+  </form>
+</div>
+`;
+
 exports[`offline batch round data entry finalizes offline batches 1`] = `
 <div>
   <form
@@ -889,6 +1090,207 @@ exports[`offline batch round data entry renders with proper totals 1`] = `
               style="color: rgb(19, 124, 189); font-weight: 600;"
             >
               10
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              10
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              20
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              30
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        style="display: flex; justify-content: space-between; margin-top: 20px;"
+      >
+        <button
+          class="bp3-button bp3-intent-primary"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-plus"
+            icon="plus"
+          >
+            <svg
+              data-icon="plus"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                plus
+              </desc>
+              <path
+                d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Add batch
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          style="width: 160px;"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-clipboard"
+            icon="clipboard"
+          >
+            <svg
+              data-icon="clipboard"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                clipboard
+              </desc>
+              <path
+                d="M11 2c0-.55-.45-1-1-1h.22C9.88.4 9.24 0 8.5 0S7.12.4 6.78 1H7c-.55 0-1 .45-1 1v1h5V2zm2 0h-1v2H5V2H4c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h9c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Copy to clipboard
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Finalize Results
+          </span>
+        </button>
+      </div>
+    </fieldset>
+  </form>
+</div>
+`;
+
+exports[`offline batch round data entry submits offline batch 1`] = `
+<div>
+  <form
+    class="sc-bdVaJa hazmWT"
+  >
+    <div
+      style="width: 510px; margin-bottom: 20px;"
+    >
+      <p>
+        When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice for each batch of audited ballots.
+      </p>
+      
+    </div>
+    <fieldset>
+      <table
+        class="bp3-html-table bp3-html-table-bordered bp3-html-table-striped"
+        id="results-table"
+      >
+        <thead>
+          <tr>
+            <th />
+            <th>
+              Batch Name
+            </th>
+            <th>
+              Batch Type
+            </th>
+            <th>
+              Choice One
+            </th>
+            <th>
+              Choice Two
+            </th>
+            <th
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <button
+                class="bp3-button"
+                type="button"
+              >
+                <span
+                  class="bp3-icon bp3-icon-edit"
+                  icon="edit"
+                >
+                  <svg
+                    data-icon="edit"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      edit
+                    </desc>
+                    <path
+                      d="M3.25 10.26l2.47 2.47 6.69-6.69-2.46-2.48-6.7 6.7zM.99 14.99l3.86-1.39-2.46-2.44-1.4 3.83zm12.25-14c-.48 0-.92.2-1.24.51l-1.44 1.44 2.47 2.47 1.44-1.44c.32-.32.51-.75.51-1.24.01-.95-.77-1.74-1.74-1.74z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="bp3-button-text"
+                >
+                  Edit
+                </span>
+              </button>
+            </td>
+            <td>
+              Batch1
+            </td>
+            <td>
+              Other
+            </td>
+            <td>
+              10
+            </td>
+            <td>
+              20
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              30
             </td>
           </tr>
           <tr>

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/OfflineBatchRoundDataEntry.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/OfflineBatchRoundDataEntry.test.tsx.snap
@@ -1,0 +1,1156 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`offline batch round data entry deletes offline batch 1`] = `
+<div>
+  <form
+    class="sc-bdVaJa hazmWT"
+  >
+    <div
+      style="width: 510px; margin-bottom: 20px;"
+    >
+      <p>
+        When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice for each batch of audited ballots.
+      </p>
+      
+    </div>
+    <fieldset>
+      <table
+        class="bp3-html-table bp3-html-table-bordered bp3-html-table-striped"
+        id="results-table"
+      >
+        <thead>
+          <tr>
+            <th />
+            <th>
+              Batch Name
+            </th>
+            <th>
+              Batch Type
+            </th>
+            <th>
+              Choice One
+            </th>
+            <th>
+              Choice Two
+            </th>
+            <th
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              colspan="5"
+            >
+              No batches added. Add your first batch below.
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              0
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              0
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        style="display: flex; justify-content: space-between; margin-top: 20px;"
+      >
+        <button
+          class="bp3-button bp3-intent-primary"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-plus"
+            icon="plus"
+          >
+            <svg
+              data-icon="plus"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                plus
+              </desc>
+              <path
+                d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Add batch
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          style="width: 160px;"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-clipboard"
+            icon="clipboard"
+          >
+            <svg
+              data-icon="clipboard"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                clipboard
+              </desc>
+              <path
+                d="M11 2c0-.55-.45-1-1-1h.22C9.88.4 9.24 0 8.5 0S7.12.4 6.78 1H7c-.55 0-1 .45-1 1v1h5V2zm2 0h-1v2H5V2H4c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h9c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Copy to clipboard
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Finalize Results
+          </span>
+        </button>
+      </div>
+    </fieldset>
+  </form>
+</div>
+`;
+
+exports[`offline batch round data entry finalizes offline batches 1`] = `
+<div>
+  <form
+    class="sc-bdVaJa hazmWT"
+  >
+    <div
+      style="width: 510px; margin-bottom: 20px;"
+    >
+      <p>
+        When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice for each batch of audited ballots.
+      </p>
+      <div
+        class="bp3-callout bp3-intent-success bp3-callout-icon"
+        style="margin: 20px 0px 20px 0px;"
+      >
+        <span
+          class="bp3-icon bp3-icon-tick-circle"
+          icon="tick-circle"
+        >
+          <svg
+            data-icon="tick-circle"
+            height="20"
+            viewBox="0 0 20 20"
+            width="20"
+          >
+            <desc>
+              tick-circle
+            </desc>
+            <path
+              d="M10 20C4.48 20 0 15.52 0 10S4.48 0 10 0s10 4.48 10 10-4.48 10-10 10zm5-14c-.28 0-.53.11-.71.29L8 12.59l-2.29-2.3a1.003 1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29.28 0 .53-.11.71-.29l7-7A1.003 1.003 0 0015 6z"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </span>
+        Results finalized at
+         
+        4/13/2021, 3:01:00 PM
+      </div>
+    </div>
+    <fieldset
+      disabled=""
+    >
+      <table
+        class="bp3-html-table bp3-html-table-bordered bp3-html-table-striped"
+        id="results-table"
+      >
+        <thead>
+          <tr>
+            <th />
+            <th>
+              Batch Name
+            </th>
+            <th>
+              Batch Type
+            </th>
+            <th>
+              Choice One
+            </th>
+            <th>
+              Choice Two
+            </th>
+            <th
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <button
+                class="bp3-button"
+                type="button"
+              >
+                <span
+                  class="bp3-icon bp3-icon-edit"
+                  icon="edit"
+                >
+                  <svg
+                    data-icon="edit"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      edit
+                    </desc>
+                    <path
+                      d="M3.25 10.26l2.47 2.47 6.69-6.69-2.46-2.48-6.7 6.7zM.99 14.99l3.86-1.39-2.46-2.44-1.4 3.83zm12.25-14c-.48 0-.92.2-1.24.51l-1.44 1.44 2.47 2.47 1.44-1.44c.32-.32.51-.75.51-1.24.01-.95-.77-1.74-1.74-1.74z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="bp3-button-text"
+                >
+                  Edit
+                </span>
+              </button>
+            </td>
+            <td>
+              Batch12
+            </td>
+            <td>
+              Other
+            </td>
+            <td>
+              10
+            </td>
+            <td>
+              20
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              30
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              10
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              20
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              30
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        style="display: flex; justify-content: space-between; margin-top: 20px;"
+      >
+        <button
+          class="bp3-button bp3-disabled bp3-intent-primary"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-plus"
+            icon="plus"
+          >
+            <svg
+              data-icon="plus"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                plus
+              </desc>
+              <path
+                d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Add batch
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          style="width: 160px;"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-clipboard"
+            icon="clipboard"
+          >
+            <svg
+              data-icon="clipboard"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                clipboard
+              </desc>
+              <path
+                d="M11 2c0-.55-.45-1-1-1h.22C9.88.4 9.24 0 8.5 0S7.12.4 6.78 1H7c-.55 0-1 .45-1 1v1h5V2zm2 0h-1v2H5V2H4c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h9c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Copy to clipboard
+          </span>
+        </button>
+        <button
+          class="bp3-button bp3-disabled"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Finalize Results
+          </span>
+        </button>
+      </div>
+    </fieldset>
+  </form>
+</div>
+`;
+
+exports[`offline batch round data entry renders 1`] = `
+<div>
+  <form
+    class="sc-bdVaJa hazmWT"
+  >
+    <div
+      style="width: 510px; margin-bottom: 20px;"
+    >
+      <p>
+        When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice for each batch of audited ballots.
+      </p>
+      
+    </div>
+    <fieldset>
+      <table
+        class="bp3-html-table bp3-html-table-bordered bp3-html-table-striped"
+        id="results-table"
+      >
+        <thead>
+          <tr>
+            <th />
+            <th>
+              Batch Name
+            </th>
+            <th>
+              Batch Type
+            </th>
+            <th>
+              Choice One
+            </th>
+            <th>
+              Choice Two
+            </th>
+            <th
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              colspan="5"
+            >
+              No batches added. Add your first batch below.
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              0
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              0
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        style="display: flex; justify-content: space-between; margin-top: 20px;"
+      >
+        <button
+          class="bp3-button bp3-intent-primary"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-plus"
+            icon="plus"
+          >
+            <svg
+              data-icon="plus"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                plus
+              </desc>
+              <path
+                d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Add batch
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          style="width: 160px;"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-clipboard"
+            icon="clipboard"
+          >
+            <svg
+              data-icon="clipboard"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                clipboard
+              </desc>
+              <path
+                d="M11 2c0-.55-.45-1-1-1h.22C9.88.4 9.24 0 8.5 0S7.12.4 6.78 1H7c-.55 0-1 .45-1 1v1h5V2zm2 0h-1v2H5V2H4c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h9c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Copy to clipboard
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Finalize Results
+          </span>
+        </button>
+      </div>
+    </fieldset>
+  </form>
+</div>
+`;
+
+exports[`offline batch round data entry renders with offline batches 1`] = `
+<div>
+  <form
+    class="sc-bdVaJa hazmWT"
+  >
+    <div
+      style="width: 510px; margin-bottom: 20px;"
+    >
+      <p>
+        When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice for each batch of audited ballots.
+      </p>
+      
+    </div>
+    <fieldset>
+      <table
+        class="bp3-html-table bp3-html-table-bordered bp3-html-table-striped"
+        id="results-table"
+      >
+        <thead>
+          <tr>
+            <th />
+            <th>
+              Batch Name
+            </th>
+            <th>
+              Batch Type
+            </th>
+            <th>
+              Choice One
+            </th>
+            <th>
+              Choice Two
+            </th>
+            <th
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <button
+                class="bp3-button"
+                type="button"
+              >
+                <span
+                  class="bp3-icon bp3-icon-edit"
+                  icon="edit"
+                >
+                  <svg
+                    data-icon="edit"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      edit
+                    </desc>
+                    <path
+                      d="M3.25 10.26l2.47 2.47 6.69-6.69-2.46-2.48-6.7 6.7zM.99 14.99l3.86-1.39-2.46-2.44-1.4 3.83zm12.25-14c-.48 0-.92.2-1.24.51l-1.44 1.44 2.47 2.47 1.44-1.44c.32-.32.51-.75.51-1.24.01-.95-.77-1.74-1.74-1.74z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="bp3-button-text"
+                >
+                  Edit
+                </span>
+              </button>
+            </td>
+            <td>
+              Batch1
+            </td>
+            <td>
+              Other
+            </td>
+            <td>
+              10
+            </td>
+            <td>
+              20
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              30
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              10
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              20
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              30
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        style="display: flex; justify-content: space-between; margin-top: 20px;"
+      >
+        <button
+          class="bp3-button bp3-intent-primary"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-plus"
+            icon="plus"
+          >
+            <svg
+              data-icon="plus"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                plus
+              </desc>
+              <path
+                d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Add batch
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          style="width: 160px;"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-clipboard"
+            icon="clipboard"
+          >
+            <svg
+              data-icon="clipboard"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                clipboard
+              </desc>
+              <path
+                d="M11 2c0-.55-.45-1-1-1h.22C9.88.4 9.24 0 8.5 0S7.12.4 6.78 1H7c-.55 0-1 .45-1 1v1h5V2zm2 0h-1v2H5V2H4c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h9c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Copy to clipboard
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Finalize Results
+          </span>
+        </button>
+      </div>
+    </fieldset>
+  </form>
+</div>
+`;
+
+exports[`offline batch round data entry renders with proper totals 1`] = `
+<div>
+  <form
+    class="sc-bdVaJa hazmWT"
+  >
+    <div
+      style="width: 510px; margin-bottom: 20px;"
+    >
+      <p>
+        When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice for each batch of audited ballots.
+      </p>
+      
+    </div>
+    <fieldset>
+      <table
+        class="bp3-html-table bp3-html-table-bordered bp3-html-table-striped"
+        id="results-table"
+      >
+        <thead>
+          <tr>
+            <th />
+            <th>
+              Batch Name
+            </th>
+            <th>
+              Batch Type
+            </th>
+            <th>
+              Choice One
+            </th>
+            <th>
+              Choice Two
+            </th>
+            <th
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <button
+                class="bp3-button"
+                type="button"
+              >
+                <span
+                  class="bp3-icon bp3-icon-edit"
+                  icon="edit"
+                >
+                  <svg
+                    data-icon="edit"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      edit
+                    </desc>
+                    <path
+                      d="M3.25 10.26l2.47 2.47 6.69-6.69-2.46-2.48-6.7 6.7zM.99 14.99l3.86-1.39-2.46-2.44-1.4 3.83zm12.25-14c-.48 0-.92.2-1.24.51l-1.44 1.44 2.47 2.47 1.44-1.44c.32-.32.51-.75.51-1.24.01-.95-.77-1.74-1.74-1.74z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="bp3-button-text"
+                >
+                  Edit
+                </span>
+              </button>
+            </td>
+            <td>
+              Batch1
+            </td>
+            <td>
+              Other
+            </td>
+            <td>
+              5
+            </td>
+            <td>
+              15
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              20
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <button
+                class="bp3-button"
+                type="button"
+              >
+                <span
+                  class="bp3-icon bp3-icon-edit"
+                  icon="edit"
+                >
+                  <svg
+                    data-icon="edit"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      edit
+                    </desc>
+                    <path
+                      d="M3.25 10.26l2.47 2.47 6.69-6.69-2.46-2.48-6.7 6.7zM.99 14.99l3.86-1.39-2.46-2.44-1.4 3.83zm12.25-14c-.48 0-.92.2-1.24.51l-1.44 1.44 2.47 2.47 1.44-1.44c.32-.32.51-.75.51-1.24.01-.95-.77-1.74-1.74-1.74z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="bp3-button-text"
+                >
+                  Edit
+                </span>
+              </button>
+            </td>
+            <td>
+              Batch2
+            </td>
+            <td>
+              Provisional
+            </td>
+            <td>
+              5
+            </td>
+            <td>
+              5
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              10
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              10
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              20
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              30
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        style="display: flex; justify-content: space-between; margin-top: 20px;"
+      >
+        <button
+          class="bp3-button bp3-intent-primary"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-plus"
+            icon="plus"
+          >
+            <svg
+              data-icon="plus"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                plus
+              </desc>
+              <path
+                d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Add batch
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          style="width: 160px;"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-clipboard"
+            icon="clipboard"
+          >
+            <svg
+              data-icon="clipboard"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                clipboard
+              </desc>
+              <path
+                d="M11 2c0-.55-.45-1-1-1h.22C9.88.4 9.24 0 8.5 0S7.12.4 6.78 1H7c-.55 0-1 .45-1 1v1h5V2zm2 0h-1v2H5V2H4c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h9c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Copy to clipboard
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Finalize Results
+          </span>
+        </button>
+      </div>
+    </fieldset>
+  </form>
+</div>
+`;
+
+exports[`offline batch round data entry validation error for blank submission 1`] = `
+<div>
+  <form
+    class="sc-bdVaJa hazmWT"
+  >
+    <div
+      style="width: 510px; margin-bottom: 20px;"
+    >
+      <p>
+        When you have examined all the ballots assigned to you, enter the number of votes recorded for each candidate/choice for each batch of audited ballots.
+      </p>
+      
+    </div>
+    <fieldset>
+      <table
+        class="bp3-html-table bp3-html-table-bordered bp3-html-table-striped"
+        id="results-table"
+      >
+        <thead>
+          <tr>
+            <th />
+            <th>
+              Batch Name
+            </th>
+            <th>
+              Batch Type
+            </th>
+            <th>
+              Choice One
+            </th>
+            <th>
+              Choice Two
+            </th>
+            <th
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              colspan="5"
+            >
+              No batches added. Add your first batch below.
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              Total
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            />
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              0
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              0
+            </td>
+            <td
+              style="color: rgb(19, 124, 189); font-weight: 600;"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        style="display: flex; justify-content: space-between; margin-top: 20px;"
+      >
+        <button
+          class="bp3-button bp3-intent-primary"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-plus"
+            icon="plus"
+          >
+            <svg
+              data-icon="plus"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                plus
+              </desc>
+              <path
+                d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Add batch
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          style="width: 160px;"
+          type="button"
+        >
+          <span
+            class="bp3-icon bp3-icon-clipboard"
+            icon="clipboard"
+          >
+            <svg
+              data-icon="clipboard"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                clipboard
+              </desc>
+              <path
+                d="M11 2c0-.55-.45-1-1-1h.22C9.88.4 9.24 0 8.5 0S7.12.4 6.78 1H7c-.55 0-1 .45-1 1v1h5V2zm2 0h-1v2H5V2H4c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h9c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="bp3-button-text"
+          >
+            Copy to clipboard
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            Finalize Results
+          </span>
+        </button>
+      </div>
+    </fieldset>
+  </form>
+</div>
+`;

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
@@ -1,6 +1,10 @@
 import { IBatch } from './useBatchResults'
 import { IRound } from '../useRoundsAuditAdmin'
 import { FileProcessingStatus } from '../useCSV'
+import {
+  IOfflineBatchResult,
+  IOfflineBatchResults,
+} from './useOfflineBatchResults'
 
 export interface INullResultValues {
   [contestId: string]: {
@@ -9,7 +13,7 @@ export interface INullResultValues {
 }
 
 export const roundMocks: {
-  [key in 'incomplete' | 'complete']: IRound
+  [key in 'incomplete' | 'complete' | 'singleIncompleteOffline']: IRound
 } = {
   incomplete: {
     id: 'round-1',
@@ -32,6 +36,20 @@ export const roundMocks: {
     endedAt: '2020-09-14T17:35:19.482Z',
     isAuditComplete: true,
     sampledAllBallots: false,
+    drawSampleTask: {
+      status: FileProcessingStatus.PROCESSED,
+      startedAt: '2020-09-14T17:35:19.482Z',
+      completedAt: '2020-09-14T17:36:19.482Z',
+      error: null,
+    },
+  },
+  singleIncompleteOffline: {
+    id: 'round-1',
+    roundNum: 1,
+    startedAt: '2020-09-14T17:35:19.482Z',
+    endedAt: null,
+    isAuditComplete: false,
+    sampledAllBallots: true,
     drawSampleTask: {
       status: FileProcessingStatus.PROCESSED,
       startedAt: '2020-09-14T17:35:19.482Z',
@@ -154,5 +172,105 @@ export const batchesMocks: {
         },
       },
     ],
+  },
+}
+
+export const offlineBatchMocks: {
+  [key in
+    | 'empty'
+    | 'complete'
+    | 'updated'
+    | 'finalized'
+    | 'completeWithMultipleBatch']: IOfflineBatchResults
+} = {
+  empty: {
+    finalizedAt: '',
+    results: [],
+  },
+  complete: {
+    finalizedAt: '',
+    results: [
+      {
+        batchName: 'Batch1',
+        batchType: 'Other',
+        choiceResults: {
+          'choice-id-1': 10,
+          'choice-id-2': 20,
+        },
+      },
+    ],
+  },
+  completeWithMultipleBatch: {
+    finalizedAt: '',
+    results: [
+      {
+        batchName: 'Batch1',
+        batchType: 'Other',
+        choiceResults: {
+          'choice-id-1': 5,
+          'choice-id-2': 15,
+        },
+      },
+      {
+        batchName: 'Batch2',
+        batchType: 'Provisional',
+        choiceResults: {
+          'choice-id-1': 5,
+          'choice-id-2': 5,
+        },
+      },
+    ],
+  },
+  updated: {
+    finalizedAt: '',
+    results: [
+      {
+        batchName: 'Batch12',
+        batchType: 'Other',
+        choiceResults: {
+          'choice-id-1': 10,
+          'choice-id-2': 20,
+        },
+      },
+    ],
+  },
+  finalized: {
+    finalizedAt: '2021-04-13T15:01:00.383031+00:00',
+    results: [
+      {
+        batchName: 'Batch12',
+        batchType: 'Other',
+        choiceResults: {
+          'choice-id-1': 10,
+          'choice-id-2': 20,
+        },
+      },
+    ],
+  },
+}
+
+export const offlineBatchResultsMocks: {
+  [key in 'empty' | 'complete' | 'updated']: IOfflineBatchResult
+} = {
+  empty: {
+    batchName: '',
+    batchType: '',
+    choiceResults: {},
+  },
+  complete: {
+    batchName: 'Batch1',
+    batchType: 'Other',
+    choiceResults: {
+      'choice-id-1': 10,
+      'choice-id-2': 20,
+    },
+  },
+  updated: {
+    batchName: 'Batch12',
+    batchType: 'Other',
+    choiceResults: {
+      'choice-id-1': 10,
+      'choice-id-2': 20,
+    },
   },
 }

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useOfflineBatchResults.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useOfflineBatchResults.ts
@@ -11,7 +11,7 @@ export interface IOfflineBatchResult {
     | 'Other'
     | ''
   choiceResults: {
-    [choiceId: string]: number
+    [choiceId: string]: number | string
   }
 }
 

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useOfflineBatchResults.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useOfflineBatchResults.ts
@@ -11,7 +11,7 @@ export interface IOfflineBatchResult {
     | 'Other'
     | ''
   choiceResults: {
-    [choiceId: string]: number | string
+    [choiceId: string]: number
   }
 }
 


### PR DESCRIPTION
**Description**

- Console warning issue: initial values to be set so that it stops complaining about fields changing between controlled and uncontrolled. For choice results, it was just assigning blank array and there was no values initially. So added code to fetch the choices and assigned a blank value to it. This then required changing the data type of choice results value to `number | string` so that `''` can be assigned. (We could assign 0 as well, but it will then display 0 by default.)

- Dialogs were opening still after results finalized: once the results are finalized, made changes so that when buttons are clicked, the popup doesn’t open.

**Testing**

- Added a cypress test for handling offline batch data entry paths
