### PR TITLE
Bugfix: load audits separately from user data

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -8,11 +8,11 @@ import {
   auditSettings,
   manifestMocks,
   talliesMocks,
-  cvrsMocks,
 } from './components/MultiJurisdictionAudit/useSetupMenuItems/_mocks'
 import {
   jaApiCalls,
   aaApiCalls,
+  mockOrganizations,
 } from './components/MultiJurisdictionAudit/_mocks'
 
 jest.unmock('react-toastify')
@@ -56,7 +56,10 @@ describe('App', () => {
     })
 
     it('renders aa logged in properly', async () => {
-      const expectedCalls = [aaApiCalls.getUser, aaApiCalls.getUser]
+      const expectedCalls = [
+        aaApiCalls.getUser,
+        aaApiCalls.getOrganizations(mockOrganizations.oneOrgNoAudits),
+      ]
       await withMockFetch(expectedCalls, async () => {
         const { container } = renderView('/')
         expect(
@@ -99,7 +102,10 @@ describe('App', () => {
     })
 
     it('renders aa logged in properly', async () => {
-      const expectedCalls = [aaApiCalls.getUser, aaApiCalls.getUser]
+      const expectedCalls = [
+        aaApiCalls.getUser,
+        aaApiCalls.getOrganizations(mockOrganizations.oneOrgNoAudits),
+      ]
       await withMockFetch(expectedCalls, async () => {
         const { container } = renderView(
           '/election/1/audit-board/audit-board-1'
@@ -160,7 +166,10 @@ describe('App', () => {
     })
 
     it('renders aa logged in properly', async () => {
-      const expectedCalls = [aaApiCalls.getUser, aaApiCalls.getUser]
+      const expectedCalls = [
+        aaApiCalls.getUser,
+        aaApiCalls.getOrganizations(mockOrganizations.oneOrgNoAudits),
+      ]
       await withMockFetch(expectedCalls, async () => {
         const { container } = renderView(
           '/election/1/jurisdiction/jurisdiction-id-1'

--- a/client/src/__snapshots__/App.test.tsx.snap
+++ b/client/src/__snapshots__/App.test.tsx.snap
@@ -153,21 +153,17 @@ exports[`App / renders aa logged in properly 1`] = `
         class="sc-bwzfXH jiphYj"
       >
         <div
-          style="width: 50%;"
+          style="width: 50%; padding: 30px 30px 30px 0px;"
         >
-          <div
-            class="sc-cmthru ibpZkp"
-          >
-            <div>
-              <h2>
-                Audits - 
-                State of California
-              </h2>
-              <p>
-                You haven't created any audits yet for 
-                State of California
-              </p>
-            </div>
+          <div>
+            <h2>
+              Audits - 
+              State of California
+            </h2>
+            <p>
+              You haven't created any audits yet for 
+              State of California
+            </p>
           </div>
         </div>
         <div
@@ -637,21 +633,17 @@ exports[`App /election/:electionId/audit-board/:auditBoardId renders aa logged i
         class="sc-bwzfXH jiphYj"
       >
         <div
-          style="width: 50%;"
+          style="width: 50%; padding: 30px 30px 30px 0px;"
         >
-          <div
-            class="sc-cmthru ibpZkp"
-          >
-            <div>
-              <h2>
-                Audits - 
-                State of California
-              </h2>
-              <p>
-                You haven't created any audits yet for 
-                State of California
-              </p>
-            </div>
+          <div>
+            <h2>
+              Audits - 
+              State of California
+            </h2>
+            <p>
+              You haven't created any audits yet for 
+              State of California
+            </p>
           </div>
         </div>
         <div
@@ -1440,21 +1432,17 @@ exports[`App /election/:electionId/jurisdiction/:jurisdictionId renders aa logge
         class="sc-bwzfXH jiphYj"
       >
         <div
-          style="width: 50%;"
+          style="width: 50%; padding: 30px 30px 30px 0px;"
         >
-          <div
-            class="sc-cmthru ibpZkp"
-          >
-            <div>
-              <h2>
-                Audits - 
-                State of California
-              </h2>
-              <p>
-                You haven't created any audits yet for 
-                State of California
-              </p>
-            </div>
+          <div>
+            <h2>
+              Audits - 
+              State of California
+            </h2>
+            <p>
+              You haven't created any audits yet for 
+              State of California
+            </p>
           </div>
         </div>
         <div

--- a/client/src/components/Header.test.tsx
+++ b/client/src/components/Header.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { screen, within } from '@testing-library/react'
+import { screen, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Header from './Header'
 import AuthDataProvider from './UserContext'
@@ -24,6 +24,11 @@ describe('Header', () => {
     const expectedCalls = [apiCalls.unauthenticatedUser]
     await withMockFetch(expectedCalls, async () => {
       renderHeader('/')
+      // Since the header renders the exact same thing when loading the user
+      // data vs when there is no authenticated user, we wait to make sure the
+      // api request completes by hackily checking to see when the expected
+      // calls are consumed.
+      await waitFor(() => expectedCalls.length === 0)
 
       // Arlo logo
       const arloLogo = screen.getAllByRole('link', {
@@ -88,7 +93,7 @@ describe('Header', () => {
   })
 
   it('shows navigation buttons when authenticated on audit screens', async () => {
-    const expectedCalls = [aaApiCalls.getUserWithAudit]
+    const expectedCalls = [aaApiCalls.getUser]
     await withMockFetch(expectedCalls, async () => {
       renderHeader('/election/1')
 

--- a/client/src/components/HomeScreen.test.tsx
+++ b/client/src/components/HomeScreen.test.tsx
@@ -7,6 +7,7 @@ import {
   aaApiCalls,
   jaApiCalls,
   apiCalls,
+  mockOrganizations,
 } from './MultiJurisdictionAudit/_mocks'
 import { auditSettings } from './MultiJurisdictionAudit/useSetupMenuItems/_mocks'
 
@@ -129,6 +130,9 @@ describe('Home screen', () => {
       )
       let toast = await screen.findByRole('alert')
       expect(toast).toHaveTextContent('Internal error')
+      userEvent.click(
+        within(toast.parentElement!).getByRole('button', { name: 'close' })
+      )
 
       // Navigate to form to submit code
       userEvent.click(
@@ -160,6 +164,9 @@ describe('Home screen', () => {
       )
       toast = await screen.findByRole('alert')
       expect(toast).toHaveTextContent('Internal error')
+      userEvent.click(
+        within(toast.parentElement!).getByRole('button', { name: 'close' })
+      )
 
       // Click back button to request a new code
       userEvent.click(
@@ -168,6 +175,10 @@ describe('Home screen', () => {
         })
       )
       screen.getByLabelText('Enter your email to log in:')
+
+      await waitFor(() =>
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      )
     })
   })
 
@@ -184,7 +195,7 @@ describe('Home screen', () => {
   it('shows a list of audits and create audit form for audit admins', async () => {
     const expectedCalls = [
       aaApiCalls.getUser,
-      aaApiCalls.getUser, // Extra call to load the list of audits
+      aaApiCalls.getOrganizations(mockOrganizations.oneOrgNoAudits),
       aaApiCalls.postNewAudit({
         organizationId: 'org-id',
         auditName: 'November Presidential Election 2020',
@@ -197,7 +208,7 @@ describe('Home screen', () => {
       ...setupScreenCalls,
       aaApiCalls.getSettings(auditSettings.blank),
       aaApiCalls.getJurisdictionFile,
-      aaApiCalls.getUserWithAudit,
+      aaApiCalls.getOrganizations(mockOrganizations.oneOrgOneAudit),
       ...setupScreenCalls,
       aaApiCalls.getJurisdictionFile,
       aaApiCalls.getRounds([]),
@@ -255,8 +266,8 @@ describe('Home screen', () => {
 
   it('shows a list of audits and create audit form for audit admins with multiple orgs', async () => {
     const expectedCalls = [
-      aaApiCalls.getUserMultipleOrgs,
-      aaApiCalls.getUserMultipleOrgs,
+      aaApiCalls.getUser,
+      aaApiCalls.getOrganizations(mockOrganizations.twoOrgs),
       aaApiCalls.postNewAudit({
         organizationId: 'org-id-2',
         auditName: 'Presidential Primary',
@@ -319,10 +330,10 @@ describe('Home screen', () => {
 
   it('deletes an audit', async () => {
     const expectedCalls = [
-      aaApiCalls.getUserWithAudit,
-      aaApiCalls.getUserWithAudit, // Extra call to load the list of audits
-      aaApiCalls.deleteAudit,
       aaApiCalls.getUser,
+      aaApiCalls.getOrganizations(mockOrganizations.oneOrgOneAudit),
+      aaApiCalls.deleteAudit,
+      aaApiCalls.getOrganizations(mockOrganizations.oneOrgNoAudits),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView('/')
@@ -352,8 +363,8 @@ describe('Home screen', () => {
 
   it('should not delete audit when cancelled', async () => {
     const expectedCalls = [
-      aaApiCalls.getUserWithAudit,
-      aaApiCalls.getUserWithAudit, // Extra call to load the list of audits
+      aaApiCalls.getUser,
+      aaApiCalls.getOrganizations(mockOrganizations.oneOrgOneAudit),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView('/')
@@ -384,7 +395,7 @@ describe('Home screen', () => {
   it('creates batch comparison audits', async () => {
     const expectedCalls = [
       aaApiCalls.getUser,
-      aaApiCalls.getUser, // Extra call to load the list of audits
+      aaApiCalls.getOrganizations(mockOrganizations.oneOrgOneAudit),
       aaApiCalls.postNewAudit({
         organizationId: 'org-id',
         auditName: 'November Presidential Election 2020',
@@ -422,7 +433,7 @@ describe('Home screen', () => {
   it('creates ballot comparison audits', async () => {
     const expectedCalls = [
       aaApiCalls.getUser,
-      aaApiCalls.getUser, // Extra call to load the list of audits
+      aaApiCalls.getOrganizations(mockOrganizations.oneOrgNoAudits),
       aaApiCalls.postNewAudit({
         organizationId: 'org-id',
         auditName: 'November Presidential Election 2020',
@@ -460,7 +471,7 @@ describe('Home screen', () => {
   it('creates hybrid audits', async () => {
     const expectedCalls = [
       aaApiCalls.getUser,
-      aaApiCalls.getUser, // Extra call to load the list of audits
+      aaApiCalls.getOrganizations(mockOrganizations.oneOrgNoAudits),
       aaApiCalls.postNewAudit({
         organizationId: 'org-id',
         auditName: 'November Presidential Election 2020',

--- a/client/src/components/HomeScreen.tsx
+++ b/client/src/components/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import {
   Card,
   RadioGroup,
@@ -15,13 +15,14 @@ import styled from 'styled-components'
 import { Formik, FormikProps, Field } from 'formik'
 import { useForm } from 'react-hook-form'
 import { toast } from 'react-toastify'
+import { useQuery, useMutation, useQueryClient } from 'react-query'
 import {
   useAuthDataContext,
-  IAuditAdmin,
   IJurisdictionAdmin,
   IElection,
+  IOrganization,
 } from './UserContext'
-import { api, parseApiError, addCSRFToken } from './utilities'
+import { parseApiError, addCSRFToken } from './utilities'
 import LinkButton from './Atoms/LinkButton'
 import FormSection from './Atoms/Form/FormSection'
 import FormButton from './Atoms/Form/FormButton'
@@ -31,6 +32,7 @@ import { groupBy, sortBy } from '../utils/array'
 import { IAuditSettings } from './MultiJurisdictionAudit/useAuditSettings'
 import { useConfirm, Confirm } from './Atoms/Confirm'
 import { ErrorLabel } from './Atoms/Form/_helpers'
+import { fetchApi } from './SupportTools/support-api'
 
 const HomeScreen: React.FC = () => {
   const auth = useAuthDataContext()
@@ -45,12 +47,7 @@ const HomeScreen: React.FC = () => {
       return (
         <Wrapper>
           <Inner>
-            <div style={{ width: '50%' }}>
-              <ListAuditsAuditAdmin />
-            </div>
-            <div style={{ width: '50%' }}>
-              <CreateAudit user={user} />
-            </div>
+            <AuditAdminHomeScreen />
           </Inner>
         </Wrapper>
       )
@@ -243,31 +240,21 @@ const LoginScreen: React.FC = () => {
   )
 }
 
-const ListAuditsWrapper = styled.div`
-  padding: 30px 30px 30px 0;
-`
-
-const ListAuditsAuditAdmin: React.FC = () => {
-  // Normally, we would use useAuthDataContext to get the audit admin's metadata
-  // (including the list of audits). However, since this screen also is
-  // responsible for creating audits, we need to make sure the list of audits
-  // reloads when we create a new audit. So we load the user's data fresh every
-  // time this component renders. It's a bit hacky and inefficient, but this is
-  // the only screen that should have this issue. A better solution might be to
-  // decouple loading the list of audits from loading the user data.
-  const [user, setUser] = useState<IAuditAdmin | null>(null)
+const AuditAdminHomeScreen = () => {
+  const queryClient = useQueryClient()
+  const organizations = useQuery<IOrganization[]>('orgs', () =>
+    fetchApi(`/api/organizations`)
+  )
+  const deleteElection = useMutation(
+    ({ electionId }: { electionId: string }) =>
+      fetchApi(`/api/election/${electionId}`, {
+        method: 'DELETE',
+      }),
+    {
+      onSuccess: () => queryClient.invalidateQueries('orgs'),
+    }
+  )
   const { confirm, confirmProps } = useConfirm()
-
-  const loadUser = async () => {
-    const response = await api<{ user: IAuditAdmin }>('/me')
-    setUser(response && response.user)
-  }
-
-  useEffect(() => {
-    loadUser()
-  }, [])
-
-  if (!user) return null // Still loading
 
   const onClickDeleteAudit = (election: IElection) => {
     confirm({
@@ -282,53 +269,61 @@ const ListAuditsAuditAdmin: React.FC = () => {
       ),
       yesButtonLabel: 'Delete',
       yesButtonIntent: Intent.DANGER,
-      onYesClick: async () => {
-        await api(`/election/${election.id}`, { method: 'DELETE' })
-        await loadUser()
-      },
+      onYesClick: () => deleteElection.mutateAsync({ electionId: election.id }),
     })
   }
 
+  if (!organizations.isSuccess) return null
+
   return (
-    <ListAuditsWrapper>
-      {sortBy(user.organizations, o => o.name).map(organization => (
-        <div key={organization.id}>
-          <h2>Audits - {organization.name}</h2>
-          {organization.elections.length === 0 ? (
-            <p>
-              You haven&apos;t created any audits yet for {organization.name}
-            </p>
-          ) : (
-            sortBy(organization.elections, e => e.auditName).map(election => (
-              <ButtonGroup
-                key={election.id}
-                fill
-                large
-                style={{ marginBottom: '15px' }}
-              >
-                <LinkButton
-                  style={{ justifyContent: 'start' }}
-                  to={`/election/${election.id}`}
-                  intent="primary"
+    <>
+      <div style={{ width: '50%', padding: '30px 30px 30px 0' }}>
+        {sortBy(organizations.data, o => o.name).map(organization => (
+          <div key={organization.id}>
+            <h2>Audits - {organization.name}</h2>
+            {organization.elections.length === 0 ? (
+              <p>
+                You haven&apos;t created any audits yet for {organization.name}
+              </p>
+            ) : (
+              sortBy(organization.elections, e => e.auditName).map(election => (
+                <ButtonGroup
+                  key={election.id}
                   fill
+                  large
+                  style={{ marginBottom: '15px' }}
                 >
-                  {election.auditName}
-                </LinkButton>
-                <Button
-                  icon="trash"
-                  intent="primary"
-                  aria-label="Delete Audit"
-                  onClick={() => onClickDeleteAudit(election)}
-                />
-              </ButtonGroup>
-            ))
-          )}
-        </div>
-      ))}
-      <Confirm {...confirmProps} />
-    </ListAuditsWrapper>
+                  <LinkButton
+                    style={{ justifyContent: 'start' }}
+                    to={`/election/${election.id}`}
+                    intent="primary"
+                    fill
+                  >
+                    {election.auditName}
+                  </LinkButton>
+                  <Button
+                    icon="trash"
+                    intent="primary"
+                    aria-label="Delete Audit"
+                    onClick={() => onClickDeleteAudit(election)}
+                  />
+                </ButtonGroup>
+              ))
+            )}
+          </div>
+        ))}
+        <Confirm {...confirmProps} />
+      </div>
+      <div style={{ width: '50%' }}>
+        <CreateAudit organizations={organizations.data} />
+      </div>
+    </>
   )
 }
+
+const ListAuditsWrapper = styled.div`
+  padding: 30px 30px 30px 0;
+`
 
 const ListAuditsJurisdictionAdmin = ({
   user,
@@ -398,41 +393,29 @@ const WideField = styled(FormField)`
   width: 100%;
 `
 
-const CreateAudit = ({ user }: { user: IAuditAdmin }) => {
+const CreateAudit = ({ organizations }: { organizations: IOrganization[] }) => {
   const history = useHistory()
-  const [submitting, setSubmitting] = useState(false)
+  const createElection = useMutation<{ electionId: string }, unknown, IValues>(
+    (newAudit: IValues) =>
+      fetchApi('/api/election', {
+        method: 'POST',
+        body: JSON.stringify(newAudit),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+  )
 
-  const onSubmit = async ({
-    organizationId,
-    auditName,
-    auditType,
-    auditMathType,
-  }: IValues) => {
-    setSubmitting(true)
-    const response: { electionId: string } | null = await api('/election', {
-      method: 'POST',
-      body: JSON.stringify({
-        organizationId,
-        auditName,
-        auditType,
-        auditMathType,
-      }),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
-    if (response) {
-      const { electionId } = response
-      history.push(`/election/${electionId}/setup`)
-    } else {
-      setSubmitting(false)
-    }
+  const onSubmit = async (newAudit: IValues) => {
+    const { electionId } = await createElection.mutateAsync(newAudit)
+    history.push(`/election/${electionId}/setup`)
   }
+
   return (
     <Formik
       onSubmit={onSubmit}
       initialValues={{
-        organizationId: user.organizations[0].id,
+        organizationId: organizations[0].id,
         auditName: '',
         auditType: 'BALLOT_POLLING',
         auditMathType: 'BRAVO',
@@ -440,6 +423,7 @@ const CreateAudit = ({ user }: { user: IAuditAdmin }) => {
     >
       {({
         handleSubmit,
+        isSubmitting,
         setFieldValue,
         setValues,
         values,
@@ -448,7 +432,7 @@ const CreateAudit = ({ user }: { user: IAuditAdmin }) => {
           <h2>New Audit</h2>
           <FormSection>
             {/* eslint-disable jsx-a11y/label-has-associated-control */}
-            {user.organizations.length > 1 && (
+            {organizations.length > 1 && (
               <label htmlFor="organizationId">
                 <p>Organization</p>
                 <HTMLSelect
@@ -458,7 +442,7 @@ const CreateAudit = ({ user }: { user: IAuditAdmin }) => {
                     setFieldValue('organizationId', e.currentTarget.value)
                   }
                   value={values.organizationId}
-                  options={user.organizations.map(({ id, name }) => ({
+                  options={organizations.map(({ id, name }) => ({
                     label: name,
                     value: id,
                   }))}
@@ -474,7 +458,7 @@ const CreateAudit = ({ user }: { user: IAuditAdmin }) => {
                 id="auditName"
                 name="auditName"
                 type="text"
-                disabled={submitting}
+                disabled={isSubmitting}
                 validate={(v: string) => (v ? undefined : 'Required')}
                 component={WideField}
               />
@@ -530,7 +514,7 @@ const CreateAudit = ({ user }: { user: IAuditAdmin }) => {
             fill
             large
             onClick={handleSubmit}
-            loading={submitting}
+            loading={isSubmitting}
           >
             Create Audit
           </FormButton>

--- a/client/src/components/HomeScreen.tsx
+++ b/client/src/components/HomeScreen.tsx
@@ -21,6 +21,7 @@ import {
   IJurisdictionAdmin,
   IElection,
   IOrganization,
+  IAuditAdmin,
 } from './UserContext'
 import { parseApiError, addCSRFToken } from './utilities'
 import LinkButton from './Atoms/LinkButton'
@@ -47,7 +48,7 @@ const HomeScreen: React.FC = () => {
       return (
         <Wrapper>
           <Inner>
-            <AuditAdminHomeScreen />
+            <AuditAdminHomeScreen user={user} />
           </Inner>
         </Wrapper>
       )
@@ -240,10 +241,10 @@ const LoginScreen: React.FC = () => {
   )
 }
 
-const AuditAdminHomeScreen = () => {
+const AuditAdminHomeScreen = ({ user }: { user: IAuditAdmin }) => {
   const queryClient = useQueryClient()
   const organizations = useQuery<IOrganization[]>('orgs', () =>
-    fetchApi(`/api/organizations`)
+    fetchApi(`/api/audit_admins/${user.id}/organizations`)
   )
   const deleteElection = useMutation(
     ({ electionId }: { electionId: string }) =>

--- a/client/src/components/MultiJurisdictionAudit/ActivityLog.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/ActivityLog.test.tsx
@@ -1,12 +1,10 @@
 import React from 'react'
-import { screen, waitFor } from '@testing-library/react'
-import { QueryClientProvider } from 'react-query'
+import { screen, waitFor, render } from '@testing-library/react'
+import { QueryClientProvider, QueryClient } from 'react-query'
 import userEvent from '@testing-library/user-event'
-import { aaApiCalls } from './_mocks'
-import { withMockFetch, renderWithRouter } from '../testUtilities'
+import { aaApiCalls, mockOrganizations } from './_mocks'
+import { withMockFetch } from '../testUtilities'
 import ActivityLog from './ActivityLog'
-import AuthDataProvider from '../UserContext'
-import { PrivateRoute, queryClient } from '../../App'
 import * as utilities from '../utilities'
 
 const mockElection = {
@@ -197,17 +195,22 @@ const apiCalls = {
 }
 
 const renderActivityLog = () =>
-  renderWithRouter(
-    <QueryClientProvider client={queryClient}>
-      <AuthDataProvider>
-        <PrivateRoute userType="audit_admin" component={ActivityLog} />
-      </AuthDataProvider>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <ActivityLog />
     </QueryClientProvider>
   )
 
 describe('Activity Log', () => {
   it('shows a table of activity for the org', async () => {
-    const expectedCalls = [aaApiCalls.getUser, apiCalls.getActivities]
+    const expectedCalls = [
+      aaApiCalls.getOrganizations(mockOrganizations.oneOrgNoAudits),
+      apiCalls.getActivities,
+    ]
     await withMockFetch(expectedCalls, async () => {
       renderActivityLog()
       await screen.findByRole('heading', { name: 'Activity Log' })
@@ -220,7 +223,7 @@ describe('Activity Log', () => {
 
   it('has a dropdown for audit admins with multiple orgs', async () => {
     const expectedCalls = [
-      aaApiCalls.getUserMultipleOrgs,
+      aaApiCalls.getOrganizations(mockOrganizations.twoOrgs),
       apiCalls.getActivities,
       { url: '/api/organizations/org-id-2/activities', response: [] },
     ]
@@ -253,7 +256,7 @@ describe('Activity Log', () => {
       .mockImplementation()
 
     const expectedCalls = [
-      aaApiCalls.getUserMultipleOrgs,
+      aaApiCalls.getOrganizations(mockOrganizations.twoOrgs),
       apiCalls.getActivities,
     ]
     await withMockFetch(expectedCalls, async () => {

--- a/client/src/components/MultiJurisdictionAudit/ActivityLog.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/ActivityLog.test.tsx
@@ -6,6 +6,7 @@ import { aaApiCalls, mockOrganizations } from './_mocks'
 import { withMockFetch } from '../testUtilities'
 import ActivityLog from './ActivityLog'
 import * as utilities from '../utilities'
+import AuthDataProvider from '../UserContext'
 
 const mockElection = {
   id: 'election-id-1',
@@ -196,18 +197,21 @@ const apiCalls = {
 
 const renderActivityLog = () =>
   render(
-    <QueryClientProvider
-      client={
-        new QueryClient({ defaultOptions: { queries: { retry: false } } })
-      }
-    >
-      <ActivityLog />
-    </QueryClientProvider>
+    <AuthDataProvider>
+      <QueryClientProvider
+        client={
+          new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        }
+      >
+        <ActivityLog />
+      </QueryClientProvider>
+    </AuthDataProvider>
   )
 
 describe('Activity Log', () => {
   it('shows a table of activity for the org', async () => {
     const expectedCalls = [
+      aaApiCalls.getUser,
       aaApiCalls.getOrganizations(mockOrganizations.oneOrgNoAudits),
       apiCalls.getActivities,
     ]
@@ -223,6 +227,7 @@ describe('Activity Log', () => {
 
   it('has a dropdown for audit admins with multiple orgs', async () => {
     const expectedCalls = [
+      aaApiCalls.getUser,
       aaApiCalls.getOrganizations(mockOrganizations.twoOrgs),
       apiCalls.getActivities,
       { url: '/api/organizations/org-id-2/activities', response: [] },
@@ -256,6 +261,7 @@ describe('Activity Log', () => {
       .mockImplementation()
 
     const expectedCalls = [
+      aaApiCalls.getUser,
       aaApiCalls.getOrganizations(mockOrganizations.twoOrgs),
       apiCalls.getActivities,
     ]

--- a/client/src/components/MultiJurisdictionAudit/ActivityLog.tsx
+++ b/client/src/components/MultiJurisdictionAudit/ActivityLog.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useQuery } from 'react-query'
 import { HTMLSelect, H3 } from '@blueprintjs/core'
-import { IOrganization } from '../UserContext'
+import { IOrganization, useAuthDataContext, IAuditAdmin } from '../UserContext'
 import { Wrapper, Inner } from '../Atoms/Wrapper'
 import { StyledTable, DownloadCSVButton } from '../Atoms/Table'
 import { fetchApi } from '../SupportTools/support-api'
@@ -67,8 +67,12 @@ const prettyAction = (activity: IActivity) => {
 }
 
 const ActivityLog = () => {
-  const organizations = useQuery<IOrganization[]>('orgs', () =>
-    fetchApi('/api/organizations')
+  const auth = useAuthDataContext()
+  const user = auth && (auth.user as IAuditAdmin)
+  const organizations = useQuery<IOrganization[]>(
+    'orgs',
+    () => fetchApi(`/api/audit_admins/${user!.id}/organizations`),
+    { enabled: !!user }
   )
   if (!organizations.isSuccess) return null
   return <ActivityLogOrgsLoaded organizations={organizations.data} />

--- a/client/src/components/MultiJurisdictionAudit/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/_mocks.ts
@@ -12,6 +12,7 @@ import jurisdictionFile, {
 } from './AASetup/Participants/_mocks'
 import { IBatch } from './RoundManagement/useBatchResults'
 import mockJSON from './Progress/us-states-counties'
+import { IOrganization } from '../UserContext'
 
 const jurisdictionFormData: FormData = new FormData()
 jurisdictionFormData.append(
@@ -232,15 +233,44 @@ export const jaApiCalls = {
   },
 }
 
-const aaUser = {
-  type: 'audit_admin',
-  name: 'Joe',
-  email: 'auditadmin@email.org',
-  jurisdictions: [],
-  organizations: [
+export const mockOrganizations = {
+  oneOrgNoAudits: [
     {
       id: 'org-id',
       name: 'State of California',
+      elections: [],
+    },
+  ],
+  oneOrgOneAudit: [
+    {
+      id: 'org-id',
+      name: 'State of California',
+      elections: [
+        {
+          id: '1',
+          auditName: 'November Presidential Election 2020',
+          electionName: '',
+          state: 'CA',
+        },
+      ],
+    },
+  ],
+  twoOrgs: [
+    {
+      id: 'org-id',
+      name: 'State of California',
+      elections: [
+        {
+          id: '1',
+          auditName: 'November Presidential Election 2020',
+          electionName: '',
+          state: 'CA',
+        },
+      ],
+    },
+    {
+      id: 'org-id-2',
+      name: 'State of Georgia',
       elections: [],
     },
   ],
@@ -250,61 +280,17 @@ export const aaApiCalls = {
   getUser: {
     url: '/api/me',
     response: {
-      user: aaUser,
-      supportUser: null,
-    },
-  },
-  getUserWithAudit: {
-    url: '/api/me',
-    response: {
       user: {
-        ...aaUser,
-        organizations: [
-          {
-            id: 'org-id',
-            name: 'State of California',
-            elections: [
-              {
-                id: '1',
-                auditName: 'November Presidential Election 2020',
-                electionName: '',
-                state: 'CA',
-              },
-            ],
-          },
-        ],
+        type: 'audit_admin',
+        email: 'auditadmin@email.org',
       },
       supportUser: null,
     },
   },
-  getUserMultipleOrgs: {
-    url: '/api/me',
-    response: {
-      user: {
-        ...aaUser,
-        organizations: [
-          {
-            id: 'org-id',
-            name: 'State of California',
-            elections: [
-              {
-                id: '1',
-                auditName: 'November Presidential Election 2020',
-                electionName: '',
-                state: 'CA',
-              },
-            ],
-          },
-          {
-            id: 'org-id-2',
-            name: 'State of Georgia',
-            elections: [],
-          },
-        ],
-      },
-      supportUser: null,
-    },
-  },
+  getOrganizations: (organizations: IOrganization[]) => ({
+    url: '/api/organizations',
+    response: organizations,
+  }),
   postNewAudit: (body: {}) => ({
     url: '/api/election',
     options: {
@@ -484,7 +470,7 @@ export const supportApiCalls = {
   getUserImpersonatingAA: {
     url: '/api/me',
     response: {
-      user: aaUser,
+      user: aaApiCalls.getUser.response.user,
       supportUser: { email: 'support@example.com' },
     },
   },

--- a/client/src/components/MultiJurisdictionAudit/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/_mocks.ts
@@ -6,7 +6,8 @@ import { IBallot } from './RoundManagement/useBallots'
 import { IAuditBoard } from './useAuditBoards'
 import { IRound } from './useRoundsAuditAdmin'
 import { IAuditSettings } from './useAuditSettings'
-import jurisdictionFile, {
+import {
+  jurisdictionFile,
   jurisdictionErrorFile,
   standardizedContestsFile,
 } from './AASetup/Participants/_mocks'
@@ -283,12 +284,13 @@ export const aaApiCalls = {
       user: {
         type: 'audit_admin',
         email: 'auditadmin@email.org',
+        id: 'audit-admin-1-id',
       },
       supportUser: null,
     },
   },
   getOrganizations: (organizations: IOrganization[]) => ({
-    url: '/api/organizations',
+    url: '/api/audit_admins/audit-admin-1-id/organizations',
     response: organizations,
   }),
   postNewAudit: (body: {}) => ({

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ToastContainer } from 'react-toastify'
-import { QueryClientProvider } from 'react-query'
+import { QueryClientProvider, QueryClient } from 'react-query'
 import { withMockFetch, renderWithRouter } from '../testUtilities'
 import SupportTools from './SupportTools'
 import AuthDataProvider from '../UserContext'
@@ -163,9 +163,20 @@ const serverError = (
   error: { status: 500, statusText: 'Server Error' },
 })
 
+const queryClientOptions = queryClient.getDefaultOptions()
+
 const renderRoute = (route: string) =>
   renderWithRouter(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider
+      client={
+        new QueryClient({
+          defaultOptions: {
+            ...queryClientOptions,
+            queries: { ...queryClientOptions.queries, retry: false },
+          },
+        })
+      }
+    >
       <AuthDataProvider>
         <SupportTools />
         <ToastContainer />

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -2,13 +2,22 @@ import { useQuery, useMutation, useQueryClient } from 'react-query'
 import { useHistory } from 'react-router-dom'
 import { tryJson, addCSRFToken } from '../utilities'
 
+export class ApiError extends Error {
+  public statusCode: number
+
+  public constructor(message: string, statusCode: number) {
+    super(message)
+    this.statusCode = statusCode
+  }
+}
+
 export const fetchApi = async (url: string, options?: RequestInit) => {
   const response = await fetch(url, addCSRFToken(options))
   if (response.ok) return response.json()
   const text = await response.text()
   const { errors } = tryJson(text)
   const error = errors && errors.length && errors[0].message
-  throw new Error(error || text)
+  throw new ApiError(error || text, response.status)
 }
 
 export interface IOrganizationBase {

--- a/client/src/components/UserContext.tsx
+++ b/client/src/components/UserContext.tsx
@@ -48,8 +48,6 @@ export interface IAuditAdmin {
   type: 'audit_admin'
   name: string
   email: string
-  organizations: IOrganization[]
-  jurisdictions: []
 }
 
 export interface IJurisdictionAdmin {

--- a/client/src/components/UserContext.tsx
+++ b/client/src/components/UserContext.tsx
@@ -48,6 +48,7 @@ export interface IAuditAdmin {
   type: 'audit_admin'
   name: string
   email: string
+  id: string
 }
 
 export interface IJurisdictionAdmin {

--- a/server/api/elections.py
+++ b/server/api/elections.py
@@ -109,13 +109,13 @@ def delete_election(election: Election):
     return jsonify(status="ok")
 
 
-@api.route("/organizations", methods=["GET"])
-def list_organizations_and_elections():
+@api.route("/audit_admins/<audit_admin_id>/organizations", methods=["GET"])
+def list_organizations_and_elections(audit_admin_id: str):
     user_type, user_key = get_loggedin_user(session)
-    if user_type != UserType.AUDIT_ADMIN:
-        raise Forbidden(f"Access forbidden for user type {user_type}")
+    user = User.query.get(audit_admin_id)
+    if user is None or user.email != user_key or user_type != UserType.AUDIT_ADMIN:
+        raise Forbidden()
 
-    user = User.query.filter_by(email=user_key).one()
     return jsonify(
         [
             {

--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -82,7 +82,7 @@ def auth_me():
     user = None
     if user_type == UserType.AUDIT_ADMIN:
         db_user = User.query.filter_by(email=user_key).one()
-        user = dict(type=user_type, email=db_user.email,)
+        user = dict(type=user_type, email=db_user.email, id=db_user.id)
     if user_type == UserType.JURISDICTION_ADMIN:
         db_user = User.query.filter_by(email=user_key).one()
         user = dict(

--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -80,23 +80,14 @@ def serialize_election(election):
 def auth_me():
     user_type, user_key = get_loggedin_user(session)
     user = None
-    if user_type in [UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN]:
+    if user_type == UserType.AUDIT_ADMIN:
+        db_user = User.query.filter_by(email=user_key).one()
+        user = dict(type=user_type, email=db_user.email,)
+    if user_type == UserType.JURISDICTION_ADMIN:
         db_user = User.query.filter_by(email=user_key).one()
         user = dict(
             type=user_type,
             email=db_user.email,
-            organizations=[
-                {
-                    "id": org.id,
-                    "name": org.name,
-                    "elections": [
-                        serialize_election(election)
-                        for election in org.elections
-                        if election.deleted_at is None
-                    ],
-                }
-                for org in db_user.organizations
-            ],
             jurisdictions=[
                 {
                     "id": jurisdiction.id,

--- a/server/models.py
+++ b/server/models.py
@@ -316,7 +316,10 @@ class User(BaseModel):
     external_id = Column(String(200), unique=True)
 
     organizations = relationship(
-        "Organization", secondary="audit_administration", uselist=True
+        "Organization",
+        secondary="audit_administration",
+        uselist=True,
+        order_by="Organization.name",
     )
     jurisdictions = relationship(
         "Jurisdiction", secondary="jurisdiction_administration", uselist=True

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -64,7 +64,7 @@ def test_support_get_organization(client: FlaskClient, org_id: str, election_id:
 
 def test_support_delete_organization(client: FlaskClient):
     set_support_user(client, SUPPORT_EMAIL)
-    org_id, _ = create_org_and_admin("Test Delete Org", "admin-delete@example.com")
+    org_id, aa_id = create_org_and_admin("Test Delete Org", "admin-delete@example.com")
     set_logged_in_user(client, UserType.AUDIT_ADMIN, "admin-delete@example.com")
     election_id = create_election(client, organization_id=org_id)
 
@@ -88,7 +88,7 @@ def test_support_delete_organization(client: FlaskClient):
     rv = client.get(f"/api/support/organizations/{org_id}")
     assert rv.status_code == 404
 
-    rv = client.get("/api/organizations")
+    rv = client.get(f"/api/audit_admins/{aa_id}/organizations")
     assert json.loads(rv.data) == []
 
     assert Election.query.get(election_id) is None

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -88,8 +88,8 @@ def test_support_delete_organization(client: FlaskClient):
     rv = client.get(f"/api/support/organizations/{org_id}")
     assert rv.status_code == 404
 
-    rv = client.get("/api/me")
-    assert json.loads(rv.data)["user"]["organizations"] == []
+    rv = client.get("/api/organizations")
+    assert json.loads(rv.data) == []
 
     assert Election.query.get(election_id) is None
 

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -600,9 +600,10 @@ def test_audit_board_not_found(client: FlaskClient,):
 def test_auth_me_audit_admin(client: FlaskClient, aa_email: str):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, aa_email)
 
+    user = User.query.filter_by(email=aa_email).one()
     rv = client.get("/api/me")
     assert json.loads(rv.data) == {
-        "user": {"type": "audit_admin", "email": aa_email},
+        "user": {"type": "audit_admin", "email": aa_email, "id": user.id},
         "supportUser": None,
     }
 

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -597,33 +597,12 @@ def test_audit_board_not_found(client: FlaskClient,):
 # Tests for /api/me
 
 
-def test_auth_me_audit_admin(
-    client: FlaskClient, election_id: str, org_id: str, aa_email: str
-):
+def test_auth_me_audit_admin(client: FlaskClient, aa_email: str):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, aa_email)
-    election = Election.query.get(election_id)
 
     rv = client.get("/api/me")
     assert json.loads(rv.data) == {
-        "user": {
-            "type": "audit_admin",
-            "email": aa_email,
-            "organizations": [
-                {
-                    "name": "Test Org test_auth_me_audit_admin",
-                    "id": org_id,
-                    "elections": [
-                        {
-                            "id": election_id,
-                            "auditName": election.audit_name,
-                            "electionName": None,
-                            "state": None,
-                        }
-                    ],
-                }
-            ],
-            "jurisdictions": [],
-        },
+        "user": {"type": "audit_admin", "email": aa_email},
         "supportUser": None,
     }
 
@@ -639,7 +618,6 @@ def test_auth_me_jurisdiction_admin(
         "user": {
             "type": UserType.JURISDICTION_ADMIN,
             "email": ja_email,
-            "organizations": [],
             "jurisdictions": [
                 {
                     "id": jurisdiction_id,


### PR DESCRIPTION
Previously, we loaded the list of an audit admin's audits with their user data. This caused complications in a few different places, which we previously hacked around. A bug appeared when leaving an audit admin page open when logged in as a different user type, and then trying to load the home screen for the audit admin page again.

To fix this, we create a separate endpoint for loading the list of audits and decouple that from loading the user data. This impacts:
- loading the list of audits on login
- reloading the list of audits after deleting an audit
- *not* reloading the list of audits after creating an audit, since we immediately redirect to the setup page