### PR TITLE
Store Cypress screenshots/videos in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,10 @@ jobs:
           name: cypress
           command: |
             ./client/run-cypress-tests.sh
+      - store_artifacts:
+          path: client/cypress/screenshots
+      - store_artifacts:
+          path: client/cypress/videos
 workflows:
   version: 2
   build-and-test:


### PR DESCRIPTION
On test failures, Cypress produces screenshots and videos of the test run. We store these as artifacts in CircleCI so that we can go see what happened.