### PR TITLE
Status box: Fix bug from race condition when starting audit

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
@@ -209,14 +209,16 @@ export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
   if (!endedAt) {
     const numCompleted = jurisdictions.filter(
       ({ currentRoundStatus }) =>
-        currentRoundStatus!.status === JurisdictionRoundStatus.COMPLETE
+        currentRoundStatus &&
+        currentRoundStatus.status === JurisdictionRoundStatus.COMPLETE
     ).length
 
     const canUndoLaunch =
       roundNum === 1 &&
       jurisdictions.every(
         ({ currentRoundStatus }) =>
-          currentRoundStatus!.status !== JurisdictionRoundStatus.IN_PROGRESS
+          currentRoundStatus &&
+          currentRoundStatus.status !== JurisdictionRoundStatus.IN_PROGRESS
       )
 
     return (


### PR DESCRIPTION
This was only happening in Cypress tests on occasion. When starting an audit, the rounds would load before the jurisdictions would reload with round status, so trying to access it would fail. These data are always loaded at the same time, but not in the same request.

Simple fix is just to check for null - it shouldn't cause real impact.
