### PR TITLE
Support tools: button to clear offline results

### DIFF
--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -48,7 +48,7 @@ export interface IJurisdiction extends IJurisdictionBase {
   election: IElectionBase
   jurisdictionAdmins: IJurisdictionAdmin[]
   auditBoards: IAuditBoard[]
-  recordedResultsAt: string
+  recordedResultsAt: string | null
 }
 
 export interface IJurisdictionAdmin {

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -28,6 +28,7 @@ export interface IElectionBase {
     | 'BALLOT_COMPARISON'
     | 'BATCH_COMPARISON'
     | 'HYBRID'
+  online: boolean
 }
 
 export interface IAuditAdmin {
@@ -44,8 +45,10 @@ export interface IJurisdictionBase {
 }
 
 export interface IJurisdiction extends IJurisdictionBase {
+  election: IElectionBase
   jurisdictionAdmins: IJurisdictionAdmin[]
   auditBoards: IAuditBoard[]
+  recordedResultsAt: string
 }
 
 export interface IJurisdictionAdmin {
@@ -157,6 +160,28 @@ export const useReopenAuditBoard = () => {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return useMutation<any, Error, any>(reopenAuditBoard, {
+    onSuccess: (_data, variables) =>
+      queryClient.invalidateQueries([
+        'jurisdictions',
+        variables.jurisdictionId,
+      ]),
+  })
+}
+
+export const useClearOfflineResults = () => {
+  const clearOfflineResults = async ({
+    jurisdictionId,
+  }: {
+    jurisdictionId: string
+  }) =>
+    fetchApi(`/api/support/jurisdictions/${jurisdictionId}/results`, {
+      method: 'DELETE',
+    })
+
+  const queryClient = useQueryClient()
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return useMutation<any, Error, any>(clearOfflineResults, {
     onSuccess: (_data, variables) =>
       queryClient.invalidateQueries([
         'jurisdictions',

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -133,6 +133,7 @@ def get_election(election_id: str):
         id=election.id,
         auditName=election.audit_name,
         auditType=election.audit_type,
+        online=election.online,
         jurisdictions=[
             dict(id=jurisdiction.id, name=jurisdiction.name,)
             for jurisdiction in election.jurisdictions

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -23,6 +23,7 @@ from ..config import (
     FLASK_ENV,
 )
 from ..util.jsonschema import validate
+from ..util.isoformat import isoformat
 from .rounds import get_current_round
 from .batches import already_audited_batches
 
@@ -230,7 +231,7 @@ def get_jurisdiction(jurisdiction_id: str):
             )
             for audit_board in audit_boards
         ],
-        recordedResultsAt=recorded_results_at,
+        recordedResultsAt=isoformat(recorded_results_at),
     )
 
 

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -24,6 +24,7 @@ from ..config import (
 )
 from ..util.jsonschema import validate
 from .rounds import get_current_round
+from .batches import already_audited_batches
 
 AUTH0_DOMAIN = urlparse(AUDITADMIN_AUTH0_BASE_URL).hostname
 
@@ -109,6 +110,7 @@ def get_organization(organization_id: str):
                 id=election.id,
                 auditName=election.audit_name,
                 auditType=election.audit_type,
+                online=election.online,
             )
             for election in organization.elections
         ],
@@ -186,9 +188,33 @@ def get_jurisdiction(jurisdiction_id: str):
         jurisdiction_id=jurisdiction.id, round_id=round and round.id
     )
 
+    if jurisdiction.election.audit_type == AuditType.BATCH_COMPARISON:
+        recorded_results_at = (
+            BatchResult.query.join(Batch)
+            .filter_by(jurisdiction_id=jurisdiction_id)
+            .join(SampledBatchDraw)
+            .filter_by(round_id=round and round.id)
+            .limit(1)
+            .value(BatchResult.created_at)
+        )
+    else:
+        recorded_results_at = (
+            JurisdictionResult.query.filter_by(
+                jurisdiction_id=jurisdiction.id, round_id=round and round.id
+            )
+            .limit(1)
+            .value(JurisdictionResult.created_at)
+        )
+
     return jsonify(
         id=jurisdiction.id,
         name=jurisdiction.name,
+        election=dict(
+            id=jurisdiction.election.id,
+            auditName=jurisdiction.election.audit_name,
+            auditType=jurisdiction.election.audit_type,
+            online=jurisdiction.election.online,
+        ),
         jurisdictionAdmins=sorted(
             [
                 dict(email=admin.user.email)
@@ -204,6 +230,7 @@ def get_jurisdiction(jurisdiction_id: str):
             )
             for audit_board in audit_boards
         ],
+        recordedResultsAt=recorded_results_at,
     )
 
 
@@ -250,6 +277,44 @@ def reopen_audit_board(audit_board_id: str):
         raise Conflict("Audit board has not signed off.")
 
     audit_board.signed_off_at = None
+    db_session.commit()
+
+    return jsonify(status="ok")
+
+
+@api.route("/support/jurisdictions/<jurisdiction_id>/results", methods=["DELETE"])
+@restrict_access_support
+def clear_offline_results(jurisdiction_id: str):
+    jurisdiction = get_or_404(Jurisdiction, jurisdiction_id)
+    round = get_current_round(jurisdiction.election)
+
+    if not round:
+        raise Conflict("Audit has not started.")
+    if round.ended_at:
+        raise Conflict("Can't clear results after round ends.")
+
+    if jurisdiction.election.audit_type == AuditType.BATCH_COMPARISON:
+        num_deleted = (
+            BatchResult.query.filter(
+                BatchResult.batch_id.in_(
+                    Batch.query.filter_by(jurisdiction_id=jurisdiction_id)
+                    .join(SampledBatchDraw)
+                    .filter_by(round_id=round.id)
+                    .with_entities(Batch.id)
+                    .subquery()
+                )
+            )
+            .filter(Batch.id.notin_(already_audited_batches(jurisdiction, round)))
+            .delete(synchronize_session=False)
+        )
+    else:
+        num_deleted = JurisdictionResult.query.filter_by(
+            jurisdiction_id=jurisdiction.id, round_id=round.id
+        ).delete(synchronize_session=False)
+
+    if num_deleted == 0:
+        raise Conflict("Jurisdiction doesn't have any results recorded.")
+
     db_session.commit()
 
     return jsonify(status="ok")

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -73,6 +73,7 @@ def test_support_get_election(
             "id": election_id,
             "auditName": "Test Audit test_support_get_election",
             "auditType": "BALLOT_POLLING",
+            "online": True,
             "jurisdictions": [
                 {"id": jurisdiction_ids[0], "name": "J1",},
                 {"id": jurisdiction_ids[1], "name": "J2",},

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -54,6 +54,7 @@ def test_support_get_organization(client: FlaskClient, org_id: str, election_id:
                     "id": election_id,
                     "auditName": "Test Audit test_support_get_organization",
                     "auditType": "BALLOT_POLLING",
+                    "online": False,
                 }
             ],
             "auditAdmins": [{"email": DEFAULT_AA_EMAIL}],
@@ -231,11 +232,18 @@ def test_support_get_jurisdiction(
         {
             "id": jurisdiction_ids[0],
             "name": "J1",
+            "election": {
+                "id": election_id,
+                "auditName": "Test Audit test_support_get_jurisdiction",
+                "auditType": "BALLOT_POLLING",
+                "online": True,
+            },
             "jurisdictionAdmins": [{"email": default_ja_email(election_id)}],
             "auditBoards": [
                 {"id": id, "name": f"Audit Board #{i+1}", "signedOffAt": None}
                 for i, id in enumerate(audit_board_round_1_ids)
             ],
+            "recordedResultsAt": None,
         },
     )
 
@@ -417,3 +425,123 @@ def test_support_reopen_audit_board(
     assert_ok(rv)
 
     assert AuditBoard.query.get(audit_board.id).signed_off_at is None
+
+
+# See test_batch_comparison.py for batch comparison test case
+def test_support_clear_offline_results_ballot_polling(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_ids: List[str],
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+):
+    election = Election.query.get(election_id)
+    election.online = False
+    db_session.commit()
+
+    set_support_user(client, SUPPORT_EMAIL)
+    rv = client.get(f"/api/support/jurisdictions/{jurisdiction_ids[0]}")
+    assert json.loads(rv.data)["recordedResultsAt"] is None
+
+    # Can't clear results if audit hasn't started
+    rv = client.delete(f"/api/support/jurisdictions/{jurisdiction_ids[0]}/results")
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [{"errorType": "Conflict", "message": "Audit has not started.",}]
+    }
+
+    # Start the round
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    sample_sizes = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 1,
+            "sampleSizes": {contest_ids[0]: sample_sizes[contest_ids[0]][0]},
+        },
+    )
+    assert_ok(rv)
+    rv = client.get(f"/api/election/{election_id}/round")
+    round_1_id = json.loads(rv.data)["rounds"][0]["id"]
+
+    # Can't clear results if results haven't been recorded yet
+    rv = client.delete(f"/api/support/jurisdictions/{jurisdiction_ids[0]}/results")
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Conflict",
+                "message": "Jurisdiction doesn't have any results recorded.",
+            }
+        ]
+    }
+
+    # Create audit boards and record results
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
+        [{"name": "Audit Board #1"}],
+    )
+    assert_ok(rv)
+    contests = (
+        Contest.query.filter_by(election_id=election_id)
+        .order_by(Contest.created_at)
+        .all()
+    )
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results",
+        {
+            contest.id: {choice.id: 1 for choice in contest.choices}
+            for contest in contests
+        },
+    )
+    assert_ok(rv)
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results"
+    )
+
+    rv = client.get(f"/api/support/jurisdictions/{jurisdiction_ids[0]}")
+    assert_is_date(json.loads(rv.data)["recordedResultsAt"])
+
+    # Clear results
+    rv = client.delete(f"/api/support/jurisdictions/{jurisdiction_ids[0]}/results")
+    assert_ok(rv)
+
+    contests = (
+        Contest.query.filter_by(election_id=election_id)
+        .order_by(Contest.created_at)
+        .all()
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results"
+    )
+    assert json.loads(rv.data) == {
+        contest.id: {choice.id: None for choice in contest.choices}
+        for contest in contests
+    }
+
+    rv = client.get(f"/api/support/jurisdictions/{jurisdiction_ids[0]}")
+    assert json.loads(rv.data)["recordedResultsAt"] is None
+
+    # End the round
+    election = Election.query.get(election_id)
+    end_round(election, election.rounds[0])
+
+    # Can't clear results after round ends
+    rv = client.delete(f"/api/support/jurisdictions/{jurisdiction_ids[0]}/results")
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Conflict",
+                "message": "Can't clear results after round ends.",
+            }
+        ]
+    }

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -73,7 +73,7 @@ def test_support_get_election(
             "id": election_id,
             "auditName": "Test Audit test_support_get_election",
             "auditType": "BALLOT_POLLING",
-            "online": True,
+            "online": False,
             "jurisdictions": [
                 {"id": jurisdiction_ids[0], "name": "J1",},
                 {"id": jurisdiction_ids[1], "name": "J2",},


### PR DESCRIPTION
For ballot polling audits, clear jurisdiction results. For batch comparison audits, clear batch results.


https://user-images.githubusercontent.com/530106/123299573-871b5900-d4ce-11eb-899d-887b1a6a03ea.mov

