### PR TITLE
Rename offline batch results -> full hand tally batch results

### DIFF
--- a/client/cypress/end-to-end/full-hand-tally.spec.js
+++ b/client/cypress/end-to-end/full-hand-tally.spec.js
@@ -2,7 +2,7 @@ import 'cypress-file-upload'
 
 before(() => cy.exec('./cypress/seed-test-db.sh'))
 
-describe('Offline Batch Data Entry', () => {
+describe('Full Hand Tally Data Entry', () => {
   const auditAdmin = 'audit-admin-cypress@example.com'
   const jurisdictionAdmin = 'wtarkin@empire.gov'
   const uuid = () => Cypress._.random(0, 1e6)

--- a/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
@@ -143,13 +143,13 @@ const JurisdictionDetail = ({
   </Dialog>
 )
 
-const unfinalizeOfflineBatchResults = async (
+const unfinalizeFullHandTallyResults = async (
   electionId: string,
   jurisdictionId: string,
   roundId: string
 ): Promise<boolean> => {
   return !!(await api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch/finalize`,
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/finalize`,
     { method: 'DELETE' }
   ))
 }
@@ -195,7 +195,7 @@ const RoundStatusSection = ({
             initialValues={{}}
             onSubmit={async () => {
               if (
-                await unfinalizeOfflineBatchResults(
+                await unfinalizeFullHandTallyResults(
                   electionId,
                   jurisdiction.id,
                   round.id

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
@@ -275,7 +275,7 @@ const Progress: React.FC<IProps> = ({
         Footer: totalFooter(`${ballotsOrBatches} Remaining`),
       }
     )
-    // Special column for offline batch results (full hand tally)
+    // Special column for full hand tally
     if (
       jurisdictions[0].currentRoundStatus &&
       jurisdictions[0].currentRoundStatus.numBatchesAudited !== undefined

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/FullHandTallyDataEntry.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/FullHandTallyDataEntry.test.tsx
@@ -4,18 +4,18 @@ import userEvent from '@testing-library/user-event'
 import { useParams } from 'react-router-dom'
 import { contestMocks } from '../useSetupMenuItems/_mocks'
 import {
-  offlineBatchMocks,
-  offlineBatchResultsMocks,
+  fullHandTallyBatchResultMock,
+  fullHandTallyBatchResultsMock,
   roundMocks,
 } from './_mocks'
 import { renderWithRouter, withMockFetch } from '../../testUtilities'
 import { IContest } from '../../../types'
 import { IBatch } from './useBatchResults'
-import OfflineBatchRoundDataEntry from './OfflineBatchRoundDataEntry'
 import {
-  IOfflineBatchResult,
-  IOfflineBatchResults,
-} from './useOfflineBatchResults'
+  IFullHandTallyBatchResult,
+  IFullHandTallyBatchResults,
+} from './useFullHandTallyResults'
+import FullHandTallyDataEntry from './FullHandTallyDataEntry'
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
@@ -37,12 +37,12 @@ const apiCalls = {
     url: '/api/election/1/jurisdiction/1/round/round-1/batches',
     response,
   }),
-  getResults: (response: IOfflineBatchResults) => ({
-    url: '/api/election/1/jurisdiction/1/round/round-1/results/batch',
+  getResults: (response: IFullHandTallyBatchResults) => ({
+    url: '/api/election/1/jurisdiction/1/round/round-1/full-hand-tally/batch',
     response,
   }),
-  postResults: (results: IOfflineBatchResult) => ({
-    url: '/api/election/1/jurisdiction/1/round/round-1/results/batch/',
+  postResults: (results: IFullHandTallyBatchResult) => ({
+    url: '/api/election/1/jurisdiction/1/round/round-1/full-hand-tally/batch/',
     options: {
       method: 'POST',
       body: JSON.stringify(results),
@@ -52,8 +52,11 @@ const apiCalls = {
     },
     response: { status: 'ok' },
   }),
-  putResults: (results: IOfflineBatchResult, previousBatchName: string) => ({
-    url: `/api/election/1/jurisdiction/1/round/round-1/results/batch/${previousBatchName}`,
+  putResults: (
+    results: IFullHandTallyBatchResult,
+    previousBatchName: string
+  ) => ({
+    url: `/api/election/1/jurisdiction/1/round/round-1/full-hand-tally/batch/${previousBatchName}`,
     options: {
       method: 'PUT',
       body: JSON.stringify(results),
@@ -64,14 +67,15 @@ const apiCalls = {
     response: { status: 'ok' },
   }),
   deleteResults: (batchName: string) => ({
-    url: `/api/election/1/jurisdiction/1/round/round-1/results/batch/${batchName}`,
+    url: `/api/election/1/jurisdiction/1/round/round-1/full-hand-tally/batch/${batchName}`,
     options: {
       method: 'DELETE',
     },
     response: { status: 'ok' },
   }),
   finalizeResults: {
-    url: '/api/election/1/jurisdiction/1/round/round-1/results/batch/finalize',
+    url:
+      '/api/election/1/jurisdiction/1/round/round-1/full-hand-tally/finalize',
     options: {
       method: 'POST',
     },
@@ -79,15 +83,15 @@ const apiCalls = {
   },
 }
 
-describe('offline batch round data entry', () => {
+describe('full hand tally data entry', () => {
   it('renders', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.empty),
+      apiCalls.getResults(fullHandTallyBatchResultMock.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -102,11 +106,11 @@ describe('offline batch round data entry', () => {
   it('validation error for blank submission', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.empty),
+      apiCalls.getResults(fullHandTallyBatchResultMock.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -132,16 +136,16 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it('submits offline batch', async () => {
+  it('submits full hand tally batch result', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.empty),
-      apiCalls.postResults(offlineBatchResultsMocks.complete),
-      apiCalls.getResults(offlineBatchMocks.complete),
+      apiCalls.getResults(fullHandTallyBatchResultMock.empty),
+      apiCalls.postResults(fullHandTallyBatchResultsMock.complete),
+      apiCalls.getResults(fullHandTallyBatchResultMock.complete),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -179,14 +183,14 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it('renders with offline batches', async () => {
+  it('renders with full hand tally results', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.complete),
+      apiCalls.getResults(fullHandTallyBatchResultMock.complete),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -202,11 +206,13 @@ describe('offline batch round data entry', () => {
   it('renders with proper totals', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.completeWithMultipleBatch),
+      apiCalls.getResults(
+        fullHandTallyBatchResultMock.completeWithMultipleBatch
+      ),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -226,16 +232,16 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it('edits offline batch', async () => {
+  it('edits full hand tally batch result', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.complete),
-      apiCalls.putResults(offlineBatchResultsMocks.updated, 'Batch1'),
-      apiCalls.getResults(offlineBatchMocks.updated),
+      apiCalls.getResults(fullHandTallyBatchResultMock.complete),
+      apiCalls.putResults(fullHandTallyBatchResultsMock.updated, 'Batch1'),
+      apiCalls.getResults(fullHandTallyBatchResultMock.updated),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -263,16 +269,16 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it('deletes offline batch', async () => {
+  it('deletes full hand tally batch result', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.complete),
-      apiCalls.deleteResults(offlineBatchResultsMocks.complete.batchName),
-      apiCalls.getResults(offlineBatchMocks.empty),
+      apiCalls.getResults(fullHandTallyBatchResultMock.complete),
+      apiCalls.deleteResults(fullHandTallyBatchResultsMock.complete.batchName),
+      apiCalls.getResults(fullHandTallyBatchResultMock.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -297,16 +303,16 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it('finalizes offline batches', async () => {
+  it('finalizes full hand tally results', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.complete),
+      apiCalls.getResults(fullHandTallyBatchResultMock.complete),
       apiCalls.finalizeResults,
-      apiCalls.getResults(offlineBatchMocks.finalized),
+      apiCalls.getResults(fullHandTallyBatchResultMock.finalized),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/FullHandTallyDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/FullHandTallyDataEntry.tsx
@@ -21,14 +21,14 @@ import {
 import styled from 'styled-components'
 import useContestsJurisdictionAdmin from './useContestsJurisdictionAdmin'
 import { IRound } from '../useRoundsAuditAdmin'
-import useOfflineBatchResults, {
-  IOfflineBatchResult,
-} from './useOfflineBatchResults'
 import { testNumber } from '../../utilities'
 import CopyToClipboard from '../../Atoms/CopyToClipboard'
 import { sum } from '../../../utils/number'
+import useFullHandTallyResults, {
+  IFullHandTallyBatchResult,
+} from './useFullHandTallyResults'
 
-const OfflineBatchResultsForm = styled.form`
+const FullHandTallyResultsForm = styled.form`
   table {
     position: relative;
     border: 1px solid ${Colors.LIGHT_GRAY1};
@@ -105,7 +105,7 @@ interface IProps {
   round: IRound
 }
 
-const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
+const FullHandTallyDataEntry = ({ round }: IProps) => {
   const { electionId, jurisdictionId } = useParams<{
     electionId: string
     jurisdictionId: string
@@ -117,7 +117,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
     updateResult,
     removeResult,
     finalizeResults,
-  ] = useOfflineBatchResults(electionId, jurisdictionId, round.id)
+  ] = useFullHandTallyResults(electionId, jurisdictionId, round.id)
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
 
   if (!contests || !batchResults) return null
@@ -130,14 +130,14 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
   const total = (choiceId: string) =>
     sum(results.map(batch => batch.choiceResults[choiceId]))
 
-  const emptyBatch = (): IOfflineBatchResult => ({
+  const emptyBatch = (): IFullHandTallyBatchResult => ({
     batchName: '',
     batchType: '',
     choiceResults: {},
   })
 
   interface FormValues {
-    editingBatch: IOfflineBatchResult | null
+    editingBatch: IFullHandTallyBatchResult | null
     editingBatchIndex: number | null
   }
 
@@ -183,7 +183,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
           handleReset,
         } = props
         return (
-          <OfflineBatchResultsForm>
+          <FullHandTallyResultsForm>
             <div style={{ width: '510px', marginBottom: '20px' }}>
               <p>
                 When you have examined all the ballots assigned to you, enter
@@ -470,11 +470,11 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                 </div>
               </div>
             </Dialog>
-          </OfflineBatchResultsForm>
+          </FullHandTallyResultsForm>
         )
       }}
     </Formik>
   )
 }
 
-export default OfflineBatchRoundDataEntry
+export default FullHandTallyDataEntry

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`offline batch round data entry deletes offline batch 1`] = `
+exports[`full hand tally data entry deletes full hand tally batch result 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -156,7 +156,7 @@ exports[`offline batch round data entry deletes offline batch 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry edits offline batch 1`] = `
+exports[`full hand tally data entry edits full hand tally batch result 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -357,7 +357,7 @@ exports[`offline batch round data entry edits offline batch 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry finalizes offline batches 1`] = `
+exports[`full hand tally data entry finalizes full hand tally results 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -590,7 +590,7 @@ exports[`offline batch round data entry finalizes offline batches 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry renders 1`] = `
+exports[`full hand tally data entry renders 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -746,7 +746,7 @@ exports[`offline batch round data entry renders 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry renders with offline batches 1`] = `
+exports[`full hand tally data entry renders with full hand tally results 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -947,7 +947,7 @@ exports[`offline batch round data entry renders with offline batches 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry renders with proper totals 1`] = `
+exports[`full hand tally data entry renders with proper totals 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -1200,7 +1200,7 @@ exports[`offline batch round data entry renders with proper totals 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry submits offline batch 1`] = `
+exports[`full hand tally data entry submits full hand tally batch result 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -1401,7 +1401,7 @@ exports[`offline batch round data entry submits offline batch 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry validation error for blank submission 1`] = `
+exports[`full hand tally data entry validation error for blank submission 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
@@ -2,9 +2,9 @@ import { IBatches } from './useBatchResults'
 import { IRound } from '../useRoundsAuditAdmin'
 import { FileProcessingStatus } from '../useCSV'
 import {
-  IOfflineBatchResult,
-  IOfflineBatchResults,
-} from './useOfflineBatchResults'
+  IFullHandTallyBatchResults,
+  IFullHandTallyBatchResult,
+} from './useFullHandTallyResults'
 
 export interface INullResultValues {
   [contestId: string]: {
@@ -192,13 +192,13 @@ export const batchesMocks: {
   },
 }
 
-export const offlineBatchMocks: {
+export const fullHandTallyBatchResultMock: {
   [key in
     | 'empty'
     | 'complete'
     | 'updated'
     | 'finalized'
-    | 'completeWithMultipleBatch']: IOfflineBatchResults
+    | 'completeWithMultipleBatch']: IFullHandTallyBatchResults
 } = {
   empty: {
     finalizedAt: '',
@@ -266,8 +266,8 @@ export const offlineBatchMocks: {
   },
 }
 
-export const offlineBatchResultsMocks: {
-  [key in 'empty' | 'complete' | 'updated']: IOfflineBatchResult
+export const fullHandTallyBatchResultsMock: {
+  [key in 'empty' | 'complete' | 'updated']: IFullHandTallyBatchResult
 } = {
   empty: {
     batchName: '',

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
@@ -9,7 +9,7 @@ import {
   batchesMocks,
   batchResultsMocks,
   INullResultValues,
-  offlineBatchMocks,
+  fullHandTallyBatchResultMock,
 } from './_mocks'
 import { dummyBallots } from '../../DataEntry/_mocks'
 import {
@@ -22,8 +22,8 @@ import { IBatch } from './useBatchResults'
 import { jaApiCalls } from '../_mocks'
 import AuthDataProvider from '../../UserContext'
 import { IAuditSettings } from '../useAuditSettings'
-import { IOfflineBatchResults } from './useOfflineBatchResults'
 import { queryClient } from '../../../App'
+import { IFullHandTallyBatchResults } from './useFullHandTallyResults'
 
 const renderView = (props: IRoundManagementProps) =>
   renderWithRouter(
@@ -60,9 +60,9 @@ const apiCalls = {
     url: '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/batches',
     response,
   }),
-  getOfflineBatchResults: (response: IOfflineBatchResults) => ({
+  getFullHandTallyBatchResults: (response: IFullHandTallyBatchResults) => ({
     url:
-      '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/results/batch',
+      '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/full-hand-tally/batch',
     response,
   }),
 }
@@ -215,13 +215,13 @@ describe('RoundManagement', () => {
     })
   })
 
-  it('shows offline batch results data entry when all ballots sampled', async () => {
+  it('shows full hand tally data entry when all ballots sampled', async () => {
     const expectedCalls = [
       apiCalls.getSettings(auditSettings.offlineAll),
       jaApiCalls.getUser,
       apiCalls.getBallotCount,
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getOfflineBatchResults(offlineBatchMocks.empty),
+      apiCalls.getFullHandTallyBatchResults(fullHandTallyBatchResultMock.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView({

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
@@ -18,10 +18,10 @@ import useAuditSettingsJurisdictionAdmin from './useAuditSettingsJurisdictionAdm
 import BatchRoundDataEntry from './BatchRoundDataEntry'
 import { useAuthDataContext, IJurisdictionAdmin } from '../../UserContext'
 import { IRound } from '../useRoundsAuditAdmin'
-import OfflineBatchRoundDataEntry from './OfflineBatchRoundDataEntry'
 import { IAuditSettings } from '../useAuditSettings'
 import AsyncButton from '../../Atoms/AsyncButton'
 import useSampleCount from './useBallots'
+import FullHandTallyDataEntry from './FullHandTallyDataEntry'
 
 const PaddedWrapper = styled(Wrapper)`
   flex-direction: column;
@@ -148,7 +148,7 @@ const RoundManagement = ({
         ) : auditSettings.online ? (
           <RoundProgress auditBoards={auditBoards} />
         ) : round.sampledAllBallots ? (
-          <OfflineBatchRoundDataEntry round={round} />
+          <FullHandTallyDataEntry round={round} />
         ) : (
           <RoundDataEntry round={round} />
         )}

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useFullHandTallyResults.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useFullHandTallyResults.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { api } from '../../utilities'
 
-export interface IOfflineBatchResult {
+export interface IFullHandTallyBatchResult {
   batchName: string
   batchType:
     | 'Absentee By Mail'
@@ -15,18 +15,18 @@ export interface IOfflineBatchResult {
   }
 }
 
-export interface IOfflineBatchResults {
+export interface IFullHandTallyBatchResults {
   finalizedAt: string
-  results: IOfflineBatchResult[]
+  results: IFullHandTallyBatchResult[]
 }
 
 const getResults = async (
   electionId: string,
   jurisdictionId: string,
   roundId: string
-): Promise<IOfflineBatchResults | null> => {
+): Promise<IFullHandTallyBatchResults | null> => {
   return api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch`
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/batch`
   )
 }
 
@@ -34,10 +34,10 @@ const postResult = async (
   electionId: string,
   jurisdictionId: string,
   roundId: string,
-  newResult: IOfflineBatchResult
+  newResult: IFullHandTallyBatchResult
 ): Promise<boolean> => {
   return !!(await api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch/`,
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/batch/`,
     {
       method: 'POST',
       body: JSON.stringify(newResult),
@@ -53,10 +53,10 @@ const putResult = async (
   jurisdictionId: string,
   roundId: string,
   batchName: string,
-  newResult: IOfflineBatchResult
+  newResult: IFullHandTallyBatchResult
 ): Promise<boolean> => {
   return !!(await api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch/${encodeURIComponent(
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/batch/${encodeURIComponent(
       batchName
     )}`,
     {
@@ -76,7 +76,7 @@ const deleteResult = async (
   batchName: string
 ): Promise<boolean> => {
   return !!(await api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch/${encodeURIComponent(
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/batch/${encodeURIComponent(
       batchName
     )}`,
     {
@@ -91,28 +91,30 @@ const postFinalizeResults = async (
   roundId: string
 ): Promise<boolean> => {
   return !!(await api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch/finalize`,
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/finalize`,
     {
       method: 'POST',
     }
   ))
 }
 
-const useOfflineBatchResults = (
+const useFullHandTallyResults = (
   electionId: string,
   jurisdictionId: string,
   roundId: string
 ): [
-  IOfflineBatchResults | null,
-  (newResult: IOfflineBatchResult) => Promise<boolean>,
-  (batchName: string, newResult: IOfflineBatchResult) => Promise<boolean>,
+  IFullHandTallyBatchResults | null,
+  (newResult: IFullHandTallyBatchResult) => Promise<boolean>,
+  (batchName: string, newResult: IFullHandTallyBatchResult) => Promise<boolean>,
   (batchName: string) => Promise<boolean>,
   () => Promise<boolean>
 ] => {
-  const [results, setResults] = useState<IOfflineBatchResults | null>(null)
+  const [results, setResults] = useState<IFullHandTallyBatchResults | null>(
+    null
+  )
 
   const addResult = async (
-    newResult: IOfflineBatchResult
+    newResult: IFullHandTallyBatchResult
   ): Promise<boolean> => {
     const success = await postResult(
       electionId,
@@ -127,7 +129,7 @@ const useOfflineBatchResults = (
 
   const updateResult = async (
     batchName: string,
-    newResult: IOfflineBatchResult
+    newResult: IFullHandTallyBatchResult
   ): Promise<boolean> => {
     const success = await putResult(
       electionId,
@@ -179,4 +181,4 @@ const useOfflineBatchResults = (
   return [results, addResult, updateResult, removeResult, finalizeResults]
 }
 
-export default useOfflineBatchResults
+export default useFullHandTallyResults

--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -18,7 +18,7 @@ from . import audit_boards
 from . import ballots
 from . import batches
 from . import offline_results
-from . import offline_batch_results
+from . import full_hand_tally
 from . import reports
 from . import activity
 from . import support

--- a/server/api/full_hand_tally.py
+++ b/server/api/full_hand_tally.py
@@ -23,7 +23,7 @@ class BatchType(str, enum.Enum):
     OTHER = "Other"
 
 
-OFFLINE_BATCH_RESULT_SCHEMA = {
+FULL_HAND_TALLY_BATCH_RESULT_SCHEMA = {
     "type": "object",
     "properties": {
         "batchName": {"type": "string", "minLength": 1, "maxLength": 200},
@@ -47,11 +47,11 @@ OFFLINE_BATCH_RESULT_SCHEMA = {
 }
 
 
-def validate_offline_batch_result_request(
+def validate_full_hand_tally_batch_result_request(
     election: Election, jurisdiction: Jurisdiction, round: Round,
 ):
     if len(list(election.contests)) > 1:
-        raise Conflict("Offline batch results only supported for single contest audits")
+        raise Conflict("Full hand tally only supported for single contest audits")
 
     # We only support one contest for now
     contest = list(election.contests)[0]
@@ -60,11 +60,9 @@ def validate_offline_batch_result_request(
         raise Conflict("Jurisdiction not in contest universe")
 
     if not sampled_all_ballots(round, election):
-        raise Conflict(
-            "Offline batch results only supported if all ballots are sampled"
-        )
+        raise Conflict("Full hand tally only supported if all ballots are sampled")
 
-    if jurisdiction.finalized_offline_batch_results_at is not None:
+    if jurisdiction.finalized_full_hand_tally_results_at is not None:
         raise Conflict("Results have already been finalized")
 
     current_round = get_current_round(election)
@@ -78,15 +76,15 @@ def validate_offline_batch_result_request(
         raise Conflict("Must set up audit boards before recording results")
 
 
-def validate_offline_batch_result(
+def validate_full_hand_tally_batch_result(
     election: Election,
     jurisdiction: Jurisdiction,
     round: Round,
     batch_result: JSONDict,
 ):
-    validate_offline_batch_result_request(election, jurisdiction, round)
+    validate_full_hand_tally_batch_result_request(election, jurisdiction, round)
 
-    validate(batch_result, OFFLINE_BATCH_RESULT_SCHEMA)
+    validate(batch_result, FULL_HAND_TALLY_BATCH_RESULT_SCHEMA)
 
     # We only support one contest for now
     contest = list(election.contests)[0]
@@ -96,33 +94,23 @@ def validate_offline_batch_result(
         raise BadRequest(f"Invalid choice ids for batch {batch_result['batchName']}")
 
 
-def load_offline_batch_results(jurisdiction: Jurisdiction) -> List[OfflineBatchResult]:
-    return list(
-        OfflineBatchResult.query.filter_by(jurisdiction_id=jurisdiction.id)
-        .order_by(OfflineBatchResult.created_at)
-        .all()
-    )
-
-
-def serialize_offline_batch_results(
-    offline_batch_results: List[OfflineBatchResult], contest: Contest
+def serialize_full_hand_tally_batch_results(
+    results: List[FullHandTallyBatchResult], contest: Contest
 ) -> List[JSONDict]:
     # We want to display batches in the order the user created them. Dict keys
     # are ordered, so we use a dict to dedupe the batch names while preserving
-    # order. (Assumes offline_batch_results is already ordered by created_at)
+    # order. (Assumes results is already ordered by created_at)
     ordered_batches = list(
-        dict.fromkeys(
-            (result.batch_name, result.batch_type) for result in offline_batch_results
-        )
+        dict.fromkeys((result.batch_name, result.batch_type) for result in results)
     )
 
     results_by_batch: JSONDict = defaultdict(
         lambda: {choice.id: None for choice in contest.choices}
     )
-    for result in offline_batch_results:
+    for result in results:
         results_by_batch[result.batch_name][result.contest_choice_id] = result.result
 
-    results = [
+    json_results = [
         {
             "batchName": batch_name,
             "batchType": batch_type,
@@ -130,45 +118,30 @@ def serialize_offline_batch_results(
         }
         for batch_name, batch_type in ordered_batches
     ]
-    return results
+    return json_results
 
 
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch",
-    methods=["PUT"],
-)
-@restrict_access([UserType.JURISDICTION_ADMIN])
-def record_offline_batch_results(
-    election: Election,  # pylint: disable=unused-argument
-    jurisdiction: Jurisdiction,
-    round: Round,
-):
-    raise Conflict(
-        "Arlo has been updated. Please refresh your browser for the latest version."
-    )
-
-
-@api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch/",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/batch/",
     methods=["POST"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def add_offline_batch_result(
+def add_full_hand_tally_batch_result(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,
 ):
     batch_result = request.get_json()
-    validate_offline_batch_result(election, jurisdiction, round, batch_result)
+    validate_full_hand_tally_batch_result(election, jurisdiction, round, batch_result)
 
-    if OfflineBatchResult.query.filter_by(
+    if FullHandTallyBatchResult.query.filter_by(
         jurisdiction_id=jurisdiction.id, batch_name=batch_result["batchName"]
     ).first():
         raise Conflict("Batch names must be unique")
 
     for contest_choice_id, result in batch_result["choiceResults"].items():
         db_session.add(
-            OfflineBatchResult(
+            FullHandTallyBatchResult(
                 jurisdiction_id=jurisdiction.id,
                 batch_name=batch_result["batchName"],
                 batch_type=batch_result["batchType"],
@@ -183,29 +156,29 @@ def add_offline_batch_result(
 
 
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch/<path:batch_name>",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/batch/<path:batch_name>",
     methods=["PUT"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def update_offline_batch_result(
+def update_full_hand_tally_batch_result(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,
     batch_name: str,
 ):
     batch_result = request.get_json()
-    validate_offline_batch_result(election, jurisdiction, round, batch_result)
+    validate_full_hand_tally_batch_result(election, jurisdiction, round, batch_result)
 
     if (
         batch_name != batch_result["batchName"]
-        and OfflineBatchResult.query.filter_by(
+        and FullHandTallyBatchResult.query.filter_by(
             jurisdiction_id=jurisdiction.id, batch_name=batch_result["batchName"]
         ).first()
     ):
         raise Conflict("Batch names must be unique")
 
     for contest_choice_id, result in batch_result["choiceResults"].items():
-        new_batch_result = OfflineBatchResult.query.filter_by(
+        new_batch_result = FullHandTallyBatchResult.query.filter_by(
             jurisdiction_id=jurisdiction.id,
             batch_name=batch_name,
             contest_choice_id=contest_choice_id,
@@ -226,19 +199,19 @@ def update_offline_batch_result(
 # We use the `path:` converter for the batch_name parameter because it's
 # URI-encoded and we want to decode it with support for slashes
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch/<path:batch_name>",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/batch/<path:batch_name>",
     methods=["DELETE"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def delete_offline_batch_result(
+def delete_full_hand_tally_batch_result(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,  # pylint: disable=unused-argument
     batch_name: str,
 ):
-    validate_offline_batch_result_request(election, jurisdiction, round)
+    validate_full_hand_tally_batch_result_request(election, jurisdiction, round)
 
-    OfflineBatchResult.query.filter_by(
+    FullHandTallyBatchResult.query.filter_by(
         jurisdiction_id=jurisdiction.id, batch_name=batch_name
     ).delete()
 
@@ -248,22 +221,23 @@ def delete_offline_batch_result(
 
 
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch/finalize",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/finalize",
     methods=["POST"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def finalize_offline_batch_results(
+def finalize_full_hand_tally_batch_results(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,
 ):
-    jurisdiction.finalized_offline_batch_results_at = datetime.now(timezone.utc)
+    jurisdiction.finalized_full_hand_tally_results_at = datetime.now(timezone.utc)
 
     sum_results_by_choice = (
-        OfflineBatchResult.query.filter_by(jurisdiction_id=jurisdiction.id)
-        .group_by(OfflineBatchResult.contest_choice_id)
+        FullHandTallyBatchResult.query.filter_by(jurisdiction_id=jurisdiction.id)
+        .group_by(FullHandTallyBatchResult.contest_choice_id)
         .values(
-            OfflineBatchResult.contest_choice_id, func.sum(OfflineBatchResult.result)
+            FullHandTallyBatchResult.contest_choice_id,
+            func.sum(FullHandTallyBatchResult.result),
         )
     )
 
@@ -287,22 +261,22 @@ def finalize_offline_batch_results(
 
 
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch/finalize",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/finalize",
     methods=["DELETE"],
 )
 @restrict_access([UserType.AUDIT_ADMIN])
-def unfinalize_offline_batch_results(
+def unfinalize_full_hand_tally_batch_results(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,
 ):
-    if jurisdiction.finalized_offline_batch_results_at is None:
+    if jurisdiction.finalized_full_hand_tally_results_at is None:
         raise Conflict("Results have not been finalized")
 
     if round.ended_at is not None:
         raise Conflict("Results cannot be unfinalized after the audit round ends")
 
-    jurisdiction.finalized_offline_batch_results_at = None
+    jurisdiction.finalized_full_hand_tally_results_at = None
 
     JurisdictionResult.query.filter_by(
         round_id=round.id, jurisdiction_id=jurisdiction.id,
@@ -314,11 +288,11 @@ def unfinalize_offline_batch_results(
 
 
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/batch",
     methods=["GET"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def get_offline_batch_results(
+def get_full_hand_tally_batch_results(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,  # pylint: disable=unused-argument
@@ -326,11 +300,15 @@ def get_offline_batch_results(
     # We only support one contest for now
     contest = list(election.contests)[0]
 
+    results = list(
+        FullHandTallyBatchResult.query.filter_by(jurisdiction_id=jurisdiction.id)
+        .order_by(FullHandTallyBatchResult.created_at)
+        .all()
+    )
+
     return jsonify(
         {
-            "finalizedAt": isoformat(jurisdiction.finalized_offline_batch_results_at),
-            "results": serialize_offline_batch_results(
-                load_offline_batch_results(jurisdiction), contest
-            ),
+            "finalizedAt": isoformat(jurisdiction.finalized_full_hand_tally_results_at),
+            "results": serialize_full_hand_tally_batch_results(results, contest),
         }
     )

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -402,18 +402,18 @@ def round_rows(election: Election):
     return rows
 
 
-def offline_batch_result_rows(election: Election, jurisdiction: Jurisdiction = None):
-    rows = [heading("BATCH RESULTS")]
+def full_hand_tally_result_rows(election: Election, jurisdiction: Jurisdiction = None):
+    rows = [heading("FULL HAND TALLY BATCH RESULTS")]
 
     results_query = (
-        OfflineBatchResult.query.join(Jurisdiction)
+        FullHandTallyBatchResult.query.join(Jurisdiction)
         .filter_by(election_id=election.id)
-        .order_by(Jurisdiction.name, OfflineBatchResult.batch_name)
+        .order_by(Jurisdiction.name, FullHandTallyBatchResult.batch_name)
     )
     if jurisdiction:
         results_query = results_query.filter(Jurisdiction.id == jurisdiction.id)
     results = list(
-        results_query.with_entities(Jurisdiction.name, OfflineBatchResult).all()
+        results_query.with_entities(Jurisdiction.name, FullHandTallyBatchResult).all()
     )
 
     # For now, we only support one contest
@@ -446,7 +446,7 @@ def sampled_ballot_rows(election: Election, jurisdiction: Jurisdiction = None):
     # Special case: if we sampled all ballots, don't show this section
     rounds = list(election.rounds)
     if len(rounds) > 0 and sampled_all_ballots(rounds[0], election):
-        return offline_batch_result_rows(election, jurisdiction)
+        return full_hand_tally_result_rows(election, jurisdiction)
 
     rows = [heading("SAMPLED BALLOTS")]
 

--- a/server/migrations/versions/266fba5a5c8a_rename_offlinebatchresult_to_.py
+++ b/server/migrations/versions/266fba5a5c8a_rename_offlinebatchresult_to_.py
@@ -1,0 +1,57 @@
+# pylint: disable=invalid-name
+"""Rename OfflineBatchResult to FullHandTallyBatchResult
+
+Revision ID: 266fba5a5c8a
+Revises: 30f47ec7308c
+Create Date: 2021-11-04 17:29:16.156954+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "266fba5a5c8a"
+down_revision = "30f47ec7308c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.rename_table("offline_batch_result", "full_hand_tally_batch_result")
+    op.drop_constraint("offline_batch_result_pkey", "full_hand_tally_batch_result")
+    op.drop_constraint(
+        "offline_batch_result_jurisdiction_id_fkey", "full_hand_tally_batch_result"
+    )
+    op.drop_constraint(
+        "offline_batch_result_contest_choice_id_fkey", "full_hand_tally_batch_result"
+    )
+    op.create_foreign_key(
+        "full_hand_tally_batch_result_contest_choice_id_fkey",
+        "full_hand_tally_batch_result",
+        "contest_choice",
+        ["contest_choice_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    op.create_foreign_key(
+        "full_hand_tally_batch_result_jurisdiction_id_fkey",
+        "full_hand_tally_batch_result",
+        "jurisdiction",
+        ["jurisdiction_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    op.create_primary_key(
+        "full_hand_tally_batch_result_pkey",
+        "full_hand_tally_batch_result",
+        ["jurisdiction_id", "batch_name", "contest_choice_id",],
+    )
+
+    op.alter_column(
+        "jurisdiction",
+        "finalized_offline_batch_results_at",
+        new_column_name="finalized_full_hand_tally_results_at",
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -292,8 +292,7 @@ class Jurisdiction(BaseModel):
     # { contest_name: cvr_contest_name }
     contest_name_standardizations = Column(JSON)
 
-    # For ballot polling audits where offline batch results are recorded (currently only full hand counts)
-    finalized_offline_batch_results_at = Column(UTCDateTime)
+    finalized_full_hand_tally_results_at = Column(UTCDateTime)
 
     batches = relationship(
         "Batch", back_populates="jurisdiction", uselist=True, passive_deletes=True
@@ -746,10 +745,10 @@ class RoundContestResult(BaseModel):
     result = Column(Integer, nullable=False)
 
 
-# In an offline ballot polling audit, records the audited vote count for one
+# In a full hand tally, records the audited vote count for one
 # batch for one contest choice. Note that we don't require the batch name to
 # match any of the batches in the ballot manifest.
-class OfflineBatchResult(BaseModel):
+class FullHandTallyBatchResult(BaseModel):
     jurisdiction_id = Column(
         String(200), ForeignKey("jurisdiction.id", ondelete="cascade"), nullable=False,
     )

--- a/server/tests/snapshots/snap_test_full_hand_tally.py
+++ b/server/tests/snapshots/snap_test_full_hand_tally.py
@@ -15,7 +15,7 @@ snapshots["test_all_ballots_audit 1"] = {
 
 snapshots[
     "test_all_ballots_audit 2"
-] = """######## BATCH RESULTS ########\r
+] = """######## FULL HAND TALLY BATCH RESULTS ########\r
 Jurisdiction Name,Batch Name,Batch Type,candidate 1,candidate 2,candidate 3\r
 J1,Batch One,Provisional,125000,124875,125\r
 J1,Batch Three,Election Day,125000,124875,125\r
@@ -40,7 +40,7 @@ Test Audit test_all_ballots_audit,BALLOT_POLLING,BRAVO,10%,1234567890,No\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
 1,Contest 1,Targeted,2000000,Yes,0,DATETIME,DATETIME,candidate 1: 1000000; candidate 2: 999000; candidate 3: 1000\r
 \r
-######## BATCH RESULTS ########\r
+######## FULL HAND TALLY BATCH RESULTS ########\r
 Jurisdiction Name,Batch Name,Batch Type,candidate 1,candidate 2,candidate 3\r
 J1,Batch One,Provisional,125000,124875,125\r
 J1,Batch Three,Election Day,125000,124875,125\r

--- a/server/tests/test_full_hand_tally.py
+++ b/server/tests/test_full_hand_tally.py
@@ -176,13 +176,13 @@ def test_all_ballots_audit(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/",
         jurisdiction_1_results,
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
@@ -201,13 +201,13 @@ def test_all_ballots_audit(
 
     rv = put_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/{urllib.parse.quote('Batch/Zero')}",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/{urllib.parse.quote('Batch/Zero')}",
         jurisdiction_1_results,
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
@@ -267,27 +267,27 @@ def test_all_ballots_audit(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/",
         next_jurisdiction_1_results_a,
     )
     assert_ok(rv)
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/",
         next_jurisdiction_1_results_b,
     )
     assert_ok(rv)
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/",
         next_jurisdiction_1_results_c,
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
@@ -298,11 +298,11 @@ def test_all_ballots_audit(
     # Delete a result
     updated_jurisdiction_1_results = updated_jurisdiction_1_results[:-1]
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/{urllib.parse.quote('Batch/Bogus')}"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/{urllib.parse.quote('Batch/Bogus')}"
     )
     assert_ok(rv)
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
@@ -312,13 +312,13 @@ def test_all_ballots_audit(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
     # Finalize the results
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     compare_json(
@@ -392,13 +392,13 @@ def test_all_ballots_audit(
     for result in jurisdiction_2_results:
         rv = post_json(
             client,
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/results/batch/",
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/full-hand-tally/batch/",
             result,
         )
         assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
@@ -408,12 +408,12 @@ def test_all_ballots_audit(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     compare_json(
@@ -452,7 +452,7 @@ def test_all_ballots_audit(
     assert_match_report(rv.data, snapshot)
 
 
-def test_offline_batch_results_validation(
+def test_full_hand_tally_results_validation(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
@@ -563,7 +563,7 @@ def test_offline_batch_results_validation(
     for invalid_result, expected_message in invalid_results:
         rv = post_json(
             client,
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
             invalid_result,
         )
         assert rv.status_code == 400
@@ -574,7 +574,7 @@ def test_offline_batch_results_validation(
         if invalid_result.get("batchName"):
             rv = put_json(
                 client,
-                f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/{invalid_result['batchName']}",
+                f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/{invalid_result['batchName']}",
                 invalid_result,
             )
             assert rv.status_code == 400
@@ -585,7 +585,7 @@ def test_offline_batch_results_validation(
     # No duplicate batch names
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 1",
             "batchType": "Provisional",
@@ -598,7 +598,7 @@ def test_offline_batch_results_validation(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 1",
             "batchType": "Election Day",
@@ -615,7 +615,7 @@ def test_offline_batch_results_validation(
     # No renaming to another batch's name
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 2",
             "batchType": "Provisional",
@@ -628,7 +628,7 @@ def test_offline_batch_results_validation(
 
     rv = put_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/Batch 2",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/Batch 2",
         {
             "batchName": "Batch 1",
             "batchType": "Provisional",
@@ -645,7 +645,7 @@ def test_offline_batch_results_validation(
     # Can't edit a batch that doesn't exist
     rv = put_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/not a real batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/not a real batch",
         {
             "batchName": "Batch 3",
             "batchType": "Election Day",
@@ -661,19 +661,19 @@ def test_offline_batch_results_validation(
 
     # Special case: deleting a batch that doesn't exist is ok (maybe somebody else already deleted it)
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/not a real batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/not a real batch",
     )
     assert_ok(rv)
 
     # Can't edit a batch that's been deleted
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/Batch 1",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/Batch 1",
     )
     assert_ok(rv)
 
     rv = put_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/Batch 1",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/Batch 1",
         {
             "batchName": "Batch 1",
             "batchType": "Provisional",
@@ -690,13 +690,13 @@ def test_offline_batch_results_validation(
     # Can't add/edit/delete results after finalizing
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         [
             {
                 "batchName": "Batch 1",
@@ -717,7 +717,7 @@ def test_offline_batch_results_validation(
 
     rv = put_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/Batch 1",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/Batch 1",
         [
             {
                 "batchName": "Batch 1",
@@ -737,7 +737,7 @@ def test_offline_batch_results_validation(
     }
 
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/Batch 1",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/Batch 1",
     )
     assert rv.status_code == 409
     assert json.loads(rv.data) == {
@@ -747,52 +747,7 @@ def test_offline_batch_results_validation(
     }
 
 
-def test_offline_batch_results_old_endpoint(
-    client: FlaskClient,
-    election_id: str,
-    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
-    round_1_id: str,
-):
-    set_logged_in_user(
-        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
-    )
-    rv = post_json(
-        client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
-        [{"name": "Audit Board #1"}, {"name": "Audit Board #2"}],
-    )
-
-    rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/contest"
-    )
-    contest = json.loads(rv.data)["contests"][0]
-
-    rv = put_json(
-        client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch",
-        [
-            {
-                "batchName": "Batch 1",
-                "batchType": "Provisional",
-                "choiceResults": {
-                    choice["id"]: choice["numVotes"] / 4
-                    for choice in contest["choices"]
-                },
-            }
-        ],
-    )
-    assert rv.status_code == 409
-    assert json.loads(rv.data) == {
-        "errors": [
-            {
-                "errorType": "Conflict",
-                "message": "Arlo has been updated. Please refresh your browser for the latest version.",
-            }
-        ]
-    }
-
-
-def test_offline_batch_results_unfinalize(
+def test_full_hand_tally_results_unfinalize(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
@@ -815,7 +770,7 @@ def test_offline_batch_results_unfinalize(
     # JA uploads results
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 1",
             "batchType": "Provisional",
@@ -829,7 +784,7 @@ def test_offline_batch_results_unfinalize(
     # AA tries to unfinalize the results before they have been finalized
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize"
     )
     assert rv.status_code == 409
     assert json.loads(rv.data) == {
@@ -844,19 +799,19 @@ def test_offline_batch_results_unfinalize(
     )
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch"
     )
     assert_is_date(json.loads(rv.data)["finalizedAt"])
 
     # AA unfinalizes the results
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize"
     )
     assert_ok(rv)
 
@@ -864,14 +819,14 @@ def test_offline_batch_results_unfinalize(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch"
     )
     assert json.loads(rv.data)["finalizedAt"] is None
 
     # JA updates the results
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 2",
             "batchType": "Election Day",
@@ -885,12 +840,12 @@ def test_offline_batch_results_unfinalize(
     # JA refinalizes the results
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch"
     )
     assert_is_date(json.loads(rv.data)["finalizedAt"])
 
@@ -902,7 +857,7 @@ def test_offline_batch_results_unfinalize(
     )
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 1",
             "batchType": "Election Day",
@@ -915,7 +870,7 @@ def test_offline_batch_results_unfinalize(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
@@ -929,7 +884,7 @@ def test_offline_batch_results_unfinalize(
     # AA tries to unfinalize results but can't
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize"
     )
     assert rv.status_code == 409
     assert json.loads(rv.data) == {


### PR DESCRIPTION
The previous naming for this feature "offline batch results" was confusingly similar to two other parts of Arlo - "offline results" for ballot polling audits, and "batch results" for batch comparison audits.

In order to make it clear that this feature is meant specifically for full hand tallying, we rename it just that: full hand tally batch results.

This will make things clearer alongside some upcoming changes to how we detect and flag full hand tallies.