### PR TITLE
Reported batch results and discrepancies in audit report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,7 @@ omit =
     scripts/*
 
 [report]
-fail_under = 98
+fail_under = 99
 precision = 2
 skip_covered = true
 show_missing = true

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -164,26 +164,6 @@ def pretty_choice_votes(
     )
 
 
-def pretty_batch_results(batch: Batch, contest: Contest) -> str:
-    return pretty_choice_votes(
-        {
-            choice.name: next(
-                (
-                    result.result
-                    for result in batch.results
-                    if result.contest_choice_id == choice.id
-                ),
-                0,
-            )
-            for choice in contest.choices
-        }
-    )
-
-
-def pretty_batch_tallies() -> str:
-    pass
-
-
 def heading(heading: str):
     return [f"######## {heading} ########"]
 

--- a/server/audit_math/macro.py
+++ b/server/audit_math/macro.py
@@ -11,21 +11,20 @@ https://papers.ssrn.com/sol3/papers.cfm?abstract_id=1443314 for the
 publication).
 """
 from decimal import Decimal, ROUND_CEILING
-from typing import Dict, Tuple, Any, TypedDict
+from typing import Dict, Tuple, Any, TypedDict, Optional, List
 from .sampler_contest import Contest
 
 
 class BatchError(TypedDict):
-    error: int
+    counted_as: int
     weighted_error: Decimal
 
 
-# TODO record negative errors in the report even though we count them as 0
 def compute_error(
     batch_results: Dict[str, Dict[str, int]],
     sampled_results: Dict[str, Dict[str, int]],
     contest: Contest,
-) -> BatchError:
+) -> Optional[BatchError]:
     """
     Computes the error in this batch
 
@@ -48,30 +47,35 @@ def compute_error(
         the maximum across-contest relative overstatement for batch p
     """
 
-    max_error = BatchError(error=0, weighted_error=Decimal(0.0))
-    margins = contest.margins
-
     if contest.name not in batch_results:
-        return max_error
+        return None
 
-    for winner in margins["winners"]:
-        for loser in margins["losers"]:
-            v_wp = batch_results[contest.name][winner]
-            v_lp = batch_results[contest.name][loser]
+    def error_for_candidate_pair(winner, loser) -> Optional[BatchError]:
+        v_wp = batch_results[contest.name][winner]
+        v_lp = batch_results[contest.name][loser]
 
-            a_wp = sampled_results[contest.name][winner]
-            a_lp = sampled_results[contest.name][loser]
+        a_wp = sampled_results[contest.name][winner]
+        a_lp = sampled_results[contest.name][loser]
 
-            V_wl = contest.candidates[winner] - contest.candidates[loser]
-            if V_wl == 0:
-                return Decimal("inf")
+        V_wl = contest.candidates[winner] - contest.candidates[loser]
+        error = (v_wp - v_lp) - (a_wp - a_lp)
+        if error == 0:
+            return None
 
-            error = (v_wp - v_lp) - (a_wp - a_lp)
-            weighted_error = Decimal(error) / Decimal(V_wl)
-            if error["weighted_error"] > max_error["weighted_error"]:
-                max_error = error
+        # Count negative errors (errors in favor of the winner) as 0 to be conservative
+        error = max(error, 0)
+        weighted_error = Decimal(error) / Decimal(V_wl) if V_wl > 0 else Decimal("inf")
+        return BatchError(counted_as=error, weighted_error=weighted_error)
 
-    return max_error
+    maybe_errors = [
+        error_for_candidate_pair(winner, loser)
+        for winner in contest.margins["winners"]
+        for loser in contest.margins["losers"]
+    ]
+    errors: List[BatchError] = [error for error in maybe_errors if error is not None]
+    if len(errors) == 0:
+        return None
+    return max(errors, key=lambda error: error["weighted_error"])
 
 
 def compute_max_error(
@@ -154,9 +158,10 @@ def compute_U(
     U = Decimal(0.0)
     for batch in reported_results:
         if batch in sample_results:
-            U += compute_error(reported_results[batch], sample_results[batch], contest)[
-                "weighted_error"
-            ]
+            error = compute_error(
+                reported_results[batch], sample_results[batch], contest
+            )
+            U += error["weighted_error"] if error else 0
         else:
             U += compute_max_error(reported_results[batch], contest)
 
@@ -283,9 +288,8 @@ def compute_risk(
     U = compute_U(reported_results, {}, contest)
 
     for batch in sample_results:
-        e_p = compute_error(reported_results[batch], sample_results[batch], contest)[
-            "weighted_error"
-        ]
+        error = compute_error(reported_results[batch], sample_results[batch], contest)
+        e_p = error["weighted_error"] if error else Decimal(0)
 
         u_p = compute_max_error(reported_results[batch], contest)
 

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -32,11 +32,11 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 1,Contest 1,Targeted,6,Yes,0.0825517715,DATETIME,DATETIME,candidate 1: 1200; candidate 2: 600; candidate 3: 600\r
 \r
 ######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Result\r
-J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250\r
-J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50\r
-J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50\r
-J2,Batch 3,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250\r
+Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Discrepancy\r
+J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,\r
+J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,\r
+J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,\r
+J2,Batch 3,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,\r
 """
 
 snapshots["test_batch_comparison_round_1 1"] = {
@@ -138,25 +138,25 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 2,Contest 1,Targeted,5,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
 \r
 ######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Result\r
-J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40\r
-J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40\r
-J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40\r
-J2,Batch 3,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 100; candidate 2: 100; candidate 3: 40\r
-J1,Batch 3,Round 2: 0.753710009967479876,No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
-J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
-J2,Batch 4,"Round 2: 0.608147659546583410, 0.868820918994249069",No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
+Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Discrepancy\r
+J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,0\r
+J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,0\r
+J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,0\r
+J2,Batch 3,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 100; candidate 2: 100; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,250\r
+J1,Batch 3,Round 2: 0.753710009967479876,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,\r
+J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,\r
+J2,Batch 4,"Round 2: 0.608147659546583410, 0.868820918994249069",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,\r
 """
 
 snapshots[
     "test_batch_comparison_round_2 9"
 ] = """######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Result\r
-J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40\r
-J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40\r
-J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40\r
-J1,Batch 3,Round 2: 0.753710009967479876,No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
-J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
+Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Discrepancy\r
+J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,0\r
+J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,0\r
+J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,0\r
+J1,Batch 3,Round 2: 0.753710009967479876,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,\r
+J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,\r
 """
 
 snapshots["test_batch_comparison_sample_size 1"] = [

--- a/server/tests/batch_comparison/snapshots/snap_test_batches.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batches.py
@@ -27,11 +27,11 @@ Batch 10,,,Audit Board #1
 snapshots[
     "test_batches_human_sort_order 2"
 ] = """######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Result\r
-J1,Batch 1 - 1,"Round 1: 0.9610467367288398089, 0.9743784458526487453",No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
-J1,Batch 1 - 10,Round 1: 0.109576900310237874,No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
-J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
-J1,Batch 10,"Round 1: 0.772049767819343419, 0.875085546411266410",No,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
+Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Discrepancy\r
+J1,Batch 1 - 1,"Round 1: 0.9610467367288398089, 0.9743784458526487453",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,\r
+J1,Batch 1 - 10,Round 1: 0.109576900310237874,No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,\r
+J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,\r
+J1,Batch 10,"Round 1: 0.772049767819343419, 0.875085546411266410",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,\r
 """
 
 snapshots["test_record_batch_results 1"] = {


### PR DESCRIPTION
Task: #1222 

Reworks `macro.compute_error` to return a `BatchError` dict so that we can return both the raw error in votes and the weighted error (mirroring what we do in `supersimple` for ballot comparison). Then adds the raw error to the audit report, along with the reported results from the batch tallies file. We count and report negative errors as 0, while batches with no error are counted as 0 but reported as blank.