### PR TITLE
Remove special case for round one sample sizes

### DIFF
--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -148,12 +148,11 @@ def count_audited_votes(election: Election, round: Round):
             db_session.add(result)
 
 
-# Get round-by-round audit results
-def contest_results_by_round(contest: Contest) -> Dict[str, Dict[str, int]]:
+def contest_results_by_round(contest: Contest) -> Optional[Dict[str, Dict[str, int]]]:
     results_by_round: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
     for result in contest.results:
         results_by_round[result.round_id][result.contest_choice_id] = result.result
-    return results_by_round
+    return results_by_round if len(results_by_round) > 0 else None
 
 
 # { batch_key: { contest_id: { choice_id: votes }}}
@@ -333,7 +332,7 @@ def sampled_ballot_interpretations_to_cvrs(
 
 
 def hybrid_contest_strata(
-    contest: Contest, round_one: bool = False
+    contest: Contest,
 ) -> Tuple[suite.BallotPollingStratum, suite.BallotComparisonStratum]:
     total_ballots = hybrid_contest_total_ballots(contest)
     vote_counts = hybrid_contest_choice_vote_counts(contest)
@@ -345,38 +344,34 @@ def hybrid_contest_strata(
         choice_id: vote_count.cvr for choice_id, vote_count in vote_counts.items()
     }
 
-    if round_one:
-        non_cvr_previous_samples = 0
-        cvr_previous_samples = 0
+    # For targeted contests, count the number of samples drawn for this
+    # contest so far
+    if contest.is_targeted:
+        num_previous_samples_dict = dict(
+            SampledBallotDraw.query.filter_by(contest_id=contest.id)
+            .join(SampledBallot)
+            .join(Batch)
+            .group_by(Batch.has_cvrs)
+            .values(Batch.has_cvrs, func.count(SampledBallotDraw.ticket_number))
+        )
+    # For opportunistic contests, count the number of ballots in jurisdictions
+    # in this contest's universe that were sampled (for some targeted contest)
     else:
-        # For targeted contests, count the number of samples drawn for this
-        # contest so far
-        if contest.is_targeted:
-            num_previous_samples_dict = dict(
-                SampledBallotDraw.query.filter_by(contest_id=contest.id)
-                .join(SampledBallot)
-                .join(Batch)
-                .group_by(Batch.has_cvrs)
-                .values(Batch.has_cvrs, func.count(SampledBallotDraw.ticket_number))
-            )
-        # For opportunistic contests, count the number of ballots in jurisdictions
-        # in this contest's universe that were sampled (for some targeted contest)
-        else:
-            num_previous_samples_dict = dict(
-                SampledBallot.query.join(Batch)
-                .join(Jurisdiction)
-                .join(Jurisdiction.contests)
-                .filter_by(id=contest.id)
-                .group_by(Batch.has_cvrs)
-                .values(Batch.has_cvrs, func.count(SampledBallot.id))
-            )
+        num_previous_samples_dict = dict(
+            SampledBallot.query.join(Batch)
+            .join(Jurisdiction)
+            .join(Jurisdiction.contests)
+            .filter_by(id=contest.id)
+            .group_by(Batch.has_cvrs)
+            .values(Batch.has_cvrs, func.count(SampledBallot.id))
+        )
 
-        non_cvr_previous_samples = num_previous_samples_dict.get(False, 0)
-        cvr_previous_samples = num_previous_samples_dict.get(True, 0)
+    non_cvr_previous_samples = num_previous_samples_dict.get(False, 0)
+    cvr_previous_samples = num_previous_samples_dict.get(True, 0)
 
     # In hybrid audits, we only store round contest results for non-CVR
     # ballots
-    non_cvr_sample_results = {} if round_one else contest_results_by_round(contest)
+    non_cvr_sample_results = contest_results_by_round(contest) or {}
     non_cvr_stratum = suite.BallotPollingStratum(
         total_ballots.non_cvr,
         non_cvr_vote_counts,
@@ -387,9 +382,7 @@ def hybrid_contest_strata(
     cvr_reported_results = cvrs_for_contest(contest)
     # The CVR sample results are filtered to only CVR ballots
     suite_contest = sampler_contest.from_db_contest(contest)
-    cvr_sample_results = (
-        {} if round_one else sampled_ballot_interpretations_to_cvrs(contest)
-    )
+    cvr_sample_results = sampled_ballot_interpretations_to_cvrs(contest)
     cvr_misstatements = suite.misstatements(
         suite_contest, cvr_reported_results, cvr_sample_results,
     )
@@ -412,7 +405,7 @@ def calculate_risk_measurements(election: Election, round: Round):
             p_values, is_complete = ballot_polling.compute_risk(
                 election.risk_limit,
                 sampler_contest.from_db_contest(contest),
-                contest_results_by_round(contest),
+                contest_results_by_round(contest) or {},
                 AuditMathType(election.audit_math_type),
                 round_sizes(contest),
             )

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -91,10 +91,6 @@ def validate_hybrid_manifests_and_cvrs(contest: Contest):
         )
 
 
-# Because the /sample-sizes endpoint is only used for the audit setup flow,
-# we always want it to return the sample size options for the first round.
-# So we support a flag in this function to compute the sample sizes for
-# round one specifically, even if the audit has progressed further.
 def sample_size_options(
     election: Election,
 ) -> Dict[str, Dict[str, ballot_polling.SampleSizeOption]]:

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -96,7 +96,7 @@ def validate_hybrid_manifests_and_cvrs(contest: Contest):
 # So we support a flag in this function to compute the sample sizes for
 # round one specifically, even if the audit has progressed further.
 def sample_size_options(
-    election: Election, round_one=False
+    election: Election,
 ) -> Dict[str, Dict[str, ballot_polling.SampleSizeOption]]:
     if not election.contests:
         raise UserError("Cannot compute sample sizes until contests are set")
@@ -106,9 +106,7 @@ def sample_size_options(
     def sample_sizes_for_contest(contest: Contest):
         assert election.risk_limit is not None
         if election.audit_type == AuditType.BALLOT_POLLING:
-            sample_results = (
-                None if round_one else rounds.contest_results_by_round(contest)
-            )
+            sample_results = rounds.contest_results_by_round(contest)
             sample_size_options = ballot_polling.get_sample_size(
                 election.risk_limit,
                 sampler_contest.from_db_contest(contest),
@@ -126,14 +124,6 @@ def sample_size_options(
             validate_batch_tallies(contest)
 
             cumulative_batch_results = rounds.cumulative_batch_results(election)
-            if round_one:
-                cumulative_batch_results = {
-                    batch_key: {
-                        contest_id: {choice_id: 0 for choice_id in contest_results}
-                        for contest_id, contest_results in batch_results.items()
-                    }
-                    for batch_key, batch_results in cumulative_batch_results.items()
-                }
             sample_size = macro.get_sample_sizes(
                 election.risk_limit,
                 sampler_contest.from_db_contest(contest),
@@ -148,27 +138,24 @@ def sample_size_options(
 
             contest_for_sampler = sampler_contest.from_db_contest(contest)
 
-            if round_one:
-                discrepancy_counts = None
-            else:
-                num_previous_samples = SampledBallotDraw.query.filter_by(
-                    contest_id=contest.id
-                ).count()
-                discrepancies = supersimple.compute_discrepancies(
-                    contest_for_sampler,
-                    rounds.cvrs_for_contest(contest),
-                    rounds.sampled_ballot_interpretations_to_cvrs(contest),
-                )
-                discrepancy_counter = Counter(
-                    d["counted_as"] for d in discrepancies.values()
-                )
-                discrepancy_counts = {
-                    "sample_size": num_previous_samples,
-                    "1-under": discrepancy_counter[-1],
-                    "1-over": discrepancy_counter[1],
-                    "2-under": discrepancy_counter[-2],
-                    "2-over": discrepancy_counter[2],
-                }
+            num_previous_samples = SampledBallotDraw.query.filter_by(
+                contest_id=contest.id
+            ).count()
+            discrepancies = supersimple.compute_discrepancies(
+                contest_for_sampler,
+                rounds.cvrs_for_contest(contest),
+                rounds.sampled_ballot_interpretations_to_cvrs(contest),
+            )
+            discrepancy_counter = Counter(
+                d["counted_as"] for d in discrepancies.values()
+            )
+            discrepancy_counts = {
+                "sample_size": num_previous_samples,
+                "1-under": discrepancy_counter[-1],
+                "1-over": discrepancy_counter[1],
+                "2-under": discrepancy_counter[-2],
+                "2-over": discrepancy_counter[2],
+            }
 
             sample_size = supersimple.get_sample_sizes(
                 election.risk_limit, contest_for_sampler, discrepancy_counts
@@ -184,9 +171,7 @@ def sample_size_options(
             validate_uploaded_cvrs(contest)
             validate_hybrid_manifests_and_cvrs(contest)
 
-            non_cvr_stratum, cvr_stratum = rounds.hybrid_contest_strata(
-                contest, round_one=round_one
-            )
+            non_cvr_stratum, cvr_stratum = rounds.hybrid_contest_strata(contest)
             size = suite.get_sample_size(
                 election.risk_limit,
                 sampler_contest.from_db_contest(contest),
@@ -209,7 +194,7 @@ def sample_size_options(
     )
     targeted_contests_that_havent_met_risk_limit = (
         targeted_contests.all()
-        if round_one
+        if len(list(election.rounds)) == 0
         else targeted_contests.join(RoundContest).filter_by(is_complete=False).all()
     )
     try:
@@ -224,7 +209,7 @@ def sample_size_options(
 @background_task
 def first_round_sample_size_options(election_id: str):
     election = Election.query.get(election_id)
-    election.sample_size_options = sample_size_options(election, round_one=True)
+    election.sample_size_options = sample_size_options(election)
 
 
 def serialize_sample_size_options(sample_size_options):

--- a/server/tests/api/test_sample_sizes.py
+++ b/server/tests/api/test_sample_sizes.py
@@ -174,26 +174,3 @@ def test_sample_sizes_background(
     }
 
     config.RUN_BACKGROUND_TASKS_IMMEDIATELY = orig_run_background_tasks_immediately
-
-
-def test_sample_sizes_background_backwards_compatible(
-    client: FlaskClient,
-    election_id: str,
-    round_1_id: str,  # pylint: disable=unused-argument
-):
-    # Test that audits that were created before we moved sample size options to
-    # a background task will still be able to load sample sizes after audit launch.
-
-    # Simulate an audit that launched without having a background task to
-    # compute sample size options.
-    election = Election.query.get(election_id)
-    election.sample_size_options = None
-    election.sample_size_options_task_id = None
-    db_session.commit()
-
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
-    response = json.loads(rv.data)
-    assert response["sampleSizes"] is not None
-    assert response["selected"] is not None
-    assert response["task"] is not None
-    assert response["task"]["status"] == "PROCESSED"


### PR DESCRIPTION
Previously, we needed to be able to compute the round one sample sizes at any time in order to show the round one sample sizes on the Review screen even after the audit launched. Now, since we store the round one sample sizes after computing them in the background, we don't need this anymore.