### PR TITLE
Ballot polling: count not found ballots for the loser

### DIFF
--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -180,7 +180,7 @@ def samples_not_found_by_round(contest: Contest) -> Dict[str, int]:
             .join(Jurisdiction)
             .join(Jurisdiction.contests)
             .filter_by(id=contest.id)
-            .join(SampledBallotDraw)
+            .join(SampledBallot.draws)
             .group_by(SampledBallotDraw.round_id)
             .values(SampledBallotDraw.round_id, func.count(SampledBallot.id.distinct()))
         )
@@ -447,12 +447,10 @@ def calculate_risk_measurements(election: Election, round: Round):
 
         if election.audit_type == AuditType.BALLOT_POLLING:
             assert election.audit_math_type is not None
-            print(samples_not_found_by_round(contest))
             p_values, is_complete = ballot_polling.compute_risk(
                 election.risk_limit,
                 sampler_contest.from_db_contest(contest),
                 contest_results_by_round(contest) or {},
-                # {},
                 samples_not_found_by_round(contest),
                 AuditMathType(election.audit_math_type),
                 round_sizes(contest),

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -164,6 +164,28 @@ def contest_results_by_round(contest: Contest) -> Optional[Dict[str, Dict[str, i
     return results_by_round if len(results_by_round) > 0 else None
 
 
+def samples_not_found_by_round(contest: Contest) -> Dict[str, int]:
+    if contest.is_targeted:
+        return dict(
+            SampledBallotDraw.query.filter_by(contest_id=contest.id)
+            .join(SampledBallot)
+            .filter_by(status=BallotStatus.NOT_FOUND)
+            .group_by(SampledBallotDraw.round_id)
+            .values(SampledBallotDraw.round_id, func.count())
+        )
+    else:
+        return dict(
+            SampledBallot.query.filter_by(status=BallotStatus.NOT_FOUND)
+            .join(Batch)
+            .join(Jurisdiction)
+            .join(Jurisdiction.contests)
+            .filter_by(id=contest.id)
+            .join(SampledBallotDraw)
+            .group_by(SampledBallotDraw.round_id)
+            .values(SampledBallotDraw.round_id, func.count(SampledBallot.id.distinct()))
+        )
+
+
 # { batch_key: { contest_id: { choice_id: votes }}}
 BatchTallies = Dict[Tuple[str, str], Dict[str, Dict[str, int]]]
 
@@ -425,10 +447,13 @@ def calculate_risk_measurements(election: Election, round: Round):
 
         if election.audit_type == AuditType.BALLOT_POLLING:
             assert election.audit_math_type is not None
+            print(samples_not_found_by_round(contest))
             p_values, is_complete = ballot_polling.compute_risk(
                 election.risk_limit,
                 sampler_contest.from_db_contest(contest),
                 contest_results_by_round(contest) or {},
+                # {},
+                samples_not_found_by_round(contest),
                 AuditMathType(election.audit_math_type),
                 round_sizes(contest),
             )

--- a/server/audit_math/ballot_polling.py
+++ b/server/audit_math/ballot_polling.py
@@ -56,6 +56,10 @@ def compute_risk(
     math_type: AuditMathType,
     round_sizes: Dict[int, int],
 ) -> Tuple[Dict[Tuple[str, str], float], bool]:
+    sample_results = {  # Make a copy so we don't mutate the original results
+        round_id: dict(round_results)
+        for round_id, round_results in sample_results.items()
+    }
     # When a sampled ballot can't be found, count it as a vote for every loser
     for round_id, num_not_found in samples_not_found.items():
         for loser in contest.losers:

--- a/server/audit_math/ballot_polling.py
+++ b/server/audit_math/ballot_polling.py
@@ -52,9 +52,14 @@ def compute_risk(
     risk_limit: int,
     contest: Contest,
     sample_results: Dict[str, Dict[str, int]],
+    samples_not_found: Dict[str, int],
     math_type: AuditMathType,
     round_sizes: Dict[int, int],
 ) -> Tuple[Dict[Tuple[str, str], float], bool]:
+    # When a sampled ballot can't be found, count it as a vote for every loser
+    for round_id, num_not_found in samples_not_found.items():
+        for loser in contest.losers:
+            sample_results[round_id][loser] += num_not_found
 
     if math_type == AuditMathType.MINERVA:
         return minerva.compute_risk(risk_limit, contest, sample_results, round_sizes)

--- a/server/tests/api/snapshots/snap_test_reports.py
+++ b/server/tests/api/snapshots/snap_test_reports.py
@@ -29,8 +29,8 @@ J1,Audit Board #2,Bubbikin Republican,Democrat,Joe Schmo,\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,119,No,,DATETIME,,candidate 1: 0; candidate 2: 0\r
-1,Contest 2,Opportunistic,,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
+1,Contest 1,Targeted,119,No,,DATETIME,,candidate 1: 0; candidate 2: 0; Ballots not found (counted for loser): 0\r
+1,Contest 2,Opportunistic,,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0; Ballots not found (counted for loser): 0\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Batch Name,Ballot Position,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,Audit Result: Contest 2\r
@@ -170,10 +170,10 @@ J1,Audit Board #2,,,,\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,119,No,1.0,DATETIME,DATETIME,candidate 1: 65; candidate 2: 54\r
-1,Contest 2,Opportunistic,,No,1.0,DATETIME,DATETIME,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
-2,Contest 1,Targeted,366,No,,DATETIME,,candidate 1: 0; candidate 2: 0\r
-2,Contest 2,Opportunistic,,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
+1,Contest 1,Targeted,119,No,1.0,DATETIME,DATETIME,candidate 1: 65; candidate 2: 54; Ballots not found (counted for loser): 0\r
+1,Contest 2,Opportunistic,,No,1.0,DATETIME,DATETIME,candidate 1: 0; candidate 2: 0; candidate 3: 0; Ballots not found (counted for loser): 0\r
+2,Contest 1,Targeted,366,No,,DATETIME,,candidate 1: 0; candidate 2: 0; Ballots not found (counted for loser): 0\r
+2,Contest 2,Opportunistic,,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0; Ballots not found (counted for loser): 0\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Batch Name,Ballot Position,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,Audit Result: Contest 2\r

--- a/server/tests/audit_math/snapshots/snap_test_bravo.py
+++ b/server/tests/audit_math/snapshots/snap_test_bravo.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots["test_ballot_polling_not_found_ballots 1"] = {
+    ("cand1", "cand3"): 1.431846034590506e-06,
+    ("cand2", "cand3"): 0.00016313261169996314,
+}

--- a/server/tests/audit_math/snapshots/snap_test_bravo.py
+++ b/server/tests/audit_math/snapshots/snap_test_bravo.py
@@ -8,6 +8,8 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots["test_ballot_polling_not_found_ballots 1"] = {
-    ("cand1", "cand3"): 1.431846034590506e-06,
-    ("cand2", "cand3"): 0.00016313261169996314,
+    ("cand1", "cand3"): 1.431846034590505e-06,
+    ("cand1", "cand4"): 1.431846034590505e-06,
+    ("cand2", "cand3"): 0.27430209050114257,
+    ("cand2", "cand4"): 0.27430209050114257,
 }

--- a/server/tests/audit_math/snapshots/snap_test_bravo.py
+++ b/server/tests/audit_math/snapshots/snap_test_bravo.py
@@ -9,7 +9,7 @@ snapshots = Snapshot()
 
 snapshots["test_ballot_polling_not_found_ballots 1"] = {
     ("cand1", "cand3"): 1.431846034590505e-06,
-    ("cand1", "cand4"): 1.431846034590505e-06,
+    ("cand1", "cand4"): 1.2886614311314533e-05,
     ("cand2", "cand3"): 0.27430209050114257,
-    ("cand2", "cand4"): 0.27430209050114257,
+    ("cand2", "cand4"): 0.6171797036275707,
 }

--- a/server/tests/audit_math/test_bravo.py
+++ b/server/tests/audit_math/test_bravo.py
@@ -525,7 +525,7 @@ def test_ballot_polling_not_found_ballots(snapshot):
 
     contest = Contest("Contest", contest_data)
 
-    sample_results = {"round1": {"cand1": 50, "cand2": 20, "cand3": 10, "cand4": 10}}
+    sample_results = {"round1": {"cand1": 50, "cand2": 20, "cand3": 10, "cand4": 12}}
 
     all_audited_p_values, _ = ballot_polling.compute_risk(
         RISK_LIMIT, contest, sample_results, {"round1": 0}, AuditMathType.BRAVO, {}
@@ -540,7 +540,7 @@ def test_ballot_polling_not_found_ballots(snapshot):
         )
         # Should add the number of not found votes for each loser
         expected_sample_results = {
-            "round1": {"cand1": 50, "cand2": 20, "cand3": 12, "cand4": 12}
+            "round1": {"cand1": 50, "cand2": 20, "cand3": 12, "cand4": 14}
         }
         mock_bravo_compute_risk.assert_called_with(
             RISK_LIMIT, contest, expected_sample_results

--- a/server/tests/audit_math/test_bravo.py
+++ b/server/tests/audit_math/test_bravo.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name
 from decimal import Decimal
 import math
+from unittest.mock import patch
 import pytest
 
 from ...audit_math import bravo
@@ -514,16 +515,17 @@ def test_tied_contest():
 def test_ballot_polling_not_found_ballots(snapshot):
     contest_data = {
         "cand1": 500,
-        "cand2": 400,
+        "cand2": 200,
         "cand3": 100,
+        "cand4": 100,
         "ballots": 1000,
         "numWinners": 2,
-        "votesAllowed": 1,
+        "votesAllowed": 2,
     }
 
     contest = Contest("Contest", contest_data)
 
-    sample_results = {"round1": {"cand1": 50, "cand2": 40, "cand3": 10}}
+    sample_results = {"round1": {"cand1": 50, "cand2": 20, "cand3": 10, "cand4": 10}}
 
     all_audited_p_values, _ = ballot_polling.compute_risk(
         RISK_LIMIT, contest, sample_results, {"round1": 0}, AuditMathType.BRAVO, {}
@@ -531,6 +533,18 @@ def test_ballot_polling_not_found_ballots(snapshot):
     not_found_p_values, _ = ballot_polling.compute_risk(
         RISK_LIMIT, contest, sample_results, {"round1": 1}, AuditMathType.BRAVO, {}
     )
+
+    with patch.object(bravo, "compute_risk") as mock_bravo_compute_risk:
+        ballot_polling.compute_risk(
+            RISK_LIMIT, contest, sample_results, {"round1": 2}, AuditMathType.BRAVO, {}
+        )
+        # Should add the number of not found votes for each loser
+        expected_sample_results = {
+            "round1": {"cand1": 50, "cand2": 20, "cand3": 12, "cand4": 12}
+        }
+        mock_bravo_compute_risk.assert_called_with(
+            RISK_LIMIT, contest, expected_sample_results
+        )
 
     for candidate_pair, all_audited_p_value in all_audited_p_values.items():
         assert all_audited_p_value < not_found_p_values[candidate_pair]

--- a/server/tests/ballot_polling/snapshots/snap_test_ballot_polling.py
+++ b/server/tests/ballot_polling/snapshots/snap_test_ballot_polling.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots[
+    "test_not_found_ballots 1"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+Test Org test_not_found_ballots,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
+Contest 1,Targeted,1,1,1000,candidate 1: 600; candidate 2: 400\r
+Contest 2,Opportunistic,2,2,600,candidate 1: 200; candidate 2: 300; candidate 3: 100\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_not_found_ballots,BALLOT_POLLING,BRAVO,10%,1234567890,Yes\r
+\r
+######## AUDIT BOARDS ########\r
+Jurisdiction Name,Audit Board Name,Member 1 Name,Member 1 Affiliation,Member 2 Name,Member 2 Affiliation\r
+J1,Audit Board #1,,,,\r
+J1,Audit Board #2,,,,\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
+1,Contest 1,Targeted,119,Yes,0.0000000035,DATETIME,DATETIME,candidate 1: 119; candidate 2: 0; Ballots not found (counted for loser): 10\r
+1,Contest 2,Opportunistic,,Yes,0.000001839,DATETIME,DATETIME,candidate 1: 60; candidate 2: 52; candidate 3: 0; Ballots not found (counted for loser): 10\r
+\r
+######## SAMPLED BALLOTS ########\r
+Jurisdiction Name,Batch Name,Ballot Position,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,Audit Result: Contest 2\r
+J1,1,3,Round 1: 0.088404500051420169,NOT_FOUND,candidate 1,candidate 1\r
+J1,1,4,Round 1: 0.056455363529765325,NOT_FOUND,candidate 1,candidate 2\r
+J1,1,6,Round 1: 0.063938772948313277,NOT_FOUND,candidate 1,candidate 1\r
+J1,1,23,Round 1: 0.026709936196363079,NOT_FOUND,candidate 1,candidate 2\r
+J1,2,2,Round 1: 0.091912034655946169,NOT_FOUND,candidate 1,candidate 1\r
+J1,2,6,Round 1: 0.028662515227396225,NOT_FOUND,candidate 1,candidate 2\r
+J1,2,25,Round 1: 0.023369462249873393,NOT_FOUND,candidate 1,candidate 1\r
+J1,2,29,Round 1: 0.071025445549972134,NOT_FOUND,candidate 1,candidate 2\r
+J1,2,30,Round 1: 0.028807763145463000,NOT_FOUND,candidate 1,candidate 1\r
+J1,2,39,Round 1: 0.115805768632379354,NOT_FOUND,candidate 1,candidate 2\r
+J1,2,70,Round 1: 0.032079033020155699,AUDITED,candidate 1,candidate 1\r
+J1,2,73,Round 1: 0.108526924051470744,AUDITED,candidate 1,candidate 2\r
+J1,2,75,Round 1: 0.035640239666365080,AUDITED,candidate 1,candidate 1\r
+J1,2,77,Round 1: 0.061243853397465359,AUDITED,candidate 1,candidate 2\r
+J1,2,84,Round 1: 0.095975333017344763,AUDITED,candidate 1,candidate 1\r
+J1,2,88,Round 1: 0.071804966402309250,AUDITED,candidate 1,candidate 2\r
+J1,2,89,Round 1: 0.054646592241035729,AUDITED,candidate 1,candidate 1\r
+J1,2,100,Round 1: 0.101396216379465808,AUDITED,candidate 1,candidate 2\r
+J1,3,2,Round 1: 0.096258425102788892,AUDITED,candidate 1,candidate 1\r
+J1,3,11,Round 1: 0.093515621534103985,AUDITED,candidate 1,candidate 2\r
+J1,3,38,Round 1: 0.018230756390081779,AUDITED,candidate 1,candidate 1\r
+J1,3,40,Round 1: 0.014739823561707141,AUDITED,candidate 1,candidate 2\r
+J1,3,50,Round 1: 0.001315804865633048,AUDITED,candidate 1,candidate 1\r
+J1,3,82,Round 1: 0.046244912686705392,AUDITED,candidate 1,candidate 2\r
+J1,3,84,Round 1: 0.101133216050746816,AUDITED,candidate 1,candidate 1\r
+J1,3,97,Round 1: 0.000454186428506763,AUDITED,candidate 1,candidate 2\r
+J1,3,100,"Round 1: 0.000619826143680938, 0.118040423696597067",AUDITED,candidate 1,candidate 1\r
+J1,3,106,Round 1: 0.061350998660180108,AUDITED,candidate 1,candidate 1\r
+J1,3,117,Round 1: 0.026152774099611906,AUDITED,candidate 1,candidate 2\r
+J1,3,121,Round 1: 0.068048811291378543,AUDITED,candidate 1,candidate 1\r
+J1,4,3,Round 1: 0.010306372247476217,AUDITED,candidate 1,candidate 2\r
+J1,4,5,"Round 1: 0.080704071573746128, 0.099341639942774926",AUDITED,candidate 1,candidate 1\r
+J1,4,6,Round 1: 0.104029943609805403,AUDITED,candidate 1,candidate 1\r
+J1,4,7,Round 1: 0.042092437205341423,AUDITED,candidate 1,candidate 2\r
+J1,4,26,Round 1: 0.074248137323249137,AUDITED,candidate 1,candidate 1\r
+J1,4,44,Round 1: 0.042228065622768503,AUDITED,candidate 1,candidate 2\r
+J1,4,61,Round 1: 0.054099586219482054,AUDITED,candidate 1,candidate 1\r
+J1,4,63,Round 1: 0.003836186945975918,AUDITED,candidate 1,candidate 2\r
+J1,4,66,Round 1: 0.096975818551066342,AUDITED,candidate 1,candidate 1\r
+J1,4,67,Round 1: 0.091470963043987134,AUDITED,candidate 1,candidate 2\r
+J1,4,90,Round 1: 0.032834360453541187,AUDITED,candidate 1,candidate 1\r
+J1,4,94,Round 1: 0.111941491629163402,AUDITED,candidate 1,candidate 2\r
+J1,4,105,Round 1: 0.023112222444256629,AUDITED,candidate 1,candidate 1\r
+J1,4,117,Round 1: 0.082550146523358971,AUDITED,candidate 1,candidate 2\r
+J1,4,120,Round 1: 0.075775152592425405,AUDITED,candidate 1,candidate 1\r
+J1,4,158,Round 1: 0.105230770286479126,AUDITED,candidate 1,candidate 2\r
+J1,4,166,Round 1: 0.077882036529627073,AUDITED,candidate 1,candidate 1\r
+J1,4,177,Round 1: 0.077933165074758787,AUDITED,candidate 1,candidate 2\r
+J1,4,195,Round 1: 0.100521475517045244,AUDITED,candidate 1,candidate 1\r
+J1,4,198,Round 1: 0.070349800984198330,AUDITED,candidate 1,candidate 2\r
+J1,4,208,Round 1: 0.036612236698180247,AUDITED,candidate 1,candidate 1\r
+J1,4,215,Round 1: 0.040595725718922402,AUDITED,candidate 1,candidate 2\r
+J1,4,217,Round 1: 0.062330471179110521,AUDITED,candidate 1,candidate 1\r
+J1,4,220,Round 1: 0.068494770695355835,AUDITED,candidate 1,candidate 2\r
+J1,4,222,Round 1: 0.072280927514051282,AUDITED,candidate 1,candidate 1\r
+J1,4,241,Round 1: 0.069869996497425336,AUDITED,candidate 1,candidate 2\r
+J1,4,249,Round 1: 0.046501275943279774,AUDITED,candidate 1,candidate 1\r
+J1,4,256,Round 1: 0.040546706799122951,AUDITED,candidate 1,candidate 2\r
+J1,4,263,Round 1: 0.013595936546478868,AUDITED,candidate 1,candidate 1\r
+J1,4,273,Round 1: 0.029372995614232565,AUDITED,candidate 1,candidate 2\r
+J1,4,280,Round 1: 0.117155998071883033,AUDITED,candidate 1,candidate 1\r
+J1,4,290,Round 1: 0.000461433395583052,AUDITED,candidate 1,candidate 2\r
+J1,4,294,Round 1: 0.085416334659259955,AUDITED,candidate 1,candidate 1\r
+J1,4,308,Round 1: 0.051954609019659065,AUDITED,candidate 1,candidate 2\r
+J1,4,325,Round 1: 0.059827989431571177,AUDITED,candidate 1,candidate 1\r
+J1,4,335,Round 1: 0.077728803876745538,AUDITED,candidate 1,candidate 2\r
+J1,4,336,Round 1: 0.085191621074810971,AUDITED,candidate 1,candidate 1\r
+J1,4,338,Round 1: 0.097544908368535753,AUDITED,candidate 1,candidate 2\r
+J1,4,339,Round 1: 0.104640686198153541,AUDITED,candidate 1,candidate 1\r
+J1,4,347,Round 1: 0.032225479026399263,AUDITED,candidate 1,candidate 2\r
+J1,4,364,"Round 1: 0.014195240836456557, 0.067991977068525173",AUDITED,candidate 1,candidate 1\r
+J1,4,375,"Round 1: 0.028954249616875816, 0.100423932182991905",AUDITED,candidate 1,candidate 1\r
+J1,4,376,Round 1: 0.041784965549179532,AUDITED,candidate 1,candidate 1\r
+J1,4,383,Round 1: 0.037428227356516192,AUDITED,candidate 1,candidate 2\r
+J1,4,390,Round 1: 0.023508408392288091,AUDITED,candidate 1,candidate 1\r
+J1,4,400,Round 1: 0.033664359681262958,AUDITED,candidate 1,candidate 2\r
+J2,1,3,Round 1: 0.026974562209906179,AUDITED,candidate 1,candidate 1\r
+J2,1,18,Round 1: 0.014104975821697965,AUDITED,candidate 1,candidate 2\r
+J2,2,4,Round 1: 0.044147335849878093,AUDITED,candidate 1,candidate 1\r
+J2,2,6,Round 1: 0.011988982664080463,AUDITED,candidate 1,candidate 2\r
+J2,2,10,Round 1: 0.045351581516619860,AUDITED,candidate 1,candidate 1\r
+J2,3,18,Round 1: 0.069668342793075274,AUDITED,candidate 1,candidate 2\r
+J2,3,30,Round 1: 0.042672901163402832,AUDITED,candidate 1,candidate 1\r
+J2,3,32,Round 1: 0.089615926764951869,AUDITED,candidate 1,candidate 2\r
+J2,3,47,Round 1: 0.040062098731520309,AUDITED,candidate 1,candidate 1\r
+J2,3,50,Round 1: 0.108342102764767955,AUDITED,candidate 1,candidate 2\r
+J2,3,51,"Round 1: 0.096120553260524803, 0.113789621888339460",AUDITED,candidate 1,candidate 1\r
+J2,3,56,"Round 1: 0.091048982285661053, 0.101378875314002018",AUDITED,candidate 1,candidate 1\r
+J2,3,58,Round 1: 0.045253125083783178,AUDITED,candidate 1,candidate 1\r
+J2,3,61,Round 1: 0.096604572871094987,AUDITED,candidate 1,candidate 2\r
+J2,3,71,Round 1: 0.088124330140694101,AUDITED,candidate 1,candidate 1\r
+J2,3,76,Round 1: 0.077988294597998248,AUDITED,candidate 1,candidate 2\r
+J2,3,88,Round 1: 0.109322394754273640,AUDITED,candidate 1,candidate 1\r
+J2,3,97,Round 1: 0.096444576053280526,AUDITED,candidate 1,candidate 2\r
+J2,3,101,"Round 1: 0.014786076170605607, 0.033699457455768933",AUDITED,candidate 1,candidate 1\r
+J2,3,106,Round 1: 0.045266995759010649,AUDITED,candidate 1,candidate 1\r
+J2,3,110,Round 1: 0.072858131275512064,AUDITED,candidate 1,candidate 2\r
+J2,3,122,Round 1: 0.073465505074563528,AUDITED,candidate 1,candidate 1\r
+J2,3,125,Round 1: 0.115573400982398903,AUDITED,candidate 1,candidate 2\r
+J2,3,154,Round 1: 0.010022804537356634,AUDITED,candidate 1,candidate 1\r
+J2,3,157,Round 1: 0.103642122132931710,AUDITED,candidate 1,candidate 2\r
+J2,3,165,Round 1: 0.047889972941670238,AUDITED,candidate 1,candidate 1\r
+J2,3,174,Round 1: 0.059804486813794551,AUDITED,candidate 1,candidate 2\r
+J2,3,180,Round 1: 0.083278065379106609,AUDITED,candidate 1,candidate 1\r
+J2,3,181,Round 1: 0.077209685743241616,AUDITED,candidate 1,candidate 2\r
+J2,3,191,Round 1: 0.073322038933809532,AUDITED,candidate 1,candidate 1\r
+J2,3,196,Round 1: 0.034526859969954916,AUDITED,candidate 1,candidate 2\r
+J2,3,206,Round 1: 0.028858006840055629,AUDITED,candidate 1,candidate 1\r
+J2,3,209,Round 1: 0.105574445837861061,AUDITED,candidate 1,candidate 2\r
+J2,3,214,Round 1: 0.082699452005387947,AUDITED,candidate 1,candidate 1\r
+J2,4,34,Round 1: 0.060816634473886193,AUDITED,candidate 1,candidate 2\r
+J2,4,37,Round 1: 0.092786549356518562,AUDITED,candidate 1,candidate 1\r
+"""

--- a/server/tests/ballot_polling/test_ballot_polling.py
+++ b/server/tests/ballot_polling/test_ballot_polling.py
@@ -1,7 +1,7 @@
 from flask.testing import FlaskClient
 
-from ...models import *
-from ..helpers import *
+from ...models import *  # pylint: disable=wildcard-import
+from ..helpers import *  # pylint: disable=wildcard-import
 
 
 def test_not_found_ballots(
@@ -9,7 +9,7 @@ def test_not_found_ballots(
     election_id: str,
     contest_ids: List[str],
     round_1_id: str,
-    audit_board_round_1_ids: List[str],
+    audit_board_round_1_ids: List[str],  # pylint: disable=unused-argument
     snapshot,
 ):
     round = Round.query.get(round_1_id)
@@ -18,7 +18,7 @@ def test_not_found_ballots(
 
     # First, audit all ballots for the winner and see what the p-value is
     ballot_draws = SampledBallotDraw.query.filter_by(round_id=round_1_id).all()
-    for draw in ballot_draws:
+    for i, draw in enumerate(ballot_draws):
         audit_ballot(
             draw.sampled_ballot,
             targeted_contest.id,
@@ -29,7 +29,7 @@ def test_not_found_ballots(
             draw.sampled_ballot,
             opportunistic_contest.id,
             Interpretation.VOTE,
-            [opportunistic_contest.choices[1]],
+            [opportunistic_contest.choices[i % 2]],
         )
     end_round(round.election, round)
     db_session.commit()
@@ -58,7 +58,6 @@ def test_not_found_ballots(
 
     # Not found ballots should be counted as votes for the losers, which should
     # increase the p-value
-    print(all_audited_p_values, not_found_p_values)
     assert (
         all_audited_p_values[targeted_contest.id]
         < not_found_p_values[targeted_contest.id]

--- a/server/tests/ballot_polling/test_bravo_ballot_polling.py
+++ b/server/tests/ballot_polling/test_bravo_ballot_polling.py
@@ -1,0 +1,73 @@
+from flask.testing import FlaskClient
+
+from ...models import *
+from ..helpers import *
+
+
+def test_not_found_ballots(
+    client: FlaskClient,
+    election_id: str,
+    contest_ids: List[str],
+    round_1_id: str,
+    audit_board_round_1_ids: List[str],
+    snapshot,
+):
+    round = Round.query.get(round_1_id)
+    targeted_contest = Contest.query.get(contest_ids[0])
+    opportunistic_contest = Contest.query.get(contest_ids[1])
+
+    # First, audit all ballots for the winner and see what the p-value is
+    ballot_draws = SampledBallotDraw.query.filter_by(round_id=round_1_id).all()
+    for draw in ballot_draws:
+        audit_ballot(
+            draw.sampled_ballot,
+            targeted_contest.id,
+            Interpretation.VOTE,
+            [targeted_contest.choices[0]],
+        )
+        audit_ballot(
+            draw.sampled_ballot,
+            opportunistic_contest.id,
+            Interpretation.VOTE,
+            [opportunistic_contest.choices[1]],
+        )
+    end_round(round.election, round)
+    db_session.commit()
+
+    all_audited_p_values = dict(
+        RoundContest.query.filter_by(round_id=round.id).values(
+            RoundContest.contest_id, RoundContest.end_p_value
+        )
+    )
+
+    for round_contest in round.round_contests:
+        round_contest.results = []
+
+    # Next, try the same thing with some of the ballots marked not found
+    num_not_found = 10
+    for draw in ballot_draws[:num_not_found]:
+        draw.sampled_ballot.status = BallotStatus.NOT_FOUND
+    end_round(round.election, round)
+    db_session.commit()
+
+    not_found_p_values = dict(
+        RoundContest.query.filter_by(round_id=round.id).values(
+            RoundContest.contest_id, RoundContest.end_p_value
+        )
+    )
+
+    # Not found ballots should be counted as votes for the losers, which should
+    # increase the p-value
+    print(all_audited_p_values, not_found_p_values)
+    assert (
+        all_audited_p_values[targeted_contest.id]
+        < not_found_p_values[targeted_contest.id]
+    )
+    assert (
+        all_audited_p_values[opportunistic_contest.id]
+        < not_found_p_values[opportunistic_contest.id]
+    )
+
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert_match_report(rv.data, snapshot)

--- a/server/tests/snapshots/snap_test_multi_winner_contest.py
+++ b/server/tests/snapshots/snap_test_multi_winner_contest.py
@@ -30,8 +30,8 @@ Jurisdiction Name,Audit Board Name,Member 1 Name,Member 1 Affiliation,Member 2 N
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,48,No,1.0,DATETIME,DATETIME,candidate 1: 24; candidate 2: 14; candidate 3: 10\r
-2,Contest 1,Targeted,72,Yes,0.0042194626,DATETIME,DATETIME,candidate 1: 50; candidate 2: 20; candidate 3: 2\r
+1,Contest 1,Targeted,48,No,1.0,DATETIME,DATETIME,candidate 1: 24; candidate 2: 14; candidate 3: 10; Ballots not found (counted for loser): 0\r
+2,Contest 1,Targeted,72,Yes,0.0042194626,DATETIME,DATETIME,candidate 1: 50; candidate 2: 20; candidate 3: 2; Ballots not found (counted for loser): 0\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Batch Name,Ballot Position,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1\r

--- a/server/tests/snapshots/snap_test_multiple_targeted_contests.py
+++ b/server/tests/snapshots/snap_test_multiple_targeted_contests.py
@@ -63,11 +63,11 @@ Jurisdiction Name,Audit Board Name,Member 1 Name,Member 1 Affiliation,Member 2 N
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
-1,Contest 1,Targeted,191,Yes,0.0000081957,DATETIME,DATETIME,candidate 1: 134; candidate 2: 57\r
-1,Contest 2,Targeted,485,No,1.0,DATETIME,DATETIME,Yes: 0; No: 0\r
-1,Contest 3,Opportunistic,,No,1.0,DATETIME,DATETIME,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
-2,Contest 2,Targeted,1468,Yes,<0.0000000001,DATETIME,DATETIME,Yes: 618; No: 274\r
-2,Contest 3,Opportunistic,,No,1.0,DATETIME,DATETIME,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
+1,Contest 1,Targeted,191,Yes,0.0000081957,DATETIME,DATETIME,candidate 1: 134; candidate 2: 57; Ballots not found (counted for loser): 0\r
+1,Contest 2,Targeted,485,No,1.0,DATETIME,DATETIME,Yes: 0; No: 0; Ballots not found (counted for loser): 0\r
+1,Contest 3,Opportunistic,,No,1.0,DATETIME,DATETIME,candidate 1: 0; candidate 2: 0; candidate 3: 0; Ballots not found (counted for loser): 0\r
+2,Contest 2,Targeted,1468,Yes,<0.0000000001,DATETIME,DATETIME,Yes: 618; No: 274; Ballots not found (counted for loser): 0\r
+2,Contest 3,Opportunistic,,No,1.0,DATETIME,DATETIME,candidate 1: 0; candidate 2: 0; candidate 3: 0; Ballots not found (counted for loser): 0\r
 \r
 ######## SAMPLED BALLOTS ########\r
 Jurisdiction Name,Batch Name,Ballot Position,Ticket Numbers: Contest 1,Ticket Numbers: Contest 2,Audited?,Audit Result: Contest 1,Audit Result: Contest 2,Audit Result: Contest 3\r


### PR DESCRIPTION
Task: #1230 

This change only applies to ballot polling audits with online data entry. We count the number of ballots not found by the audit boards and pass that into the ballot polling math, which counts those ballots as a vote for every loser. We also add a note to the audit report about not found ballots.

