### PR TITLE
Hide "Count Unique Sampled Ballots" button before audit launch

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.test.tsx
@@ -80,6 +80,12 @@ describe('Progress screen', () => {
       expect(footers[0]).toHaveTextContent('Total')
       expect(footers[1]).toHaveTextContent('1/3 complete')
       expect(footers[2]).toHaveTextContent('2,117')
+
+      expect(
+        screen.queryByRole('checkbox', {
+          name: 'Count unique sampled ballots',
+        })
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
@@ -33,7 +33,7 @@ const Wrapper = styled.div`
 
 const TableControls = styled.div`
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   margin-bottom: 0.5rem;
 `
@@ -322,12 +322,14 @@ const Progress: React.FC<IProps> = ({
             onChange={value => setFilter(value)}
           />
         </div>
-        <Switch
-          checked={isShowingUnique}
-          label={`Count unique sampled ${ballotsOrBatches.toLowerCase()}`}
-          onChange={() => setIsShowingUnique(!isShowingUnique)}
-          style={{ marginRight: '20px' }}
-        />
+        {round && (
+          <Switch
+            checked={isShowingUnique}
+            label={`Count unique sampled ${ballotsOrBatches.toLowerCase()}`}
+            onChange={() => setIsShowingUnique(!isShowingUnique)}
+            style={{ marginRight: '20px', marginBottom: 0 }}
+          />
+        )}
         <DownloadCSVButton
           tableId="progress-table"
           fileName={`audit-progress-${


### PR DESCRIPTION
It doesn't apply until the audit has launched.
