### PR TITLE
Use psycopg2 connection from db_session for CVR writes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -222,7 +222,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=Base.metadata,db_session.(commit|add|rollback|delete|merge|execute|begin_nested|close|flush),app.logger.(info|warning|error|critical|debug|exception)
+generated-members=Base.metadata,db_session.(commit|add|rollback|delete|merge|execute|begin_nested|close|flush|connection),app.logger.(info|warning|error|critical|debug|exception)
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).


### PR DESCRIPTION
I discovered this was possible during some other investigation. So now we don't have the problem of having the CVR ballot writes in a separate transaction. Note that this is already covered by a specific test case.