### PR TITLE
Minor cleanups for warnings

### DIFF
--- a/client/src/components/Atoms/AsyncButton.test.tsx
+++ b/client/src/components/Atoms/AsyncButton.test.tsx
@@ -20,7 +20,7 @@ const asyncMock = (): [
 
 describe('AsyncButton', () => {
   it('disables the button until onClick resolves', async () => {
-    const [onClickMock, resolve, _] = asyncMock()
+    const [onClickMock, resolve] = asyncMock()
     render(<AsyncButton onClick={onClickMock}>Download</AsyncButton>)
     userEvent.click(screen.getByRole('button', { name: 'Download' }))
     expect(screen.getByRole('button')).toBeDisabled()

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.test.tsx
@@ -3,11 +3,7 @@ import { fireEvent, waitFor, render, screen } from '@testing-library/react'
 import { toast } from 'react-toastify'
 import { useParams } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
-import {
-  regexpEscape,
-  withMockFetch,
-  renderWithRouter,
-} from '../../../testUtilities'
+import { regexpEscape } from '../../../testUtilities'
 import * as utilities from '../../../utilities'
 import Contests from './index'
 import relativeStages from '../_mocks'
@@ -16,7 +12,6 @@ import { numberifyContest, IContestNumbered } from '../../useContests'
 import { IJurisdiction } from '../../useJurisdictions'
 import { IContest } from '../../../../types'
 import { jurisdictionMocks } from '../../useSetupMenuItems/_mocks'
-import { aaApiCalls } from '../../_mocks'
 
 const toastSpy = jest.spyOn(toast, 'error').mockImplementation()
 const apiMock: jest.SpyInstance<

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import RoundProgress from './RoundProgress'
 import { auditBoardMocks } from '../useSetupMenuItems/_mocks'
 


### PR DESCRIPTION
**Description**

- Cleans up some unused variable lint warnings that have been in the codebase for a while but haven't gotten cleaned up yet

**Testing**

- None needed

**Progress**

- All clean now!
