### PR TITLE
Support Tools: only toast once on error

### DIFF
--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { screen, within } from '@testing-library/react'
+import { screen, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ToastContainer } from 'react-toastify'
 import { QueryClientProvider, QueryClient } from 'react-query'
@@ -16,6 +16,18 @@ import {
   IJurisdiction,
 } from './support-api'
 import { queryClient } from '../../App'
+
+// It's important to close the toast after checking it so there's no rendering
+// happen after the test ends
+const findAndCloseToast = async (expectedContent: string) => {
+  const toastBody = await screen.findByRole('alert')
+  expect(toastBody).toHaveTextContent(expectedContent)
+  const toast = toastBody.closest('div.Toastify__toast')! as HTMLElement
+  userEvent.click(within(toast).getByRole('button', { name: 'close' }))
+  await waitFor(() =>
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  )
+}
 
 const mockOrganizationBase: IOrganizationBase = {
   id: 'organization-id-1',
@@ -204,8 +216,7 @@ describe('Support Tools', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       renderRoute('/support')
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent('something went wrong: getOrganizations')
+      await findAndCloseToast('something went wrong: getOrganizations')
     })
   })
 
@@ -254,8 +265,7 @@ describe('Support Tools', () => {
         screen.getByRole('button', { name: /Create Organization/ })
       )
 
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent('something went wrong: postOrganization')
+      await findAndCloseToast('something went wrong: postOrganization')
     })
   })
 
@@ -288,8 +298,7 @@ describe('Support Tools', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       renderRoute('/support/orgs/organization-id-1')
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent('something went wrong')
+      await findAndCloseToast('something went wrong: getOrganization')
     })
   })
 
@@ -357,8 +366,7 @@ describe('Support Tools', () => {
         screen.getByRole('button', { name: /Create Audit Admin/ })
       )
 
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent('something went wrong: postAuditAdmin')
+      await findAndCloseToast('something went wrong: postAuditAdmin')
     })
   })
 
@@ -417,10 +425,7 @@ describe('Support Tools', () => {
       )
       userEvent.click(within(dialog).getByRole('button', { name: 'Submit' }))
 
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent(
-        'something went wrong: renameOrganization'
-      )
+      await findAndCloseToast('something went wrong: renameOrganization')
       expect(dialog).toBeInTheDocument()
     })
   })
@@ -447,6 +452,8 @@ describe('Support Tools', () => {
         'Are you sure you want to delete organization Organization 1?'
       )
       userEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+      await findAndCloseToast('Deleted organization Organization 1')
 
       await screen.findByRole('heading', { name: 'Organizations' })
       expect(history.location.pathname).toEqual('/support')
@@ -478,10 +485,7 @@ describe('Support Tools', () => {
       )
       userEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
 
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent(
-        'something went wrong: deleteOrganization'
-      )
+      await findAndCloseToast('something went wrong: deleteOrganization')
       expect(history.location.pathname).toEqual(
         '/support/orgs/organization-id-1'
       )
@@ -518,8 +522,7 @@ describe('Support Tools', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       renderRoute('/support/audits/election-id-1')
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent('something went wrong: getElection')
+      await findAndCloseToast('something went wrong: getElection')
     })
   })
 
@@ -572,8 +575,7 @@ describe('Support Tools', () => {
       )
       userEvent.click(within(dialog).getByRole('button', { name: 'Reopen' }))
 
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent('Reopened Audit Board #1')
+      await findAndCloseToast('Reopened Audit Board #1')
 
       expect(
         within(screen.getByText('Audit Board #1').closest('tr')!).getByRole(
@@ -594,8 +596,7 @@ describe('Support Tools', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       renderRoute('/support/jurisdictions/jurisdiction-id-1')
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent('something went wrong: getJurisdiction')
+      await findAndCloseToast('something went wrong: getJurisdiction')
     })
   })
 
@@ -622,8 +623,7 @@ describe('Support Tools', () => {
       })).closest('.bp3-dialog')! as HTMLElement
       userEvent.click(within(dialog).getByRole('button', { name: 'Reopen' }))
 
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent('something went wrong: reopenAuditBoard')
+      await findAndCloseToast('something went wrong: reopenAuditBoard')
     })
   })
 
@@ -683,8 +683,7 @@ describe('Support Tools', () => {
         within(dialog).getByRole('button', { name: /Clear audit boards/ })
       )
 
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent('Cleared audit boards for Jurisdiction 1')
+      await findAndCloseToast('Cleared audit boards for Jurisdiction 1')
 
       screen.getByText("The jurisdiction hasn't created audit boards yet.")
     })
@@ -716,8 +715,7 @@ describe('Support Tools', () => {
         within(dialog).getByRole('button', { name: /Clear audit boards/ })
       )
 
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent('something went wrong: deleteAuditBoards')
+      await findAndCloseToast('something went wrong: deleteAuditBoards')
     })
   })
 
@@ -760,8 +758,7 @@ describe('Support Tools', () => {
         within(dialog).getByRole('button', { name: /Clear results/ })
       )
 
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent('Cleared results for Jurisdiction 1')
+      await findAndCloseToast('Cleared results for Jurisdiction 1')
 
       screen.getByText('No results recorded yet.')
     })
@@ -795,10 +792,7 @@ describe('Support Tools', () => {
         within(dialog).getByRole('button', { name: /Clear results/ })
       )
 
-      const toast = await screen.findByRole('alert')
-      expect(toast).toHaveTextContent(
-        'something went wrong: deleteOfflineResults'
-      )
+      await findAndCloseToast('something went wrong: deleteOfflineResults')
     })
   })
 })

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -101,13 +101,8 @@ const Organizations = () => {
 
   if (!organizations.isSuccess) return null
 
-  const onSubmitCreateOrganization = async ({ name }: { name: string }) => {
-    try {
-      await createOrganization.mutateAsync({ name })
-      reset()
-    } catch (error) {
-      toast.error(error.message)
-    }
+  const onSubmitCreateOrganization = ({ name }: { name: string }) => {
+    createOrganization.mutate({ name }, { onSuccess: () => reset() })
   }
 
   return (
@@ -186,13 +181,11 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
 
   if (!organization.isSuccess) return null
 
-  const onSubmitCreateAuditAdmin = async (auditAdmin: IAuditAdmin) => {
-    try {
-      await createAuditAdmin.mutateAsync({ organizationId, auditAdmin })
-      resetCreateAdmin()
-    } catch (error) {
-      toast.error(error.message)
-    }
+  const onSubmitCreateAuditAdmin = (auditAdmin: IAuditAdmin) => {
+    createAuditAdmin.mutate(
+      { organizationId, auditAdmin },
+      { onSuccess: () => resetCreateAdmin() }
+    )
   }
 
   const { name, elections, auditAdmins } = organization.data
@@ -203,12 +196,8 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
       description: `Are you sure you want to delete organization ${name}?`,
       yesButtonLabel: 'Delete',
       onYesClick: async () => {
-        try {
-          await deleteOrganization.mutateAsync({})
-          toast.success(`Deleted organization ${name}`)
-        } catch (error) {
-          toast.error(error.message)
-        }
+        await deleteOrganization.mutateAsync()
+        toast.success(`Deleted organization ${name}`)
       },
     })
 
@@ -232,11 +221,7 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
       yesButtonLabel: 'Submit',
       // eslint-disable-next-line no-shadow
       onYesClick: handleSubmitRename(async ({ name }: { name: string }) => {
-        try {
-          await renameOrganization.mutateAsync({ name })
-        } catch (error) {
-          toast.error(error.message)
-        }
+        await renameOrganization.mutateAsync({ name })
       }),
     })
 
@@ -384,12 +369,8 @@ const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
       description: `Are you sure you want to clear the audit boards for ${name}?`,
       yesButtonLabel: 'Clear audit boards',
       onYesClick: async () => {
-        try {
-          await clearAuditBoards.mutateAsync({ jurisdictionId })
-          toast.success(`Cleared audit boards for ${name}`)
-        } catch (error) {
-          toast.error(error.message)
-        }
+        await clearAuditBoards.mutateAsync({ jurisdictionId })
+        toast.success(`Cleared audit boards for ${name}`)
       },
     })
   }
@@ -400,15 +381,11 @@ const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
       description: `Are you sure you want to reopen ${auditBoard.name}?`,
       yesButtonLabel: 'Reopen',
       onYesClick: async () => {
-        try {
-          await reopenAuditBoard.mutateAsync({
-            jurisdictionId,
-            auditBoardId: auditBoard.id,
-          })
-          toast.success(`Reopened ${auditBoard.name}`)
-        } catch (error) {
-          toast.error(error.message)
-        }
+        await reopenAuditBoard.mutateAsync({
+          jurisdictionId,
+          auditBoardId: auditBoard.id,
+        })
+        toast.success(`Reopened ${auditBoard.name}`)
       },
     })
   }
@@ -419,15 +396,10 @@ const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
       description: `Are you sure you want to clear results for ${name}?`,
       yesButtonLabel: 'Clear results',
       onYesClick: async () => {
-        try {
-          await clearOfflineResults.mutateAsync({
-            jurisdictionId,
-          })
-          toast.success(`Cleared results for ${name}`)
-        } catch (error) {
-          toast.error(error.message)
-          throw error
-        }
+        await clearOfflineResults.mutateAsync({
+          jurisdictionId,
+        })
+        toast.success(`Cleared results for ${name}`)
       },
     })
   }

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -86,8 +86,7 @@ export const useCreateOrganization = () => {
 
   const queryClient = useQueryClient()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return useMutation<any, Error, any>(postOrganization, {
+  return useMutation(postOrganization, {
     onSuccess: () => queryClient.invalidateQueries('organizations'),
   })
 }
@@ -107,8 +106,7 @@ export const useRenameOrganization = (organizationId: string) => {
 
   const queryClient = useQueryClient()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return useMutation<any, Error, any>(renameOrganization, {
+  return useMutation(renameOrganization, {
     onSuccess: () =>
       queryClient.invalidateQueries(['organizations', organizationId]),
   })
@@ -123,8 +121,7 @@ export const useDeleteOrganization = (organizationId: string) => {
   const queryClient = useQueryClient()
   const history = useHistory()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return useMutation<any, Error, any>(deleteOrganization, {
+  return useMutation(deleteOrganization, {
     onSuccess: () => {
       queryClient.removeQueries(['organizations', organizationId])
       queryClient.resetQueries('organizations')
@@ -149,8 +146,7 @@ export const useCreateAuditAdmin = () => {
 
   const queryClient = useQueryClient()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return useMutation<any, Error, any>(postAuditAdmin, {
+  return useMutation(postAuditAdmin, {
     onSuccess: (_data, variables) =>
       queryClient.invalidateQueries([
         'organizations',
@@ -181,8 +177,7 @@ export const useClearAuditBoards = () => {
 
   const queryClient = useQueryClient()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return useMutation<any, Error, any>(deleteAuditBoards, {
+  return useMutation(deleteAuditBoards, {
     onSuccess: (_data, variables) =>
       queryClient.invalidateQueries([
         'jurisdictions',
@@ -204,8 +199,7 @@ export const useReopenAuditBoard = () => {
 
   const queryClient = useQueryClient()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return useMutation<any, Error, any>(reopenAuditBoard, {
+  return useMutation(reopenAuditBoard, {
     onSuccess: (_data, variables) =>
       queryClient.invalidateQueries([
         'jurisdictions',
@@ -226,8 +220,7 @@ export const useClearOfflineResults = () => {
 
   const queryClient = useQueryClient()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return useMutation<any, Error, any>(clearOfflineResults, {
+  return useMutation(clearOfflineResults, {
     onSuccess: (_data, variables) =>
       queryClient.invalidateQueries([
         'jurisdictions',


### PR DESCRIPTION
- Since we added a default onError handler to the QueryClient that toasts errors, the individual error toasting on each query are no longer needed (and are in fact causing duplicate toasts)
- Also fixes tests to close toasts after checking them to make sure there are no state updates happening after the test is complete (which can cause weird bugs)