### PR TITLE
Tweak JA ballot/batch count to avoid pluralization issues

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
@@ -15,12 +15,9 @@ exports[`RoundManagement renders audit setup with ballot audit 1`] = `
     <p
       class="sc-hMqMXs cTbGLd"
     >
+      Ballots
+       to audit: 
       27
-       
-      ballots
-       to audit in Round
-       
-      1
     </p>
     <div
       class="sc-dnqmqq jnbCEU"
@@ -697,12 +694,9 @@ exports[`RoundManagement renders audit setup with batch audit 1`] = `
     <p
       class="sc-hMqMXs cTbGLd"
     >
+      Batches
+       to audit: 
       3
-       
-      batches
-       to audit in Round
-       
-      1
     </p>
     <div
       class="sc-dnqmqq jnbCEU"
@@ -1396,12 +1390,9 @@ exports[`RoundManagement renders links & data entry with batch audit 1`] = `
       <p
         class="sc-hMqMXs cTbGLd"
       >
+        Batches
+         to audit: 
         3
-         
-        batches
-         to audit in Round
-         
-        1
       </p>
       <div
         class="bp3-button-group bp3-vertical bp3-align-left"
@@ -1647,12 +1638,9 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
       <p
         class="sc-hMqMXs cTbGLd"
       >
+        Ballots
+         to audit: 
         27
-         
-        ballots
-         to audit in Round
-         
-        1
       </p>
       <div
         class="bp3-button-group bp3-vertical bp3-align-left"
@@ -1901,12 +1889,9 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
       <p
         class="sc-hMqMXs cTbGLd"
       >
+        Ballots
+         to audit: 
         27
-         
-        ballots
-         to audit in Round
-         
-        1
       </p>
       <div
         class="bp3-button-group bp3-vertical bp3-align-left"

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
@@ -83,14 +83,14 @@ const RoundManagement = ({
   }
 
   const ballotsOrBatches =
-    auditSettings.auditType === 'BATCH_COMPARISON' ? 'batches' : 'ballots'
+    auditSettings.auditType === 'BATCH_COMPARISON' ? 'Batches' : 'Ballots'
 
   if (numSamples === 0 && !round.sampledAllBallots) {
     return (
       <PaddedWrapper>
         <StrongP>
-          Your jurisdiction has not been assigned any {ballotsOrBatches} to
-          audit in this round.
+          Your jurisdiction has not been assigned any{' '}
+          {ballotsOrBatches.toLowerCase()} to audit in this round.
         </StrongP>
       </PaddedWrapper>
     )
@@ -103,8 +103,7 @@ const RoundManagement = ({
     </StrongP>
   ) : (
     <StrongP>
-      {numSamples.toLocaleString()} {ballotsOrBatches} to audit in Round{' '}
-      {roundNum}
+      {ballotsOrBatches} to audit: {numSamples.toLocaleString()}
     </StrongP>
   )
 


### PR DESCRIPTION
The old language only made sense for more than one ballot/batch. This new language works for one or more ballots/batches.