### PR TITLE
Jurisdiction progress improvements

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
@@ -131,6 +131,89 @@ describe('Progress screen', () => {
     within(rows[3]).getByRole('cell', { name: '0' })
   })
 
+  it('shows additional columns during setup for batch audits', () => {
+    render(
+      <Progress
+        jurisdictions={jurisdictionMocks.twoManifestsOneTallies}
+        auditSettings={auditSettings.batchComparisonAll}
+        round={null}
+      />
+    )
+    screen.getByRole('columnheader', { name: 'Jurisdiction' })
+    screen.getByRole('columnheader', { name: 'Status' })
+    screen.getByRole('columnheader', { name: 'Ballots in Manifest' })
+    screen.getByRole('columnheader', { name: 'Batches in Manifest' })
+    screen.getByRole('columnheader', { name: 'Valid Voted Ballots in Batches' })
+    const rows = screen.getAllByRole('row')
+    // Jurisdiction 1 - manifest errored, no ballot/batches count shown
+    const row1 = within(rows[1]).getAllByRole('cell')
+    expect(row1[2]).toBeEmpty()
+    expect(row1[3]).toBeEmpty()
+    expect(row1[4]).toBeEmpty()
+    // Jurisdiction 2 - manifest success, no tallies
+    const row2 = within(rows[2]).getAllByRole('cell')
+    expect(row2[2]).toHaveTextContent('2,117')
+    expect(row2[3]).toHaveTextContent('10')
+    expect(row2[4]).toBeEmpty()
+    // Jurisdiction 3 - manifest success, tallies success
+    const row3 = within(rows[3]).getAllByRole('cell')
+    expect(row3[2]).toHaveTextContent('2,117')
+    expect(row3[3]).toHaveTextContent('10')
+    expect(row3[4]).toHaveTextContent('15')
+  })
+
+  it('shows additional columns during setup for ballot comparison audits', () => {
+    render(
+      <Progress
+        jurisdictions={jurisdictionMocks.allManifestsSomeCVRs}
+        auditSettings={auditSettings.ballotComparisonAll}
+        round={null}
+      />
+    )
+    screen.getByRole('columnheader', { name: 'Jurisdiction' })
+    screen.getByRole('columnheader', { name: 'Status' })
+    screen.getByRole('columnheader', { name: 'Ballots in Manifest' })
+    screen.getByRole('columnheader', { name: 'Ballots in CVR' })
+    const rows = screen.getAllByRole('row')
+    // Jurisdiction 1 - manifest success, no CVR
+    const row1 = within(rows[1]).getAllByRole('cell')
+    expect(row1[2]).toHaveTextContent('2,117')
+    expect(row1[3]).toBeEmpty()
+    // Jurisdiction 2 - manifest success, CVR success
+    const row2 = within(rows[2]).getAllByRole('cell')
+    expect(row2[2]).toHaveTextContent('2,117')
+    expect(row2[3]).toHaveTextContent('10')
+  })
+
+  it('shows additional columns during setup for hybrid audits', () => {
+    render(
+      <Progress
+        jurisdictions={jurisdictionMocks.hybridTwoManifestsOneCvr}
+        auditSettings={auditSettings.hybridAll}
+        round={null}
+      />
+    )
+    screen.getByRole('columnheader', { name: 'Jurisdiction' })
+    screen.getByRole('columnheader', { name: 'Status' })
+    screen.getByRole('columnheader', { name: 'Ballots in Manifest' })
+    screen.getByRole('columnheader', { name: 'Non-CVR Ballots in Manifest' })
+    screen.getByRole('columnheader', { name: 'CVR Ballots in Manifest' })
+    screen.getByRole('columnheader', { name: 'Ballots in CVR' })
+    const rows = screen.getAllByRole('row')
+    // Jurisdiction 1 - manifest success, no CVR
+    const row1 = within(rows[1]).getAllByRole('cell')
+    expect(row1[2]).toHaveTextContent('2,117')
+    expect(row1[3]).toHaveTextContent('117')
+    expect(row1[4]).toHaveTextContent('2,000')
+    expect(row1[5]).toBeEmpty()
+    // Jurisdiction 2 - manifest success, CVR success
+    const row2 = within(rows[2]).getAllByRole('cell')
+    expect(row2[2]).toHaveTextContent('2,117')
+    expect(row2[3]).toHaveTextContent('1,117')
+    expect(row2[4]).toHaveTextContent('1,000')
+    expect(row2[5]).toHaveTextContent('10')
+  })
+
   it('shows a different toggle label for batch audits', () => {
     render(
       <Progress

--- a/client/src/components/MultiJurisdictionAudit/useJurisdictions.ts
+++ b/client/src/components/MultiJurisdictionAudit/useJurisdictions.ts
@@ -5,6 +5,17 @@ import { IFileInfo } from './useCSV'
 export interface IBallotManifestInfo extends IFileInfo {
   numBallots: number | null
   numBatches: number | null
+  // Only in Hybrid audits
+  numBallotsCvr?: number | null
+  numBallotsNonCvr?: number | null
+}
+
+export interface ICvrFileInfo extends IFileInfo {
+  numBallots: number | null
+}
+
+export interface IBatchTalliesFileInfo extends IFileInfo {
+  numBallots: number | null
 }
 
 export enum JurisdictionRoundStatus {
@@ -17,8 +28,8 @@ export interface IJurisdiction {
   id: string
   name: string
   ballotManifest: IBallotManifestInfo
-  batchTallies?: IFileInfo
-  cvrs?: IFileInfo
+  batchTallies?: IBatchTalliesFileInfo
+  cvrs?: ICvrFileInfo
   currentRoundStatus: {
     status: JurisdictionRoundStatus
     numSamples: number

--- a/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/_mocks/index.ts
+++ b/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/_mocks/index.ts
@@ -377,7 +377,7 @@ export const talliesMocks: { [key: string]: IBatchTalliesFileInfo } = {
       completedAt: '2020-07-08T21:39:14.574+00:00',
       error: null,
     },
-    numBallots: 10,
+    numBallots: 15,
   },
   errored: {
     file: {
@@ -685,6 +685,38 @@ export const jurisdictionMocks: { [key: string]: IJurisdiction[] } = {
       name: 'Jurisdiction 3',
       ballotManifest: manifestMocks.processed,
       cvrs: cvrsMocks.processed,
+      currentRoundStatus: null,
+    },
+  ],
+  // Hybrid
+  hybridTwoManifestsOneCvr: [
+    {
+      id: 'jurisdiction-id-1',
+      name: 'Jurisdiction 1',
+      ballotManifest: {
+        ...manifestMocks.processed,
+        numBallotsCvr: 2000,
+        numBallotsNonCvr: 117,
+      },
+      cvrs: cvrsMocks.empty,
+      currentRoundStatus: null,
+    },
+    {
+      id: 'jurisdiction-id-2',
+      name: 'Jurisdiction 2',
+      ballotManifest: {
+        ...manifestMocks.processed,
+        numBallotsCvr: 1000,
+        numBallotsNonCvr: 1117,
+      },
+      cvrs: cvrsMocks.processed,
+      currentRoundStatus: null,
+    },
+    {
+      id: 'jurisdiction-id-3',
+      name: 'Jurisdiction 3',
+      ballotManifest: manifestMocks.empty,
+      cvrs: cvrsMocks.empty,
       currentRoundStatus: null,
     },
   ],

--- a/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/_mocks/index.ts
+++ b/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/_mocks/index.ts
@@ -5,6 +5,8 @@ import {
   IJurisdiction,
   JurisdictionRoundStatus,
   IBallotManifestInfo,
+  ICvrFileInfo,
+  IBatchTalliesFileInfo,
 } from '../../useJurisdictions' // uses IFileInfo instead of IBallotManifest and allows `file: null`
 import { IAuditBoard } from '../../useAuditBoards'
 import { IRound } from '../../useRoundsAuditAdmin'
@@ -361,10 +363,11 @@ export const manifestMocks: { [key: string]: IBallotManifestInfo } = {
   },
 }
 
-export const talliesMocks: { [key: string]: IFileInfo } = {
+export const talliesMocks: { [key: string]: IBatchTalliesFileInfo } = {
   empty: {
     file: null,
     processing: null,
+    numBallots: null,
   },
   processed: {
     file: { name: 'tallies.csv', uploadedAt: '2020-07-08T21:39:05.765+00:00' },
@@ -374,6 +377,7 @@ export const talliesMocks: { [key: string]: IFileInfo } = {
       completedAt: '2020-07-08T21:39:14.574+00:00',
       error: null,
     },
+    numBallots: 10,
   },
   errored: {
     file: {
@@ -386,13 +390,15 @@ export const talliesMocks: { [key: string]: IFileInfo } = {
       startedAt: '2020-05-05T17:25:26.09743+00:00',
       status: FileProcessingStatus.ERRORED,
     },
+    numBallots: null,
   },
 }
 
-export const cvrsMocks: { [key: string]: IFileInfo } = {
+export const cvrsMocks: { [key: string]: ICvrFileInfo } = {
   empty: {
     file: null,
     processing: null,
+    numBallots: null,
   },
   processed: {
     file: { name: 'cvrs.csv', uploadedAt: '2020-11-18T21:39:05.765+00:00' },
@@ -402,6 +408,7 @@ export const cvrsMocks: { [key: string]: IFileInfo } = {
       completedAt: '2020-11-18T21:39:14.574+00:00',
       error: null,
     },
+    numBallots: 10,
   },
   errored: {
     file: {
@@ -414,6 +421,7 @@ export const cvrsMocks: { [key: string]: IFileInfo } = {
       startedAt: '2020-11-15T17:25:26.09743+00:00',
       status: FileProcessingStatus.ERRORED,
     },
+    numBallots: null,
   },
 }
 

--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -58,6 +58,17 @@ def hybrid_contest_total_ballots(contest: Contest) -> HybridPair:
     )
 
 
+def hybrid_jurisdiction_total_ballots(jurisdiction: Jurisdiction) -> HybridPair:
+    total_ballots = dict(
+        Batch.query.filter_by(jurisdiction_id=jurisdiction.id)
+        .group_by(Batch.has_cvrs)
+        .values(Batch.has_cvrs, func.sum(Batch.num_ballots))
+    )
+    return HybridPair(
+        cvr=total_ballots.get(True, 0), non_cvr=total_ballots.get(False, 0)
+    )
+
+
 def process_ballot_manifest_file(
     session: Session, jurisdiction: Jurisdiction, file: File
 ):

--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -12,6 +12,7 @@ from ..models import *  # pylint: disable=wildcard-import
 from ..database import db_session
 from ..auth import restrict_access, UserType
 from .rounds import get_current_round, sampled_all_ballots
+from .ballot_manifest import hybrid_jurisdiction_total_ballots
 from ..util.process_file import serialize_file, serialize_file_processing
 from ..util.jsonschema import JSONDict
 from ..util.csv_parse import decode_csv_file
@@ -21,7 +22,7 @@ from ..util.csv_download import csv_response
 def serialize_jurisdiction(
     election: Election, jurisdiction: Jurisdiction, round_status: Optional[JSONDict]
 ) -> JSONDict:
-    json_jurisdiction = {
+    json_jurisdiction: JSONDict = {
         "id": jurisdiction.id,
         "name": jurisdiction.name,
         "ballotManifest": {
@@ -32,16 +33,43 @@ def serialize_jurisdiction(
         },
         "currentRoundStatus": round_status,
     }
+
     if election.audit_type == AuditType.BATCH_COMPARISON:
         json_jurisdiction["batchTallies"] = {
             "file": serialize_file(jurisdiction.batch_tallies_file),
             "processing": serialize_file_processing(jurisdiction.batch_tallies_file),
         }
+
     if election.audit_type in [AuditType.BALLOT_COMPARISON, AuditType.HYBRID]:
+        processing = serialize_file_processing(jurisdiction.cvr_file)
+        num_cvr_ballots = (
+            CvrBallot.query.join(Batch)
+            .filter_by(jurisdiction_id=jurisdiction.id)
+            .count()
+            if processing and processing["status"] == ProcessingStatus.PROCESSED
+            else None
+        )
         json_jurisdiction["cvrs"] = {
             "file": serialize_file(jurisdiction.cvr_file),
             "processing": serialize_file_processing(jurisdiction.cvr_file),
+            "numBallots": num_cvr_ballots,
         }
+
+    if election.audit_type == AuditType.HYBRID:
+        ballot_counts = (
+            hybrid_jurisdiction_total_ballots(jurisdiction)
+            if json_jurisdiction["ballotManifest"]["processing"]
+            and json_jurisdiction["ballotManifest"]["processing"]["status"]
+            == ProcessingStatus.PROCESSED
+            else None
+        )
+        json_jurisdiction["ballotManifest"]["numBallotsCvr"] = (
+            ballot_counts and ballot_counts.cvr
+        )
+        json_jurisdiction["ballotManifest"]["numBallotsNonCvr"] = (
+            ballot_counts and ballot_counts.non_cvr
+        )
+
     return json_jurisdiction
 
 

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -42,6 +42,12 @@ def test_batch_tallies_upload(
     contest_id: str,
     manifests,  # pylint: disable=unused-argument
 ):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/jurisdiction")
+    assert rv.status_code == 200
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+    assert jurisdictions[0]["batchTallies"]["numBallots"] is None
+
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
@@ -135,6 +141,7 @@ def test_batch_tallies_upload(
                 "completedAt": assert_is_date,
                 "error": None,
             },
+            "numBallots": (111 + 222 + 333) / 2,
         },
     )
 

--- a/server/tests/hybrid/test_hybrid.py
+++ b/server/tests/hybrid/test_hybrid.py
@@ -70,6 +70,11 @@ def test_contest_vote_counts_before_cvrs(
         ],
     )
 
+    rv = client.get(f"/api/election/{election_id}/jurisdiction")
+    assert rv.status_code == 200
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+    assert jurisdictions[0]["cvrs"]["numBallots"] is None
+
 
 def test_contest_vote_counts(
     client: FlaskClient,
@@ -127,6 +132,11 @@ def test_contest_vote_counts(
             },
         ],
     )
+
+    rv = client.get(f"/api/election/{election_id}/jurisdiction")
+    assert rv.status_code == 200
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+    assert jurisdictions[0]["cvrs"]["numBallots"] == len(TEST_CVRS.splitlines()) - 4
 
 
 def test_sample_size(


### PR DESCRIPTION
Task: #1214 

Adds a few new columns to the jurisdiction progress screen based on audit type:
- Batch Comparison: Ballots in Manifest, Valid Voted Ballots in Batches
- Ballot Comparison: Ballots in CVR
- Hybrid: Non-CVR Ballots in Manifest, CVR Ballots in Manifest, Ballots in CVR

These new columns are only shown during audit setup.