### PR TITLE
Clean up jurisdictions file endpoint

### DIFF
--- a/client/cypress/end-to-end/ballot-comparison.spec.js
+++ b/client/cypress/end-to-end/ballot-comparison.spec.js
@@ -34,10 +34,10 @@ describe('Ballot Comparison Test Cases', () => {
     cy.findAllByText('Upload File').spread((firstButton, secondButton) => {
       firstButton.click()
     })
-    cy.findAndCloseToast('Missing required CSV field "Jurisdiction"')
+    cy.findByText('Missing required column: Jurisdiction.')
 
     // upload valid jurisdiction filesheet
-    cy.findAllByText('Upload File').should('have.length', 2)
+    cy.findByRole('button', { name: 'Replace File' }).click()
     cy.fixture('CSVs/jurisdiction/sample_jurisdiction_filesheet.csv').then(
       fileContent => {
         cy.get('input[type="file"]')

--- a/client/cypress/end-to-end/batch-comparison.spec.js
+++ b/client/cypress/end-to-end/batch-comparison.spec.js
@@ -18,22 +18,6 @@ describe('Batch Comparison', () => {
     cy.viewport(1000, 2000)
     cy.contains('Audit Setup')
 
-    // upload invalid jurisdiction filesheet
-    cy.fixture(
-      'CSVs/jurisdiction/sample_jurisdiction_filesheet_jurisdiction_col_error.csv'
-    ).then(fileContent => {
-      cy.get('input[type="file"]')
-        .first()
-        .attachFile({
-          fileContent: fileContent.toString(),
-          fileName: 'sample_jurisdiction_filesheet_jurisdiction_col_error.csv',
-          mimeType: 'csv',
-        })
-    })
-    cy.findByText('Upload File').click({ force: true })
-    cy.findAndCloseToast('Missing required CSV field "Jurisdiction"')
-
-    // upload valid jurisdiction filesheet
     cy.fixture('CSVs/jurisdiction/sample_jurisdiction_filesheet.csv').then(
       fileContent => {
         cy.get('input[type="file"]')


### PR DESCRIPTION
Remove CSV validation in the endpoint, since the CSV parsing (which happens in the background job) checks the same things.