### PR TITLE
Load only JA files used for audit type

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -147,7 +147,6 @@ describe('App', () => {
         jaApiCalls.getRounds([]),
         jaApiCalls.getBallotManifestFile(manifestMocks.empty),
         jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
-        jaApiCalls.getCVRSfile(cvrsMocks.empty),
       ]
       await withMockFetch(expectedCalls, async () => {
         const { container } = renderView(

--- a/client/src/components/HomeScreen.test.tsx
+++ b/client/src/components/HomeScreen.test.tsx
@@ -505,8 +505,6 @@ describe('Home screen', () => {
       jaApiCalls.getSettings(auditSettings.blank),
       jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile({ file: null, processing: null }),
-      jaApiCalls.getBatchTalliesFile({ file: null, processing: null }),
-      jaApiCalls.getCVRSfile({ file: null, processing: null }),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView('/')
@@ -575,8 +573,6 @@ describe('Home screen', () => {
       jaApiCalls.getSettings(auditSettings.blank),
       jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile({ file: null, processing: null }),
-      jaApiCalls.getBatchTalliesFile({ file: null, processing: null }),
-      jaApiCalls.getCVRSfile({ file: null, processing: null }),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView('/')

--- a/client/src/components/MultiJurisdictionAudit/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.test.tsx
@@ -419,7 +419,6 @@ describe('JA setup', () => {
       jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.empty),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
-      jaApiCalls.getCVRSfile(cvrsMocks.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -435,7 +434,6 @@ describe('JA setup', () => {
       jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.empty),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
-      jaApiCalls.getCVRSfile(cvrsMocks.empty),
       jaApiCalls.putManifest,
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
     ]
@@ -476,7 +474,6 @@ describe('JA setup', () => {
       jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.empty),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
-      jaApiCalls.getCVRSfile(cvrsMocks.empty),
       jaApiCalls.putManifest,
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
       jaApiCalls.deleteManifest,
@@ -523,7 +520,6 @@ describe('JA setup', () => {
       jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
-      jaApiCalls.getCVRSfile(cvrsMocks.empty),
       jaApiCalls.putTallies,
       jaApiCalls.getBatchTalliesFile(talliesMocks.processed),
     ]
@@ -556,7 +552,6 @@ describe('JA setup', () => {
       jaApiCalls.getSettings(auditSettings.ballotComparisonAll),
       jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
-      jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
       jaApiCalls.getCVRSfile(cvrsMocks.empty),
       jaApiCalls.putCVRs,
       jaApiCalls.getCVRSfile(cvrsMocks.processed),
@@ -591,7 +586,6 @@ describe('JA setup', () => {
       jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.empty),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
-      jaApiCalls.getCVRSfile(cvrsMocks.empty),
       jaApiCalls.putManifest,
       jaApiCalls.getBallotManifestFile(manifestMocks.errored),
     ]
@@ -630,7 +624,6 @@ describe('JA setup', () => {
       jaApiCalls.getRounds([]),
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
       jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
-      jaApiCalls.getCVRSfile(cvrsMocks.empty),
       jaApiCalls.putManifest,
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
     ]
@@ -669,8 +662,6 @@ describe('JA setup', () => {
       jaApiCalls.getSettings(auditSettings.all),
       jaApiCalls.getRounds(roundMocks.drawSampleInProgress),
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
-      jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
-      jaApiCalls.getCVRSfile(cvrsMocks.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -685,8 +676,6 @@ describe('JA setup', () => {
       jaApiCalls.getSettings(auditSettings.all),
       jaApiCalls.getRounds(roundMocks.drawSampleErrored),
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
-      jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
-      jaApiCalls.getCVRSfile(cvrsMocks.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -196,8 +196,12 @@ export const JurisdictionAdminView: React.FC = () => {
     batchTallies,
     uploadBatchTallies,
     deleteBatchTallies,
-  ] = useBatchTallies(electionId, jurisdictionId)
-  const [cvrs, uploadCVRS, deleteCVRS] = useCVRs(electionId, jurisdictionId)
+  ] = useBatchTallies(electionId, jurisdictionId, auditSettings)
+  const [cvrs, uploadCVRS, deleteCVRS] = useCVRs(
+    electionId,
+    jurisdictionId,
+    auditSettings
+  )
   const [auditBoards, createAuditBoards] = useAuditBoards(
     electionId,
     jurisdictionId,

--- a/client/src/components/MultiJurisdictionAudit/useCSV.ts
+++ b/client/src/components/MultiJurisdictionAudit/useCSV.ts
@@ -137,13 +137,27 @@ export const useBallotManifest = (electionId: string, jurisdictionId: string) =>
     'manifest'
   )
 
-export const useBatchTallies = (electionId: string, jurisdictionId: string) =>
+export const useBatchTallies = (
+  electionId: string,
+  jurisdictionId: string,
+  auditSettings: IAuditSettings | null
+) =>
   useCSV(
     `/election/${electionId}/jurisdiction/${jurisdictionId}/batch-tallies`,
-    'batchTallies'
+    'batchTallies',
+    !!auditSettings && auditSettings.auditType === 'BATCH_COMPARISON'
   )
 
-export const useCVRs = (electionId: string, jurisdictionId: string) =>
-  useCSV(`/election/${electionId}/jurisdiction/${jurisdictionId}/cvrs`, 'cvrs')
-
+export const useCVRs = (
+  electionId: string,
+  jurisdictionId: string,
+  auditSettings: IAuditSettings | null
+) =>
+  useCSV(
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/cvrs`,
+    'cvrs',
+    !!auditSettings &&
+      (auditSettings.auditType === 'BALLOT_COMPARISON' ||
+        auditSettings.auditType === 'HYBRID')
+  )
 export default useCSV


### PR DESCRIPTION
Previously we tried loading the ballot manifest, batch tallies, and CVRs for all audit types. This removes unnecessary API calls to load files that don't apply for a specific audit type.
