### PR TITLE
Undo audit launch button

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/ConfirmLaunch.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/ConfirmLaunch.tsx
@@ -22,10 +22,7 @@ const ConfirmLaunch = ({
       title="Are you sure you want to launch the audit?"
       isOpen={isOpen}
     >
-      <div className={Classes.DIALOG_BODY}>
-        <p>This action cannot be undone</p>
-        {message && <p>{message}</p>}
-      </div>
+      <div className={Classes.DIALOG_BODY}>{message && <p>{message}</p>}</div>
       <div className={Classes.DIALOG_FOOTER}>
         <div className={Classes.DIALOG_FOOTER_ACTIONS}>
           <FormButton disabled={isSubmitting} onClick={handleClose}>

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
@@ -48,6 +48,7 @@ describe('StatusBox', () => {
           <AuditAdminStatusBox
             rounds={[]}
             startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
             jurisdictions={[]}
             contests={[]}
             auditSettings={auditSettings.blank!}
@@ -69,6 +70,7 @@ describe('StatusBox', () => {
           <AuditAdminStatusBox
             rounds={[]}
             startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
             jurisdictions={jurisdictionMocks.oneManifest}
             contests={[]}
             auditSettings={auditSettings.blank!}
@@ -86,6 +88,7 @@ describe('StatusBox', () => {
           <AuditAdminStatusBox
             rounds={[]}
             startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
             jurisdictions={jurisdictionMocks.allManifests}
             contests={[]}
             auditSettings={auditSettings.blank!}
@@ -104,6 +107,7 @@ describe('StatusBox', () => {
             <AuditAdminStatusBox
               rounds={[]}
               startNextRound={jest.fn()}
+              undoRoundStart={jest.fn()}
               jurisdictions={jurisdictionMocks.allManifestsSomeCVRs}
               contests={[]}
               auditSettings={
@@ -125,6 +129,7 @@ describe('StatusBox', () => {
             <AuditAdminStatusBox
               rounds={[]}
               startNextRound={jest.fn()}
+              undoRoundStart={jest.fn()}
               jurisdictions={jurisdictionMocks.allManifestsWithCVRs}
               contests={[]}
               auditSettings={
@@ -147,6 +152,7 @@ describe('StatusBox', () => {
           <AuditAdminStatusBox
             rounds={[]}
             startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
             jurisdictions={jurisdictionMocks.twoManifestsOneTallies}
             contests={[]}
             auditSettings={auditSettings.blankBatch}
@@ -164,6 +170,7 @@ describe('StatusBox', () => {
           <AuditAdminStatusBox
             rounds={[]}
             startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
             jurisdictions={jurisdictionMocks.allManifestsAllTallies}
             contests={[]}
             auditSettings={auditSettings.blankBatch}
@@ -181,6 +188,7 @@ describe('StatusBox', () => {
           <AuditAdminStatusBox
             rounds={[]}
             startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
             jurisdictions={jurisdictionMocks.allManifests}
             contests={contestMocks.filledTargeted.contests}
             auditSettings={auditSettings.all}
@@ -192,12 +200,31 @@ describe('StatusBox', () => {
       screen.getByText('3 of 3 jurisdictions have completed file uploads.')
     })
 
+    it('renders just launched round one state', () => {
+      render(
+        <Router>
+          <AuditAdminStatusBox
+            rounds={roundMocks.singleIncomplete}
+            startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
+            jurisdictions={jurisdictionMocks.noneStarted}
+            contests={contestMocks.filledTargeted.contests}
+            auditSettings={auditSettings.all}
+          />
+        </Router>
+      )
+      screen.getByText('Round 1 of the audit is in progress')
+      screen.getByText('1 of 3 jurisdictions have completed Round 1')
+      screen.getByRole('button', { name: 'Undo Audit Launch' })
+    })
+
     it('renders one of two jurisdictions done round one state', () => {
       render(
         <Router>
           <AuditAdminStatusBox
             rounds={roundMocks.singleIncomplete}
             startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
             jurisdictions={jurisdictionMocks.oneComplete}
             contests={contestMocks.filledTargeted.contests}
             auditSettings={auditSettings.all}
@@ -206,6 +233,7 @@ describe('StatusBox', () => {
       )
       screen.getByText('Round 1 of the audit is in progress')
       screen.getByText('1 of 3 jurisdictions have completed Round 1')
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
     })
 
     it('renders round complete, need another round state', () => {
@@ -214,6 +242,7 @@ describe('StatusBox', () => {
           <AuditAdminStatusBox
             rounds={roundMocks.needAnother}
             startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
             jurisdictions={jurisdictionMocks.allComplete}
             contests={contestMocks.filledTargeted.contests}
             auditSettings={auditSettings.all}
@@ -234,6 +263,7 @@ describe('StatusBox', () => {
           <AuditAdminStatusBox
             rounds={roundMocks.needAnother}
             startNextRound={startNextRoundMock}
+            undoRoundStart={jest.fn()}
             jurisdictions={jurisdictionMocks.allComplete}
             contests={contestMocks.filledTargeted.contests}
             auditSettings={auditSettings.all}
@@ -256,6 +286,7 @@ describe('StatusBox', () => {
           <AuditAdminStatusBox
             rounds={roundMocks.singleComplete}
             startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
             jurisdictions={jurisdictionMocks.allComplete}
             contests={contestMocks.filledTargeted.contests}
             auditSettings={auditSettings.all}
@@ -274,6 +305,7 @@ describe('StatusBox', () => {
           <AuditAdminStatusBox
             rounds={roundMocks.singleComplete}
             startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
             jurisdictions={jurisdictionMocks.allComplete}
             contests={contestMocks.filledTargeted.contests}
             auditSettings={auditSettings.all}

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
@@ -134,6 +134,7 @@ export const isSetupComplete = (
 interface IAuditAdminProps {
   rounds: IRound[]
   startNextRound: () => Promise<boolean>
+  undoRoundStart: () => Promise<boolean>
   jurisdictions: IJurisdiction[]
   contests: IContest[]
   auditSettings: IAuditSettings
@@ -143,6 +144,7 @@ interface IAuditAdminProps {
 export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
   rounds,
   startNextRound,
+  undoRoundStart,
   jurisdictions,
   contests,
   auditSettings,
@@ -193,6 +195,8 @@ export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
           `Error: ${drawSampleError(rounds)}`,
         ]}
         auditName={auditSettings.auditName}
+        buttonLabel={rounds.length === 1 ? 'Undo Audit Launch' : undefined}
+        onButtonClick={rounds.length === 1 ? undoRoundStart : undefined}
       >
         {children}
       </StatusBox>
@@ -205,9 +209,16 @@ export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
   if (!endedAt) {
     const numCompleted = jurisdictions.filter(
       ({ currentRoundStatus }) =>
-        currentRoundStatus &&
-        currentRoundStatus.status === JurisdictionRoundStatus.COMPLETE
+        currentRoundStatus!.status === JurisdictionRoundStatus.COMPLETE
     ).length
+
+    const canUndoLaunch =
+      roundNum === 1 &&
+      jurisdictions.every(
+        ({ currentRoundStatus }) =>
+          currentRoundStatus!.status !== JurisdictionRoundStatus.IN_PROGRESS
+      )
+
     return (
       <StatusBox
         headline={`Round ${roundNum} of the audit is in progress`}
@@ -216,6 +227,8 @@ export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
             ` have completed Round ${roundNum}`,
         ]}
         auditName={auditSettings.auditName}
+        buttonLabel={canUndoLaunch ? 'Undo Audit Launch' : undefined}
+        onButtonClick={canUndoLaunch ? undoRoundStart : undefined}
       >
         {children}
       </StatusBox>

--- a/client/src/components/MultiJurisdictionAudit/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.test.tsx
@@ -321,6 +321,7 @@ describe('AA setup flow', () => {
       aaApiCalls.getUser,
       ...loadAfterLaunch,
       ...loadAfterLaunch,
+      ...loadAfterLaunch,
     ]
     const routeProps = routerTestProps('/election/1', { electionId: '1' })
     await withMockFetch(expectedCalls, async () => {
@@ -343,7 +344,7 @@ describe('AA setup flow', () => {
     })
   })
 
-  it('shows an error if drawing the sample fails', async () => {
+  it('shows an error and undo button if drawing the sample fails', async () => {
     const loadAfterLaunch = [
       aaApiCalls.getRounds(roundMocks.drawSampleErrored),
       aaApiCalls.getJurisdictions,
@@ -356,6 +357,12 @@ describe('AA setup flow', () => {
       ...loadAfterLaunch,
       aaApiCalls.getSettings(auditSettings.all),
       aaApiCalls.getJurisdictionFile,
+      {
+        url: '/api/election/1/round/round-1',
+        options: { method: 'DELETE' },
+        response: { status: 'ok' },
+      },
+      aaApiCalls.getRounds(roundMocks.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       render(
@@ -372,6 +379,9 @@ describe('AA setup flow', () => {
         'Please contact our support team for help resolving this issue.'
       )
       screen.getByText('Error: something went wrong')
+
+      userEvent.click(screen.getByRole('button', { name: 'Undo Audit Launch' }))
+      await screen.findByText('The audit has not started.')
     })
   })
 })

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -45,7 +45,10 @@ export const AuditAdminView: React.FC = () => {
   const { electionId, view } = useParams<IParams>()
   const [refreshId, setRefreshId] = useState(uuidv4())
 
-  const [rounds, startNextRound] = useRoundsAuditAdmin(electionId, refreshId)
+  const [rounds, startNextRound, undoRoundStart] = useRoundsAuditAdmin(
+    electionId,
+    refreshId
+  )
   const jurisdictions = useJurisdictions(electionId, refreshId)
   const [contests] = useContests(electionId, undefined, refreshId)
   const [auditSettings] = useAuditSettings(electionId, refreshId)
@@ -54,8 +57,6 @@ export const AuditAdminView: React.FC = () => {
     auditSettings !== null && auditSettings.auditType === 'BALLOT_COMPARISON'
   const isHybrid =
     auditSettings !== null && auditSettings.auditType === 'HYBRID'
-  const isDrawingSample =
-    rounds !== null && rounds.length > 0 && !isDrawSampleComplete(rounds)
   const [stage, setStage] = useState<ElementType<typeof setupStages>>(
     'participants'
   )
@@ -68,7 +69,12 @@ export const AuditAdminView: React.FC = () => {
     setRefreshId
   )
 
-  useEffect(refresh, [refresh, isBallotComparison, isHybrid, isDrawingSample])
+  useEffect(refresh, [
+    refresh,
+    isBallotComparison,
+    isHybrid,
+    rounds !== null && isAuditStarted(rounds),
+  ])
 
   if (!jurisdictions || !contests || !rounds || !auditSettings) return null // Still loading
 
@@ -83,7 +89,7 @@ export const AuditAdminView: React.FC = () => {
     }
   })
 
-  if (isDrawingSample) {
+  if (rounds.length > 0 && !isDrawSampleComplete(rounds)) {
     return (
       <Wrapper>
         <Inner>
@@ -114,6 +120,7 @@ export const AuditAdminView: React.FC = () => {
           <AuditAdminStatusBox
             rounds={rounds}
             startNextRound={startNextRound}
+            undoRoundStart={undoRoundStart}
             jurisdictions={jurisdictions}
             contests={contests}
             auditSettings={auditSettings}
@@ -138,6 +145,7 @@ export const AuditAdminView: React.FC = () => {
           <AuditAdminStatusBox
             rounds={rounds}
             startNextRound={startNextRound}
+            undoRoundStart={undoRoundStart}
             jurisdictions={jurisdictions}
             contests={contests}
             auditSettings={auditSettings}

--- a/client/src/components/MultiJurisdictionAudit/timers.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/timers.test.tsx
@@ -90,7 +90,6 @@ describe('timers', () => {
       aaApiCalls.getUser,
       ...loadAfterLaunch,
       ...loadAfterLaunch,
-      ...loadAfterLaunch,
     ]
     await withMockFetch(expectedCalls, async () => {
       renderWithRoute('/election/1/progress', <AuditAdminViewWithAuth />)

--- a/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/_mocks/index.ts
+++ b/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/_mocks/index.ts
@@ -559,6 +559,47 @@ export const jurisdictionMocks: { [key: string]: IJurisdiction[] } = {
     },
   ],
   // In progress - Batch comparison (can also be used for ballot polling)
+  noneStarted: [
+    {
+      id: 'jurisdiction-id-1',
+      name: 'Jurisdiction 1',
+      ballotManifest: manifestMocks.processed,
+      batchTallies: talliesMocks.processed,
+      currentRoundStatus: {
+        status: JurisdictionRoundStatus.NOT_STARTED,
+        numUniqueAudited: 0,
+        numUnique: 10,
+        numSamplesAudited: 0,
+        numSamples: 11,
+      },
+    },
+    {
+      id: 'jurisdiction-id-2',
+      name: 'Jurisdiction 2',
+      ballotManifest: manifestMocks.processed,
+      batchTallies: talliesMocks.processed,
+      currentRoundStatus: {
+        status: JurisdictionRoundStatus.NOT_STARTED,
+        numUniqueAudited: 0,
+        numUnique: 20,
+        numSamplesAudited: 0,
+        numSamples: 22,
+      },
+    },
+    {
+      id: 'jurisdiction-id-3',
+      name: 'Jurisdiction 3',
+      ballotManifest: manifestMocks.processed,
+      batchTallies: talliesMocks.processed,
+      currentRoundStatus: {
+        status: JurisdictionRoundStatus.COMPLETE,
+        numUniqueAudited: 0,
+        numUnique: 0,
+        numSamplesAudited: 0,
+        numSamples: 0,
+      },
+    },
+  ],
   oneComplete: [
     {
       id: 'jurisdiction-id-1',

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -557,3 +557,21 @@ def test_batch_comparison_sample_all_batches(
 
     # Every batch should get sampled exactly once
     assert len(all_batches) == sample_size
+
+
+def test_batch_comparison_undo_start_round_1(
+    client: FlaskClient, election_id: str, round_1_id: str
+):
+    rv = client.delete(f"/api/election/{election_id}/round/{round_1_id}")
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/round")
+    assert json.loads(rv.data) == {"rounds": []}
+
+    assert (
+        SampledBatchDraw.query.join(Batch)
+        .join(Jurisdiction)
+        .filter_by(election_id=election_id)
+        .count()
+        == 0
+    )


### PR DESCRIPTION
Task: #1219 

Adds a button to undo launching the audit as long as no jurisdiction has started auditing yet.


https://user-images.githubusercontent.com/530106/122292420-d5b36c80-ceaa-11eb-9420-41d64e95fbd6.mov

