### PR TITLE
CSV upload: fix bug where file name persists after delete

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/CSVForm/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/CSVForm/index.tsx
@@ -226,7 +226,10 @@ const CSVFile = ({
                     {deleteCSVFile && (
                       <AsyncButton
                         key="delete"
-                        onClick={deleteCSVFile}
+                        onClick={async () => {
+                          await deleteCSVFile()
+                          setFieldValue('csv', null)
+                        }}
                         disabled={!enabled}
                         style={{ marginLeft: '5px' }}
                       >


### PR DESCRIPTION
Due to some recent changes to persist the form state over rerenders (in order to preserve the CVR file type selection), the name of the file was also getting persisted after the Delete File button was clicked. So we manually clear it out.
