### PR TITLE
Recompute contest metadata when standardized contests/jurisdictions change

### DIFF
--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -19,7 +19,8 @@ from ..util.file import serialize_file, serialize_file_processing
 from ..util.csv_download import csv_response
 from ..util.csv_parse import decode_csv_file, parse_csv, CSVValueType, CSVColumnType
 from ..audit_math.suite import HybridPair
-from .cvrs import clear_cvr_data, process_cvr_file
+from . import contests
+from . import cvrs
 from .batch_tallies import (
     clear_batch_tallies_data,
     process_batch_tallies_file,
@@ -129,16 +130,14 @@ def process_ballot_manifest_file(
         jurisdiction.manifest_num_ballots = num_ballots
         jurisdiction.manifest_num_batches = num_batches
 
-        if jurisdiction.election.audit_type != AuditType.BALLOT_POLLING:
-            for contest in jurisdiction.contests:
-                set_total_ballots_from_manifests(contest)
+        contests.set_contest_metadata(jurisdiction.election)
 
         # If CVR file already uploaded, try reprocessing it, since it depends on
         # batch names from the manifest
         if jurisdiction.cvr_file:
-            clear_cvr_data(jurisdiction)
+            cvrs.clear_cvr_data(jurisdiction)
             jurisdiction.cvr_file.task = create_background_task(
-                process_cvr_file,
+                cvrs.process_cvr_file,
                 dict(
                     jurisdiction_id=jurisdiction.id,
                     jurisdiction_admin_email=jurisdiction_admin_email,

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -8,8 +8,8 @@ from ..auth import restrict_access, UserType
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from ..util.jsonschema import validate, JSONDict
-from . import cvrs
-from . import ballot_manifest
+from . import cvrs  # pylint: disable=cyclic-import
+from . import ballot_manifest  # pylint: disable=cyclic-import
 
 
 CONTEST_CHOICE_SCHEMA = {

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -8,8 +8,8 @@ from ..auth import restrict_access, UserType
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
 from ..util.jsonschema import validate, JSONDict
-from .cvrs import hybrid_contest_choice_vote_counts, set_contest_metadata_from_cvrs
-from .ballot_manifest import set_total_ballots_from_manifests
+from . import cvrs
+from . import ballot_manifest
 
 
 CONTEST_CHOICE_SCHEMA = {
@@ -86,7 +86,7 @@ def serialize_contest(contest: Contest) -> JSONDict:
         for choice in contest.choices
     ]
     if contest.election.audit_type == AuditType.HYBRID:
-        vote_counts = hybrid_contest_choice_vote_counts(contest)
+        vote_counts = cvrs.hybrid_contest_choice_vote_counts(contest)
         for choice in choices:
             choice["numVotesCvr"] = vote_counts and vote_counts[str(choice["id"])].cvr
             choice["numVotesNonCvr"] = (
@@ -183,6 +183,18 @@ def validate_contests(contests: List[JSONDict], election: Election):
                 )
 
 
+# In various audit types, we set different pieces of contest metadata from
+# different underlying data sources (e.g. manifest or CVR files). Whenever a
+# contest changes or when those data sources change, we need to recompute the
+# metadata.
+def set_contest_metadata(election: Election):
+    for contest in election.contests:
+        if election.audit_type != AuditType.BALLOT_POLLING:
+            ballot_manifest.set_total_ballots_from_manifests(contest)
+        if election.audit_type == AuditType.BALLOT_COMPARISON:
+            cvrs.set_contest_metadata_from_cvrs(contest)
+
+
 @api.route("/election/<election_id>/contest", methods=["PUT"])
 @restrict_access([UserType.AUDIT_ADMIN])
 def create_or_update_all_contests(election: Election):
@@ -190,19 +202,11 @@ def create_or_update_all_contests(election: Election):
     validate_contests(json_contests, election)
 
     Contest.query.filter_by(election_id=election.id).delete()
-
-    contests = [
+    election.contests = [
         deserialize_contest(json_contest, election.id) for json_contest in json_contests
     ]
-    db_session.add_all(contests)
 
-    if election.audit_type != AuditType.BALLOT_POLLING:
-        for contest in contests:
-            set_total_ballots_from_manifests(contest)
-
-    if election.audit_type == AuditType.BALLOT_COMPARISON:
-        for contest in contests:
-            set_contest_metadata_from_cvrs(contest)
+    set_contest_metadata(election)
 
     db_session.commit()
 
@@ -274,8 +278,7 @@ def put_contest_name_standardizations(election: Election):
             jurisdiction.id
         )
 
-    for contest in election.contests:
-        set_contest_metadata_from_cvrs(contest)
+    set_contest_metadata(election)
 
     db_session.commit()
 

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from . import api
 from ..database import db_session, engine as db_engine
 from ..models import *  # pylint: disable=wildcard-import
+from . import contests
 from ..auth import restrict_access, UserType, get_loggedin_user, get_support_user
 from ..worker.tasks import (
     UserError,
@@ -516,9 +517,7 @@ def process_cvr_file(
             )
         )
 
-        if jurisdiction.election.audit_type == AuditType.BALLOT_COMPARISON:
-            for contest in jurisdiction.election.contests:
-                set_contest_metadata_from_cvrs(contest)
+        contests.set_contest_metadata(jurisdiction.election)
 
         emit_progress(total_lines, total_lines)
 

--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -15,6 +15,7 @@ from ..database import db_session
 from ..auth import restrict_access, UserType
 from .rounds import get_current_round, sampled_all_ballots
 from .ballot_manifest import hybrid_jurisdiction_total_ballots
+from .contests import set_contest_metadata
 from .standardized_contests import process_standardized_contests_file
 from ..worker.tasks import (
     background_task,
@@ -94,6 +95,8 @@ def process_jurisdictions_file(election_id: str):
     Jurisdiction.query.filter(Jurisdiction.id.in_(unmanaged_admin_ids)).delete(
         synchronize_session="fetch"
     )
+
+    set_contest_metadata(election)
 
     # If standardized contests file already uploaded, try reprocessing the
     # standardized contests file as well, since it depends on jurisdiction names.

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -8,6 +8,7 @@ from . import api
 from ..auth import restrict_access, UserType
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
+from .contests import set_contest_metadata
 from ..worker.tasks import (
     UserError,
     background_task,
@@ -89,6 +90,8 @@ def process_standardized_contests_file(election_id: str):
             contest.jurisdictions = Jurisdiction.query.filter(
                 Jurisdiction.id.in_(standardized_contest["jurisdictionIds"])
             ).all()
+
+    set_contest_metadata(election)
 
 
 def validate_standardized_contests_upload(request: Request, election: Election):

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -209,6 +209,68 @@ def test_set_contest_metadata_on_manifest_and_cvr_upload(
     )
 
 
+def test_set_contest_metadata_on_jurisdiction_change(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    cvrs,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    contest_id = str(uuid.uuid4())
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/contest",
+        [
+            {
+                "id": contest_id,
+                "name": "Contest 2",
+                "numWinners": 1,
+                "jurisdictionIds": jurisdiction_ids[:2],
+                "isTargeted": True,
+            }
+        ],
+    )
+    assert_ok(rv)
+
+    # Contest metadata is set
+    rv = client.get(f"/api/election/{election_id}/contest")
+    original_contest = json.loads(rv.data)["contests"][0]
+    assert original_contest["totalBallotsCast"] is not None
+    assert original_contest["votesAllowed"] is not None
+    assert original_contest["choices"] != []
+
+    # Upload new jurisdictions, removing J1
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/file",
+        data={
+            "jurisdictions": (
+                io.BytesIO(
+                    (
+                        "Jurisdiction,Admin Email\n"
+                        f"J2,{default_ja_email(election_id)}\n"
+                        f"J3,j3-{election_id}@example.com\n"
+                    ).encode()
+                ),
+                "jurisdictions.csv",
+            )
+        },
+    )
+    assert_ok(rv)
+
+    # Contest universe and metadata changes
+    rv = client.get(f"/api/election/{election_id}/contest")
+    contest = json.loads(rv.data)["contests"][0]
+    assert contest["jurisdictionIds"] == [jurisdiction_ids[1]]
+    assert contest["totalBallotsCast"] == original_contest["totalBallotsCast"] / 2
+    assert contest["votesAllowed"] == original_contest["votesAllowed"]
+    assert (
+        contest["choices"][0]["numVotes"]
+        == original_contest["choices"][0]["numVotes"] / 2
+    )
+
+
 def test_require_cvr_uploads(
     client: FlaskClient,
     election_id: str,


### PR DESCRIPTION
If standardized contests/jurisdictions are reuploaded and change after contests are already created, the contest universe for those contests will change (which we already handled). If the contest universe changes, however, that means that any contest metadata that was computed from files uploaded in that universe (manifests, CVRs) also needs to be updated.

This change ensures that we recompute that metadata in those two cases. It also factors out the recomputing of metadata functionality into one function to make sure that it happens consistently whenever any dependencies change.
