### PR TITLE
Fixing bug where we report stopping size as round size

### DIFF
--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -153,9 +153,19 @@ def sample_size_options(
                 "2-over": discrepancy_counter[2],
             }
 
-            sample_size = supersimple.get_sample_sizes(
+            # Since this computation comptues the total stopping size, We need
+            # to subtract the number of samples drawn already to get to a round
+            # size
+            sampled_so_far = sum(rounds.round_sizes(contest).values())
+
+            stopping_size = supersimple.get_sample_sizes(
                 election.risk_limit, contest_for_sampler, discrepancy_counts
             )
+            sample_size = stopping_size - sampled_so_far
+
+            if sample_size < 1:
+                raise ValueError('Audit should have already finished!')
+
             return {
                 "supersimple": {"key": "supersimple", "size": sample_size, "prob": None}
             }


### PR DESCRIPTION
**Description**

Currently subsequent rounds in ballot comparison audits report the estimated stopping size, not the round size, which is (stopping size) - (ballots sampled so far). This fixes that. 

**Testing**

Many test cases are broken, need @jonahkagan's help to fix them.

**Progress**

Tests need to be fixed. 
