### PR TITLE
Quick fix for mistyped JA logins

### DIFF
--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -204,7 +204,16 @@ def jurisdictionadmin_login_callback():
         user = User.query.filter_by(email=userinfo["email"]).first()
         if user and len(user.jurisdiction_administrations) > 0:
             set_loggedin_user(session, UserType.JURISDICTION_ADMIN, userinfo["email"])
-
+        else:
+            return redirect(
+                "/?"
+                + urlencode(
+                    {
+                        "error": "email_not_found",
+                        "message": "Incorrect Email ID, please check & try again.",
+                    }
+                )
+            )
     return redirect("/")
 
 

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -370,6 +370,21 @@ def test_audit_board_not_found(client: FlaskClient,):
         assert session.get("_user") is None
 
 
+def test_jurisdictionadmin_incorrect_email(client: FlaskClient):
+    with patch.object(auth0_ja, "authorize_access_token", return_value=None):
+        mock_response = Mock()
+        mock_response.json = MagicMock(return_value={"email": "test@test.com"})
+        with patch.object(auth0_ja, "get", return_value=mock_response):
+            rv = client.get("/auth/jurisdictionadmin/callback?code=foobar")
+            assert rv.status_code == 302
+            location = urlparse(rv.location)
+            assert location.path == "/"
+            assert (
+                location.query
+                == "error=email_not_found&message=Incorrect+Email+ID%2C+please+check+%26+try+again."
+            )
+
+
 # Tests for /api/me
 
 


### PR DESCRIPTION
**Description**

Addresses #994 by providing feedback to the UI when an email isn't found for JA login. Not a complete solution, but looks like it solves the main issue.

**Testing**

- Added backend testing

**Progress**

This looks like it could be useful for the AA login as well, so we could add that in here too. Thoughts?
