### PR TITLE
Compute total hybrid custom sample size on frontend

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
@@ -377,7 +377,7 @@ describe('Audit Setup > Review & Launch', () => {
             key: 'custom',
             sizeCvr: 10,
             sizeNonCvr: 20,
-            size: null,
+            size: 30,
             prob: null,
           },
         })

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -581,8 +581,14 @@ const Review: React.FC<IProps> = ({
                                       }
                                       onValueChange={(value: number) =>
                                         setFieldValue(
-                                          `sampleSizes[${contest.id}].sizeCvr`,
-                                          value
+                                          `sampleSizes[${contest.id}]`,
+                                          {
+                                            ...currentOption,
+                                            sizeCvr: value,
+                                            size:
+                                              (currentOption.sizeNonCvr || 0) +
+                                              value,
+                                          }
                                         )
                                       }
                                       type="number"
@@ -609,8 +615,14 @@ const Review: React.FC<IProps> = ({
                                       }
                                       onValueChange={(value: number) =>
                                         setFieldValue(
-                                          `sampleSizes[${contest.id}].sizeNonCvr`,
-                                          value
+                                          `sampleSizes[${contest.id}]`,
+                                          {
+                                            ...currentOption,
+                                            sizeNonCvr: value,
+                                            size:
+                                              (currentOption.sizeCvr || 0) +
+                                              value,
+                                          }
                                         )
                                       }
                                       type="number"

--- a/server/tests/hybrid/test_hybrid.py
+++ b/server/tests/hybrid/test_hybrid.py
@@ -782,7 +782,7 @@ def test_hybrid_custom_sample_size(
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     sample_size = {
         "key": "custom",
-        "size": None,
+        "size": 10,
         "sizeCvr": 2,
         "sizeNonCvr": 8,
         "prob": None,
@@ -828,9 +828,13 @@ def test_hybrid_invalid_sample_size(
             "'sizeNonCvr' is a required property",
         ),
         (
+            {"key": "custom", "sizeCvr": 2, "sizeNonCvr": 2, "prob": None},
+            "'size' is a required property",
+        ),
+        (
             {
                 "key": "custom",
-                "size": None,
+                "size": 50,
                 "sizeCvr": 40,
                 "sizeNonCvr": 10,
                 "prob": None,
@@ -840,7 +844,7 @@ def test_hybrid_invalid_sample_size(
         (
             {
                 "key": "custom",
-                "size": None,
+                "size": 50,
                 "sizeCvr": 20,
                 "sizeNonCvr": 30,
                 "prob": None,
@@ -850,7 +854,7 @@ def test_hybrid_invalid_sample_size(
         (
             {
                 "key": "custom",
-                "size": None,
+                "size": 50,
                 "sizeCvr": 30,
                 "sizeNonCvr": 20,
                 "prob": None,
@@ -860,7 +864,7 @@ def test_hybrid_invalid_sample_size(
         (
             {
                 "key": "suite",
-                "size": None,
+                "size": 52,
                 "sizeCvr": 31,
                 "sizeNonCvr": 21,
                 "prob": None,


### PR DESCRIPTION
Previously, we didn't require the frontend to compute the total sample size based on the custom CVR/non-CVR strata sample sizes. In order to ensure that every selected RoundContest sample size stored in the database has a correct `size` field, we make things uniform by requiring this edge case behave like every other case.