### PR TITLE
Show total ballots in batches to JA when creating audit boards

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
@@ -18,7 +18,7 @@ import useAuditBoards from '../useAuditBoards'
 import StatusTag from '../../Atoms/StatusTag'
 import { api } from '../../utilities'
 import { IAuditSettings } from '../useAuditSettings'
-import useBallotOrBatchCount from '../RoundManagement/useBallots'
+import useSampleCount from '../RoundManagement/useBallots'
 
 const FileStatusTag = ({
   processing,
@@ -165,13 +165,13 @@ const RoundStatusSection = ({
   auditSettings: IAuditSettings
 }) => {
   const [auditBoards] = useAuditBoards(electionId, jurisdiction.id, [round])
-  const numSamples = useBallotOrBatchCount(
+  const sampleCount = useSampleCount(
     electionId,
     jurisdiction.id,
     round.id,
     auditSettings.auditType
   )
-  if (!auditBoards || numSamples === null) return null
+  if (!auditBoards || !sampleCount) return null
 
   const status = (() => {
     const jurisdictionStatus =
@@ -213,10 +213,7 @@ const RoundStatusSection = ({
       )
     }
 
-    const ballotsOrBatches =
-      auditSettings.auditType === 'BATCH_COMPARISON' ? 'batches' : 'ballots'
-
-    if (numSamples === 0) return <p>No {ballotsOrBatches} sampled</p>
+    if (sampleCount.ballots === 0) return <p>No ballots sampled</p>
     if (jurisdictionStatus === JurisdictionRoundStatus.COMPLETE)
       return <p>Data entry complete</p>
     if (auditBoards.length === 0)

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
@@ -862,7 +862,7 @@ describe('Progress screen', () => {
       const modal = screen
         .getByRole('heading', { name: 'Jurisdiction 1' })
         .closest('div.bp3-dialog')! as HTMLElement
-      await within(modal).findByText('No batches sampled')
+      await within(modal).findByText('No ballots sampled')
     })
   })
 

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
@@ -22,6 +22,7 @@ import StatusTag from '../../Atoms/StatusTag'
 import { IAuditSettings } from '../useAuditSettings'
 import { FileProcessingStatus, IFileInfo } from '../useCSV'
 import Map from './ProgressMap'
+import { sum } from '../../../utils/number'
 
 const Wrapper = styled.div`
   flex-grow: 1;
@@ -39,8 +40,6 @@ const TableControls = styled.div`
 
 const formatNumber = ({ value }: { value: number | null }) =>
   value && value.toLocaleString()
-
-const sum = (nums: number[]) => nums.reduce((a, b) => a + b, 0)
 
 const totalFooter = <T extends object>(headerName: string) => (
   info: TableInstance<T>

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/OfflineBatchRoundDataEntry.tsx
@@ -26,8 +26,7 @@ import useOfflineBatchResults, {
 } from './useOfflineBatchResults'
 import { testNumber } from '../../utilities'
 import CopyToClipboard from '../../Atoms/CopyToClipboard'
-
-const sum = (nums: number[]) => nums.reduce((a, b) => a + b, 0)
+import { sum } from '../../../utils/number'
 
 const OfflineBatchResultsForm = styled.form`
   table {

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/RoundProgress.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { ProgressBar, H4, Tag, Intent } from '@blueprintjs/core'
 import styled from 'styled-components'
 import { IAuditBoard } from '../useAuditBoards'
+import { sum } from '../../../utils/number'
 
 const MainBarWrapper = styled.div`
   margin-bottom: 30px;
@@ -27,7 +28,6 @@ const SmallBarWrapper = styled.div`
 
 const RoundProgress = ({ auditBoards }: { auditBoards: IAuditBoard[] }) => {
   if (!auditBoards.length) return null
-  const sum = (ns: number[]) => ns.reduce((a, b) => a + b)
   const auditedBallots = sum(
     auditBoards.map(ab => ab.currentRoundStatus.numAuditedBallots)
   )

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/index.test.tsx.snap
@@ -15,8 +15,7 @@ exports[`RoundManagement renders audit setup with ballot audit 1`] = `
     <p
       class="sc-hMqMXs cTbGLd"
     >
-      Ballots
-       to audit: 
+      Ballots to audit: 
       27
     </p>
     <div
@@ -694,9 +693,11 @@ exports[`RoundManagement renders audit setup with batch audit 1`] = `
     <p
       class="sc-hMqMXs cTbGLd"
     >
-      Batches
-       to audit: 
+      Batches to audit: 
       3
+      <br />
+      Total ballots in batches: 
+      300
     </p>
     <div
       class="sc-dnqmqq jnbCEU"
@@ -1390,9 +1391,11 @@ exports[`RoundManagement renders links & data entry with batch audit 1`] = `
       <p
         class="sc-hMqMXs cTbGLd"
       >
-        Batches
-         to audit: 
+        Batches to audit: 
         3
+        <br />
+        Total ballots in batches: 
+        300
       </p>
       <div
         class="bp3-button-group bp3-vertical bp3-align-left"
@@ -1638,8 +1641,7 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
       <p
         class="sc-hMqMXs cTbGLd"
       >
-        Ballots
-         to audit: 
+        Ballots to audit: 
         27
       </p>
       <div
@@ -1889,8 +1891,7 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
       <p
         class="sc-hMqMXs cTbGLd"
       >
-        Ballots
-         to audit: 
+        Ballots to audit: 
         27
       </p>
       <div

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
@@ -82,6 +82,8 @@ describe('RoundManagement', () => {
         createAuditBoards: jest.fn(),
       })
       await screen.findByText('Round 1 Audit Board Setup')
+      screen.getByText(/Batches to audit: 3/)
+      screen.getByText(/Total ballots in batches: 300/)
       expect(container).toMatchSnapshot()
     })
   })
@@ -99,6 +101,7 @@ describe('RoundManagement', () => {
         createAuditBoards: jest.fn(),
       })
       await screen.findByText('Round 1 Audit Board Setup')
+      screen.getByText('Ballots to audit: 27')
       expect(container).toMatchSnapshot()
     })
   })
@@ -209,7 +212,7 @@ describe('RoundManagement', () => {
         createAuditBoards: jest.fn(),
       })
       await screen.findByText(
-        'Your jurisdiction has not been assigned any batches to audit in this round.'
+        'Your jurisdiction has not been assigned any ballots to audit in this round.'
       )
     })
   })

--- a/client/src/utils/number.test.ts
+++ b/client/src/utils/number.test.ts
@@ -1,0 +1,7 @@
+import { sum } from './number'
+
+test('sum', () => {
+  expect(sum([])).toEqual(0)
+  expect(sum([1, 2, 3])).toEqual(6)
+  expect(sum([-1, 2, 3])).toEqual(4)
+})

--- a/client/src/utils/number.ts
+++ b/client/src/utils/number.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/prefer-default-export
+export function sum(nums: number[]): number {
+  return nums.reduce((a, b) => a + b, 0)
+}


### PR DESCRIPTION
It's important info to know how many audit boards to create.

Also, some tidbits:
- Abstract the `sum` function
- Simplify some copy when no ballots/batches are sampled for a given jurisdiction to just say "No ballots samples" (it's not important to say whether they are sampling ballots or batches in these contexts)
