### PR TITLE
CSRF protection

### DIFF
--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -1,8 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query'
-import { tryJson } from '../utilities'
+import { tryJson, addCSRFToken } from '../utilities'
 
 const fetchApi = async (url: string, options?: RequestInit) => {
-  const response = await fetch(url, options)
+  const response = await fetch(url, addCSRFToken(options))
   if (response.ok) return response.json()
   const text = await response.text()
   const { errors } = tryJson(text)

--- a/client/src/components/testUtilities.tsx
+++ b/client/src/components/testUtilities.tsx
@@ -74,11 +74,31 @@ interface FetchRequest {
   url: string
   options?: RequestInit
   response: object | null
-  skipBody?: boolean
   error?: {
     status: number
     statusText: string
   }
+}
+
+const isEqualRequestBody = (
+  body1?: BodyInit | null,
+  body2?: BodyInit | null
+) => {
+  const formDataToObject = (body?: BodyInit | null) =>
+    body instanceof FormData
+      ? Object.fromEntries(
+          [...body.entries()].map(([key, value]) => [
+            key,
+            value instanceof File
+              ? {
+                  name: value.name,
+                  type: value.type,
+                }
+              : value,
+          ])
+        )
+      : body
+  return equal(formDataToObject(body1), formDataToObject(body2))
 }
 
 export const withMockFetch = async (
@@ -86,45 +106,22 @@ export const withMockFetch = async (
   testFn: () => Promise<void>
 ) => {
   const requestsLeft = [...requests]
-  const mockFetch = jest.fn(async (url: string, options?: RequestInit) => {
+  const mockFetch = jest.fn(async (url: string, options: RequestInit = {}) => {
     const [expectedRequest] = requestsLeft.splice(0, 1)
+    const expectedOptions = expectedRequest.options || {}
     if (
       expectedRequest &&
-      expectedRequest.url === url
-      // equal(expectedRequest.options, options)
-      // (expectedRequest.skipBody || equal(expectedRequest.options, options))
+      expectedRequest.url === url &&
+      expectedOptions.method === options.method &&
+      equal(expectedOptions.headers, options.headers) &&
+      isEqualRequestBody(expectedOptions.body, options.body)
     ) {
-      if (
-        expectedRequest.options &&
-        expectedRequest.options.body instanceof FormData &&
-        options &&
-        options.body &&
-        options.body instanceof FormData
-      ) {
-        const expectedData = expectedRequest.options.body
-        const receivedData = options.body
-        // defined expectedData and receivedData here because TS won't recognize the typechecks above
-        // when expectedRequest.options.body and options.body are used in the loop
-        const fileNamesMatch: boolean = Array.from(expectedData.keys())
-          .map(key => {
-            const expectedFile = expectedData.get(key) as File // the only time we ever send a FormData is when submitting a File
-            const receivedFile = receivedData.get(key) as File
-            if (expectedFile.name === receivedFile.name) {
-              return true
-            }
-            return false
-          })
-          .every(v => v) // treating it as a list even though we only send one at a time because we don't know the key that will be used
-        if (fileNamesMatch)
-          return new Response(JSON.stringify(expectedRequest.response))
-      } else if (equal(expectedRequest.options, options)) {
-        return expectedRequest.error
-          ? new Response(
-              JSON.stringify(expectedRequest.response),
-              expectedRequest.error
-            )
-          : new Response(JSON.stringify(expectedRequest.response))
-      }
+      return expectedRequest.error
+        ? new Response(
+            JSON.stringify(expectedRequest.response),
+            expectedRequest.error
+          )
+        : new Response(JSON.stringify(expectedRequest.response))
     }
 
     if (expectedRequest) {
@@ -140,7 +137,7 @@ export const withMockFetch = async (
       // eslint-disable-next-line no-console
       console.error('Unexpected extra fetch request:\n', { url, options })
     }
-    return new Response(JSON.stringify({}))
+    return new Response(JSON.stringify(null))
   })
   window.fetch = mockFetch as typeof window.fetch
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,6 +15,9 @@ ignore_missing_imports = True
 [mypy-flask_talisman]
 ignore_missing_imports = True
 
+[mypy-flask_seasurf]
+ignore_missing_imports = True
+
 [mypy-scipy]
 ignore_missing_imports = True
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -282,6 +282,17 @@ docs = ["sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-
 dotenv = ["python-dotenv"]
 
 [[package]]
+name = "flask-seasurf"
+version = "0.3.0"
+description = "An updated CSRF extension for Flask."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Flask = "*"
+
+[[package]]
 name = "flask-talisman"
 version = "0.8.1"
 description = "HTTP security headers for Flask."
@@ -697,7 +708,7 @@ numpy = ">=1.16.5,<1.23.0"
 
 [[package]]
 name = "sentry-sdk"
-version = "1.3.0"
+version = "1.3.1"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
 optional = false
@@ -903,7 +914,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "3.8.11"
-content-hash = "82814853c9cd8708bfc0d63261e6cc9b19c91cc78b50563c1fe0169b1a9b7ed2"
+content-hash = "c7f1a9420db304b94ad99535937cb68196ac7a26bdd2279b8350e004f140eff6"
 
 [metadata.files]
 alembic = [
@@ -1097,6 +1108,10 @@ filelock = [
 flask = [
     {file = "Flask-1.1.4-py2.py3-none-any.whl", hash = "sha256:c34f04500f2cbbea882b1acb02002ad6fe6b7ffa64a6164577995657f50aed22"},
     {file = "Flask-1.1.4.tar.gz", hash = "sha256:0fbeb6180d383a9186d0d6ed954e0042ad9f18e0e8de088b2b419d526927d196"},
+]
+flask-seasurf = [
+    {file = "Flask-SeaSurf-0.3.0.tar.gz", hash = "sha256:10d4946fdd9745a8ae0a38a46c48a9add0cca4896333c0893b3133e3852c2e80"},
+    {file = "Flask_SeaSurf-0.3.0-py3-none-any.whl", hash = "sha256:505c1101e5489ef3505bb6d6bc722808ed4e6882606e07006d9914c06fb5878c"},
 ]
 flask-talisman = [
     {file = "flask-talisman-0.8.1.tar.gz", hash = "sha256:5d502ec0c51bf1755a797b8cffbe4e94f8684af712ba0b56f3d80b79277ef285"},
@@ -1442,8 +1457,8 @@ scipy = [
     {file = "scipy-1.6.3.tar.gz", hash = "sha256:a75b014d3294fce26852a9d04ea27b5671d86736beb34acdfc05859246260707"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-1.3.0.tar.gz", hash = "sha256:5210a712dd57d88d225c1fc3fe3a3626fee493637bcd54e204826cf04b8d769c"},
-    {file = "sentry_sdk-1.3.0-py2.py3-none-any.whl", hash = "sha256:6864dcb6f7dec692635e5518c2a5c80010adf673c70340817f1a1b713d65bb41"},
+    {file = "sentry-sdk-1.3.1.tar.gz", hash = "sha256:ebe99144fa9618d4b0e7617e7929b75acd905d258c3c779edcd34c0adfffe26c"},
+    {file = "sentry_sdk-1.3.1-py2.py3-none-any.whl", hash = "sha256:f33d34c886d0ba24c75ea8885a8b3a172358853c7cbde05979fc99c29ef7bc52"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ athena = {git = "https://github.com/filipzz/athena.git", rev = "v0.8.3"}
 psycopg2-binary = "~2.8.6"
 consistent-sampler = {git = "https://github.com/votingworks/consistent_sampler.git"}
 scipy = "~1.6.0"
+Flask-SeaSurf = "^0.3.0"
 
 [tool.poetry.dev-dependencies]
 filelock = "^3.0.12"

--- a/server/app.py
+++ b/server/app.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 from flask import Flask
 from flask_talisman import Talisman
+from flask_seasurf import SeaSurf
 from werkzeug.wrappers import Request
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -26,7 +27,7 @@ if FLASK_ENV not in DEVELOPMENT_ENVS:
 app = Flask("arlo", static_folder=None, template_folder=STATIC_FOLDER)
 app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore
 app.testing = FLASK_ENV == "test"
-T = Talisman(
+Talisman(
     app,
     force_https_permanent=True,
     session_cookie_http_only=True,
@@ -38,6 +39,7 @@ T = Talisman(
         "style-src": "'self' 'unsafe-inline'",
     },
 )
+csrf = SeaSurf(app)
 app.secret_key = SESSION_SECRET
 
 init_db()


### PR DESCRIPTION
Use the flask_seasurf library (recommended by the docs of flask_talisman, which we already use in Arlo) to implement CSRF protection for all POST/PUT/DELETE API endpoints using a token set in a cookie.