### PR TITLE
Show batch count, not ballot count, in batch comparison audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ format-server:
 	pipenv run black .
 
 lint-server:
-	pipenv run pylint -j 0 server scripts
+	pipenv run pylint server scripts
 
 test-client:
 	yarn --cwd client lint

--- a/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
@@ -18,7 +18,7 @@ import useAuditBoards from '../useAuditBoards'
 import StatusTag from '../../Atoms/StatusTag'
 import { api } from '../../utilities'
 import { IAuditSettings } from '../useAuditSettings'
-import useBallotCount from '../RoundManagement/useBallots'
+import useBallotOrBatchCount from '../RoundManagement/useBallots'
 
 const FileStatusTag = ({
   processing,
@@ -154,8 +154,13 @@ const RoundStatusSection = ({
   auditSettings: IAuditSettings
 }) => {
   const [auditBoards] = useAuditBoards(electionId, jurisdiction.id, [round])
-  const numBallots = useBallotCount(electionId, jurisdiction.id, round.id)
-  if (!auditBoards || numBallots === null) return null
+  const numSamples = useBallotOrBatchCount(
+    electionId,
+    jurisdiction.id,
+    round.id,
+    auditSettings.auditType
+  )
+  if (!auditBoards || numSamples === null) return null
 
   const status = (() => {
     const jurisdictionStatus =
@@ -197,7 +202,10 @@ const RoundStatusSection = ({
       )
     }
 
-    if (numBallots === 0) return <p>No ballots sampled</p>
+    const ballotsOrBatches =
+      auditSettings.auditType === 'BATCH_COMPARISON' ? 'batches' : 'ballots'
+
+    if (numSamples === 0) return <p>No {ballotsOrBatches} sampled</p>
     if (jurisdictionStatus === JurisdictionRoundStatus.COMPLETE)
       return <p>Data entry complete</p>
     if (auditBoards.length === 0)

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
@@ -423,7 +423,7 @@ describe('Progress screen', () => {
     render(
       <Progress
         jurisdictions={jurisdictionMocks.twoManifestsOneTallies}
-        auditSettings={auditSettings.all}
+        auditSettings={auditSettings.batchComparisonAll}
         round={null}
       />
     )
@@ -447,7 +447,7 @@ describe('Progress screen', () => {
     rows = screen.getAllByRole('row')
     within(rows[1]).getByRole('cell', { name: '2/2 files uploaded' })
 
-    // Shows manifest and tallies the modal
+    // Shows manifest and tallies in the modal
     userEvent.click(screen.getByText('2/2 files uploaded'))
     const modal = screen
       .getByRole('heading', { name: 'Jurisdiction 3' })
@@ -474,5 +474,27 @@ describe('Progress screen', () => {
       'href',
       '/api/election/1/jurisdiction/jurisdiction-id-3/batch-tallies/csv'
     )
+  })
+
+  it('shows a message in the detail modal when no batches sampled', async () => {
+    const expectedCalls = [
+      jaApiCalls.getAuditBoards(auditBoardMocks.unfinished),
+      jaApiCalls.getBatches([]),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render(
+        <Progress
+          jurisdictions={jurisdictionMocks.oneComplete}
+          auditSettings={auditSettings.batchComparisonAll}
+          round={roundMocks.singleIncomplete[0]}
+        />
+      )
+
+      userEvent.click(screen.getByRole('button', { name: 'Jurisdiction 1' }))
+      const modal = screen
+        .getByRole('heading', { name: 'Jurisdiction 1' })
+        .closest('div.bp3-dialog')! as HTMLElement
+      await within(modal).findByText('No batches sampled')
+    })
   })
 })

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.test.tsx
@@ -88,7 +88,7 @@ describe('offline batch round data entry', () => {
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
         <OfflineBatchRoundDataEntry
-          round={roundMocks.singleIncompleteOffline}
+          round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
           route: '/election/1/jurisdiction/1',
@@ -107,7 +107,7 @@ describe('offline batch round data entry', () => {
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
         <OfflineBatchRoundDataEntry
-          round={roundMocks.singleIncompleteOffline}
+          round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
           route: '/election/1/jurisdiction/1',
@@ -142,7 +142,7 @@ describe('offline batch round data entry', () => {
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
         <OfflineBatchRoundDataEntry
-          round={roundMocks.singleIncompleteOffline}
+          round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
           route: '/election/1/jurisdiction/1',
@@ -187,7 +187,7 @@ describe('offline batch round data entry', () => {
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
         <OfflineBatchRoundDataEntry
-          round={roundMocks.singleIncompleteOffline}
+          round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
           route: '/election/1/jurisdiction/1',
@@ -207,7 +207,7 @@ describe('offline batch round data entry', () => {
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
         <OfflineBatchRoundDataEntry
-          round={roundMocks.singleIncompleteOffline}
+          round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
           route: '/election/1/jurisdiction/1',
@@ -236,7 +236,7 @@ describe('offline batch round data entry', () => {
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
         <OfflineBatchRoundDataEntry
-          round={roundMocks.singleIncompleteOffline}
+          round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
           route: '/election/1/jurisdiction/1',
@@ -273,7 +273,7 @@ describe('offline batch round data entry', () => {
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
         <OfflineBatchRoundDataEntry
-          round={roundMocks.singleIncompleteOffline}
+          round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
           route: '/election/1/jurisdiction/1',
@@ -307,7 +307,7 @@ describe('offline batch round data entry', () => {
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
         <OfflineBatchRoundDataEntry
-          round={roundMocks.singleIncompleteOffline}
+          round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
           route: '/election/1/jurisdiction/1',

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
@@ -16,7 +16,10 @@ exports[`RoundManagement renders audit setup with ballot audit 1`] = `
       class="sc-hMqMXs cTbGLd"
     >
       27
-       ballots to audit in Round 
+       
+      ballots
+       to audit in Round
+       
       1
     </p>
     <div
@@ -694,8 +697,11 @@ exports[`RoundManagement renders audit setup with batch audit 1`] = `
     <p
       class="sc-hMqMXs cTbGLd"
     >
-      27
-       ballots to audit in Round 
+      3
+       
+      batches
+       to audit in Round
+       
       1
     </p>
     <div
@@ -1390,8 +1396,11 @@ exports[`RoundManagement renders links & data entry with batch audit 1`] = `
       <p
         class="sc-hMqMXs cTbGLd"
       >
-        27
-         ballots to audit in Round 
+        3
+         
+        batches
+         to audit in Round
+         
         1
       </p>
       <div
@@ -1639,7 +1648,10 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
         class="sc-hMqMXs cTbGLd"
       >
         27
-         ballots to audit in Round 
+         
+        ballots
+         to audit in Round
+         
         1
       </p>
       <div
@@ -1890,7 +1902,10 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
         class="sc-hMqMXs cTbGLd"
       >
         27
-         ballots to audit in Round 
+         
+        ballots
+         to audit in Round
+         
         1
       </p>
       <div

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
@@ -13,7 +13,7 @@ export interface INullResultValues {
 }
 
 export const roundMocks: {
-  [key in 'incomplete' | 'complete' | 'singleIncompleteOffline']: IRound
+  [key in 'incomplete' | 'complete' | 'sampledAllBallotsIncomplete']: IRound
 } = {
   incomplete: {
     id: 'round-1',
@@ -43,7 +43,7 @@ export const roundMocks: {
       error: null,
     },
   },
-  singleIncompleteOffline: {
+  sampledAllBallotsIncomplete: {
     id: 'round-1',
     roundNum: 1,
     startedAt: '2020-09-14T17:35:19.482Z',

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
@@ -8,6 +8,7 @@ import {
   batchesMocks,
   batchResultsMocks,
   INullResultValues,
+  offlineBatchMocks,
 } from './_mocks'
 import { dummyBallots } from '../../DataEntry/_mocks'
 import {
@@ -20,6 +21,7 @@ import { IBatch } from './useBatchResults'
 import { jaApiCalls } from '../_mocks'
 import AuthDataProvider from '../../UserContext'
 import { IAuditSettings } from '../useAuditSettings'
+import { IOfflineBatchResults } from './useOfflineBatchResults'
 
 const renderView = (props: IRoundManagementProps) =>
   renderWithRouter(
@@ -57,6 +59,11 @@ const apiCalls = {
   }),
   getBatches: (response: { batches: IBatch[] }) => ({
     url: '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/batches',
+    response,
+  }),
+  getOfflineBatchResults: (response: IOfflineBatchResults) => ({
+    url:
+      '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/results/batch',
     response,
   }),
 }
@@ -204,6 +211,27 @@ describe('RoundManagement', () => {
       await screen.findByText(
         'Your jurisdiction has not been assigned any batches to audit in this round.'
       )
+    })
+  })
+
+  it('shows offline batch results data entry when all ballots sampled', async () => {
+    const expectedCalls = [
+      apiCalls.getSettings(auditSettings.offlineAll),
+      jaApiCalls.getUser,
+      apiCalls.getBallotCount,
+      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getOfflineBatchResults(offlineBatchMocks.empty),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderView({
+        round: roundMocks.sampledAllBallotsIncomplete,
+        auditBoards: auditBoardMocks.unfinished,
+        createAuditBoards: jest.fn(),
+      })
+      await screen.findByText(
+        'Please audit all of the ballots in your jurisdiction (100 ballots)'
+      )
+      screen.getByText('No batches added. Add your first batch below.')
     })
   })
 })

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
@@ -64,9 +64,9 @@ const apiCalls = {
 describe('RoundManagement', () => {
   it('renders audit setup with batch audit', async () => {
     const expectedCalls = [
-      apiCalls.getBallotCount,
       apiCalls.getSettings(auditSettings.batchComparisonAll),
       jaApiCalls.getUser,
+      apiCalls.getBatches(batchesMocks.emptyInitial),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView({
@@ -81,9 +81,9 @@ describe('RoundManagement', () => {
 
   it('renders audit setup with ballot audit', async () => {
     const expectedCalls = [
-      apiCalls.getBallotCount,
       apiCalls.getSettings(auditSettings.all),
       jaApiCalls.getUser,
+      apiCalls.getBallotCount,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView({
@@ -98,9 +98,9 @@ describe('RoundManagement', () => {
 
   it('renders complete view', async () => {
     const expectedCalls = [
-      apiCalls.getBallotCount,
       apiCalls.getSettings(auditSettings.all),
       jaApiCalls.getUser,
+      apiCalls.getBallotCount,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView({
@@ -117,9 +117,9 @@ describe('RoundManagement', () => {
 
   it('renders links & progress with online ballot audit', async () => {
     const expectedCalls = [
-      apiCalls.getBallotCount,
       apiCalls.getSettings(auditSettings.all),
       jaApiCalls.getUser,
+      apiCalls.getBallotCount,
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView({
@@ -134,9 +134,9 @@ describe('RoundManagement', () => {
 
   it('renders links & data entry with offline ballot audit', async () => {
     const expectedCalls = [
-      apiCalls.getBallotCount,
       apiCalls.getSettings(auditSettings.offlineAll),
       jaApiCalls.getUser,
+      apiCalls.getBallotCount,
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
       apiCalls.getResults(batchResultsMocks.empty),
     ]
@@ -153,9 +153,9 @@ describe('RoundManagement', () => {
 
   it('renders links & data entry with batch audit', async () => {
     const expectedCalls = [
-      apiCalls.getBallotCount,
       apiCalls.getSettings(auditSettings.batchComparisonAll),
       jaApiCalls.getUser,
+      apiCalls.getBatches(batchesMocks.emptyInitial),
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
       apiCalls.getBatches(batchesMocks.emptyInitial),
       apiCalls.getBatchResults(batchResultsMocks.empty),
@@ -168,6 +168,42 @@ describe('RoundManagement', () => {
       })
       await screen.findByText('Download Aggregated Batch Retrieval List')
       expect(container).toMatchSnapshot()
+    })
+  })
+
+  it('shows a message when no ballots assigned', async () => {
+    const expectedCalls = [
+      apiCalls.getSettings(auditSettings.all),
+      jaApiCalls.getUser,
+      jaApiCalls.getBallotCount([]),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderView({
+        round: roundMocks.incomplete,
+        auditBoards: auditBoardMocks.unfinished,
+        createAuditBoards: jest.fn(),
+      })
+      await screen.findByText(
+        'Your jurisdiction has not been assigned any ballots to audit in this round.'
+      )
+    })
+  })
+
+  it('shows a message when no batches assigned', async () => {
+    const expectedCalls = [
+      apiCalls.getSettings(auditSettings.batchComparisonAll),
+      jaApiCalls.getUser,
+      apiCalls.getBatches({ batches: [] }),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderView({
+        round: roundMocks.incomplete,
+        auditBoards: auditBoardMocks.unfinished,
+        createAuditBoards: jest.fn(),
+      })
+      await screen.findByText(
+        'Your jurisdiction has not been assigned any batches to audit in this round.'
+      )
     })
   })
 })

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
@@ -81,10 +81,11 @@ const RoundManagement = ({
       </PaddedWrapper>
     )
   }
+
   const ballotsOrBatches =
     auditSettings.auditType === 'BATCH_COMPARISON' ? 'batches' : 'ballots'
 
-  if (numSamples === 0) {
+  if (numSamples === 0 && !round.sampledAllBallots) {
     return (
       <PaddedWrapper>
         <StrongP>

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useBallots.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useBallots.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react'
 import { api } from '../../utilities'
 import { IAuditBoard } from '../useAuditBoards'
 import { BallotStatus, IBallotInterpretation } from '../../../types'
+import { IAuditSettings } from '../useAuditSettings'
+import { getBatches } from './useBatchResults'
 
 export interface IBallot {
   id: string
@@ -41,20 +43,27 @@ const getBallotCount = async (
   return response && response.count
 }
 
-const useBallotCount = (
+const useBallotOrBatchCount = (
   electionId: string,
   jurisdictionId: string,
-  roundId: string
+  roundId: string,
+  auditType: IAuditSettings['auditType'] | null
 ): number | null => {
-  const [numBallots, setNumBallots] = useState<number | null>(null)
+  const [count, setCount] = useState<number | null>(null)
 
   useEffect(() => {
     ;(async () => {
-      setNumBallots(await getBallotCount(electionId, jurisdictionId, roundId))
+      if (auditType === null) return
+      if (auditType === 'BATCH_COMPARISON') {
+        const batches = await getBatches(electionId, jurisdictionId, roundId)
+        setCount(batches && batches.length)
+      } else {
+        setCount(await getBallotCount(electionId, jurisdictionId, roundId))
+      }
     })()
-  }, [electionId, jurisdictionId, roundId])
+  }, [electionId, jurisdictionId, roundId, auditType])
 
-  return numBallots
+  return count
 }
 
-export default useBallotCount
+export default useBallotOrBatchCount

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useBatchResults.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useBatchResults.ts
@@ -52,7 +52,7 @@ const getResults = async (
   return reformatResults(response, false)
 }
 
-const getBatches = async (
+export const getBatches = async (
   electionId: string,
   jurisdictionId: string,
   roundId: string
@@ -107,23 +107,6 @@ const useBatchResults = (
     })()
   }, [electionId, jurisdictionId, roundId])
   return [results, batches, updateResults]
-}
-
-export const useBatchCount = (
-  electionId: string,
-  jurisdictionId: string,
-  roundId: string
-): number | null => {
-  const [numBatches, setNumBatches] = useState<number | null>(null)
-
-  useEffect(() => {
-    ;(async () => {
-      const batches = await getBatches(electionId, jurisdictionId, roundId)
-      if (batches) setNumBatches(batches.length)
-    })()
-  })
-
-  return numBatches
 }
 
 export default useBatchResults

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useBatchResults.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useBatchResults.ts
@@ -109,4 +109,21 @@ const useBatchResults = (
   return [results, batches, updateResults]
 }
 
+export const useBatchCount = (
+  electionId: string,
+  jurisdictionId: string,
+  roundId: string
+): number | null => {
+  const [numBatches, setNumBatches] = useState<number | null>(null)
+
+  useEffect(() => {
+    ;(async () => {
+      const batches = await getBatches(electionId, jurisdictionId, roundId)
+      if (batches) setNumBatches(batches.length)
+    })()
+  })
+
+  return numBatches
+}
+
 export default useBatchResults

--- a/client/src/components/MultiJurisdictionAudit/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/_mocks.ts
@@ -73,6 +73,7 @@ export const jaApiCalls = {
               electionName: 'election one',
               state: 'AL',
             },
+            numBallots: 100,
           },
           {
             id: 'jurisdiction-id-2',
@@ -83,6 +84,7 @@ export const jaApiCalls = {
               electionName: 'election two',
               state: 'AL',
             },
+            numBallots: 200,
           },
           {
             id: 'jurisdiction-id-3',
@@ -93,6 +95,7 @@ export const jaApiCalls = {
               electionName: 'election one',
               state: 'AL',
             },
+            numBallots: 300,
           },
         ],
         organizations: [],

--- a/client/src/components/MultiJurisdictionAudit/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/_mocks.ts
@@ -10,6 +10,7 @@ import jurisdictionFile, {
   jurisdictionErrorFile,
   standardizedContestsFile,
 } from './AASetup/Participants/_mocks'
+import { IBatch } from './RoundManagement/useBatchResults'
 
 const jurisdictionFormData: FormData = new FormData()
 jurisdictionFormData.append(
@@ -193,6 +194,10 @@ export const jaApiCalls = {
     url:
       '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/ballots?count=true',
     response: { count: ballots.length },
+  }),
+  getBatches: (batches: IBatch[]) => ({
+    url: '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/batches',
+    response: { batches },
   }),
   deleteManifest: {
     url: '/api/election/1/jurisdiction/jurisdiction-id-1/ballot-manifest',


### PR DESCRIPTION
Task: #1213 

Changes the `useBallotCount` hook to `useBallotOrBatchCount`, conditioning on the audit type. Under the hood, we use the existing endpoint to load batches and count them on the frontend, since the number of sampled batches should be small enough that this will be performant (unlike with ballots, where we count them server-side).

Also adds a special case for when no ballots/batches were sampled for that jurisdiction, hiding the usual actions they can take and showing a message instead.