### PR TITLE
Cypress tweaks

### DIFF
--- a/client/cypress/support/commands.js
+++ b/client/cypress/support/commands.js
@@ -55,9 +55,11 @@ Cypress.Commands.add('loginJurisdictionAdmin', jaEmail => {
 
 Cypress.Commands.add('logout', email => {
   cy.intercept('/auth/logout').as('logout')
+  cy.intercept('/api/me').as('me')
   cy.findByText(email).click()
-  cy.findByText('Log out').click()
-  cy.wait(['@logout'])
+  cy.findByRole('link', { name: 'Log out' }).click()
+  cy.wait('@logout')
+  cy.wait('@me')
   cy.contains('Participating in an audit in your local jurisdiction?')
 })
 

--- a/client/run-cypress-tests.sh
+++ b/client/run-cypress-tests.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-export ARLO_AUDITADMIN_AUTH0_BASE_URL=http://localhost:8080
 export ARLO_SMTP_HOST=localhost
 export ARLO_SMTP_PORT=1025
 export ARLO_SMTP_USERNAME=cypress-smtp-username
@@ -8,6 +7,5 @@ export ARLO_SMTP_PASSWORD=cypress-smtp-password
 
 trap 'kill 0' SIGINT SIGHUP EXIT
 cd "$(dirname "${BASH_SOURCE[0]}")"
-PORT=8080 poetry run python -m noauth &
 FLASK_ENV=test ../run-dev.sh &
 yarn run cypress run --browser chrome


### PR DESCRIPTION
- Wait on the /api/me request after logout to try to prevent flakiness
- Remove the command to run noauth from the run-cypress-tests.sh script because it's already part of run-dev.sh, which that script calls