### PR TITLE
Fix full hand tally warning for batch comparison audit

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/__snapshots__/index.test.tsx.snap
@@ -264,59 +264,14 @@ exports[`Audit Setup > Review & Launch custom sample size validation - ballot co
                   checked=""
                   name="sampleSizes[contest-id]"
                   type="radio"
-                  value="asn"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                BRAVO Average Sample Number: 
-                20 samples
-                 (54% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.7"
+                  value="supersimple"
                 />
                 <span
                   class="bp3-control-indicator"
                 />
                 
-                21 samples
-                 (70% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.5"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
+                15 samples
                 
-                22 samples
-                 (50% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.9"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                
-                31 samples
-                 (90% chance of reaching risk limit and completing the audit in one round)
               </label>
               <label
                 class="bp3-control bp3-radio"
@@ -614,59 +569,14 @@ exports[`Audit Setup > Review & Launch custom sample size validation - batch com
                   checked=""
                   name="sampleSizes[contest-id]"
                   type="radio"
-                  value="asn"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                BRAVO Average Sample Number: 
-                20 samples
-                 (54% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.7"
+                  value="macro"
                 />
                 <span
                   class="bp3-control-indicator"
                 />
                 
-                21 samples
-                 (70% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.5"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
+                4 samples
                 
-                22 samples
-                 (50% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.9"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                
-                31 samples
-                 (90% chance of reaching risk limit and completing the audit in one round)
               </label>
               <label
                 class="bp3-control bp3-radio"
@@ -1664,59 +1574,14 @@ exports[`Audit Setup > Review & Launch renders full state with batch comparison 
                   checked=""
                   name="sampleSizes[contest-id]"
                   type="radio"
-                  value="asn"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                BRAVO Average Sample Number: 
-                20 samples
-                 (54% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.7"
+                  value="macro"
                 />
                 <span
                   class="bp3-control-indicator"
                 />
                 
-                21 samples
-                 (70% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.5"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
+                4 samples
                 
-                22 samples
-                 (50% chance of reaching risk limit and completing the audit in one round)
-              </label>
-              <label
-                class="bp3-control bp3-radio"
-              >
-                <input
-                  name="sampleSizes[contest-id]"
-                  type="radio"
-                  value="0.9"
-                />
-                <span
-                  class="bp3-control-indicator"
-                />
-                
-                31 samples
-                 (90% chance of reaching risk limit and completing the audit in one round)
               </label>
               <label
                 class="bp3-control bp3-radio"

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/_mocks.ts
@@ -46,21 +46,39 @@ export const settingsMock: {
   },
 }
 
+const taskCompleteMock = {
+  status: FileProcessingStatus.PROCESSED,
+  startedAt: '2019-07-18T16:34:07.000+00:00',
+  completedAt: '2019-07-18T16:35:07.000+00:00',
+  error: null,
+}
+
 export const sampleSizeMock = {
-  sampleSizes: {
-    'contest-id': [
-      { prob: 0.54, size: 20, key: 'asn' },
-      { prob: 0.7, size: 21, key: '0.7' },
-      { prob: 0.5, size: 22, key: '0.5' },
-      { prob: 0.9, size: 31, key: '0.9' },
-    ],
+  batchComparison: {
+    sampleSizes: {
+      'contest-id': [{ prob: null, size: 4, key: 'macro' }],
+    },
+    selected: null,
+    task: taskCompleteMock,
   },
-  selected: null,
-  task: {
-    status: FileProcessingStatus.PROCESSED,
-    startedAt: '2019-07-18T16:34:07.000+00:00',
-    completedAt: '2019-07-18T16:35:07.000+00:00',
-    error: null,
+  ballotComparison: {
+    sampleSizes: {
+      'contest-id': [{ prob: null, size: 15, key: 'supersimple' }],
+    },
+    selected: null,
+    task: taskCompleteMock,
+  },
+  ballotPolling: {
+    sampleSizes: {
+      'contest-id': [
+        { prob: 0.54, size: 20, key: 'asn' },
+        { prob: 0.7, size: 21, key: '0.7' },
+        { prob: 0.5, size: 22, key: '0.5' },
+        { prob: 0.9, size: 31, key: '0.9' },
+      ],
+    },
+    selected: null,
+    task: taskCompleteMock,
   },
 }
 

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
@@ -142,7 +142,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -159,7 +159,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -176,7 +176,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -209,7 +209,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.batchComparison),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -228,7 +228,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -245,7 +245,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -313,7 +313,7 @@ describe('Audit Setup > Review & Launch', () => {
         cvrContestNames: {},
       }),
       apiCalls.getSampleSizeOptions({
-        ...sampleSizeMock,
+        ...sampleSizeMock.ballotPolling,
         sampleSizes: {
           'contest-id': [
             { key: 'suite', size: 10, sizeCvr: 3, sizeNonCvr: 7, prob: null },
@@ -400,10 +400,10 @@ describe('Audit Setup > Review & Launch', () => {
         cvrContestNames: {},
       }),
       apiCalls.getSampleSizeOptions({
-        ...sampleSizeMock,
+        ...sampleSizeMock.ballotPolling,
         sampleSizes: null,
         task: {
-          ...sampleSizeMock.task,
+          ...sampleSizeMock.ballotPolling.task,
           status: FileProcessingStatus.ERRORED,
           error: 'sample sizes error',
         },
@@ -482,7 +482,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -509,7 +509,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -535,7 +535,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -565,7 +565,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -577,14 +577,14 @@ describe('Audit Setup > Review & Launch', () => {
       fireEvent.change(customSampleSizeInput, { target: { value: '40' } }) // userEvent has a problem with this field due to the lack of an explicit value field: https://github.com/testing-library/user-event/issues/356
       fireEvent.blur(customSampleSizeInput)
       await screen.findByText(
-        'Must be less than or equal to: 30 (the total number of ballots in the contest)'
+        'Must be less than or equal to 30 (the total number of ballots in the contest)'
       )
       userEvent.clear(customSampleSizeInput)
       fireEvent.change(customSampleSizeInput, { target: { value: '5' } })
       await waitFor(() =>
         expect(
           screen.queryByText(
-            'Must be less than or equal to: 30 (the total number of ballots in the contest)'
+            'Must be less than or equal to 30 (the total number of ballots in the contest)'
           )
         ).toBeNull()
       )
@@ -643,7 +643,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.batchComparison),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -659,7 +659,7 @@ describe('Audit Setup > Review & Launch', () => {
       fireEvent.change(customSampleSizeInput, { target: { value: '40' } }) // userEvent has a problem with this field due to the lack of an explicit value field: https://github.com/testing-library/user-event/issues/356
       fireEvent.blur(customSampleSizeInput)
       await screen.findByText(
-        'Must be less than or equal to: 20 (the total number of batches in the contest)'
+        'Must be less than or equal to 20 (the total number of batches in the contest)'
       )
     })
   })
@@ -677,7 +677,7 @@ describe('Audit Setup > Review & Launch', () => {
         standardizations: {},
         cvrContestNames: {},
       }),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotComparison),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = renderView()
@@ -693,7 +693,7 @@ describe('Audit Setup > Review & Launch', () => {
       fireEvent.change(customSampleSizeInput, { target: { value: '50' } }) // userEvent has a problem with this field due to the lack of an explicit value field: https://github.com/testing-library/user-event/issues/356
       fireEvent.blur(customSampleSizeInput)
       await screen.findByText(
-        'Must be less than or equal to: 30 (the total number of ballots in the contest)'
+        'Must be less than or equal to 30 (the total number of ballots in the contest)'
       )
     })
   })
@@ -707,7 +707,7 @@ describe('Audit Setup > Review & Launch', () => {
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
       apiCalls.getSampleSizeOptions({
-        ...sampleSizeMock,
+        ...sampleSizeMock.ballotPolling,
         selected: { 'contest-id': { key: 'custom', size: 100, prob: null } },
       }),
     ]
@@ -796,7 +796,7 @@ describe('Audit Setup > Review & Launch', () => {
         },
         cvrContestNames,
       }),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotComparison),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -894,7 +894,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargeted),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -933,10 +933,11 @@ describe('Audit Setup > Review & Launch', () => {
         ],
       }),
       apiCalls.getSampleSizeOptions({
-        ...sampleSizeMock,
+        ...sampleSizeMock.ballotPolling,
         sampleSizes: {
-          ...sampleSizeMock.sampleSizes,
-          'contest-id-2': sampleSizeMock.sampleSizes['contest-id'],
+          ...sampleSizeMock.ballotPolling.sampleSizes,
+          'contest-id-2':
+            sampleSizeMock.ballotPolling.sampleSizes['contest-id'],
         },
       }),
     ]
@@ -970,7 +971,7 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargeted),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -996,7 +997,37 @@ describe('Audit Setup > Review & Launch', () => {
     })
   })
 
-  it('in a non-ballot-polling audit, shows an error when sample size is a full hand tally', async () => {
+  it('in a ballot comparison audit, shows an error when sample size is a full hand tally', async () => {
+    const expectedCalls = [
+      apiCalls.getSettings(auditSettings.ballotComparisonAll),
+      apiCalls.getJurisdictions({
+        jurisdictions: jurisdictionMocks.allManifestsWithCVRs,
+      }),
+      apiCalls.getJurisdictionFile,
+      apiCalls.getContests(contestMocks.filledTargeted),
+      apiCalls.getStandardizedContestsFile,
+      apiCalls.getStandardizations({
+        standardizations: {},
+        cvrContestNames: {},
+      }),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotComparison),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderView()
+      await screen.findByText(/Choose the initial sample size/)
+      userEvent.click(screen.getByLabelText(/Enter your own sample size/))
+      userEvent.type(screen.getByRole('spinbutton'), '30')
+      const warning = (await screen.findByText(
+        'The currently selected sample size for this contest requires a full hand tally.'
+      )).closest('.bp3-callout') as HTMLElement
+      expect(warning).toHaveClass('bp3-intent-danger')
+      within(warning).getByText(
+        'To use Arlo for a full hand tally, recreate this audit using the ballot polling audit type.'
+      )
+    })
+  })
+
+  it('in a batch comparison audit, shows an error when sample size is a full hand tally', async () => {
     const expectedCalls = [
       apiCalls.getSettings(auditSettings.batchComparisonAll),
       apiCalls.getJurisdictions({
@@ -1004,12 +1035,13 @@ describe('Audit Setup > Review & Launch', () => {
       }),
       apiCalls.getJurisdictionFile,
       apiCalls.getContests(contestMocks.filledTargeted),
-      apiCalls.getSampleSizeOptions(sampleSizeMock),
+      apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
       await screen.findByText(/Choose the initial sample size/)
-      userEvent.click(screen.getByLabelText(/90%/))
+      userEvent.click(screen.getByLabelText(/Enter your own sample size/))
+      userEvent.type(screen.getByRole('spinbutton'), '20')
       const warning = (await screen.findByText(
         'The currently selected sample size for this contest requires a full hand tally.'
       )).closest('.bp3-callout') as HTMLElement

--- a/client/src/components/MultiJurisdictionAudit/timers.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/timers.test.tsx
@@ -119,7 +119,7 @@ describe('timers', () => {
       aaApiCalls.getContests,
       ...loadEach,
       aaApiCalls.getSampleSizes,
-      { ...aaApiCalls.getSampleSizes, response: sampleSizeMock },
+      { ...aaApiCalls.getSampleSizes, response: sampleSizeMock.ballotPolling },
     ]
     await withMockFetch(expectedCalls, async () => {
       renderWithRoute('/election/1/setup', <AuditAdminViewWithAuth />)


### PR DESCRIPTION
- We were using the total ballots cast instead of the total batches to check if the sample size was a full hand tally, which was incorrect
- Also, we were validating the custom sample size in terms of the participating jurisdictions for the entire audit, not the specific contest (though since we only allow 1 contest for batch comparison audits, it was the same, it seemed like a latent bug waiting to happen).

Since the two pieces of logic use the same calculation (the total ballots/batches in the contest) I did a little refactoring to clean that up.