### PR TITLE
Reload files on frontend after reprocessing

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Participants/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Participants/_mocks.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
 
-const jurisdictionFile = new File(
+export const jurisdictionFile = new File(
   [
     readFileSync(
       join(

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Participants/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Participants/index.tsx
@@ -27,7 +27,7 @@ const Participants: React.FC<IProps> = ({ nextStage, refresh }: IProps) => {
   const [
     standardizedContestsFile,
     uploadStandardizedContestsFile,
-  ] = useStandardizedContestsFile(electionId, auditSettings)
+  ] = useStandardizedContestsFile(electionId, auditSettings, jurisdictionsFile)
 
   // Once the file uploads are complete, we need to notify the setupMenuItems to
   // refresh and unlock the next stage.

--- a/client/src/components/MultiJurisdictionAudit/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.tsx
@@ -196,11 +196,12 @@ export const JurisdictionAdminView: React.FC = () => {
     batchTallies,
     uploadBatchTallies,
     deleteBatchTallies,
-  ] = useBatchTallies(electionId, jurisdictionId, auditSettings)
+  ] = useBatchTallies(electionId, jurisdictionId, auditSettings, ballotManifest)
   const [cvrs, uploadCVRS, deleteCVRS] = useCVRs(
     electionId,
     jurisdictionId,
-    auditSettings
+    auditSettings,
+    ballotManifest
   )
   const [auditBoards, createAuditBoards] = useAuditBoards(
     electionId,

--- a/client/src/components/MultiJurisdictionAudit/useCSV.ts
+++ b/client/src/components/MultiJurisdictionAudit/useCSV.ts
@@ -54,7 +54,8 @@ const deleteCSVFile = async (url: string): Promise<boolean> => {
 const useCSV = (
   url: string,
   formKey: string,
-  shouldFetch: boolean = true
+  shouldFetch: boolean = true,
+  dependencyFile?: IFileInfo | null
 ): [
   IFileInfo | null,
   (csv: File) => Promise<boolean>,
@@ -64,9 +65,14 @@ const useCSV = (
 
   useEffect(() => {
     ;(async () => {
-      setCSV(await loadCSVFile(url, shouldFetch))
+      // Reload this file whenever a file it depends finishes processing. This is
+      // useful when one file gets reprocessed on the backend after its dependency
+      // processes (e.g. CVR depends on ballot manifest).
+      if (dependencyFile === undefined || dependencyFile) {
+        setCSV(await loadCSVFile(url, shouldFetch))
+      }
     })()
-  }, [url, shouldFetch])
+  }, [url, shouldFetch, dependencyFile])
 
   const uploadCSV = async (csvFile: File): Promise<boolean> => {
     if (!shouldFetch) return false
@@ -118,14 +124,16 @@ export const useJurisdictionsFile = (
 
 export const useStandardizedContestsFile = (
   electionId: string,
-  auditSettings: IAuditSettings | null
+  auditSettings: IAuditSettings | null,
+  jurisdictionsFile?: IFileInfo | null
 ): [IFileInfo | null, (csv: File) => Promise<boolean>] => {
   const [csv, uploadCSV] = useCSV(
     `/election/${electionId}/standardized-contests/file`,
     'standardized-contests',
     !!auditSettings &&
       (auditSettings.auditType === 'BALLOT_COMPARISON' ||
-        auditSettings.auditType === 'HYBRID')
+        auditSettings.auditType === 'HYBRID'),
+    jurisdictionsFile
   )
   // Delete not supported
   return [csv, uploadCSV]
@@ -140,24 +148,28 @@ export const useBallotManifest = (electionId: string, jurisdictionId: string) =>
 export const useBatchTallies = (
   electionId: string,
   jurisdictionId: string,
-  auditSettings: IAuditSettings | null
+  auditSettings: IAuditSettings | null,
+  ballotManifest: IFileInfo | null
 ) =>
   useCSV(
     `/election/${electionId}/jurisdiction/${jurisdictionId}/batch-tallies`,
     'batchTallies',
-    !!auditSettings && auditSettings.auditType === 'BATCH_COMPARISON'
+    !!auditSettings && auditSettings.auditType === 'BATCH_COMPARISON',
+    ballotManifest
   )
 
 export const useCVRs = (
   electionId: string,
   jurisdictionId: string,
-  auditSettings: IAuditSettings | null
+  auditSettings: IAuditSettings | null,
+  ballotManifest: IFileInfo | null
 ) =>
   useCSV(
     `/election/${electionId}/jurisdiction/${jurisdictionId}/cvrs`,
     'cvrs',
     !!auditSettings &&
       (auditSettings.auditType === 'BALLOT_COMPARISON' ||
-        auditSettings.auditType === 'HYBRID')
+        auditSettings.auditType === 'HYBRID'),
+    ballotManifest
   )
 export default useCSV

--- a/client/src/components/MultiJurisdictionAudit/useCSV.ts
+++ b/client/src/components/MultiJurisdictionAudit/useCSV.ts
@@ -68,7 +68,7 @@ const useCSV = (
       // Reload this file whenever a file it depends finishes processing. This is
       // useful when one file gets reprocessed on the backend after its dependency
       // processes (e.g. CVR depends on ballot manifest).
-      if (dependencyFile === undefined || dependencyFile) {
+      if (dependencyFile !== null) {
         setCSV(await loadCSVFile(url, shouldFetch))
       }
     })()


### PR DESCRIPTION
Task: #1262 

After a file gets reprocessed due to a file it depends on being changed, we need to reload that file to see what happened (specifically, we need to show errors).