### PR TITLE
Bugfix: Create audit admins with email case-insensitity

### DIFF
--- a/server/api/support.py
+++ b/server/api/support.py
@@ -189,7 +189,7 @@ def create_audit_admin(organization_id: str):
     audit_admin = request.get_json()
     validate(audit_admin, AUDIT_ADMIN_SCHEMA)
 
-    user = User.query.filter_by(email=audit_admin["email"]).one_or_none()
+    user = User.query.filter_by(email=audit_admin["email"].lower()).one_or_none()
     if not user:
         user = User(
             id=str(uuid.uuid4()),

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -260,7 +260,8 @@ def test_support_create_audit_admin_already_exists(  # pylint: disable=invalid-n
     MockAuth0, MockGetToken, client: FlaskClient, org_id: str,
 ):
     # Start with an existing user that isn't already an audit admin for this org
-    user_id = create_user(email="already-exists@example.org").id
+    aa_email = "Already-exists@example.org"  # Test case-insensitivity
+    user_id = create_user(email=aa_email).id
     db_session.commit()
     user = User.query.get(user_id)
 
@@ -276,7 +277,7 @@ def test_support_create_audit_admin_already_exists(  # pylint: disable=invalid-n
     rv = post_json(
         client,
         f"/api/support/organizations/{org_id}/audit-admins",
-        {"email": user.email},
+        {"email": aa_email},
     )
     assert_ok(rv)
 


### PR DESCRIPTION
Task: #1329 

While we were saving the email as lowercase (due to the validator on User.email), we weren't finding existing audit admins with lowercase emails.