### PR TITLE
Show JA setup screen while drawing sample/if sample errors

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -138,7 +138,7 @@ describe('App', () => {
       const expectedCalls = [
         jaApiCalls.getUser,
         jaApiCalls.getSettings(auditSettings.batchComparisonAll),
-        jaApiCalls.getRounds,
+        jaApiCalls.getRounds([]),
         jaApiCalls.getBallotManifestFile(manifestMocks.empty),
         jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
         jaApiCalls.getCVRSfile(cvrsMocks.empty),

--- a/client/src/components/HomeScreen.test.tsx
+++ b/client/src/components/HomeScreen.test.tsx
@@ -371,7 +371,7 @@ describe('Home screen', () => {
     const expectedCalls = [
       jaApiCalls.getUser,
       jaApiCalls.getSettings(auditSettings.blank),
-      jaApiCalls.getRounds,
+      jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile({ file: null, processing: null }),
       jaApiCalls.getBatchTalliesFile({ file: null, processing: null }),
       jaApiCalls.getCVRSfile({ file: null, processing: null }),
@@ -441,7 +441,7 @@ describe('Home screen', () => {
     const expectedCalls = [
       jaApiCalls.getUserWithOneElection,
       jaApiCalls.getSettings(auditSettings.blank),
-      jaApiCalls.getRounds,
+      jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile({ file: null, processing: null }),
       jaApiCalls.getBatchTalliesFile({ file: null, processing: null }),
       jaApiCalls.getCVRSfile({ file: null, processing: null }),

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
@@ -9,7 +9,7 @@ import { apiDownload } from '../../utilities'
 import { Inner } from '../../Atoms/Wrapper'
 import { IContest } from '../../../types'
 import { IAuditBoard } from '../useAuditBoards'
-import { IRound, drawSampleError } from '../useRoundsAuditAdmin'
+import { IRound, drawSampleError, isAuditStarted } from '../useRoundsAuditAdmin'
 import { IAuditSettings } from '../useAuditSettings'
 
 const SpacedH3 = styled(H3)`
@@ -278,7 +278,7 @@ export const JurisdictionAdminStatusBox = ({
   }>()
 
   // Audit has not started
-  if (rounds.length === 0) {
+  if (!isAuditStarted(rounds)) {
     const files: IFileInfo['processing'][] = [ballotManifest.processing]
     if (auditType === 'BATCH_COMPARISON') files.push(batchTallies.processing)
     if (auditType === 'BALLOT_COMPARISON' || auditType === 'HYBRID')

--- a/client/src/components/MultiJurisdictionAudit/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/_mocks.ts
@@ -140,10 +140,10 @@ export const jaApiCalls = {
       supportUser: null,
     },
   },
-  getRounds: {
+  getRounds: (rounds: IRound[]) => ({
     url: '/api/election/1/jurisdiction/jurisdiction-id-1/round',
-    response: { rounds: [] },
-  },
+    response: { rounds },
+  }),
   getBallotManifestFile: (response: IFileInfo) => ({
     url: '/api/election/1/jurisdiction/jurisdiction-id-1/ballot-manifest',
     response,

--- a/client/src/components/MultiJurisdictionAudit/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.test.tsx
@@ -406,7 +406,7 @@ describe('JA setup', () => {
     const expectedCalls = [
       jaApiCalls.getUser,
       jaApiCalls.getSettings(auditSettings.batchComparisonAll),
-      jaApiCalls.getRounds,
+      jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.empty),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
       jaApiCalls.getCVRSfile(cvrsMocks.empty),
@@ -422,7 +422,7 @@ describe('JA setup', () => {
     const expectedCalls = [
       jaApiCalls.getUser,
       jaApiCalls.getSettings(auditSettings.batchComparisonAll),
-      jaApiCalls.getRounds,
+      jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.empty),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
       jaApiCalls.getCVRSfile(cvrsMocks.empty),
@@ -463,7 +463,7 @@ describe('JA setup', () => {
     const expectedCalls = [
       jaApiCalls.getUser,
       jaApiCalls.getSettings(auditSettings.batchComparisonAll),
-      jaApiCalls.getRounds,
+      jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.empty),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
       jaApiCalls.getCVRSfile(cvrsMocks.empty),
@@ -510,7 +510,7 @@ describe('JA setup', () => {
     const expectedCalls = [
       jaApiCalls.getUser,
       jaApiCalls.getSettings(auditSettings.batchComparisonAll),
-      jaApiCalls.getRounds,
+      jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
       jaApiCalls.getCVRSfile(cvrsMocks.empty),
@@ -544,7 +544,7 @@ describe('JA setup', () => {
     const expectedCalls = [
       jaApiCalls.getUser,
       jaApiCalls.getSettings(auditSettings.ballotComparisonAll),
-      jaApiCalls.getRounds,
+      jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
       jaApiCalls.getCVRSfile(cvrsMocks.empty),
@@ -578,7 +578,7 @@ describe('JA setup', () => {
     const expectedCalls = [
       jaApiCalls.getUser,
       jaApiCalls.getSettings(auditSettings.batchComparisonAll),
-      jaApiCalls.getRounds,
+      jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.empty),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
       jaApiCalls.getCVRSfile(cvrsMocks.empty),
@@ -617,7 +617,7 @@ describe('JA setup', () => {
     const expectedCalls = [
       jaApiCalls.getUser,
       jaApiCalls.getSettings(auditSettings.batchComparisonAll),
-      jaApiCalls.getRounds,
+      jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
       jaApiCalls.getCVRSfile(cvrsMocks.empty),
@@ -650,6 +650,38 @@ describe('JA setup', () => {
 
       userEvent.click(manifestButton)
       await screen.findByText('Current file:')
+    })
+  })
+
+  it('stays on the file upload screen when sample is being drawn', async () => {
+    const expectedCalls = [
+      jaApiCalls.getUser,
+      jaApiCalls.getSettings(auditSettings.all),
+      jaApiCalls.getRounds(roundMocks.drawSampleInProgress),
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
+      jaApiCalls.getCVRSfile(cvrsMocks.empty),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderView()
+      await screen.findByRole('heading', { name: 'Audit Source Data' })
+      screen.getByText('The audit has not started.')
+    })
+  })
+
+  it('stays on the file upload screen when drawing sample errors', async () => {
+    const expectedCalls = [
+      jaApiCalls.getUser,
+      jaApiCalls.getSettings(auditSettings.all),
+      jaApiCalls.getRounds(roundMocks.drawSampleErrored),
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
+      jaApiCalls.getCVRSfile(cvrsMocks.empty),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderView()
+      await screen.findByRole('heading', { name: 'Audit Source Data' })
+      screen.getByText('The audit has not started.')
     })
   })
 })

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -25,6 +25,7 @@ import useContests from './useContests'
 import useRoundsAuditAdmin, {
   isDrawSampleComplete,
   drawSampleError,
+  isAuditStarted,
 } from './useRoundsAuditAdmin'
 import useAuditSettingsJurisdictionAdmin from './RoundManagement/useAuditSettingsJurisdictionAdmin'
 import H2Title from '../Atoms/H2Title'
@@ -205,7 +206,7 @@ export const JurisdictionAdminView: React.FC = () => {
   )
     return null // Still loading
 
-  if (!rounds.length) {
+  if (!isAuditStarted(rounds)) {
     return (
       <Wrapper>
         <JurisdictionAdminStatusBox

--- a/client/src/components/MultiJurisdictionAudit/useAuditBoards.ts
+++ b/client/src/components/MultiJurisdictionAudit/useAuditBoards.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { api } from '../utilities'
 import { hashBy } from '../../utils/array'
-import { IRound } from './useRoundsAuditAdmin'
+import { IRound, isAuditStarted } from './useRoundsAuditAdmin'
 
 export interface IAuditBoardMember {
   name: string
@@ -64,7 +64,7 @@ const useAuditBoards = (
   useEffect(() => {
     ;(async () => {
       if (!rounds) return setAuditBoards(null)
-      if (rounds.length === 0) return setAuditBoards([])
+      if (!isAuditStarted(rounds)) return setAuditBoards([])
       const roundId = rounds[rounds.length - 1].id
       return setAuditBoards(
         await getAuditBoards(electionId, jurisdictionId, roundId)

--- a/client/src/components/MultiJurisdictionAudit/useRoundsAuditAdmin.ts
+++ b/client/src/components/MultiJurisdictionAudit/useRoundsAuditAdmin.ts
@@ -54,6 +54,9 @@ export const isDrawSampleComplete = (rounds: IRound[]) =>
 export const drawSampleError = (rounds: IRound[]) =>
   rounds.length > 0 && rounds[rounds.length - 1].drawSampleTask.error
 
+export const isAuditStarted = (rounds: IRound[]) =>
+  rounds.length > 0 && isDrawSampleComplete(rounds) && !drawSampleError(rounds)
+
 const useRoundsAuditAdmin = (
   electionId: string,
   refreshId?: string


### PR DESCRIPTION
Task: #1179 

When the sample is being drawn or if drawing the sample errors, the audit hasn't started yet, and the JA can't begin their auditing. So we keep them on the setup screen.