### PR TITLE
Statusbox fix for batch comparison

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
@@ -340,6 +340,7 @@ describe('StatusBox', () => {
             cvrs={{ file: null, processing: null }}
             auditType="BALLOT_POLLING"
             auditName="Test Audit"
+            isAuditOnline
           />
         </Router>
       )
@@ -366,6 +367,7 @@ describe('StatusBox', () => {
             cvrs={{ file: null, processing: null }}
             auditType="BALLOT_POLLING"
             auditName="Test Audit"
+            isAuditOnline
           />
         </Router>
       )
@@ -388,6 +390,7 @@ describe('StatusBox', () => {
             cvrs={{ file: null, processing: null }}
             auditType="BALLOT_POLLING"
             auditName="Test Audit"
+            isAuditOnline
           />
         </Router>
       )
@@ -409,6 +412,7 @@ describe('StatusBox', () => {
             cvrs={{ file: null, processing: null }}
             auditType="BALLOT_POLLING"
             auditName="Test Audit"
+            isAuditOnline
           />
         </Router>
       )
@@ -430,6 +434,7 @@ describe('StatusBox', () => {
             cvrs={{ file: null, processing: null }}
             auditType="BALLOT_POLLING"
             auditName="Test Audit"
+            isAuditOnline
           />
         </Router>
       )
@@ -451,12 +456,41 @@ describe('StatusBox', () => {
             cvrs={{ file: null, processing: null }}
             auditType="BALLOT_POLLING"
             auditName="Test Audit"
+            isAuditOnline
           />
         </Router>
       )
       screen.getByText('Round 1 of the audit is in progress.')
       screen.getByText('1 of 1 audit boards complete.')
       screen.getByText('Waiting for all jurisdictions to complete Round 1.')
+    })
+
+    it('renders no audit board status if offline', async () => {
+      render(
+        <Router>
+          <JurisdictionAdminStatusBox
+            rounds={roundMocks.singleIncomplete}
+            auditBoards={auditBoardMocks.signedOff}
+            ballotManifest={{
+              file: null,
+              processing: fileProcessingMocks.processed,
+            }}
+            batchTallies={{ file: null, processing: null }}
+            cvrs={{ file: null, processing: null }}
+            auditType="BALLOT_POLLING"
+            auditName="Test Audit"
+            isAuditOnline={false}
+          />
+        </Router>
+      )
+      screen.getByText('Round 1 of the audit is in progress.')
+      screen.queryByText('1 of 1 audit boards complete.')
+      screen.getByText('Waiting for all jurisdictions to complete Round 1.')
+      await waitFor(() =>
+        expect(
+          screen.queryByText('1 of 1 audit boards complete.')
+        ).not.toBeInTheDocument()
+      )
     })
 
     it('renders completion in first round state', () => {
@@ -473,6 +507,7 @@ describe('StatusBox', () => {
             cvrs={{ file: null, processing: null }}
             auditType="BALLOT_POLLING"
             auditName="Test Audit"
+            isAuditOnline
           />
         </Router>
       )
@@ -497,6 +532,7 @@ describe('StatusBox', () => {
             cvrs={{ file: null, processing: null }}
             auditType="BALLOT_POLLING"
             auditName="Test Audit"
+            isAuditOnline
           />
         </Router>
       )
@@ -532,6 +568,7 @@ describe('StatusBox', () => {
               cvrs={{ file: null, processing: null }}
               auditType={auditType}
               auditName="Test Audit"
+              isAuditOnline
             />
           </Router>
         )
@@ -556,6 +593,7 @@ describe('StatusBox', () => {
               }}
               auditType={auditType}
               auditName="Test Audit"
+              isAuditOnline
             />
           </Router>
         )
@@ -581,6 +619,7 @@ describe('StatusBox', () => {
               }}
               auditType={auditType}
               auditName="Test Audit"
+              isAuditOnline
             />
           </Router>
         )
@@ -603,6 +642,7 @@ describe('StatusBox', () => {
             cvrs={{ file: null, processing: null }}
             auditType="BATCH_COMPARISON"
             auditName="Test Audit"
+            isAuditOnline={false}
           />
         </Router>
       )
@@ -627,6 +667,7 @@ describe('StatusBox', () => {
             cvrs={{ file: null, processing: null }}
             auditType="BATCH_COMPARISON"
             auditName="Test Audit"
+            isAuditOnline={false}
           />
         </Router>
       )
@@ -652,6 +693,7 @@ describe('StatusBox', () => {
             cvrs={{ file: null, processing: null }}
             auditType="BATCH_COMPARISON"
             auditName="Test Audit"
+            isAuditOnline={false}
           />
         </Router>
       )

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
@@ -484,7 +484,6 @@ describe('StatusBox', () => {
         </Router>
       )
       screen.getByText('Round 1 of the audit is in progress.')
-      screen.queryByText('1 of 1 audit boards complete.')
       screen.getByText('Waiting for all jurisdictions to complete Round 1.')
       await waitFor(() =>
         expect(

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
@@ -367,7 +367,7 @@ export const JurisdictionAdminStatusBox = ({
     const details = [
       `${numCompleted} of ${auditBoards.length} audit boards complete.`,
     ]
-    /* temporary fix to prevent confusion of '1 of 1 audit boards complete' message before audit boards start */
+    // Batch Comparison audits always have 0 numSampledBallots and 0 numAuditedBallots
     if (auditType === 'BATCH_COMPARISON') {
       details.pop()
     }

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
@@ -273,6 +273,7 @@ interface IJurisdictionAdminProps {
   auditType: IAuditSettings['auditType']
   children?: ReactElement
   auditName: string
+  isAuditOnline: boolean
 }
 
 export const JurisdictionAdminStatusBox = ({
@@ -284,6 +285,7 @@ export const JurisdictionAdminStatusBox = ({
   auditType,
   children,
   auditName,
+  isAuditOnline,
 }: IJurisdictionAdminProps) => {
   const { electionId, jurisdictionId } = useParams<{
     electionId: string
@@ -364,12 +366,11 @@ export const JurisdictionAdminStatusBox = ({
       ({ currentRoundStatus, signedOffAt }) =>
         currentRoundStatus.numSampledBallots === 0 || signedOffAt
     ).length
-    const details = [
-      `${numCompleted} of ${auditBoards.length} audit boards complete.`,
-    ]
-    // Batch Comparison audits always have 0 numSampledBallots and 0 numAuditedBallots
-    if (auditType === 'BATCH_COMPARISON') {
-      details.pop()
+    const details = []
+    if (isAuditOnline) {
+      details.push(
+        `${numCompleted} of ${auditBoards.length} audit boards complete.`
+      )
     }
     if (numCompleted === auditBoards.length)
       details.push(

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
@@ -367,6 +367,10 @@ export const JurisdictionAdminStatusBox = ({
     const details = [
       `${numCompleted} of ${auditBoards.length} audit boards complete.`,
     ]
+    /* temporary fix to prevent confusion of '1 of 1 audit boards complete' message before audit boards start */
+    if (auditType === 'BATCH_COMPARISON') {
+      details.pop()
+    }
     if (numCompleted === auditBoards.length)
       details.push(
         `Waiting for all jurisdictions to complete Round ${roundNum}.`

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -225,6 +225,7 @@ export const JurisdictionAdminView: React.FC = () => {
           auditBoards={auditBoards}
           auditType={auditSettings.auditType}
           auditName={auditSettings.auditName}
+          isAuditOnline={!!auditSettings.online}
         />
         <VerticalInner>
           <H2Title>Audit Source Data</H2Title>
@@ -329,6 +330,7 @@ export const JurisdictionAdminView: React.FC = () => {
         auditBoards={auditBoards}
         auditType={auditSettings.auditType}
         auditName={auditSettings.auditName}
+        isAuditOnline={!!auditSettings.online}
       />
       <Inner>
         <RoundManagement


### PR DESCRIPTION
**Description**

Closes #1238 

**Testing**

- Currently no test updates

**Notes**

So the bug was in JA login after Batch Audit is launched. Basically, for Batch Comparison, as it's about batches, the Audit Board API has numSampledBallots & numAuditedBallots both always as 0. Due to that it shows "1 of 1 Audit Boards complete."

For now, this is a frontend fix by popping "1 of 1 Audit Boards complete" from the details & not thus showing this line for Batch Comparison.

As a backend fix, we would need to update the API to calculate numSampledBallots based on total numBallots across all Batches.