### PR TITLE
Bugfix: toast CSV upload errors correctly

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/__snapshots__/index.test.tsx.snap
@@ -457,5 +457,8 @@ exports[`JA setup renders initial state 1`] = `
       </form>
     </div>
   </div>
+  <div
+    class="Toastify"
+  />
 </div>
 `;

--- a/client/src/components/MultiJurisdictionAudit/useCSV.ts
+++ b/client/src/components/MultiJurisdictionAudit/useCSV.ts
@@ -58,7 +58,10 @@ const putCSVFile = async (
     }) as AxiosRequestConfig)
     return true
   } catch (error) {
-    toast.error(error.message)
+    const { errors } = error.response.data
+    const message =
+      errors && errors.length ? errors[0].message : error.response.statusText
+    toast.error(message)
     return false
   }
 }

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -3,7 +3,7 @@ import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ToastContainer } from 'react-toastify'
 import { QueryClientProvider, QueryClient } from 'react-query'
-import { withMockFetch, renderWithRouter } from '../testUtilities'
+import { withMockFetch, renderWithRouter, serverError } from '../testUtilities'
 import SupportTools from './SupportTools'
 import AuthDataProvider from '../UserContext'
 import { supportApiCalls } from '../MultiJurisdictionAudit/_mocks'
@@ -149,19 +149,6 @@ const apiCalls = {
     response: { status: 'ok' },
   },
 }
-
-const serverError = (
-  name: string,
-  apiCall: { url: string; options?: object }
-) => ({
-  ...apiCall,
-  response: {
-    errors: [
-      { errorType: 'Server Error', message: `something went wrong: ${name}` },
-    ],
-  },
-  error: { status: 500, statusText: 'Server Error' },
-})
 
 const queryClientOptions = queryClient.getDefaultOptions()
 


### PR DESCRIPTION
When we switched to using axios for CSV upload requests (in order to show upload progress), I didn't realize that axios errors had a different return type than fetch (and somehow the type checker didn't notice either). So our error messages weren't getting toasted properly.
