### PR TITLE
Retry cypress/client tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,11 @@ jobs:
           name: test client
           command: |
             make test-client
+      - run:
+          name: test client second attempt
+          command: |
+            make test-client
+          when: on_fail
 
   cypress:
     executor: arlo
@@ -182,6 +187,11 @@ jobs:
           name: cypress
           command: |
             ./client/run-cypress-tests.sh
+      - run:
+          name: cypress second attempt
+          command: |
+            ./client/run-cypress-tests.sh
+          when: on_fail
       - store_artifacts:
           path: client/cypress/screenshots
       - store_artifacts:


### PR DESCRIPTION
While it would be nice to be able to resolve all test flakiness, it's proving very difficult. This change adds a single retry to the cypress and client tests (which have been the most flaky). That way, a test suite has to fail twice in a row to register as a failure.