### PR TITLE
Improve error on duplicate row in jurisdictions file

### DIFF
--- a/server/util/jurisdiction_bulk_update.py
+++ b/server/util/jurisdiction_bulk_update.py
@@ -12,8 +12,8 @@ JURISDICTION_NAME = "Jurisdiction"
 ADMIN_EMAIL = "Admin Email"
 
 JURISDICTIONS_COLUMNS = [
-    CSVColumnType("Jurisdiction", CSVValueType.TEXT),
-    CSVColumnType("Admin Email", CSVValueType.EMAIL),
+    CSVColumnType("Jurisdiction", CSVValueType.TEXT, unique=True),
+    CSVColumnType("Admin Email", CSVValueType.EMAIL, unique=True),
 ]
 
 


### PR DESCRIPTION
We were getting an internal database error. Instead, we use our CSV parsing validation to provide a useful error message.
