### PR TITLE
Adding confirmation toast for ballot data entry

### DIFF
--- a/client/cypress/end-to-end/ballot-comparison.spec.js
+++ b/client/cypress/end-to-end/ballot-comparison.spec.js
@@ -247,9 +247,9 @@ describe('Ballot Comparison Test Cases', () => {
         .click({ force: true })
       cy.findByRole('button', { name: 'Submit Selections' }).click()
       cy.findByText('Confirm Selections').click()
-      cy.findByText('Success! Now showing the next ballot to audit.')
+      cy.findAndCloseToast('Success! Now showing the next ballot to audit.')
       cy.findByText('Change Selections').should('not.exist')
-      cy.findByText(/All Ballots/).click({ force: true })
+      cy.findByText(/All Ballots/).click()
     })
 
     cy.contains('Ballots for Audit Board #1')

--- a/client/cypress/end-to-end/ballot-comparison.spec.js
+++ b/client/cypress/end-to-end/ballot-comparison.spec.js
@@ -247,7 +247,6 @@ describe('Ballot Comparison Test Cases', () => {
         .click({ force: true })
       cy.findByRole('button', { name: 'Submit Selections' }).click()
       cy.findByText('Confirm Selections').click()
-      cy.findAndCloseToast('Success! Now showing the next ballot to audit.')
       cy.findByText('Change Selections').should('not.exist')
       cy.findByText(/All Ballots/).click()
     })
@@ -268,6 +267,7 @@ describe('Ballot Comparison Test Cases', () => {
           .click({ force: true })
         cy.findByRole('button', { name: 'Submit Selections' }).click()
         cy.findByText('Confirm Selections').click()
+        cy.findAndCloseToast('Success! Now showing the next ballot to audit.')
         cy.findByText('Change Selections').should('not.exist')
       }
     })
@@ -283,6 +283,7 @@ describe('Ballot Comparison Test Cases', () => {
     cy.findByRole('button', { name: 'Submit Selections' }).click()
     cy.findByText('Confirm Selections').click()
     cy.findByText('Change Selections').should('not.exist')
+    cy.findAndCloseToast('Success! Now showing the next ballot to audit.')
     cy.findByText(/All Ballots/).click({ force: true })
 
     cy.findByText(/Not Audited/).should('have.length', 1)

--- a/client/cypress/end-to-end/ballot-comparison.spec.js
+++ b/client/cypress/end-to-end/ballot-comparison.spec.js
@@ -247,6 +247,7 @@ describe('Ballot Comparison Test Cases', () => {
         .click({ force: true })
       cy.findByRole('button', { name: 'Submit Selections' }).click()
       cy.findByText('Confirm Selections').click()
+      cy.findByText('Success! Now showing the next ballot to audit.')
       cy.findByText('Change Selections').should('not.exist')
       cy.findByText(/All Ballots/).click({ force: true })
     })
@@ -258,7 +259,7 @@ describe('Ballot Comparison Test Cases', () => {
       // iterate through exactly the number of ballots available to avoid conditions
       if (index == 0) {
         // button name when some ballots are audited
-        cy.findByText('Audit Next Ballot').click()
+        cy.findByText('Audit Next Ballot').click({ force: true })
       }
       // since the first ballot is already audited
       if (index < list.length - 1) {

--- a/client/src/components/DataEntry/Ballot.test.tsx
+++ b/client/src/components/DataEntry/Ballot.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   within,
 } from '@testing-library/react'
+import { ToastContainer } from 'react-toastify'
 import userEvent from '@testing-library/user-event'
 import { Router } from 'react-router-dom'
 import { createMemoryHistory } from 'history'
@@ -205,6 +206,7 @@ describe('Ballot', () => {
           batchId="batch-id-1"
           ballotPosition={2112}
         />
+        <ToastContainer />
       </Router>
     )
 
@@ -224,7 +226,7 @@ describe('Ballot', () => {
       within(dialog).getByRole('button', { name: 'Confirm Selections' })
     )
 
-    // await findAndCloseToast('Success! Now showing the next ballot to audit.') // should work but doesn't
+    await findAndCloseToast('Success! Now showing the next ballot to audit.')
 
     await waitFor(() => {
       expect(dialog).not.toBeInTheDocument()

--- a/client/src/components/DataEntry/Ballot.test.tsx
+++ b/client/src/components/DataEntry/Ballot.test.tsx
@@ -11,6 +11,7 @@ import { Router } from 'react-router-dom'
 import { createMemoryHistory } from 'history'
 import Ballot from './Ballot'
 import { contest, dummyBallots } from './_mocks'
+import { findAndCloseToast } from '../testUtilities'
 
 const history = createMemoryHistory()
 
@@ -87,7 +88,6 @@ describe('Ballot', () => {
     userEvent.click(
       within(dialog).getByRole('button', { name: 'Change Selections' })
     )
-
     await waitFor(() => {
       expect(dialog).not.toBeInTheDocument()
     })
@@ -223,6 +223,8 @@ describe('Ballot', () => {
     userEvent.click(
       within(dialog).getByRole('button', { name: 'Confirm Selections' })
     )
+
+    // await findAndCloseToast('Success! Now showing the next ballot to audit.') // should work but doesn't
 
     await waitFor(() => {
       expect(dialog).not.toBeInTheDocument()

--- a/client/src/components/DataEntry/Ballot.tsx
+++ b/client/src/components/DataEntry/Ballot.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { H3, H4, Button, Colors, OL } from '@blueprintjs/core'
 import styled from 'styled-components'
 import { Redirect } from 'react-router-dom'
+import { toast } from 'react-toastify'
 import LinkButton from '../Atoms/LinkButton'
 import BallotAudit from './BallotAudit'
 import {
@@ -192,6 +193,7 @@ const Ballot: React.FC<IProps> = ({
             ({ interpretation }) => interpretation !== null
           )
         )
+        toast.success('Success! Now showing the next ballot to audit.')
         nextBallot()
       },
       yesButtonLabel: 'Confirm Selections',


### PR DESCRIPTION
**Description**

Added a green confirmation toast for when a ballot data entry is completed and when the next ballot is shown to provide clear and unambiguous direction to audit board members that the next ballot is there to be audited.

**Testing**

- Updated cypress to account for the toast

**Progress**

Manually tested and works on web and mobile.
