### PR TITLE
Delete unused CvrBallots after audit completes

### DIFF
--- a/scripts/delete-unused-cvr-ballots.py
+++ b/scripts/delete-unused-cvr-ballots.py
@@ -1,0 +1,26 @@
+# pylint: disable=invalid-name
+from server.models import Election, AuditType
+from server.api.rounds import (
+    delete_unsampled_cvrs,
+    get_current_round,
+    is_audit_complete,
+)
+from server.database import db_session
+
+orgs = set()
+if __name__ == "__main__":
+    for election in Election.query.all():
+        round = get_current_round(election)
+        if election.audit_type in [AuditType.BALLOT_COMPARISON, AuditType.HYBRID]:
+            if round and is_audit_complete(round):
+                print(f"Deleting CVRs for {election.audit_name}")
+                print(delete_unsampled_cvrs(election))
+            print(f"Audit not complete: {election.audit_name}")
+            orgs.add(election.organization.name)
+        else:
+            print(f"Skipping {election.audit_name}")
+            continue
+    db_session.commit()
+    for org in orgs:
+        print(org)
+    # print("Done!")

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -20,6 +20,59 @@ TABULATOR2,BATCH2,5,2-2-6,0.442956417641278897,N,Audit Board #1
 TABULATOR2,BATCH2,6,,0.300053574780458718,N,Audit Board #1
 """
 
+snapshots[
+    "test_ballot_comparison_delete_unused_cvr_ballots 1"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+Test Org test_ballot_comparison_delete_unused_cvr_ballots,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
+Contest 1,Targeted,1,1,30,Choice 1-1: 12; Choice 1-2: 8\r
+Contest 2,Opportunistic,1,2,30,Choice 2-1: 28; Choice 2-2: 12; Choice 2-3: 16\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_ballot_comparison_delete_unused_cvr_ballots,BALLOT_COMPARISON,SUPERSIMPLE,10%,1234567890,Yes\r
+\r
+######## AUDIT BOARDS ########\r
+Jurisdiction Name,Audit Board Name,Member 1 Name,Member 1 Affiliation,Member 2 Name,Member 2 Affiliation\r
+J1,Audit Board #1,,,,\r
+J2,Audit Board #1,,,,\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
+1,Contest 1,Targeted,40,Yes,0.0704761854,DATETIME,DATETIME,Choice 1-1: 16; Choice 1-2: 11\r
+1,Contest 2,Opportunistic,,Yes,0.005910626,DATETIME,DATETIME,Choice 2-1: 24; Choice 2-2: 9; Choice 2-3: 17\r
+\r
+######## SAMPLED BALLOTS ########\r
+Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Discrepancy: Contest 2\r
+J1,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.243550726331576894,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J1,TABULATOR1,BATCH1,2,1-1-2,Round 1: 0.658361514845611561,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR1,BATCH2,2,1-2-2,Round 1: 0.125871889047705889,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J1,TABULATOR1,BATCH2,3,1-2-3,"Round 1: 0.126622033568908859, 0.570682515619614792",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH1,2,2-1-2,Round 1: 0.651118570553261125,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.607927957276839128,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.053992217600758631, 0.528652598036440834",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,3,2-2-3,Round 1: 0.255119157791673311,AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,4,2-2-4,"Round 1: 0.064984443990590400, 0.069414660569975443, 0.662654312843285447",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.442956417641278897, 0.492638838970333256",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J1,TABULATOR2,BATCH2,6,2-2-6,"Round 1: 0.300053574780458718, 0.539920212714138536, 0.614239889448737812",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J2,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.476019554092109137,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR1,BATCH1,2,1-1-2,"Round 1: 0.511105635717372621, 0.583472201399663519",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J2,TABULATOR1,BATCH1,3,1-1-3,Round 1: 0.242392535590495322,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR1,BATCH2,1,1-2-1,"Round 1: 0.200269401620671924, 0.588219390083415326",AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J2,TABULATOR1,BATCH2,3,1-2-3,Round 1: 0.556310137163677574,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J2,TABULATOR2,BATCH1,1,2-1-1,"Round 1: 0.174827909206366766, 0.638759896009674755, 0.666161104573622944",AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH1,2,2-1-2,Round 1: 0.677864268646804078,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J2,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.185417954749015145,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",\r
+J2,TABULATOR2,BATCH2,3,2-2-3,"Round 1: 0.179114059650472941, 0.443867094961314498, 0.553767880261132538",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J2,TABULATOR2,BATCH2,4,2-2-4,"Round 1: 0.583133559190710795, 0.685610948371080498",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J2,TABULATOR2,BATCH2,5,2-2-5,"Round 1: 0.462119987445142117, 0.593645562906652185",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J2,TABULATOR2,BATCH2,6,2-2-6,Round 1: 0.414184312862040881,AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+"""
+
 snapshots["test_ballot_comparison_multiple_targeted_contests_sample_size 1"] = [
     ({"key": "supersimple", "prob": None, "size": 30},)
 ]

--- a/server/tests/hybrid/snapshots/snap_test_hybrid.py
+++ b/server/tests/hybrid/snapshots/snap_test_hybrid.py
@@ -8,6 +8,55 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots[
+    "test_hybrid_delete_unused_cvrs 1"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+Test Org test_hybrid_delete_unused_cvrs,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes,Total Ballots Cast: CVR,Total Ballots Cast: Non-CVR,Tabulated Votes: CVR,Tabulated Votes: Non-CVR\r
+Contest 1,Targeted,1,1,50,Choice 1-1: 30; Choice 1-2: 10,30,20,Choice 1-1: 12; Choice 1-2: 8,Choice 1-1: 18; Choice 1-2: 2\r
+Contest 2,Opportunistic,2,2,25,Choice 2-1: 20; Choice 2-2: 8; Choice 2-3: 10,15,10,Choice 2-1: 14; Choice 2-2: 6; Choice 2-3: 8,Choice 2-1: 6; Choice 2-2: 2; Choice 2-3: 2\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_hybrid_delete_unused_cvrs,HYBRID,SUITE,10%,1234567890,Yes\r
+\r
+######## AUDIT BOARDS ########\r
+Jurisdiction Name,Audit Board Name,Member 1 Name,Member 1 Affiliation,Member 2 Name,Member 2 Affiliation\r
+J1,Audit Board #1,,,,\r
+J2,Audit Board #1,,,,\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Audited Votes: CVR,Audited Votes: Non CVR\r
+1,Contest 1,Targeted,22,Yes,0.0842758286,DATETIME,DATETIME,Choice 1-1: 12; Choice 1-2: 7,Choice 1-1: 5; Choice 1-2: 6,Choice 1-1: 7; Choice 1-2: 1\r
+1,Contest 2,Opportunistic,,No,1.0,DATETIME,DATETIME,Choice 2-1: 10; Choice 2-2: 4; Choice 2-3: 4,Choice 2-1: 6; Choice 2-2: 3; Choice 2-3: 4,Choice 2-1: 4; Choice 2-2: 1; Choice 2-3: 0\r
+\r
+######## SAMPLED BALLOTS ########\r
+Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Discrepancy: Contest 2\r
+J1,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.243550726331576894,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J1,TABULATOR1,BATCH2,2,1-2-2,Round 1: 0.125871889047705889,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",\r
+J1,TABULATOR1,BATCH2,3,1-2-3,Round 1: 0.126622033568908859,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,2,2-2-2,Round 1: 0.053992217600758631,AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,3,2-2-3,Round 1: 0.255119157791673311,AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR2,BATCH2,4,2-2-4,"Round 1: 0.064984443990590400, 0.069414660569975443",AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",\r
+J1,TABULATOR3,BATCH1,1,,Round 1: 0.029052899542529576,AUDITED,Choice 1-1,,,Choice 2-1,,\r
+J1,TABULATOR3,BATCH1,2,,Round 1: 0.078395302081543460,AUDITED,Choice 1-1,,,Choice 2-1,,\r
+J1,TABULATOR3,BATCH1,3,,Round 1: 0.041030221525069793,AUDITED,Choice 1-1,,,Choice 2-1,,\r
+J1,TABULATOR3,BATCH1,5,,Round 1: 0.072664791498577026,AUDITED,Choice 1-1,,,Choice 2-1,,\r
+J1,TABULATOR3,BATCH1,10,,Round 1: 0.199742518299743122,AUDITED,Choice 1-1,,,Choice 2-2,,\r
+J2,TABULATOR1,BATCH1,3,1-1-3,Round 1: 0.242392535590495322,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2",,\r
+J2,TABULATOR1,BATCH2,1,1-2-1,Round 1: 0.200269401620671924,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3",,\r
+J2,TABULATOR2,BATCH1,1,2-1-1,Round 1: 0.174827909206366766,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2",,\r
+J2,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.185417954749015145,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3",,\r
+J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2, Choice 2-3",,\r
+J2,TABULATOR2,BATCH2,3,2-2-3,Round 1: 0.179114059650472941,AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3",,\r
+J2,TABULATOR3,BATCH1,1,,Round 1: 0.052129356711674929,AUDITED,Choice 1-1,,,CONTEST_NOT_ON_BALLOT,,\r
+J2,TABULATOR3,BATCH1,5,,Round 1: 0.037027823153316024,AUDITED,Choice 1-1,,,CONTEST_NOT_ON_BALLOT,,\r
+J2,TABULATOR3,BATCH1,10,,Round 1: 0.087764767095634400,AUDITED,Choice 1-2,,,CONTEST_NOT_ON_BALLOT,,\r
+"""
+
+snapshots[
     "test_hybrid_two_rounds 1"
 ] = """Tabulator,Batch Name,Ballot Number,Imprinted ID,Ticket Numbers,Already Audited,Audit Board
 TABULATOR1,BATCH1,1,1-1-1,0.243550726331576894,N,Audit Board #1


### PR DESCRIPTION
During a ballot comparison or hybrid audit, we need every record from the CVRs on hand in the database in case the corresponding ballot gets sampled. Once the audit completes, we only need the CVRs for the ballots that got sampled. In this change, at the end of the audit, we delete all CvrBallots that don't correspond to a sampled ballot. Since CvrBallots are the largest use of database storage by an order of magnitude, this will hopefully significantly slow database growth.