### PR TITLE
Rework how we check for full hand tallies

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,7 @@ omit =
     scripts/*
 
 [report]
-fail_under = 99.5
+fail_under = 99.6
 precision = 2
 skip_covered = true
 show_missing = true

--- a/client/cypress/end-to-end/full-hand-tally.spec.js
+++ b/client/cypress/end-to-end/full-hand-tally.spec.js
@@ -2,7 +2,7 @@ import 'cypress-file-upload'
 
 before(() => cy.exec('./cypress/seed-test-db.sh'))
 
-describe('Offline Batch Data Entry', () => {
+describe('Full Hand Tally Data Entry', () => {
   const auditAdmin = 'audit-admin-cypress@example.com'
   const jurisdictionAdmin = 'wtarkin@empire.gov'
   const uuid = () => Cypress._.random(0, 1e6)

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
@@ -264,59 +264,14 @@ exports[`Audit Setup > Review & Launch custom sample size validation - ballot co
                   checked=""
                   name="sampleSizes[contest-id]"
                   type="radio"
-                  value="asn"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                BRAVO Average Sample Number: 
-                20 samples
-                 (54% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.7"
+                  value="supersimple"
                 />
                 <span
                   class="bp3-control-indicator"
                 />
                 
-                21 samples
-                 (70% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.5"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
+                15 samples
                 
-                22 samples
-                 (50% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.9"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                
-                31 samples
-                 (90% chance of reaching risk limit and completing the audit in one round)
               </label>
               <label
                 class="bp3-control bp3-radio"
@@ -614,59 +569,14 @@ exports[`Audit Setup > Review & Launch custom sample size validation - batch com
                   checked=""
                   name="sampleSizes[contest-id]"
                   type="radio"
-                  value="asn"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                BRAVO Average Sample Number: 
-                20 samples
-                 (54% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.7"
+                  value="macro"
                 />
                 <span
                   class="bp3-control-indicator"
                 />
                 
-                21 samples
-                 (70% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.5"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
+                4 samples
                 
-                22 samples
-                 (50% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.9"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                
-                31 samples
-                 (90% chance of reaching risk limit and completing the audit in one round)
               </label>
               <label
                 class="bp3-control bp3-radio"
@@ -1664,59 +1574,14 @@ exports[`Audit Setup > Review & Launch renders full state with batch comparison 
                   checked=""
                   name="sampleSizes[contest-id]"
                   type="radio"
-                  value="asn"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                BRAVO Average Sample Number: 
-                20 samples
-                 (54% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.7"
+                  value="macro"
                 />
                 <span
                   class="bp3-control-indicator"
                 />
                 
-                21 samples
-                 (70% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.5"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
+                4 samples
                 
-                22 samples
-                 (50% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.9"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                
-                31 samples
-                 (90% chance of reaching risk limit and completing the audit in one round)
               </label>
               <label
                 class="bp3-control bp3-radio"

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/_mocks.ts
@@ -46,21 +46,39 @@ export const settingsMock: {
   },
 }
 
+const taskCompleteMock = {
+  status: FileProcessingStatus.PROCESSED,
+  startedAt: '2019-07-18T16:34:07.000+00:00',
+  completedAt: '2019-07-18T16:35:07.000+00:00',
+  error: null,
+}
+
 export const sampleSizeMock = {
-  sampleSizes: {
-    'contest-id': [
-      { prob: 0.54, size: 20, key: 'asn' },
-      { prob: 0.7, size: 21, key: '0.7' },
-      { prob: 0.5, size: 22, key: '0.5' },
-      { prob: 0.9, size: 31, key: '0.9' },
-    ],
+  batchComparison: {
+    sampleSizes: {
+      'contest-id': [{ prob: null, size: 4, key: 'macro' }],
+    },
+    selected: null,
+    task: taskCompleteMock,
   },
-  selected: null,
-  task: {
-    status: FileProcessingStatus.PROCESSED,
-    startedAt: '2019-07-18T16:34:07.000+00:00',
-    completedAt: '2019-07-18T16:35:07.000+00:00',
-    error: null,
+  ballotComparison: {
+    sampleSizes: {
+      'contest-id': [{ prob: null, size: 15, key: 'supersimple' }],
+    },
+    selected: null,
+    task: taskCompleteMock,
+  },
+  ballotPolling: {
+    sampleSizes: {
+      'contest-id': [
+        { prob: 0.54, size: 20, key: 'asn' },
+        { prob: 0.7, size: 21, key: '0.7' },
+        { prob: 0.5, size: 22, key: '0.5' },
+        { prob: 0.9, size: 31, key: '0.9' },
+      ],
+    },
+    selected: null,
+    task: taskCompleteMock,
   },
 }
 

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
@@ -142,7 +142,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -159,7 +159,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -176,7 +176,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -209,7 +209,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.batchComparison),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -228,7 +228,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -245,7 +245,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -313,7 +313,7 @@ describe('Audit Setup > Review & Launch', () => {
         cvrContestNames: {},
       }),
       apiCalls.getSampleSizeOptions({
-        ...sampleSizeMock,
+        ...sampleSizeMock.ballotPolling,
         sampleSizes: {
           'contest-id': [
             { key: 'suite', size: 10, sizeCvr: 3, sizeNonCvr: 7, prob: null },
@@ -400,10 +400,10 @@ describe('Audit Setup > Review & Launch', () => {
         cvrContestNames: {},
       }),
       apiCalls.getSampleSizeOptions({
-        ...sampleSizeMock,
+        ...sampleSizeMock.ballotPolling,
         sampleSizes: null,
         task: {
-          ...sampleSizeMock.task,
+          ...sampleSizeMock.ballotPolling.task,
           status: FileProcessingStatus.ERRORED,
           error: 'sample sizes error',
         },
@@ -482,7 +482,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -509,7 +509,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -535,7 +535,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -565,7 +565,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -577,14 +577,14 @@ describe('Audit Setup > Review & Launch', () => {
       fireEvent.change(customSampleSizeInput, { target: { value: '40' } }) // userEvent has a problem with this field due to the lack of an explicit value field: https://github.com/testing-library/user-event/issues/356
       fireEvent.blur(customSampleSizeInput)
       await screen.findByText(
-        'Must be less than or equal to: 30 (the total number of ballots in the contest)'
+        'Must be less than or equal to 30 (the total number of ballots in the contest)'
       )
       userEvent.clear(customSampleSizeInput)
       fireEvent.change(customSampleSizeInput, { target: { value: '5' } })
       await waitFor(() =>
         expect(
           screen.queryByText(
-            'Must be less than or equal to: 30 (the total number of ballots in the contest)'
+            'Must be less than or equal to 30 (the total number of ballots in the contest)'
           )
         ).toBeNull()
       )
@@ -643,7 +643,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.batchComparison),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -659,7 +659,7 @@ describe('Audit Setup > Review & Launch', () => {
       fireEvent.change(customSampleSizeInput, { target: { value: '40' } }) // userEvent has a problem with this field due to the lack of an explicit value field: https://github.com/testing-library/user-event/issues/356
       fireEvent.blur(customSampleSizeInput)
       await screen.findByText(
-        'Must be less than or equal to: 20 (the total number of batches in the contest)'
+        'Must be less than or equal to 20 (the total number of batches in the contest)'
       )
     })
   })
@@ -677,7 +677,7 @@ describe('Audit Setup > Review & Launch', () => {
         standardizations: {},
         cvrContestNames: {},
       }),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotComparison),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -693,7 +693,7 @@ describe('Audit Setup > Review & Launch', () => {
       fireEvent.change(customSampleSizeInput, { target: { value: '50' } }) // userEvent has a problem with this field due to the lack of an explicit value field: https://github.com/testing-library/user-event/issues/356
       fireEvent.blur(customSampleSizeInput)
       await screen.findByText(
-        'Must be less than or equal to: 30 (the total number of ballots in the contest)'
+        'Must be less than or equal to 30 (the total number of ballots in the contest)'
       )
     })
   })
@@ -707,7 +707,7 @@ describe('Audit Setup > Review & Launch', () => {
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
       apiCalls.getSampleSizeOptions({
-        ...sampleSizeMock,
+        ...sampleSizeMock.ballotPolling,
         selected: { 'contest-id': { key: 'custom', size: 100, prob: null } },
       }),
     ]
@@ -796,7 +796,7 @@ describe('Audit Setup > Review & Launch', () => {
         },
         cvrContestNames,
       }),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotComparison),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -894,7 +894,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargeted),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -933,10 +933,11 @@ describe('Audit Setup > Review & Launch', () => {
         ],
       }),
       apiCalls.getSampleSizeOptions({
-        ...sampleSizeMock,
+        ...sampleSizeMock.ballotPolling,
         sampleSizes: {
-          ...sampleSizeMock.sampleSizes,
-          'contest-id-2': sampleSizeMock.sampleSizes['contest-id'],
+          ...sampleSizeMock.ballotPolling.sampleSizes,
+          'contest-id-2':
+            sampleSizeMock.ballotPolling.sampleSizes['contest-id'],
         },
       }),
     ]
@@ -970,7 +971,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargeted),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -996,7 +997,37 @@ describe('Audit Setup > Review & Launch', () => {
     })
   })
 
-  it('in a non-ballot-polling audit, shows an error when sample size is a full hand tally', async () => {
+  it('in a ballot comparison audit, shows an error when sample size is a full hand tally', async () => {
+    const expectedCalls = [
+      apiCalls.getSettings(auditSettings.ballotComparisonAll),
+      apiCalls.getJurisdictions({
+        jurisdictions: jurisdictionMocks.allManifestsWithCVRs,
+      }),
+      apiCalls.getJurisdictionFile,
+      apiCalls.getContests(contestMocks.filledTargeted),
+      apiCalls.getStandardizedContestsFile,
+      apiCalls.getStandardizations({
+        standardizations: {},
+        cvrContestNames: {},
+      }),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotComparison),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderView()
+      await screen.findByText(/Choose the initial sample size/)
+      userEvent.click(screen.getByLabelText(/Enter your own sample size/))
+      userEvent.type(screen.getByRole('spinbutton'), '30')
+      const warning = (await screen.findByText(
+        'The currently selected sample size for this contest requires a full hand tally.'
+      )).closest('.bp3-callout') as HTMLElement
+      expect(warning).toHaveClass('bp3-intent-danger')
+      within(warning).getByText(
+        'To use Arlo for a full hand tally, recreate this audit using the ballot polling audit type.'
+      )
+    })
+  })
+
+  it('in a batch comparison audit, shows an error when sample size is a full hand tally', async () => {
     const expectedCalls = [
       apiCalls.getSettings(auditSettings.batchComparisonAll),
       apiCalls.getJurisdictions({
@@ -1004,12 +1035,13 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargeted),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
       await screen.findByText(/Choose the initial sample size/)
-      userEvent.click(screen.getByLabelText(/90%/))
+      userEvent.click(screen.getByLabelText(/Enter your own sample size/))
+      userEvent.type(screen.getByRole('spinbutton'), '20')
       const warning = (await screen.findByText(
         'The currently selected sample size for this contest requires a full hand tally.'
       )).closest('.bp3-callout') as HTMLElement

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
@@ -377,7 +377,7 @@ describe('Audit Setup > Review & Launch', () => {
             key: 'custom',
             sizeCvr: 10,
             sizeNonCvr: 20,
-            size: null,
+            size: 30,
             prob: null,
           },
         })

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -581,8 +581,14 @@ const Review: React.FC<IProps> = ({
                                       }
                                       onValueChange={(value: number) =>
                                         setFieldValue(
-                                          `sampleSizes[${contest.id}].sizeCvr`,
-                                          value
+                                          `sampleSizes[${contest.id}]`,
+                                          {
+                                            ...currentOption,
+                                            sizeCvr: value,
+                                            size:
+                                              (currentOption.sizeNonCvr || 0) +
+                                              value,
+                                          }
                                         )
                                       }
                                       type="number"
@@ -609,8 +615,14 @@ const Review: React.FC<IProps> = ({
                                       }
                                       onValueChange={(value: number) =>
                                         setFieldValue(
-                                          `sampleSizes[${contest.id}].sizeNonCvr`,
-                                          value
+                                          `sampleSizes[${contest.id}]`,
+                                          {
+                                            ...currentOption,
+                                            sizeNonCvr: value,
+                                            size:
+                                              (currentOption.sizeCvr || 0) +
+                                              value,
+                                          }
                                         )
                                       }
                                       type="number"

--- a/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
@@ -143,13 +143,13 @@ const JurisdictionDetail = ({
   </Dialog>
 )
 
-const unfinalizeOfflineBatchResults = async (
+const unfinalizeFullHandTallyResults = async (
   electionId: string,
   jurisdictionId: string,
   roundId: string
 ): Promise<boolean> => {
   return !!(await api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch/finalize`,
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/finalize`,
     { method: 'DELETE' }
   ))
 }
@@ -195,7 +195,7 @@ const RoundStatusSection = ({
             initialValues={{}}
             onSubmit={async () => {
               if (
-                await unfinalizeOfflineBatchResults(
+                await unfinalizeFullHandTallyResults(
                   electionId,
                   jurisdiction.id,
                   round.id

--- a/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/JurisdictionDetail.tsx
@@ -188,7 +188,7 @@ const RoundStatusSection = ({
     const jurisdictionStatus =
       jurisdiction.currentRoundStatus && jurisdiction.currentRoundStatus.status
 
-    if (round.sampledAllBallots) {
+    if (round.isFullHandTally) {
       if (jurisdictionStatus === JurisdictionRoundStatus.COMPLETE)
         return (
           <Formik

--- a/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/Progress/index.tsx
@@ -279,7 +279,7 @@ const Progress: React.FC<IProps> = ({
         Footer: totalFooter(`${ballotsOrBatches} Remaining`),
       }
     )
-    // Special column for offline batch results (full hand tally)
+    // Special column for full hand tally
     if (
       jurisdictions[0].currentRoundStatus &&
       jurisdictions[0].currentRoundStatus.numBatchesAudited !== undefined

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/FullHandTallyDataEntry.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/FullHandTallyDataEntry.test.tsx
@@ -91,9 +91,7 @@ describe('full hand tally data entry', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <FullHandTallyDataEntry
-          round={roundMocks.sampledAllBallotsIncomplete}
-        />,
+        <FullHandTallyDataEntry round={roundMocks.fullHandTallyIncomplete} />,
         {
           route: '/election/1/jurisdiction/1',
         }
@@ -110,9 +108,7 @@ describe('full hand tally data entry', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <FullHandTallyDataEntry
-          round={roundMocks.sampledAllBallotsIncomplete}
-        />,
+        <FullHandTallyDataEntry round={roundMocks.fullHandTallyIncomplete} />,
         {
           route: '/election/1/jurisdiction/1',
         }
@@ -145,9 +141,7 @@ describe('full hand tally data entry', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <FullHandTallyDataEntry
-          round={roundMocks.sampledAllBallotsIncomplete}
-        />,
+        <FullHandTallyDataEntry round={roundMocks.fullHandTallyIncomplete} />,
         {
           route: '/election/1/jurisdiction/1',
         }
@@ -190,9 +184,7 @@ describe('full hand tally data entry', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <FullHandTallyDataEntry
-          round={roundMocks.sampledAllBallotsIncomplete}
-        />,
+        <FullHandTallyDataEntry round={roundMocks.fullHandTallyIncomplete} />,
         {
           route: '/election/1/jurisdiction/1',
         }
@@ -212,9 +204,7 @@ describe('full hand tally data entry', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <FullHandTallyDataEntry
-          round={roundMocks.sampledAllBallotsIncomplete}
-        />,
+        <FullHandTallyDataEntry round={roundMocks.fullHandTallyIncomplete} />,
         {
           route: '/election/1/jurisdiction/1',
         }
@@ -241,9 +231,7 @@ describe('full hand tally data entry', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <FullHandTallyDataEntry
-          round={roundMocks.sampledAllBallotsIncomplete}
-        />,
+        <FullHandTallyDataEntry round={roundMocks.fullHandTallyIncomplete} />,
         {
           route: '/election/1/jurisdiction/1',
         }
@@ -278,9 +266,7 @@ describe('full hand tally data entry', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <FullHandTallyDataEntry
-          round={roundMocks.sampledAllBallotsIncomplete}
-        />,
+        <FullHandTallyDataEntry round={roundMocks.fullHandTallyIncomplete} />,
         {
           route: '/election/1/jurisdiction/1',
         }
@@ -312,9 +298,7 @@ describe('full hand tally data entry', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <FullHandTallyDataEntry
-          round={roundMocks.sampledAllBallotsIncomplete}
-        />,
+        <FullHandTallyDataEntry round={roundMocks.fullHandTallyIncomplete} />,
         {
           route: '/election/1/jurisdiction/1',
         }

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/FullHandTallyDataEntry.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/FullHandTallyDataEntry.test.tsx
@@ -4,18 +4,18 @@ import userEvent from '@testing-library/user-event'
 import { useParams } from 'react-router-dom'
 import { contestMocks } from '../useSetupMenuItems/_mocks'
 import {
-  offlineBatchMocks,
-  offlineBatchResultsMocks,
+  fullHandTallyBatchResultMock,
+  fullHandTallyBatchResultsMock,
   roundMocks,
 } from './_mocks'
 import { renderWithRouter, withMockFetch } from '../../testUtilities'
 import { IContest } from '../../../types'
 import { IBatch } from './useBatchResults'
-import OfflineBatchRoundDataEntry from './OfflineBatchRoundDataEntry'
 import {
-  IOfflineBatchResult,
-  IOfflineBatchResults,
-} from './useOfflineBatchResults'
+  IFullHandTallyBatchResult,
+  IFullHandTallyBatchResults,
+} from './useFullHandTallyResults'
+import FullHandTallyDataEntry from './FullHandTallyDataEntry'
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
@@ -37,12 +37,12 @@ const apiCalls = {
     url: '/api/election/1/jurisdiction/1/round/round-1/batches',
     response,
   }),
-  getResults: (response: IOfflineBatchResults) => ({
-    url: '/api/election/1/jurisdiction/1/round/round-1/results/batch',
+  getResults: (response: IFullHandTallyBatchResults) => ({
+    url: '/api/election/1/jurisdiction/1/round/round-1/full-hand-tally/batch',
     response,
   }),
-  postResults: (results: IOfflineBatchResult) => ({
-    url: '/api/election/1/jurisdiction/1/round/round-1/results/batch/',
+  postResults: (results: IFullHandTallyBatchResult) => ({
+    url: '/api/election/1/jurisdiction/1/round/round-1/full-hand-tally/batch/',
     options: {
       method: 'POST',
       body: JSON.stringify(results),
@@ -52,8 +52,11 @@ const apiCalls = {
     },
     response: { status: 'ok' },
   }),
-  putResults: (results: IOfflineBatchResult, previousBatchName: string) => ({
-    url: `/api/election/1/jurisdiction/1/round/round-1/results/batch/${previousBatchName}`,
+  putResults: (
+    results: IFullHandTallyBatchResult,
+    previousBatchName: string
+  ) => ({
+    url: `/api/election/1/jurisdiction/1/round/round-1/full-hand-tally/batch/${previousBatchName}`,
     options: {
       method: 'PUT',
       body: JSON.stringify(results),
@@ -64,14 +67,15 @@ const apiCalls = {
     response: { status: 'ok' },
   }),
   deleteResults: (batchName: string) => ({
-    url: `/api/election/1/jurisdiction/1/round/round-1/results/batch/${batchName}`,
+    url: `/api/election/1/jurisdiction/1/round/round-1/full-hand-tally/batch/${batchName}`,
     options: {
       method: 'DELETE',
     },
     response: { status: 'ok' },
   }),
   finalizeResults: {
-    url: '/api/election/1/jurisdiction/1/round/round-1/results/batch/finalize',
+    url:
+      '/api/election/1/jurisdiction/1/round/round-1/full-hand-tally/finalize',
     options: {
       method: 'POST',
     },
@@ -79,15 +83,15 @@ const apiCalls = {
   },
 }
 
-describe('offline batch round data entry', () => {
+describe('full hand tally data entry', () => {
   it('renders', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.empty),
+      apiCalls.getResults(fullHandTallyBatchResultMock.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -102,11 +106,11 @@ describe('offline batch round data entry', () => {
   it('validation error for blank submission', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.empty),
+      apiCalls.getResults(fullHandTallyBatchResultMock.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -132,16 +136,16 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it('submits offline batch', async () => {
+  it('submits full hand tally batch result', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.empty),
-      apiCalls.postResults(offlineBatchResultsMocks.complete),
-      apiCalls.getResults(offlineBatchMocks.complete),
+      apiCalls.getResults(fullHandTallyBatchResultMock.empty),
+      apiCalls.postResults(fullHandTallyBatchResultsMock.complete),
+      apiCalls.getResults(fullHandTallyBatchResultMock.complete),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -179,14 +183,14 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it('renders with offline batches', async () => {
+  it('renders with full hand tally results', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.complete),
+      apiCalls.getResults(fullHandTallyBatchResultMock.complete),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -202,11 +206,13 @@ describe('offline batch round data entry', () => {
   it('renders with proper totals', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.completeWithMultipleBatch),
+      apiCalls.getResults(
+        fullHandTallyBatchResultMock.completeWithMultipleBatch
+      ),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -226,16 +232,16 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it('edits offline batch', async () => {
+  it('edits full hand tally batch result', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.complete),
-      apiCalls.putResults(offlineBatchResultsMocks.updated, 'Batch1'),
-      apiCalls.getResults(offlineBatchMocks.updated),
+      apiCalls.getResults(fullHandTallyBatchResultMock.complete),
+      apiCalls.putResults(fullHandTallyBatchResultsMock.updated, 'Batch1'),
+      apiCalls.getResults(fullHandTallyBatchResultMock.updated),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -263,16 +269,16 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it('deletes offline batch', async () => {
+  it('deletes full hand tally batch result', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.complete),
-      apiCalls.deleteResults(offlineBatchResultsMocks.complete.batchName),
-      apiCalls.getResults(offlineBatchMocks.empty),
+      apiCalls.getResults(fullHandTallyBatchResultMock.complete),
+      apiCalls.deleteResults(fullHandTallyBatchResultsMock.complete.batchName),
+      apiCalls.getResults(fullHandTallyBatchResultMock.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {
@@ -297,16 +303,16 @@ describe('offline batch round data entry', () => {
     })
   })
 
-  it('finalizes offline batches', async () => {
+  it('finalizes full hand tally results', async () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getResults(offlineBatchMocks.complete),
+      apiCalls.getResults(fullHandTallyBatchResultMock.complete),
       apiCalls.finalizeResults,
-      apiCalls.getResults(offlineBatchMocks.finalized),
+      apiCalls.getResults(fullHandTallyBatchResultMock.finalized),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderWithRouter(
-        <OfflineBatchRoundDataEntry
+        <FullHandTallyDataEntry
           round={roundMocks.sampledAllBallotsIncomplete}
         />,
         {

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/FullHandTallyDataEntry.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/FullHandTallyDataEntry.tsx
@@ -21,14 +21,14 @@ import {
 import styled from 'styled-components'
 import useContestsJurisdictionAdmin from './useContestsJurisdictionAdmin'
 import { IRound } from '../useRoundsAuditAdmin'
-import useOfflineBatchResults, {
-  IOfflineBatchResult,
-} from './useOfflineBatchResults'
 import { testNumber } from '../../utilities'
 import CopyToClipboard from '../../Atoms/CopyToClipboard'
 import { sum } from '../../../utils/number'
+import useFullHandTallyResults, {
+  IFullHandTallyBatchResult,
+} from './useFullHandTallyResults'
 
-const OfflineBatchResultsForm = styled.form`
+const FullHandTallyResultsForm = styled.form`
   table {
     position: relative;
     border: 1px solid ${Colors.LIGHT_GRAY1};
@@ -105,7 +105,7 @@ interface IProps {
   round: IRound
 }
 
-const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
+const FullHandTallyDataEntry = ({ round }: IProps) => {
   const { electionId, jurisdictionId } = useParams<{
     electionId: string
     jurisdictionId: string
@@ -117,7 +117,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
     updateResult,
     removeResult,
     finalizeResults,
-  ] = useOfflineBatchResults(electionId, jurisdictionId, round.id)
+  ] = useFullHandTallyResults(electionId, jurisdictionId, round.id)
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
 
   if (!contests || !batchResults) return null
@@ -130,14 +130,14 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
   const total = (choiceId: string) =>
     sum(results.map(batch => batch.choiceResults[choiceId]))
 
-  const emptyBatch = (): IOfflineBatchResult => ({
+  const emptyBatch = (): IFullHandTallyBatchResult => ({
     batchName: '',
     batchType: '',
     choiceResults: {},
   })
 
   interface FormValues {
-    editingBatch: IOfflineBatchResult | null
+    editingBatch: IFullHandTallyBatchResult | null
     editingBatchIndex: number | null
   }
 
@@ -183,7 +183,7 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
           handleReset,
         } = props
         return (
-          <OfflineBatchResultsForm>
+          <FullHandTallyResultsForm>
             <div style={{ width: '510px', marginBottom: '20px' }}>
               <p>
                 When you have examined all the ballots assigned to you, enter
@@ -470,11 +470,11 @@ const OfflineBatchRoundDataEntry = ({ round }: IProps) => {
                 </div>
               </div>
             </Dialog>
-          </OfflineBatchResultsForm>
+          </FullHandTallyResultsForm>
         )
       }}
     </Formik>
   )
 }
 
-export default OfflineBatchRoundDataEntry
+export default FullHandTallyDataEntry

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`offline batch round data entry deletes offline batch 1`] = `
+exports[`full hand tally data entry deletes full hand tally batch result 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -156,7 +156,7 @@ exports[`offline batch round data entry deletes offline batch 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry edits offline batch 1`] = `
+exports[`full hand tally data entry edits full hand tally batch result 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -357,7 +357,7 @@ exports[`offline batch round data entry edits offline batch 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry finalizes offline batches 1`] = `
+exports[`full hand tally data entry finalizes full hand tally results 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -590,7 +590,7 @@ exports[`offline batch round data entry finalizes offline batches 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry renders 1`] = `
+exports[`full hand tally data entry renders 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -746,7 +746,7 @@ exports[`offline batch round data entry renders 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry renders with offline batches 1`] = `
+exports[`full hand tally data entry renders with full hand tally results 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -947,7 +947,7 @@ exports[`offline batch round data entry renders with offline batches 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry renders with proper totals 1`] = `
+exports[`full hand tally data entry renders with proper totals 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -1200,7 +1200,7 @@ exports[`offline batch round data entry renders with proper totals 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry submits offline batch 1`] = `
+exports[`full hand tally data entry submits full hand tally batch result 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"
@@ -1401,7 +1401,7 @@ exports[`offline batch round data entry submits offline batch 1`] = `
 </div>
 `;
 
-exports[`offline batch round data entry validation error for blank submission 1`] = `
+exports[`full hand tally data entry validation error for blank submission 1`] = `
 <div>
   <form
     class="sc-bdVaJa hazmWT"

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
@@ -2,9 +2,9 @@ import { IBatches } from './useBatchResults'
 import { IRound } from '../useRoundsAuditAdmin'
 import { FileProcessingStatus } from '../useCSV'
 import {
-  IOfflineBatchResult,
-  IOfflineBatchResults,
-} from './useOfflineBatchResults'
+  IFullHandTallyBatchResults,
+  IFullHandTallyBatchResult,
+} from './useFullHandTallyResults'
 
 export interface INullResultValues {
   [contestId: string]: {
@@ -192,13 +192,13 @@ export const batchesMocks: {
   },
 }
 
-export const offlineBatchMocks: {
+export const fullHandTallyBatchResultMock: {
   [key in
     | 'empty'
     | 'complete'
     | 'updated'
     | 'finalized'
-    | 'completeWithMultipleBatch']: IOfflineBatchResults
+    | 'completeWithMultipleBatch']: IFullHandTallyBatchResults
 } = {
   empty: {
     finalizedAt: '',
@@ -266,8 +266,8 @@ export const offlineBatchMocks: {
   },
 }
 
-export const offlineBatchResultsMocks: {
-  [key in 'empty' | 'complete' | 'updated']: IOfflineBatchResult
+export const fullHandTallyBatchResultsMock: {
+  [key in 'empty' | 'complete' | 'updated']: IFullHandTallyBatchResult
 } = {
   empty: {
     batchName: '',

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
@@ -13,7 +13,7 @@ export interface INullResultValues {
 }
 
 export const roundMocks: {
-  [key in 'incomplete' | 'complete' | 'sampledAllBallotsIncomplete']: IRound
+  [key in 'incomplete' | 'complete' | 'fullHandTallyIncomplete']: IRound
 } = {
   incomplete: {
     id: 'round-1',
@@ -21,7 +21,7 @@ export const roundMocks: {
     startedAt: '2020-09-14T17:35:19.482Z',
     endedAt: null,
     isAuditComplete: false,
-    sampledAllBallots: false,
+    isFullHandTally: false,
     drawSampleTask: {
       status: FileProcessingStatus.PROCESSED,
       startedAt: '2020-09-14T17:35:19.482Z',
@@ -35,7 +35,7 @@ export const roundMocks: {
     startedAt: '2020-09-14T17:35:19.482Z',
     endedAt: '2020-09-14T17:35:19.482Z',
     isAuditComplete: true,
-    sampledAllBallots: false,
+    isFullHandTally: false,
     drawSampleTask: {
       status: FileProcessingStatus.PROCESSED,
       startedAt: '2020-09-14T17:35:19.482Z',
@@ -43,13 +43,13 @@ export const roundMocks: {
       error: null,
     },
   },
-  sampledAllBallotsIncomplete: {
+  fullHandTallyIncomplete: {
     id: 'round-1',
     roundNum: 1,
     startedAt: '2020-09-14T17:35:19.482Z',
     endedAt: null,
     isAuditComplete: false,
-    sampledAllBallots: true,
+    isFullHandTally: true,
     drawSampleTask: {
       status: FileProcessingStatus.PROCESSED,
       startedAt: '2020-09-14T17:35:19.482Z',

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
@@ -9,7 +9,7 @@ import {
   batchesMocks,
   batchResultsMocks,
   INullResultValues,
-  offlineBatchMocks,
+  fullHandTallyBatchResultMock,
 } from './_mocks'
 import { dummyBallots } from '../../DataEntry/_mocks'
 import {
@@ -22,8 +22,8 @@ import { IBatch } from './useBatchResults'
 import { jaApiCalls } from '../_mocks'
 import AuthDataProvider from '../../UserContext'
 import { IAuditSettings } from '../useAuditSettings'
-import { IOfflineBatchResults } from './useOfflineBatchResults'
 import { queryClient } from '../../../App'
+import { IFullHandTallyBatchResults } from './useFullHandTallyResults'
 
 const renderView = (props: IRoundManagementProps) =>
   renderWithRouter(
@@ -60,9 +60,9 @@ const apiCalls = {
     url: '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/batches',
     response,
   }),
-  getOfflineBatchResults: (response: IOfflineBatchResults) => ({
+  getFullHandTallyBatchResults: (response: IFullHandTallyBatchResults) => ({
     url:
-      '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/results/batch',
+      '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/full-hand-tally/batch',
     response,
   }),
 }
@@ -215,13 +215,13 @@ describe('RoundManagement', () => {
     })
   })
 
-  it('shows offline batch results data entry when all ballots sampled', async () => {
+  it('shows full hand tally data entry when all ballots sampled', async () => {
     const expectedCalls = [
       apiCalls.getSettings(auditSettings.offlineAll),
       jaApiCalls.getUser,
       apiCalls.getBallotCount,
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
-      apiCalls.getOfflineBatchResults(offlineBatchMocks.empty),
+      apiCalls.getFullHandTallyBatchResults(fullHandTallyBatchResultMock.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView({

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.test.tsx
@@ -225,7 +225,7 @@ describe('RoundManagement', () => {
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView({
-        round: roundMocks.sampledAllBallotsIncomplete,
+        round: roundMocks.fullHandTallyIncomplete,
         auditBoards: auditBoardMocks.unfinished,
         createAuditBoards: jest.fn(),
       })

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
@@ -80,7 +80,7 @@ const RoundManagement = ({
     )
   }
 
-  if (sampleCount.ballots === 0 && !round.sampledAllBallots) {
+  if (sampleCount.ballots === 0 && !round.isFullHandTally) {
     return (
       <PaddedWrapper>
         <StrongP>
@@ -92,7 +92,7 @@ const RoundManagement = ({
   }
 
   const samplesToAudit = (() => {
-    if (round.sampledAllBallots)
+    if (round.isFullHandTally)
       return (
         <StrongP>
           Please audit all of the ballots in your jurisdiction (
@@ -127,7 +127,7 @@ const RoundManagement = ({
   return (
     <PaddedWrapper>
       <H3>Round {roundNum} Data Entry</H3>
-      {round.sampledAllBallots ? (
+      {round.isFullHandTally ? (
         samplesToAudit
       ) : (
         <SpacedDiv>
@@ -147,7 +147,7 @@ const RoundManagement = ({
           <BatchRoundDataEntry round={round} />
         ) : auditSettings.online ? (
           <RoundProgress auditBoards={auditBoards} />
-        ) : round.sampledAllBallots ? (
+        ) : round.isFullHandTally ? (
           <FullHandTallyDataEntry round={round} />
         ) : (
           <RoundDataEntry round={round} />

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/index.tsx
@@ -18,10 +18,10 @@ import useAuditSettingsJurisdictionAdmin from './useAuditSettingsJurisdictionAdm
 import BatchRoundDataEntry from './BatchRoundDataEntry'
 import { useAuthDataContext, IJurisdictionAdmin } from '../../UserContext'
 import { IRound } from '../useRoundsAuditAdmin'
-import OfflineBatchRoundDataEntry from './OfflineBatchRoundDataEntry'
 import { IAuditSettings } from '../useAuditSettings'
 import AsyncButton from '../../Atoms/AsyncButton'
 import useSampleCount from './useBallots'
+import FullHandTallyDataEntry from './FullHandTallyDataEntry'
 
 const PaddedWrapper = styled(Wrapper)`
   flex-direction: column;
@@ -148,7 +148,7 @@ const RoundManagement = ({
         ) : auditSettings.online ? (
           <RoundProgress auditBoards={auditBoards} />
         ) : round.sampledAllBallots ? (
-          <OfflineBatchRoundDataEntry round={round} />
+          <FullHandTallyDataEntry round={round} />
         ) : (
           <RoundDataEntry round={round} />
         )}

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/useFullHandTallyResults.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/useFullHandTallyResults.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { api } from '../../utilities'
 
-export interface IOfflineBatchResult {
+export interface IFullHandTallyBatchResult {
   batchName: string
   batchType:
     | 'Absentee By Mail'
@@ -15,18 +15,18 @@ export interface IOfflineBatchResult {
   }
 }
 
-export interface IOfflineBatchResults {
+export interface IFullHandTallyBatchResults {
   finalizedAt: string
-  results: IOfflineBatchResult[]
+  results: IFullHandTallyBatchResult[]
 }
 
 const getResults = async (
   electionId: string,
   jurisdictionId: string,
   roundId: string
-): Promise<IOfflineBatchResults | null> => {
+): Promise<IFullHandTallyBatchResults | null> => {
   return api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch`
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/batch`
   )
 }
 
@@ -34,10 +34,10 @@ const postResult = async (
   electionId: string,
   jurisdictionId: string,
   roundId: string,
-  newResult: IOfflineBatchResult
+  newResult: IFullHandTallyBatchResult
 ): Promise<boolean> => {
   return !!(await api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch/`,
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/batch/`,
     {
       method: 'POST',
       body: JSON.stringify(newResult),
@@ -53,10 +53,10 @@ const putResult = async (
   jurisdictionId: string,
   roundId: string,
   batchName: string,
-  newResult: IOfflineBatchResult
+  newResult: IFullHandTallyBatchResult
 ): Promise<boolean> => {
   return !!(await api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch/${encodeURIComponent(
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/batch/${encodeURIComponent(
       batchName
     )}`,
     {
@@ -76,7 +76,7 @@ const deleteResult = async (
   batchName: string
 ): Promise<boolean> => {
   return !!(await api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch/${encodeURIComponent(
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/batch/${encodeURIComponent(
       batchName
     )}`,
     {
@@ -91,28 +91,30 @@ const postFinalizeResults = async (
   roundId: string
 ): Promise<boolean> => {
   return !!(await api(
-    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/results/batch/finalize`,
+    `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/full-hand-tally/finalize`,
     {
       method: 'POST',
     }
   ))
 }
 
-const useOfflineBatchResults = (
+const useFullHandTallyResults = (
   electionId: string,
   jurisdictionId: string,
   roundId: string
 ): [
-  IOfflineBatchResults | null,
-  (newResult: IOfflineBatchResult) => Promise<boolean>,
-  (batchName: string, newResult: IOfflineBatchResult) => Promise<boolean>,
+  IFullHandTallyBatchResults | null,
+  (newResult: IFullHandTallyBatchResult) => Promise<boolean>,
+  (batchName: string, newResult: IFullHandTallyBatchResult) => Promise<boolean>,
   (batchName: string) => Promise<boolean>,
   () => Promise<boolean>
 ] => {
-  const [results, setResults] = useState<IOfflineBatchResults | null>(null)
+  const [results, setResults] = useState<IFullHandTallyBatchResults | null>(
+    null
+  )
 
   const addResult = async (
-    newResult: IOfflineBatchResult
+    newResult: IFullHandTallyBatchResult
   ): Promise<boolean> => {
     const success = await postResult(
       electionId,
@@ -127,7 +129,7 @@ const useOfflineBatchResults = (
 
   const updateResult = async (
     batchName: string,
-    newResult: IOfflineBatchResult
+    newResult: IFullHandTallyBatchResult
   ): Promise<boolean> => {
     const success = await putResult(
       electionId,
@@ -179,4 +181,4 @@ const useOfflineBatchResults = (
   return [results, addResult, updateResult, removeResult, finalizeResults]
 }
 
-export default useOfflineBatchResults
+export default useFullHandTallyResults

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
@@ -334,7 +334,7 @@ export const JurisdictionAdminStatusBox = ({
     )
   }
 
-  const { roundNum, isAuditComplete, sampledAllBallots } = rounds[
+  const { roundNum, isAuditComplete, isFullHandTally } = rounds[
     rounds.length - 1
   ]
   const inProgressHeadline = `Round ${roundNum} of the audit is in progress.`
@@ -353,7 +353,7 @@ export const JurisdictionAdminStatusBox = ({
 
   // Round in progress, audit boards set up
   if (!isAuditComplete) {
-    if (sampledAllBallots)
+    if (isFullHandTally)
       return (
         <StatusBox
           headline={inProgressHeadline}

--- a/client/src/components/MultiJurisdictionAudit/timers.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/timers.test.tsx
@@ -119,7 +119,7 @@ describe('timers', () => {
       aaApiCalls.getContests,
       ...loadEach,
       aaApiCalls.getSampleSizes,
-      { ...aaApiCalls.getSampleSizes, response: sampleSizeMock },
+      { ...aaApiCalls.getSampleSizes, response: sampleSizeMock.ballotPolling },
     ]
     await withMockFetch(expectedCalls, async () => {
       renderWithRoute('/election/1/setup', <AuditAdminViewWithAuth />)

--- a/client/src/components/MultiJurisdictionAudit/useRoundsAuditAdmin.ts
+++ b/client/src/components/MultiJurisdictionAudit/useRoundsAuditAdmin.ts
@@ -10,7 +10,7 @@ export interface IRound {
   startedAt: string
   endedAt: string | null
   isAuditComplete: boolean
-  sampledAllBallots: boolean
+  isFullHandTally: boolean
   drawSampleTask: {
     status: FileProcessingStatus
     startedAt: string | null

--- a/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/_mocks/index.ts
+++ b/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/_mocks/index.ts
@@ -162,7 +162,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
-      sampledAllBallots: false,
+      isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSED,
         startedAt: '2020-09-14T17:35:19.482Z',
@@ -178,7 +178,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
-      sampledAllBallots: false,
+      isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSED,
         startedAt: '2019-07-18T16:34:07.000+00:00',
@@ -192,7 +192,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-2',
-      sampledAllBallots: false,
+      isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSED,
         startedAt: '2019-07-18T16:34:07.000+00:00',
@@ -208,7 +208,7 @@ export const roundMocks: {
       isAuditComplete: true,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
-      sampledAllBallots: false,
+      isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSED,
         startedAt: '2019-07-18T16:34:07.000+00:00',
@@ -224,7 +224,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
-      sampledAllBallots: false,
+      isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSED,
         startedAt: '2020-09-14T17:35:19.482Z',
@@ -240,7 +240,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
-      sampledAllBallots: false,
+      isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSING,
         startedAt: '2020-09-14T17:35:19.482Z',
@@ -256,7 +256,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
-      sampledAllBallots: false,
+      isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.ERRORED,
         startedAt: '2020-09-14T17:35:19.482Z',

--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -18,7 +18,7 @@ from . import audit_boards
 from . import ballots
 from . import batches
 from . import offline_results
-from . import offline_batch_results
+from . import full_hand_tally
 from . import reports
 from . import activity
 from . import support

--- a/server/api/full_hand_tally.py
+++ b/server/api/full_hand_tally.py
@@ -23,7 +23,7 @@ class BatchType(str, enum.Enum):
     OTHER = "Other"
 
 
-OFFLINE_BATCH_RESULT_SCHEMA = {
+FULL_HAND_TALLY_BATCH_RESULT_SCHEMA = {
     "type": "object",
     "properties": {
         "batchName": {"type": "string", "minLength": 1, "maxLength": 200},
@@ -47,11 +47,11 @@ OFFLINE_BATCH_RESULT_SCHEMA = {
 }
 
 
-def validate_offline_batch_result_request(
+def validate_full_hand_tally_batch_result_request(
     election: Election, jurisdiction: Jurisdiction, round: Round,
 ):
     if len(list(election.contests)) > 1:
-        raise Conflict("Offline batch results only supported for single contest audits")
+        raise Conflict("Full hand tally only supported for single contest audits")
 
     # We only support one contest for now
     contest = list(election.contests)[0]
@@ -60,11 +60,9 @@ def validate_offline_batch_result_request(
         raise Conflict("Jurisdiction not in contest universe")
 
     if not sampled_all_ballots(round, election):
-        raise Conflict(
-            "Offline batch results only supported if all ballots are sampled"
-        )
+        raise Conflict("Full hand tally only supported if all ballots are sampled")
 
-    if jurisdiction.finalized_offline_batch_results_at is not None:
+    if jurisdiction.finalized_full_hand_tally_results_at is not None:
         raise Conflict("Results have already been finalized")
 
     current_round = get_current_round(election)
@@ -78,15 +76,15 @@ def validate_offline_batch_result_request(
         raise Conflict("Must set up audit boards before recording results")
 
 
-def validate_offline_batch_result(
+def validate_full_hand_tally_batch_result(
     election: Election,
     jurisdiction: Jurisdiction,
     round: Round,
     batch_result: JSONDict,
 ):
-    validate_offline_batch_result_request(election, jurisdiction, round)
+    validate_full_hand_tally_batch_result_request(election, jurisdiction, round)
 
-    validate(batch_result, OFFLINE_BATCH_RESULT_SCHEMA)
+    validate(batch_result, FULL_HAND_TALLY_BATCH_RESULT_SCHEMA)
 
     # We only support one contest for now
     contest = list(election.contests)[0]
@@ -96,33 +94,23 @@ def validate_offline_batch_result(
         raise BadRequest(f"Invalid choice ids for batch {batch_result['batchName']}")
 
 
-def load_offline_batch_results(jurisdiction: Jurisdiction) -> List[OfflineBatchResult]:
-    return list(
-        OfflineBatchResult.query.filter_by(jurisdiction_id=jurisdiction.id)
-        .order_by(OfflineBatchResult.created_at)
-        .all()
-    )
-
-
-def serialize_offline_batch_results(
-    offline_batch_results: List[OfflineBatchResult], contest: Contest
+def serialize_full_hand_tally_batch_results(
+    results: List[FullHandTallyBatchResult], contest: Contest
 ) -> List[JSONDict]:
     # We want to display batches in the order the user created them. Dict keys
     # are ordered, so we use a dict to dedupe the batch names while preserving
-    # order. (Assumes offline_batch_results is already ordered by created_at)
+    # order. (Assumes results is already ordered by created_at)
     ordered_batches = list(
-        dict.fromkeys(
-            (result.batch_name, result.batch_type) for result in offline_batch_results
-        )
+        dict.fromkeys((result.batch_name, result.batch_type) for result in results)
     )
 
     results_by_batch: JSONDict = defaultdict(
         lambda: {choice.id: None for choice in contest.choices}
     )
-    for result in offline_batch_results:
+    for result in results:
         results_by_batch[result.batch_name][result.contest_choice_id] = result.result
 
-    results = [
+    json_results = [
         {
             "batchName": batch_name,
             "batchType": batch_type,
@@ -130,45 +118,30 @@ def serialize_offline_batch_results(
         }
         for batch_name, batch_type in ordered_batches
     ]
-    return results
+    return json_results
 
 
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch",
-    methods=["PUT"],
-)
-@restrict_access([UserType.JURISDICTION_ADMIN])
-def record_offline_batch_results(
-    election: Election,  # pylint: disable=unused-argument
-    jurisdiction: Jurisdiction,
-    round: Round,
-):
-    raise Conflict(
-        "Arlo has been updated. Please refresh your browser for the latest version."
-    )
-
-
-@api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch/",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/batch/",
     methods=["POST"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def add_offline_batch_result(
+def add_full_hand_tally_batch_result(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,
 ):
     batch_result = request.get_json()
-    validate_offline_batch_result(election, jurisdiction, round, batch_result)
+    validate_full_hand_tally_batch_result(election, jurisdiction, round, batch_result)
 
-    if OfflineBatchResult.query.filter_by(
+    if FullHandTallyBatchResult.query.filter_by(
         jurisdiction_id=jurisdiction.id, batch_name=batch_result["batchName"]
     ).first():
         raise Conflict("Batch names must be unique")
 
     for contest_choice_id, result in batch_result["choiceResults"].items():
         db_session.add(
-            OfflineBatchResult(
+            FullHandTallyBatchResult(
                 jurisdiction_id=jurisdiction.id,
                 batch_name=batch_result["batchName"],
                 batch_type=batch_result["batchType"],
@@ -183,29 +156,29 @@ def add_offline_batch_result(
 
 
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch/<path:batch_name>",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/batch/<path:batch_name>",
     methods=["PUT"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def update_offline_batch_result(
+def update_full_hand_tally_batch_result(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,
     batch_name: str,
 ):
     batch_result = request.get_json()
-    validate_offline_batch_result(election, jurisdiction, round, batch_result)
+    validate_full_hand_tally_batch_result(election, jurisdiction, round, batch_result)
 
     if (
         batch_name != batch_result["batchName"]
-        and OfflineBatchResult.query.filter_by(
+        and FullHandTallyBatchResult.query.filter_by(
             jurisdiction_id=jurisdiction.id, batch_name=batch_result["batchName"]
         ).first()
     ):
         raise Conflict("Batch names must be unique")
 
     for contest_choice_id, result in batch_result["choiceResults"].items():
-        new_batch_result = OfflineBatchResult.query.filter_by(
+        new_batch_result = FullHandTallyBatchResult.query.filter_by(
             jurisdiction_id=jurisdiction.id,
             batch_name=batch_name,
             contest_choice_id=contest_choice_id,
@@ -226,19 +199,19 @@ def update_offline_batch_result(
 # We use the `path:` converter for the batch_name parameter because it's
 # URI-encoded and we want to decode it with support for slashes
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch/<path:batch_name>",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/batch/<path:batch_name>",
     methods=["DELETE"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def delete_offline_batch_result(
+def delete_full_hand_tally_batch_result(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,  # pylint: disable=unused-argument
     batch_name: str,
 ):
-    validate_offline_batch_result_request(election, jurisdiction, round)
+    validate_full_hand_tally_batch_result_request(election, jurisdiction, round)
 
-    OfflineBatchResult.query.filter_by(
+    FullHandTallyBatchResult.query.filter_by(
         jurisdiction_id=jurisdiction.id, batch_name=batch_name
     ).delete()
 
@@ -248,22 +221,23 @@ def delete_offline_batch_result(
 
 
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch/finalize",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/finalize",
     methods=["POST"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def finalize_offline_batch_results(
+def finalize_full_hand_tally_batch_results(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,
 ):
-    jurisdiction.finalized_offline_batch_results_at = datetime.now(timezone.utc)
+    jurisdiction.finalized_full_hand_tally_results_at = datetime.now(timezone.utc)
 
     sum_results_by_choice = (
-        OfflineBatchResult.query.filter_by(jurisdiction_id=jurisdiction.id)
-        .group_by(OfflineBatchResult.contest_choice_id)
+        FullHandTallyBatchResult.query.filter_by(jurisdiction_id=jurisdiction.id)
+        .group_by(FullHandTallyBatchResult.contest_choice_id)
         .values(
-            OfflineBatchResult.contest_choice_id, func.sum(OfflineBatchResult.result)
+            FullHandTallyBatchResult.contest_choice_id,
+            func.sum(FullHandTallyBatchResult.result),
         )
     )
 
@@ -287,22 +261,22 @@ def finalize_offline_batch_results(
 
 
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch/finalize",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/finalize",
     methods=["DELETE"],
 )
 @restrict_access([UserType.AUDIT_ADMIN])
-def unfinalize_offline_batch_results(
+def unfinalize_full_hand_tally_batch_results(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,
 ):
-    if jurisdiction.finalized_offline_batch_results_at is None:
+    if jurisdiction.finalized_full_hand_tally_results_at is None:
         raise Conflict("Results have not been finalized")
 
     if round.ended_at is not None:
         raise Conflict("Results cannot be unfinalized after the audit round ends")
 
-    jurisdiction.finalized_offline_batch_results_at = None
+    jurisdiction.finalized_full_hand_tally_results_at = None
 
     JurisdictionResult.query.filter_by(
         round_id=round.id, jurisdiction_id=jurisdiction.id,
@@ -314,11 +288,11 @@ def unfinalize_offline_batch_results(
 
 
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/results/batch",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/full-hand-tally/batch",
     methods=["GET"],
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
-def get_offline_batch_results(
+def get_full_hand_tally_batch_results(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
     round: Round,  # pylint: disable=unused-argument
@@ -326,11 +300,15 @@ def get_offline_batch_results(
     # We only support one contest for now
     contest = list(election.contests)[0]
 
+    results = list(
+        FullHandTallyBatchResult.query.filter_by(jurisdiction_id=jurisdiction.id)
+        .order_by(FullHandTallyBatchResult.created_at)
+        .all()
+    )
+
     return jsonify(
         {
-            "finalizedAt": isoformat(jurisdiction.finalized_offline_batch_results_at),
-            "results": serialize_offline_batch_results(
-                load_offline_batch_results(jurisdiction), contest
-            ),
+            "finalizedAt": isoformat(jurisdiction.finalized_full_hand_tally_results_at),
+            "results": serialize_full_hand_tally_batch_results(results, contest),
         }
     )

--- a/server/api/full_hand_tally.py
+++ b/server/api/full_hand_tally.py
@@ -10,7 +10,7 @@ from . import api
 from ..auth import restrict_access, UserType
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
-from .rounds import get_current_round, sampled_all_ballots
+from .rounds import get_current_round, is_full_hand_tally
 from ..util.jsonschema import JSONDict, validate
 from ..util.isoformat import isoformat
 
@@ -59,7 +59,7 @@ def validate_full_hand_tally_batch_result_request(
     if not any(c.id == contest.id for c in jurisdiction.contests):
         raise Conflict("Jurisdiction not in contest universe")
 
-    if not sampled_all_ballots(round, election):
+    if not is_full_hand_tally(round, election):
         raise Conflict("Full hand tally only supported if all ballots are sampled")
 
     if jurisdiction.finalized_full_hand_tally_results_at is not None:

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -17,8 +17,8 @@ from ..util.group_by import group_by
 from ..audit_math import supersimple, sampler_contest, macro
 from ..api.rounds import (
     cvrs_for_contest,
+    is_full_hand_tally,
     sampled_ballot_interpretations_to_cvrs,
-    sampled_all_ballots,
     samples_not_found_by_round,
 )
 from ..api.ballot_manifest import hybrid_contest_total_ballots
@@ -445,7 +445,7 @@ def full_hand_tally_result_rows(election: Election, jurisdiction: Jurisdiction =
 def sampled_ballot_rows(election: Election, jurisdiction: Jurisdiction = None):
     # Special case: if we sampled all ballots, don't show this section
     rounds = list(election.rounds)
-    if len(rounds) > 0 and sampled_all_ballots(rounds[0], election):
+    if len(rounds) > 0 and is_full_hand_tally(rounds[0], election):
         return full_hand_tally_result_rows(election, jurisdiction)
 
     rows = [heading("SAMPLED BALLOTS")]

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -402,18 +402,18 @@ def round_rows(election: Election):
     return rows
 
 
-def offline_batch_result_rows(election: Election, jurisdiction: Jurisdiction = None):
-    rows = [heading("BATCH RESULTS")]
+def full_hand_tally_result_rows(election: Election, jurisdiction: Jurisdiction = None):
+    rows = [heading("FULL HAND TALLY BATCH RESULTS")]
 
     results_query = (
-        OfflineBatchResult.query.join(Jurisdiction)
+        FullHandTallyBatchResult.query.join(Jurisdiction)
         .filter_by(election_id=election.id)
-        .order_by(Jurisdiction.name, OfflineBatchResult.batch_name)
+        .order_by(Jurisdiction.name, FullHandTallyBatchResult.batch_name)
     )
     if jurisdiction:
         results_query = results_query.filter(Jurisdiction.id == jurisdiction.id)
     results = list(
-        results_query.with_entities(Jurisdiction.name, OfflineBatchResult).all()
+        results_query.with_entities(Jurisdiction.name, FullHandTallyBatchResult).all()
     )
 
     # For now, we only support one contest
@@ -446,7 +446,7 @@ def sampled_ballot_rows(election: Election, jurisdiction: Jurisdiction = None):
     # Special case: if we sampled all ballots, don't show this section
     rounds = list(election.rounds)
     if len(rounds) > 0 and sampled_all_ballots(rounds[0], election):
-        return offline_batch_result_rows(election, jurisdiction)
+        return full_hand_tally_result_rows(election, jurisdiction)
 
     rows = [heading("SAMPLED BALLOTS")]
 

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -6,7 +6,6 @@ from typing import (
     List,
     Tuple,
     Dict,
-    cast as typing_cast,
     TypedDict,
 )
 from datetime import datetime
@@ -23,7 +22,6 @@ from ..auth import restrict_access, UserType
 from . import sample_sizes as sample_sizes_module
 from ..util.isoformat import isoformat
 from ..util.group_by import group_by
-from ..util.jsonschema import JSONDict
 from ..audit_math import (
     sampler,
     ballot_polling,
@@ -567,9 +565,9 @@ def is_round_complete(election: Election, round: Round) -> bool:
     # jurisdiction that had ballots sampled
     else:
         num_jurisdictions_without_results: int
-        # Special case: if we sampled all ballots, we just check every
+        # Special case: if we are in a full hand tally, we just check every
         # jurisdiction in the targeted contest's universe
-        if sampled_all_ballots(round, election):
+        if is_full_hand_tally(round, election):
             num_jurisdictions_without_results = (
                 Contest.query.filter_by(election_id=election.id, is_targeted=True)
                 .join(Contest.jurisdictions)
@@ -614,14 +612,52 @@ def is_round_complete(election: Election, round: Round) -> bool:
         return num_jurisdictions_without_results == 0
 
 
-def sampled_all_ballots(round: Round, election: Election):
-    return election.audit_type == AuditType.BALLOT_POLLING and any(
-        typing_cast(JSONDict, round_contest.sample_size)["size"]
-        >= round_contest.contest.total_ballots_cast
-        for round_contest in round.round_contests
-        if round_contest.sample_size is not None
-        # total_ballots_cast can't be None here, but typechecker needs this
-        and round_contest.contest.total_ballots_cast is not None
+# Calculates how the sample size threshold to trigger a full hand tally in each
+# targeted contest
+def full_hand_tally_sizes(election: Election):
+    contests_query = Contest.query.filter_by(election_id=election.id, is_targeted=True)
+    if election.audit_type == AuditType.BATCH_COMPARISON:
+        return dict(
+            contests_query.join(Contest.jurisdictions)
+            .group_by(Contest.id)
+            .values(
+                Contest.id,
+                func.coalesce(func.sum(Jurisdiction.manifest_num_batches), 0),
+            )
+        )
+    return dict(contests_query.values(Contest.id, Contest.total_ballots_cast))
+
+
+# Returns True if the sample size for any targeted contest in the given round
+# requires a full hand tally
+def needs_full_hand_tally(round: Round, election: Election) -> bool:
+    full_hand_tally_size = full_hand_tally_sizes(election)
+    cumulative_sample_sizes = dict(
+        RoundContest.query.join(Round)
+        .filter_by(election_id=round.election_id)
+        .filter(Round.round_num <= round.round_num)
+        .join(RoundContest.contest)
+        .filter_by(is_targeted=True)
+        .group_by(RoundContest.contest_id)
+        .values(
+            RoundContest.contest_id,
+            func.sum(RoundContest.sample_size["size"].as_integer()),
+        )
+    )
+    return any(
+        size >= full_hand_tally_size[contest_id]
+        for contest_id, size in cumulative_sample_sizes.items()
+    )
+
+
+# Returns True if Arlo is in full hand tally mode, which is only triggered
+# in the first round of ballot polling audits when the sample size requires a
+# full hand tally
+def is_full_hand_tally(round: Round, election: Election):
+    return (
+        election.audit_type == AuditType.BALLOT_POLLING
+        and round.round_num == 1
+        and needs_full_hand_tally(round, election)
     )
 
 
@@ -673,9 +709,9 @@ def draw_sample(round_id: str, election_id: str):
         if round_contest.sample_size
     ]
 
-    # Special case: if we are sampling all ballots, we don't need to actually
+    # Special case: if we are in a full hand tally, we don't need to actually
     # draw a sample. Instead, we force an offline audit.
-    if sampled_all_ballots(round, election):
+    if is_full_hand_tally(round, election):
         election.online = False
         return
 
@@ -876,10 +912,7 @@ def create_round_schema(audit_type: AuditType):
                                 {
                                     "sizeCvr": {"type": "integer"},
                                     "sizeNonCvr": {"type": "integer"},
-                                    # We ignore size in hybrid audits
-                                    "size": {
-                                        "anyOf": [{"type": "integer"}, {"type": "null"}]
-                                    },
+                                    "size": {"type": "integer"},
                                 }
                                 if audit_type == AuditType.HYBRID
                                 else {"size": {"type": "integer"}}
@@ -887,7 +920,7 @@ def create_round_schema(audit_type: AuditType):
                         },
                         "additionalProperties": False,
                         "required": (
-                            ["sizeCvr", "sizeNonCvr", "key", "prob"]
+                            ["sizeCvr", "sizeNonCvr", "size", "key", "prob"]
                             if audit_type == AuditType.HYBRID
                             else ["size", "key", "prob"]
                         ),
@@ -927,25 +960,17 @@ def validate_sample_size(round: dict, election: Election):
     if set(round["sampleSizes"].keys()) != {c.id for c in targeted_contests}:
         raise BadRequest("Sample sizes provided do not match targeted contest ids")
 
+    full_hand_tally_size = full_hand_tally_sizes(election)
+
     for contest in targeted_contests:
         sample_size = round["sampleSizes"][contest.id]
-        valid_keys, full_hand_tally_size = {
+        valid_keys = {
             AuditType.BALLOT_POLLING: (
-                ["asn", "0.9", "0.8", "0.7", "custom", "all-ballots"],
-                contest.total_ballots_cast,
+                ["asn", "0.9", "0.8", "0.7", "custom", "all-ballots"]
             ),
-            AuditType.BALLOT_COMPARISON: (
-                ["supersimple", "custom"],
-                contest.total_ballots_cast,
-            ),
-            AuditType.BATCH_COMPARISON: (
-                ["macro", "custom"],
-                sum(
-                    jurisdiction.manifest_num_batches or 0
-                    for jurisdiction in contest.jurisdictions
-                ),
-            ),
-            AuditType.HYBRID: (["suite", "custom"], contest.total_ballots_cast),
+            AuditType.BALLOT_COMPARISON: ["supersimple", "custom"],
+            AuditType.BATCH_COMPARISON: ["macro", "custom"],
+            AuditType.HYBRID: ["suite", "custom"],
         }[AuditType(election.audit_type)]
 
         if sample_size["key"] not in valid_keys:
@@ -956,6 +981,10 @@ def validate_sample_size(round: dict, election: Election):
         if sample_size["key"] == "custom":
             if election.audit_type == AuditType.HYBRID:
                 total_ballots = hybrid_contest_total_ballots(contest)
+                assert (
+                    sample_size["sizeCvr"] + sample_size["sizeNonCvr"]
+                    == sample_size["size"]
+                )
                 if sample_size["sizeCvr"] > total_ballots.cvr:
                     raise BadRequest(
                         f"CVR sample size for contest {contest.name} must be less than or equal to:"
@@ -967,7 +996,7 @@ def validate_sample_size(round: dict, election: Election):
                         f" {total_ballots.non_cvr} (the total number of non-CVR ballots in the contest)"
                     )
 
-            elif sample_size["size"] > full_hand_tally_size:
+            elif sample_size["size"] > full_hand_tally_size[contest.id]:
                 ballots_or_batches = (
                     "batches"
                     if election.audit_type == AuditType.BATCH_COMPARISON
@@ -975,21 +1004,19 @@ def validate_sample_size(round: dict, election: Election):
                 )
                 raise BadRequest(
                     f"Sample size for contest {contest.name} must be less than or equal to:"
-                    f" {full_hand_tally_size} (the total number of {ballots_or_batches} in the contest)"
+                    f" {full_hand_tally_size[contest.id]} (the total number of {ballots_or_batches} in the contest)"
                 )
 
-        size = (
-            sample_size["sizeCvr"] + sample_size["sizeNonCvr"]
-            if election.audit_type == AuditType.HYBRID
-            else sample_size["size"]
-        )
-        if size >= full_hand_tally_size:
-            if election.audit_type != AuditType.BALLOT_POLLING:
-                raise BadRequest(
-                    "For a full hand tally, use the ballot polling audit type."
-                )
-            if len(targeted_contests) > 1:
-                raise BadRequest("For a full hand tally, use only one target contest.")
+    if any(
+        sample_size["size"] >= full_hand_tally_size[contest_id]
+        for contest_id, sample_size in round["sampleSizes"].items()
+    ):
+        if election.audit_type != AuditType.BALLOT_POLLING:
+            raise BadRequest(
+                "For a full hand tally, use the ballot polling audit type."
+            )
+        if len(targeted_contests) > 1:
+            raise BadRequest("For a full hand tally, use only one target contest.")
 
 
 @api.route("/election/<election_id>/round", methods=["POST"])
@@ -1057,7 +1084,7 @@ def serialize_round(round: Round) -> dict:
         "startedAt": isoformat(round.created_at),
         "endedAt": isoformat(round.ended_at),
         "isAuditComplete": is_audit_complete(round),
-        "sampledAllBallots": sampled_all_ballots(round, round.election),
+        "isFullHandTally": is_full_hand_tally(round, round.election),
         "drawSampleTask": serialize_background_task(round.draw_sample_task),
     }
 

--- a/server/migrations/versions/266fba5a5c8a_rename_offlinebatchresult_to_.py
+++ b/server/migrations/versions/266fba5a5c8a_rename_offlinebatchresult_to_.py
@@ -1,0 +1,57 @@
+# pylint: disable=invalid-name
+"""Rename OfflineBatchResult to FullHandTallyBatchResult
+
+Revision ID: 266fba5a5c8a
+Revises: 30f47ec7308c
+Create Date: 2021-11-04 17:29:16.156954+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "266fba5a5c8a"
+down_revision = "30f47ec7308c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.rename_table("offline_batch_result", "full_hand_tally_batch_result")
+    op.drop_constraint("offline_batch_result_pkey", "full_hand_tally_batch_result")
+    op.drop_constraint(
+        "offline_batch_result_jurisdiction_id_fkey", "full_hand_tally_batch_result"
+    )
+    op.drop_constraint(
+        "offline_batch_result_contest_choice_id_fkey", "full_hand_tally_batch_result"
+    )
+    op.create_foreign_key(
+        "full_hand_tally_batch_result_contest_choice_id_fkey",
+        "full_hand_tally_batch_result",
+        "contest_choice",
+        ["contest_choice_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    op.create_foreign_key(
+        "full_hand_tally_batch_result_jurisdiction_id_fkey",
+        "full_hand_tally_batch_result",
+        "jurisdiction",
+        ["jurisdiction_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    op.create_primary_key(
+        "full_hand_tally_batch_result_pkey",
+        "full_hand_tally_batch_result",
+        ["jurisdiction_id", "batch_name", "contest_choice_id",],
+    )
+
+    op.alter_column(
+        "jurisdiction",
+        "finalized_offline_batch_results_at",
+        new_column_name="finalized_full_hand_tally_results_at",
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -292,8 +292,7 @@ class Jurisdiction(BaseModel):
     # { contest_name: cvr_contest_name }
     contest_name_standardizations = Column(JSON)
 
-    # For ballot polling audits where offline batch results are recorded (currently only full hand counts)
-    finalized_offline_batch_results_at = Column(UTCDateTime)
+    finalized_full_hand_tally_results_at = Column(UTCDateTime)
 
     batches = relationship(
         "Batch", back_populates="jurisdiction", uselist=True, passive_deletes=True
@@ -746,10 +745,10 @@ class RoundContestResult(BaseModel):
     result = Column(Integer, nullable=False)
 
 
-# In an offline ballot polling audit, records the audited vote count for one
+# In a full hand tally, records the audited vote count for one
 # batch for one contest choice. Note that we don't require the batch name to
 # match any of the batches in the ballot manifest.
-class OfflineBatchResult(BaseModel):
+class FullHandTallyBatchResult(BaseModel):
     jurisdiction_id = Column(
         String(200), ForeignKey("jurisdiction.id", ondelete="cascade"), nullable=False,
     )

--- a/server/tests/api/test_rounds.py
+++ b/server/tests/api/test_rounds.py
@@ -51,7 +51,7 @@ def test_rounds_create_one(
                 "startedAt": assert_is_date,
                 "endedAt": None,
                 "isAuditComplete": None,
-                "sampledAllBallots": False,
+                "isFullHandTally": False,
                 "drawSampleTask": {
                     "status": "PROCESSED",
                     "startedAt": assert_is_date,
@@ -115,7 +115,7 @@ def test_rounds_create_two(
                 "startedAt": assert_is_date,
                 "endedAt": assert_is_date,
                 "isAuditComplete": False,
-                "sampledAllBallots": False,
+                "isFullHandTally": False,
                 "drawSampleTask": {
                     "status": "PROCESSED",
                     "startedAt": assert_is_date,
@@ -129,7 +129,7 @@ def test_rounds_create_two(
                 "startedAt": assert_is_date,
                 "endedAt": None,
                 "isAuditComplete": None,
-                "sampledAllBallots": False,
+                "isFullHandTally": False,
                 "drawSampleTask": {
                     "status": "PROCESSED",
                     "startedAt": assert_is_date,
@@ -177,7 +177,7 @@ def test_rounds_complete_audit(
                 "startedAt": assert_is_date,
                 "endedAt": assert_is_date,
                 "isAuditComplete": True,
-                "sampledAllBallots": False,
+                "isFullHandTally": False,
                 "drawSampleTask": {
                     "status": "PROCESSED",
                     "startedAt": assert_is_date,

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -181,7 +181,7 @@ def test_batch_comparison_round_1(
                 "startedAt": assert_is_date,
                 "endedAt": None,
                 "isAuditComplete": None,
-                "sampledAllBallots": False,
+                "isFullHandTally": False,
                 "drawSampleTask": {
                     "status": "PROCESSED",
                     "startedAt": assert_is_date,

--- a/server/tests/hybrid/test_hybrid.py
+++ b/server/tests/hybrid/test_hybrid.py
@@ -782,7 +782,7 @@ def test_hybrid_custom_sample_size(
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     sample_size = {
         "key": "custom",
-        "size": None,
+        "size": 10,
         "sizeCvr": 2,
         "sizeNonCvr": 8,
         "prob": None,
@@ -828,9 +828,13 @@ def test_hybrid_invalid_sample_size(
             "'sizeNonCvr' is a required property",
         ),
         (
+            {"key": "custom", "sizeCvr": 2, "sizeNonCvr": 2, "prob": None},
+            "'size' is a required property",
+        ),
+        (
             {
                 "key": "custom",
-                "size": None,
+                "size": 50,
                 "sizeCvr": 40,
                 "sizeNonCvr": 10,
                 "prob": None,
@@ -840,7 +844,7 @@ def test_hybrid_invalid_sample_size(
         (
             {
                 "key": "custom",
-                "size": None,
+                "size": 50,
                 "sizeCvr": 20,
                 "sizeNonCvr": 30,
                 "prob": None,
@@ -850,7 +854,7 @@ def test_hybrid_invalid_sample_size(
         (
             {
                 "key": "custom",
-                "size": None,
+                "size": 50,
                 "sizeCvr": 30,
                 "sizeNonCvr": 20,
                 "prob": None,
@@ -860,7 +864,7 @@ def test_hybrid_invalid_sample_size(
         (
             {
                 "key": "suite",
-                "size": None,
+                "size": 52,
                 "sizeCvr": 31,
                 "sizeNonCvr": 21,
                 "prob": None,

--- a/server/tests/snapshots/snap_test_full_hand_tally.py
+++ b/server/tests/snapshots/snap_test_full_hand_tally.py
@@ -15,7 +15,7 @@ snapshots["test_all_ballots_audit 1"] = {
 
 snapshots[
     "test_all_ballots_audit 2"
-] = """######## BATCH RESULTS ########\r
+] = """######## FULL HAND TALLY BATCH RESULTS ########\r
 Jurisdiction Name,Batch Name,Batch Type,candidate 1,candidate 2,candidate 3\r
 J1,Batch One,Provisional,125000,124875,125\r
 J1,Batch Three,Election Day,125000,124875,125\r
@@ -40,7 +40,7 @@ Test Audit test_all_ballots_audit,BALLOT_POLLING,BRAVO,10%,1234567890,No\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
 1,Contest 1,Targeted,2000000,Yes,0,DATETIME,DATETIME,candidate 1: 1000000; candidate 2: 999000; candidate 3: 1000\r
 \r
-######## BATCH RESULTS ########\r
+######## FULL HAND TALLY BATCH RESULTS ########\r
 Jurisdiction Name,Batch Name,Batch Type,candidate 1,candidate 2,candidate 3\r
 J1,Batch One,Provisional,125000,124875,125\r
 J1,Batch Three,Election Day,125000,124875,125\r

--- a/server/tests/test_full_hand_tally.py
+++ b/server/tests/test_full_hand_tally.py
@@ -176,13 +176,13 @@ def test_all_ballots_audit(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/",
         jurisdiction_1_results,
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
@@ -201,13 +201,13 @@ def test_all_ballots_audit(
 
     rv = put_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/{urllib.parse.quote('Batch/Zero')}",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/{urllib.parse.quote('Batch/Zero')}",
         jurisdiction_1_results,
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
@@ -267,27 +267,27 @@ def test_all_ballots_audit(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/",
         next_jurisdiction_1_results_a,
     )
     assert_ok(rv)
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/",
         next_jurisdiction_1_results_b,
     )
     assert_ok(rv)
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/",
         next_jurisdiction_1_results_c,
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
@@ -298,11 +298,11 @@ def test_all_ballots_audit(
     # Delete a result
     updated_jurisdiction_1_results = updated_jurisdiction_1_results[:-1]
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/{urllib.parse.quote('Batch/Bogus')}"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch/{urllib.parse.quote('Batch/Bogus')}"
     )
     assert_ok(rv)
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
@@ -312,13 +312,13 @@ def test_all_ballots_audit(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
     # Finalize the results
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     compare_json(
@@ -392,13 +392,13 @@ def test_all_ballots_audit(
     for result in jurisdiction_2_results:
         rv = post_json(
             client,
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/results/batch/",
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/full-hand-tally/batch/",
             result,
         )
         assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     assert json.loads(rv.data) == {
@@ -408,12 +408,12 @@ def test_all_ballots_audit(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/results/batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_id}/full-hand-tally/batch",
     )
     assert rv.status_code == 200
     compare_json(
@@ -452,7 +452,7 @@ def test_all_ballots_audit(
     assert_match_report(rv.data, snapshot)
 
 
-def test_offline_batch_results_validation(
+def test_full_hand_tally_results_validation(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
@@ -563,7 +563,7 @@ def test_offline_batch_results_validation(
     for invalid_result, expected_message in invalid_results:
         rv = post_json(
             client,
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
             invalid_result,
         )
         assert rv.status_code == 400
@@ -574,7 +574,7 @@ def test_offline_batch_results_validation(
         if invalid_result.get("batchName"):
             rv = put_json(
                 client,
-                f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/{invalid_result['batchName']}",
+                f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/{invalid_result['batchName']}",
                 invalid_result,
             )
             assert rv.status_code == 400
@@ -585,7 +585,7 @@ def test_offline_batch_results_validation(
     # No duplicate batch names
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 1",
             "batchType": "Provisional",
@@ -598,7 +598,7 @@ def test_offline_batch_results_validation(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 1",
             "batchType": "Election Day",
@@ -615,7 +615,7 @@ def test_offline_batch_results_validation(
     # No renaming to another batch's name
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 2",
             "batchType": "Provisional",
@@ -628,7 +628,7 @@ def test_offline_batch_results_validation(
 
     rv = put_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/Batch 2",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/Batch 2",
         {
             "batchName": "Batch 1",
             "batchType": "Provisional",
@@ -645,7 +645,7 @@ def test_offline_batch_results_validation(
     # Can't edit a batch that doesn't exist
     rv = put_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/not a real batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/not a real batch",
         {
             "batchName": "Batch 3",
             "batchType": "Election Day",
@@ -661,19 +661,19 @@ def test_offline_batch_results_validation(
 
     # Special case: deleting a batch that doesn't exist is ok (maybe somebody else already deleted it)
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/not a real batch",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/not a real batch",
     )
     assert_ok(rv)
 
     # Can't edit a batch that's been deleted
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/Batch 1",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/Batch 1",
     )
     assert_ok(rv)
 
     rv = put_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/Batch 1",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/Batch 1",
         {
             "batchName": "Batch 1",
             "batchType": "Provisional",
@@ -690,13 +690,13 @@ def test_offline_batch_results_validation(
     # Can't add/edit/delete results after finalizing
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         [
             {
                 "batchName": "Batch 1",
@@ -717,7 +717,7 @@ def test_offline_batch_results_validation(
 
     rv = put_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/Batch 1",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/Batch 1",
         [
             {
                 "batchName": "Batch 1",
@@ -737,7 +737,7 @@ def test_offline_batch_results_validation(
     }
 
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/Batch 1",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/Batch 1",
     )
     assert rv.status_code == 409
     assert json.loads(rv.data) == {
@@ -747,52 +747,7 @@ def test_offline_batch_results_validation(
     }
 
 
-def test_offline_batch_results_old_endpoint(
-    client: FlaskClient,
-    election_id: str,
-    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
-    round_1_id: str,
-):
-    set_logged_in_user(
-        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
-    )
-    rv = post_json(
-        client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/audit-board",
-        [{"name": "Audit Board #1"}, {"name": "Audit Board #2"}],
-    )
-
-    rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/contest"
-    )
-    contest = json.loads(rv.data)["contests"][0]
-
-    rv = put_json(
-        client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch",
-        [
-            {
-                "batchName": "Batch 1",
-                "batchType": "Provisional",
-                "choiceResults": {
-                    choice["id"]: choice["numVotes"] / 4
-                    for choice in contest["choices"]
-                },
-            }
-        ],
-    )
-    assert rv.status_code == 409
-    assert json.loads(rv.data) == {
-        "errors": [
-            {
-                "errorType": "Conflict",
-                "message": "Arlo has been updated. Please refresh your browser for the latest version.",
-            }
-        ]
-    }
-
-
-def test_offline_batch_results_unfinalize(
+def test_full_hand_tally_results_unfinalize(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
@@ -815,7 +770,7 @@ def test_offline_batch_results_unfinalize(
     # JA uploads results
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 1",
             "batchType": "Provisional",
@@ -829,7 +784,7 @@ def test_offline_batch_results_unfinalize(
     # AA tries to unfinalize the results before they have been finalized
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize"
     )
     assert rv.status_code == 409
     assert json.loads(rv.data) == {
@@ -844,19 +799,19 @@ def test_offline_batch_results_unfinalize(
     )
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch"
     )
     assert_is_date(json.loads(rv.data)["finalizedAt"])
 
     # AA unfinalizes the results
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize"
     )
     assert_ok(rv)
 
@@ -864,14 +819,14 @@ def test_offline_batch_results_unfinalize(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch"
     )
     assert json.loads(rv.data)["finalizedAt"] is None
 
     # JA updates the results
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 2",
             "batchType": "Election Day",
@@ -885,12 +840,12 @@ def test_offline_batch_results_unfinalize(
     # JA refinalizes the results
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
     rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/batch"
     )
     assert_is_date(json.loads(rv.data)["finalizedAt"])
 
@@ -902,7 +857,7 @@ def test_offline_batch_results_unfinalize(
     )
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/results/batch/",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/full-hand-tally/batch/",
         {
             "batchName": "Batch 1",
             "batchType": "Election Day",
@@ -915,7 +870,7 @@ def test_offline_batch_results_unfinalize(
 
     rv = post_json(
         client,
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/results/batch/finalize",
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/full-hand-tally/finalize",
     )
     assert_ok(rv)
 
@@ -929,7 +884,7 @@ def test_offline_batch_results_unfinalize(
     # AA tries to unfinalize results but can't
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.delete(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/results/batch/finalize"
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/full-hand-tally/finalize"
     )
     assert rv.status_code == 409
     assert json.loads(rv.data) == {

--- a/server/tests/test_full_hand_tally.py
+++ b/server/tests/test_full_hand_tally.py
@@ -130,7 +130,7 @@ def test_all_ballots_audit(
             "startedAt": assert_is_date,
             "endedAt": None,
             "isAuditComplete": None,
-            "sampledAllBallots": True,
+            "isFullHandTally": True,
             "drawSampleTask": {
                 "status": "PROCESSED",
                 "startedAt": assert_is_date,


### PR DESCRIPTION
- Ensure that `sample_size['size']` is always populated (practically, this just means filling it in for custom sample sizes in hybrid audits - that was the only case that was missing that field)
- On the backend, check against `sample_size['size']`, making sure we differentiate between ballots/batches based on audit type
- On the frontend, make sure we differentiate between ballots/batches based on audit type