### PR TITLE
Audit progress download button

### DIFF
--- a/client/src/components/Atoms/Table.tsx
+++ b/client/src/components/Atoms/Table.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { useTable, useSortBy, Column, Row } from 'react-table'
 import styled from 'styled-components'
-import { Icon, HTMLTable } from '@blueprintjs/core'
+import { Icon, HTMLTable, Button } from '@blueprintjs/core'
+import { downloadFile } from '../utilities'
 
 const StyledTable = styled.table`
   width: 100%;
@@ -50,12 +51,49 @@ export const FilterInput = <T extends object>({
   </div>
 )
 
+interface IDownloadCSVProps {
+  tableId: string
+  fileName?: string
+}
+
+export const DownloadCSV = ({ tableId, fileName }: IDownloadCSVProps) => {
+  const onClick = () => {
+    const table = document.querySelector(`#${tableId}`)!
+    const headers = Array.from(table.querySelectorAll('th')).map(
+      header => header.innerText
+    )
+    const bodyAndFooter = Array.from(
+      table.querySelectorAll('tbody tr, tfoot tr')
+    ).map(row =>
+      Array.from(row.querySelectorAll('td')).map(cell => cell.innerText)
+    )
+    const tableRows = [headers].concat(bodyAndFooter)
+    const quotedRows = tableRows.map(row =>
+      row.map(cell => `"${cell.replace(/"/g, '""')}"`)
+    )
+    const csvString = quotedRows.map(row => row.join(',')).join('\n')
+    const csvBlob = new Blob([csvString], { type: 'text/csv' })
+    downloadFile(csvBlob, fileName)
+  }
+
+  return (
+    <Button icon="download" onClick={onClick}>
+      Download as CSV
+    </Button>
+  )
+}
+
 interface ITableProps<T extends object> {
   data: T[]
   columns: Column<T>[]
+  id?: string
 }
 
-export const Table = <T extends object>({ data, columns }: ITableProps<T>) => {
+export const Table = <T extends object>({
+  data,
+  columns,
+  id,
+}: ITableProps<T>) => {
   const {
     getTableProps,
     getTableBodyProps,
@@ -75,7 +113,7 @@ export const Table = <T extends object>({ data, columns }: ITableProps<T>) => {
   /* All the keys are added automatically by react-table */
 
   return (
-    <StyledTable {...getTableProps()}>
+    <StyledTable id={id} {...getTableProps()}>
       <thead>
         <tr>
           {headers.map(column => (

--- a/client/src/components/Atoms/Table.tsx
+++ b/client/src/components/Atoms/Table.tsx
@@ -51,12 +51,15 @@ export const FilterInput = <T extends object>({
   </div>
 )
 
-interface IDownloadCSVProps {
+interface IDownloadCSVButtonProps {
   tableId: string
   fileName?: string
 }
 
-export const DownloadCSV = ({ tableId, fileName }: IDownloadCSVProps) => {
+export const DownloadCSVButton = ({
+  tableId,
+  fileName,
+}: IDownloadCSVButtonProps) => {
   const onClick = () => {
     const table = document.querySelector(`#${tableId}`)!
     const headers = Array.from(table.querySelectorAll('th')).map(

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
@@ -6,7 +6,12 @@ import { Button, Switch, ITagProps } from '@blueprintjs/core'
 import H2Title from '../../Atoms/H2Title'
 import { JurisdictionRoundStatus, IJurisdiction } from '../useJurisdictions'
 import JurisdictionDetail from './JurisdictionDetail'
-import { Table, sortByRank, FilterInput, DownloadCSV } from '../../Atoms/Table'
+import {
+  Table,
+  sortByRank,
+  FilterInput,
+  DownloadCSVButton,
+} from '../../Atoms/Table'
 import { IRound } from '../useRoundsAuditAdmin'
 import StatusTag from '../../Atoms/StatusTag'
 import { IAuditSettings } from '../useAuditSettings'
@@ -308,7 +313,7 @@ const Progress: React.FC<IProps> = ({
           onChange={() => setIsShowingUnique(!isShowingUnique)}
           style={{ marginRight: '20px' }}
         />
-        <DownloadCSV
+        <DownloadCSVButton
           tableId="progress-table"
           fileName={`audit-progress-${
             auditSettings.auditName

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
@@ -6,7 +6,7 @@ import { Button, Switch, ITagProps } from '@blueprintjs/core'
 import H2Title from '../../Atoms/H2Title'
 import { JurisdictionRoundStatus, IJurisdiction } from '../useJurisdictions'
 import JurisdictionDetail from './JurisdictionDetail'
-import { Table, sortByRank, FilterInput } from '../../Atoms/Table'
+import { Table, sortByRank, FilterInput, DownloadCSV } from '../../Atoms/Table'
 import { IRound } from '../useRoundsAuditAdmin'
 import StatusTag from '../../Atoms/StatusTag'
 import { IAuditSettings } from '../useAuditSettings'
@@ -24,10 +24,6 @@ const TableControls = styled.div`
   align-items: baseline;
   justify-content: space-between;
   margin-bottom: 0.5rem;
-
-  > div {
-    width: 50%;
-  }
 `
 
 const formatNumber = ({ value }: { value: number | null }) =>
@@ -299,18 +295,31 @@ const Progress: React.FC<IProps> = ({
         jurisdiction.
       </p>
       <TableControls>
+        <div style={{ flexGrow: 1, marginRight: '20px' }}>
+          <FilterInput
+            placeholder="Filter by jurisdiction name..."
+            value={filter}
+            onChange={value => setFilter(value)}
+          />
+        </div>
         <Switch
           checked={isShowingUnique}
           label={`Count unique sampled ${ballotsOrBatches.toLowerCase()}`}
           onChange={() => setIsShowingUnique(!isShowingUnique)}
+          style={{ marginRight: '20px' }}
         />
-        <FilterInput
-          placeholder="Filter by jurisdiction name..."
-          value={filter}
-          onChange={value => setFilter(value)}
+        <DownloadCSV
+          tableId="progress-table"
+          fileName={`audit-progress-${
+            auditSettings.auditName
+          }-${new Date().toISOString()}.csv`}
         />
       </TableControls>
-      <Table data={filteredJurisdictions} columns={columns} />
+      <Table
+        data={filteredJurisdictions}
+        columns={columns}
+        id="progress-table"
+      />
       {jurisdictionDetail && (
         <JurisdictionDetail
           jurisdiction={jurisdictionDetail}

--- a/client/src/components/utilities.test.ts
+++ b/client/src/components/utilities.test.ts
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react'
 import { toast } from 'react-toastify'
-import { api, testNumber, poll, checkAndToast } from './utilities'
+import { api, testNumber, poll, checkAndToast, downloadFile } from './utilities'
 
 const response = () =>
   new Response(new Blob([JSON.stringify({ success: true })]))
@@ -179,6 +179,31 @@ describe('utilities.ts', () => {
       expect(checkAndToast(null)).toBeFalsy()
       expect(checkAndToast('')).toBeFalsy()
       expect(toastSpy).toBeCalledTimes(0)
+    })
+  })
+
+  describe('downloadFile', () => {
+    it('creates a hidden anchor element, attaches the file for download, and clicks it', () => {
+      const mockAnchor = {
+        href: undefined,
+        download: undefined,
+        click: jest.fn(),
+      }
+      document.createElement = jest.fn().mockReturnValue(mockAnchor)
+      document.body.appendChild = jest.fn()
+      document.body.removeChild = jest.fn()
+      URL.createObjectURL = jest.fn().mockReturnValue('test object url')
+
+      const fileContents = new Blob(['test file contents'])
+      downloadFile(fileContents, 'test filename.txt')
+
+      expect(document.createElement).toHaveBeenCalledWith('a')
+      expect(URL.createObjectURL).toHaveBeenCalledWith(fileContents)
+      expect(mockAnchor.href).toEqual('test object url')
+      expect(mockAnchor.download).toEqual('test filename.txt')
+      expect(mockAnchor.click).toHaveBeenCalled()
+      expect(document.body.appendChild).toHaveBeenCalledWith(mockAnchor)
+      expect(document.body.removeChild).toHaveBeenCalledWith(mockAnchor)
     })
   })
 })

--- a/client/src/components/utilities.ts
+++ b/client/src/components/utilities.ts
@@ -60,6 +60,15 @@ export const apiDownload = (endpoint: string) =>
     }
   })
 
+export const downloadFile = (fileBlob: Blob, fileName?: string) => {
+  const a = document.createElement('a')
+  document.body.appendChild(a)
+  a.href = URL.createObjectURL(fileBlob)
+  a.download = fileName || ''
+  a.click()
+  document.body.removeChild(a)
+}
+
 export const poll = (
   condition: () => Promise<boolean>,
   callback: () => void,


### PR DESCRIPTION
Task: #1214 

Adds a button to download the progress table as a CSV. In order to get the data out of the table to download, we read it directly from the DOM. While it would be a bit cleaner and more flexible to generate the CSV directly from React state data, there's not a reasonably straightforward way to access the rendered state of the table component, so we'd have to duplicate the logic that renders the columns (the status column in particular is thorny). The upside of this approach is that users shouldn't be surprised at all - what they see on the page is exactly what they'll get in the CSV (minus formatting).

<img width="1364" alt="Screen Shot 2021-06-14 at 4 42 47 PM" src="https://user-images.githubusercontent.com/530106/121972499-1dfa4f80-cd30-11eb-9729-35f93dc89f42.png">
<img width="554" alt="Screen Shot 2021-06-14 at 4 42 58 PM" src="https://user-images.githubusercontent.com/530106/121972504-1fc41300-cd30-11eb-9a4c-633829abed96.png">
