### PR TITLE
Record user info in file upload activity

### DIFF
--- a/server/activity_log/slack_worker.py
+++ b/server/activity_log/slack_worker.py
@@ -197,6 +197,7 @@ def slack_message(activity: activity_log.Activity):
                                 jurisdiction_context,
                                 audit_context,
                                 time_context,
+                                user_context,
                             ],
                         ),
                     ],

--- a/server/tests/api/test_activity.py
+++ b/server/tests/api/test_activity.py
@@ -101,9 +101,6 @@ def test_list_activities(
                     "jurisdiction_name": "J2",
                 },
                 "timestamp": assert_is_date,
-                # Note that in non-test environments, file uploads happen in the
-                # background, so we don't have a user session to pull this info
-                # from, and "user" is None. But we can't easily simulate that in test.
                 "user": {
                     "key": default_ja_email(election_id),
                     "supportUser": None,

--- a/server/tests/snapshots/snap_test_slack_worker.py
+++ b/server/tests/snapshots/snap_test_slack_worker.py
@@ -330,6 +330,10 @@ snapshots["test_slack_worker_message_format 7"] = {
                     "text": ":clock3: <!date^1621449073^{date_short}, {time_secs}|2021-05-19T18:31:13.576657+00:00>",
                     "type": "mrkdwn",
                 },
+                {
+                    "text": ":technologist: Jurisdiction admin test_user@example.com",
+                    "type": "mrkdwn",
+                },
             ],
             "type": "context",
         },
@@ -368,6 +372,10 @@ snapshots["test_slack_worker_message_format 8"] = {
                     "text": ":clock3: <!date^1621449073^{date_short}, {time_secs}|2021-05-19T18:31:13.576657+00:00>",
                     "type": "mrkdwn",
                 },
+                {
+                    "text": ":technologist: Jurisdiction admin test_user@example.com",
+                    "type": "mrkdwn",
+                },
             ],
             "type": "context",
         },
@@ -400,6 +408,10 @@ snapshots["test_slack_worker_message_format 9"] = {
                 },
                 {
                     "text": ":clock3: <!date^1621449073^{date_short}, {time_secs}|2021-05-19T18:31:13.576657+00:00>",
+                    "type": "mrkdwn",
+                },
+                {
+                    "text": ":technologist: Jurisdiction admin test_user@example.com",
                     "type": "mrkdwn",
                 },
             ],

--- a/server/tests/test_slack_worker.py
+++ b/server/tests/test_slack_worker.py
@@ -166,7 +166,7 @@ def test_slack_worker_message_format(snapshot):
         slack_worker.slack_message(activity_log.CalculateSampleSizes(timestamp, base))
     )
 
-    base.user_type = None
+    base.user_type = "jurisdiction_admin"
     snapshot.assert_match(
         slack_worker.slack_message(
             activity_log.UploadFile(


### PR DESCRIPTION
Since file uploads happen in the background worker, they don't have access to the session of the request that initiated the upload, so when recording the file upload activity, they couldn't report which user uploaded the file. To fix this, we pass the user info in as arguments to the background task.