### PR TITLE
Configure Sentry in all processes

### DIFF
--- a/server/activity_log/slack_worker.py
+++ b/server/activity_log/slack_worker.py
@@ -8,6 +8,7 @@ from ..models import ActivityLogRecord
 from ..auth.lib import UserType
 from ..database import db_session
 from . import activity_log
+from ..sentry import configure_sentry
 
 
 # pylint: disable=too-many-return-statements
@@ -314,6 +315,7 @@ def send_new_slack_notification(organization_id: str = None) -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover
+    configure_sentry()
     # We send at most one Slack notification per second, since that's what the
     # Slack API allows.
     while True:

--- a/server/app.py
+++ b/server/app.py
@@ -3,21 +3,19 @@ from flask import Flask
 from flask_talisman import Talisman
 from werkzeug.wrappers import Request
 from werkzeug.middleware.proxy_fix import ProxyFix
-import sentry_sdk
-from sentry_sdk.integrations.flask import FlaskIntegration
 
 from .config import (
     SESSION_SECRET,
     FLASK_ENV,
     DEVELOPMENT_ENVS,
     HTTP_ORIGIN,
-    SENTRY_DSN,
     STATIC_FOLDER,
 )
 from .database import init_db, db_session, engine
 from .api import api
 from .auth import auth
 from .auth.routes import oauth
+from .sentry import configure_sentry
 
 if FLASK_ENV not in DEVELOPMENT_ENVS:
     # Restrict which hosts we trust when not in dev/test. This works by causing
@@ -59,13 +57,7 @@ def shutdown_session(exception=None):  # pylint: disable=unused-argument
     db_session.remove()
 
 
-# Configure Sentry to record exceptions
-sentry_sdk.init(
-    SENTRY_DSN,
-    environment=FLASK_ENV,
-    integrations=[FlaskIntegration()],
-    traces_sample_rate=0.2,
-)
+configure_sentry()
 
 # Dispose the database engine after we're finished with app setup. (A new
 # connection will be created when requests start coming in.) This ensures that

--- a/server/sentry.py
+++ b/server/sentry.py
@@ -1,0 +1,12 @@
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+from .config import FLASK_ENV, SENTRY_DSN
+
+
+def configure_sentry():
+    sentry_sdk.init(
+        SENTRY_DSN,
+        environment=FLASK_ENV,
+        integrations=[FlaskIntegration()],
+        traces_sample_rate=0.2,
+    )

--- a/server/worker/bgcompute.py
+++ b/server/worker/bgcompute.py
@@ -9,6 +9,7 @@ from server.api.ballot_manifest import process_ballot_manifest_file
 from server.api.batch_tallies import process_batch_tallies_file
 from server.api.cvrs import process_cvr_file
 from server.worker.tasks import run_new_tasks
+from server.sentry import configure_sentry
 
 
 def bgcompute():
@@ -203,4 +204,5 @@ def bgcompute_forever():
 
 
 if __name__ == "__main__":
+    configure_sentry()
     bgcompute_forever()


### PR DESCRIPTION
`slack_worker` wasn't configuring Sentry at all, and `bgcompute` was only configuring it implicitly by importing `app`.
