### PR TITLE
Status box message when full hand tally is needed in later rounds

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,7 @@ omit =
     scripts/*
 
 [report]
-fail_under = 99.5
+fail_under = 99.6
 precision = 2
 skip_covered = true
 show_missing = true

--- a/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
+++ b/client/src/components/MultiJurisdictionAudit/RoundManagement/_mocks.ts
@@ -21,6 +21,7 @@ export const roundMocks: {
     startedAt: '2020-09-14T17:35:19.482Z',
     endedAt: null,
     isAuditComplete: false,
+    needsFullHandTally: false,
     isFullHandTally: false,
     drawSampleTask: {
       status: FileProcessingStatus.PROCESSED,
@@ -34,6 +35,7 @@ export const roundMocks: {
     roundNum: 1,
     startedAt: '2020-09-14T17:35:19.482Z',
     endedAt: '2020-09-14T17:35:19.482Z',
+    needsFullHandTally: false,
     isAuditComplete: true,
     isFullHandTally: false,
     drawSampleTask: {
@@ -49,6 +51,7 @@ export const roundMocks: {
     startedAt: '2020-09-14T17:35:19.482Z',
     endedAt: null,
     isAuditComplete: false,
+    needsFullHandTally: true,
     isFullHandTally: true,
     drawSampleTask: {
       status: FileProcessingStatus.PROCESSED,

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
@@ -342,6 +342,8 @@ describe('StatusBox', () => {
           />
         </Router>
       )
+      screen.getByText('Round 1 of the audit is in progress')
+      screen.getByText('1 of 3 jurisdictions have completed Round 1')
       screen.getByText('Full hand tally required')
       screen.getByText(
         'One or more target contests require a full hand tally to complete the audit.'

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
@@ -326,6 +326,27 @@ describe('StatusBox', () => {
         expect(downloadReportButton).toBeEnabled()
       })
     })
+
+    it('shows a message when a full hand tally is required', () => {
+      render(
+        <Router>
+          <AuditAdminStatusBox
+            rounds={[
+              { ...roundMocks.singleIncomplete[0], needsFullHandTally: true },
+            ]}
+            startNextRound={jest.fn()}
+            undoRoundStart={jest.fn()}
+            jurisdictions={jurisdictionMocks.noneStarted}
+            contests={contestMocks.filledTargeted.contests}
+            auditSettings={auditSettings.all}
+          />
+        </Router>
+      )
+      screen.getByText('Full hand tally required')
+      screen.getByText(
+        'One or more target contests require a full hand tally to complete the audit.'
+      )
+    })
   })
 
   describe('JurisdictionAdminStatusBox', () => {
@@ -698,6 +719,30 @@ describe('StatusBox', () => {
       )
       screen.getByText('The audit has not started.')
       screen.getByText('1/2 files successfully uploaded.')
+    })
+
+    it(`shows a message for full hand tally mode`, () => {
+      render(
+        <Router>
+          <JurisdictionAdminStatusBox
+            rounds={[
+              { ...roundMocks.singleIncomplete[0], isFullHandTally: true },
+            ]}
+            auditBoards={auditBoardMocks.unfinished}
+            ballotManifest={{
+              file: null,
+              processing: fileProcessingMocks.processed,
+            }}
+            batchTallies={null}
+            cvrs={null}
+            auditType="BALLOT_POLLING"
+            auditName="Test Audit"
+            isAuditOnline
+          />
+        </Router>
+      )
+      screen.getByText('Round 1 of the audit is in progress.')
+      screen.getByText('Auditing ballots.')
     })
   })
 })

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
@@ -211,21 +211,6 @@ export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
     isFullHandTally,
   } = rounds[rounds.length - 1]
 
-  // Special case: when a sample size has been drawn that requires a full hand
-  // tally but the audit isn't in full hand tally mode (e.g. in a second round)
-  if (needsFullHandTally && !isFullHandTally)
-    return (
-      <StatusBox
-        headline="Full hand tally required"
-        details={[
-          'One or more target contests require a full hand tally to complete the audit.',
-        ]}
-        auditName={auditSettings.auditName}
-      >
-        {children}
-      </StatusBox>
-    )
-
   // Round in progress
   if (!endedAt) {
     const numCompleted = jurisdictions.filter(
@@ -253,7 +238,20 @@ export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
         buttonLabel={canUndoLaunch ? 'Undo Audit Launch' : undefined}
         onButtonClick={canUndoLaunch ? undoRoundStart : undefined}
       >
-        {children}
+        <>
+          {/* Special case: when a sample size has been drawn that requires a full hand tally
+     but the audit isn't in full hand tally mode (e.g. in a second round) */}
+          {needsFullHandTally && !isFullHandTally && (
+            <Callout intent="warning" style={{ marginTop: '15px' }}>
+              <strong>Full hand tally required</strong>
+              <p>
+                One or more target contests require a full hand tally to
+                complete the audit.
+              </p>
+            </Callout>
+          )}
+          {children}
+        </>
       </StatusBox>
     )
   }

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.tsx
@@ -203,7 +203,28 @@ export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
     )
   }
 
-  const { roundNum, endedAt, isAuditComplete } = rounds[rounds.length - 1]
+  const {
+    roundNum,
+    endedAt,
+    isAuditComplete,
+    needsFullHandTally,
+    isFullHandTally,
+  } = rounds[rounds.length - 1]
+
+  // Special case: when a sample size has been drawn that requires a full hand
+  // tally but the audit isn't in full hand tally mode (e.g. in a second round)
+  if (needsFullHandTally && !isFullHandTally)
+    return (
+      <StatusBox
+        headline="Full hand tally required"
+        details={[
+          'One or more target contests require a full hand tally to complete the audit.',
+        ]}
+        auditName={auditSettings.auditName}
+      >
+        {children}
+      </StatusBox>
+    )
 
   // Round in progress
   if (!endedAt) {

--- a/client/src/components/MultiJurisdictionAudit/useRoundsAuditAdmin.ts
+++ b/client/src/components/MultiJurisdictionAudit/useRoundsAuditAdmin.ts
@@ -10,6 +10,7 @@ export interface IRound {
   startedAt: string
   endedAt: string | null
   isAuditComplete: boolean
+  needsFullHandTally: boolean
   isFullHandTally: boolean
   drawSampleTask: {
     status: FileProcessingStatus

--- a/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/_mocks/index.ts
+++ b/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/_mocks/index.ts
@@ -162,6 +162,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
+      needsFullHandTally: false,
       isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSED,
@@ -178,6 +179,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
+      needsFullHandTally: false,
       isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSED,
@@ -192,6 +194,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-2',
+      needsFullHandTally: false,
       isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSED,
@@ -208,6 +211,7 @@ export const roundMocks: {
       isAuditComplete: true,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
+      needsFullHandTally: false,
       isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSED,
@@ -224,6 +228,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
+      needsFullHandTally: false,
       isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSED,
@@ -240,6 +245,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
+      needsFullHandTally: false,
       isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.PROCESSING,
@@ -256,6 +262,7 @@ export const roundMocks: {
       isAuditComplete: false,
       startedAt: '2019-07-18T16:34:07.000+00:00',
       id: 'round-1',
+      needsFullHandTally: false,
       isFullHandTally: false,
       drawSampleTask: {
         status: FileProcessingStatus.ERRORED,

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -612,7 +612,7 @@ def is_round_complete(election: Election, round: Round) -> bool:
         return num_jurisdictions_without_results == 0
 
 
-# Calculates how the sample size threshold to trigger a full hand tally in each
+# Calculates the sample size threshold to trigger a full hand tally in each
 # targeted contest
 def full_hand_tally_sizes(election: Election):
     contests_query = Contest.query.filter_by(election_id=election.id, is_targeted=True)

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -6,7 +6,6 @@ from typing import (
     List,
     Tuple,
     Dict,
-    cast as typing_cast,
     TypedDict,
 )
 from datetime import datetime
@@ -23,7 +22,6 @@ from ..auth import restrict_access, UserType
 from . import sample_sizes as sample_sizes_module
 from ..util.isoformat import isoformat
 from ..util.group_by import group_by
-from ..util.jsonschema import JSONDict
 from ..audit_math import (
     sampler,
     ballot_polling,
@@ -614,14 +612,52 @@ def is_round_complete(election: Election, round: Round) -> bool:
         return num_jurisdictions_without_results == 0
 
 
+# Calculates how the sample size threshold to trigger a full hand tally in each
+# targeted contest
+def full_hand_tally_sizes(election: Election):
+    contests_query = Contest.query.filter_by(election_id=election.id, is_targeted=True)
+    if election.audit_type == AuditType.BATCH_COMPARISON:
+        return dict(
+            contests_query.join(Contest.jurisdictions)
+            .group_by(Contest.id)
+            .values(
+                Contest.id,
+                func.coalesce(func.sum(Jurisdiction.manifest_num_batches), 0),
+            )
+        )
+    return dict(contests_query.values(Contest.id, Contest.total_ballots_cast))
+
+
+# Returns True if the sample size for any targeted contest in the given round
+# requires a full hand tally
+def needs_full_hand_tally(round: Round, election: Election) -> bool:
+    full_hand_tally_size = full_hand_tally_sizes(election)
+    cumulative_sample_sizes = dict(
+        RoundContest.query.join(Round)
+        .filter_by(election_id=round.election_id)
+        .filter(Round.round_num <= round.round_num)
+        .join(RoundContest.contest)
+        .filter_by(is_targeted=True)
+        .group_by(RoundContest.contest_id)
+        .values(
+            RoundContest.contest_id,
+            func.sum(RoundContest.sample_size["size"].as_integer()),
+        )
+    )
+    return any(
+        size >= full_hand_tally_size[contest_id]
+        for contest_id, size in cumulative_sample_sizes.items()
+    )
+
+
+# Returns True if Arlo is in full hand tally mode, which is only triggered
+# in the first round of ballot polling audits when the sample size requires a
+# full hand tally
 def is_full_hand_tally(round: Round, election: Election):
-    return election.audit_type == AuditType.BALLOT_POLLING and any(
-        typing_cast(JSONDict, round_contest.sample_size)["size"]
-        >= round_contest.contest.total_ballots_cast
-        for round_contest in round.round_contests
-        if round_contest.sample_size is not None
-        # total_ballots_cast can't be None here, but typechecker needs this
-        and round_contest.contest.total_ballots_cast is not None
+    return (
+        election.audit_type == AuditType.BALLOT_POLLING
+        and round.round_num == 1
+        and needs_full_hand_tally(round, election)
     )
 
 
@@ -924,25 +960,17 @@ def validate_sample_size(round: dict, election: Election):
     if set(round["sampleSizes"].keys()) != {c.id for c in targeted_contests}:
         raise BadRequest("Sample sizes provided do not match targeted contest ids")
 
+    full_hand_tally_size = full_hand_tally_sizes(election)
+
     for contest in targeted_contests:
         sample_size = round["sampleSizes"][contest.id]
-        valid_keys, full_hand_tally_size = {
+        valid_keys = {
             AuditType.BALLOT_POLLING: (
-                ["asn", "0.9", "0.8", "0.7", "custom", "all-ballots"],
-                contest.total_ballots_cast,
+                ["asn", "0.9", "0.8", "0.7", "custom", "all-ballots"]
             ),
-            AuditType.BALLOT_COMPARISON: (
-                ["supersimple", "custom"],
-                contest.total_ballots_cast,
-            ),
-            AuditType.BATCH_COMPARISON: (
-                ["macro", "custom"],
-                sum(
-                    jurisdiction.manifest_num_batches or 0
-                    for jurisdiction in contest.jurisdictions
-                ),
-            ),
-            AuditType.HYBRID: (["suite", "custom"], contest.total_ballots_cast),
+            AuditType.BALLOT_COMPARISON: ["supersimple", "custom"],
+            AuditType.BATCH_COMPARISON: ["macro", "custom"],
+            AuditType.HYBRID: ["suite", "custom"],
         }[AuditType(election.audit_type)]
 
         if sample_size["key"] not in valid_keys:
@@ -968,7 +996,7 @@ def validate_sample_size(round: dict, election: Election):
                         f" {total_ballots.non_cvr} (the total number of non-CVR ballots in the contest)"
                     )
 
-            elif sample_size["size"] > full_hand_tally_size:
+            elif sample_size["size"] > full_hand_tally_size[contest.id]:
                 ballots_or_batches = (
                     "batches"
                     if election.audit_type == AuditType.BATCH_COMPARISON
@@ -976,10 +1004,10 @@ def validate_sample_size(round: dict, election: Election):
                 )
                 raise BadRequest(
                     f"Sample size for contest {contest.name} must be less than or equal to:"
-                    f" {full_hand_tally_size} (the total number of {ballots_or_batches} in the contest)"
+                    f" {full_hand_tally_size[contest.id]} (the total number of {ballots_or_batches} in the contest)"
                 )
 
-        if sample_size["size"] >= full_hand_tally_size:
+        if sample_size["size"] >= full_hand_tally_size[contest.id]:
             if election.audit_type != AuditType.BALLOT_POLLING:
                 raise BadRequest(
                     "For a full hand tally, use the ballot polling audit type."
@@ -1053,6 +1081,7 @@ def serialize_round(round: Round) -> dict:
         "startedAt": isoformat(round.created_at),
         "endedAt": isoformat(round.ended_at),
         "isAuditComplete": is_audit_complete(round),
+        "needsFullHandTally": needs_full_hand_tally(round, round.election),
         "isFullHandTally": is_full_hand_tally(round, round.election),
         "drawSampleTask": serialize_background_task(round.draw_sample_task),
     }

--- a/server/tests/api/test_rounds.py
+++ b/server/tests/api/test_rounds.py
@@ -51,6 +51,7 @@ def test_rounds_create_one(
                 "startedAt": assert_is_date,
                 "endedAt": None,
                 "isAuditComplete": None,
+                "needsFullHandTally": False,
                 "isFullHandTally": False,
                 "drawSampleTask": {
                     "status": "PROCESSED",
@@ -115,6 +116,7 @@ def test_rounds_create_two(
                 "startedAt": assert_is_date,
                 "endedAt": assert_is_date,
                 "isAuditComplete": False,
+                "needsFullHandTally": False,
                 "isFullHandTally": False,
                 "drawSampleTask": {
                     "status": "PROCESSED",
@@ -129,6 +131,7 @@ def test_rounds_create_two(
                 "startedAt": assert_is_date,
                 "endedAt": None,
                 "isAuditComplete": None,
+                "needsFullHandTally": False,
                 "isFullHandTally": False,
                 "drawSampleTask": {
                     "status": "PROCESSED",
@@ -177,6 +180,7 @@ def test_rounds_complete_audit(
                 "startedAt": assert_is_date,
                 "endedAt": assert_is_date,
                 "isAuditComplete": True,
+                "needsFullHandTally": False,
                 "isFullHandTally": False,
                 "drawSampleTask": {
                     "status": "PROCESSED",

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -181,6 +181,7 @@ def test_batch_comparison_round_1(
                 "startedAt": assert_is_date,
                 "endedAt": None,
                 "isAuditComplete": None,
+                "needsFullHandTally": False,
                 "isFullHandTally": False,
                 "drawSampleTask": {
                     "status": "PROCESSED",

--- a/server/tests/test_full_hand_tally.py
+++ b/server/tests/test_full_hand_tally.py
@@ -130,6 +130,7 @@ def test_all_ballots_audit(
             "startedAt": assert_is_date,
             "endedAt": None,
             "isAuditComplete": None,
+            "needsFullHandTally": True,
             "isFullHandTally": True,
             "drawSampleTask": {
                 "status": "PROCESSED",


### PR DESCRIPTION
Task: #1335 

When the sample size selected indicates we need a full hand tally in later rounds of the audit, we want to display that to the AA. In order to differentiate this from when we're in full hand tally mode intentionally, we introduce a new flag: needsFullHandTally


<img width="1305" alt="Screen Shot 2021-11-10 at 11 51 11 AM" src="https://user-images.githubusercontent.com/530106/141183345-ac446b6a-e941-406b-9e58-64e1eb96c8ae.png">

