### PR TITLE
Allow batch comparison full hand tally

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.test.tsx
@@ -1022,12 +1022,12 @@ describe('Audit Setup > Review & Launch', () => {
       )).closest('.bp3-callout') as HTMLElement
       expect(warning).toHaveClass('bp3-intent-danger')
       within(warning).getByText(
-        'To use Arlo for a full hand tally, recreate this audit using the ballot polling audit type.'
+        'To use Arlo for a full hand tally, recreate this audit using the ballot polling or batch comparison audit type.'
       )
     })
   })
 
-  it('in a batch comparison audit, shows an error when sample size is a full hand tally', async () => {
+  it('in a batch comparison audit, shows a warning when sample size is a full hand tally', async () => {
     const expectedCalls = [
       apiCalls.getSettings(auditSettings.batchComparisonAll),
       apiCalls.getJurisdictions({
@@ -1045,10 +1045,7 @@ describe('Audit Setup > Review & Launch', () => {
       const warning = (await screen.findByText(
         'The currently selected sample size for this contest requires a full hand tally.'
       )).closest('.bp3-callout') as HTMLElement
-      expect(warning).toHaveClass('bp3-intent-danger')
-      within(warning).getByText(
-        'To use Arlo for a full hand tally, recreate this audit using the ballot polling audit type.'
-      )
+      expect(warning).toHaveClass('bp3-intent-warning')
     })
   })
 })

--- a/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Review/index.tsx
@@ -484,7 +484,8 @@ const Review: React.FC<IProps> = ({
                             currentOption.size >= fullHandTallySize && (
                               <Callout
                                 intent={
-                                  auditType === 'BALLOT_POLLING' &&
+                                  (auditType === 'BALLOT_POLLING' ||
+                                    auditType === 'BATCH_COMPARISON') &&
                                   targetedContests.length === 1
                                     ? 'warning'
                                     : 'danger'
@@ -495,11 +496,14 @@ const Review: React.FC<IProps> = ({
                                   The currently selected sample size for this
                                   contest requires a full hand tally.
                                 </div>
-                                {auditType !== 'BALLOT_POLLING' && (
+                                {!(
+                                  auditType === 'BALLOT_POLLING' ||
+                                  auditType === 'BATCH_COMPARISON'
+                                ) && (
                                   <div>
                                     To use Arlo for a full hand tally, recreate
-                                    this audit using the ballot polling audit
-                                    type.
+                                    this audit using the ballot polling or batch
+                                    comparison audit type.
                                   </div>
                                 )}
                                 {auditType === 'BALLOT_POLLING' &&

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -1008,9 +1008,12 @@ def validate_sample_size(round: dict, election: Election):
                 )
 
         if sample_size["size"] >= full_hand_tally_size[contest.id]:
-            if election.audit_type != AuditType.BALLOT_POLLING:
+            if election.audit_type not in [
+                AuditType.BALLOT_POLLING,
+                AuditType.BATCH_COMPARISON,
+            ]:
                 raise BadRequest(
-                    "For a full hand tally, use the ballot polling audit type."
+                    "For a full hand tally, use the ballot polling or batch comparison audit type."
                 )
             if len(targeted_contests) > 1:
                 raise BadRequest("For a full hand tally, use only one target contest.")

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -847,11 +847,11 @@ def test_ballot_comparison_sample_size_validation(
         ),
         (
             {contest_id: {"key": "custom", "size": 30, "prob": None}},
-            "For a full hand tally, use the ballot polling audit type.",
+            "For a full hand tally, use the ballot polling or batch comparison audit type.",
         ),
         (
             {contest_id: {"key": "supersimple", "size": 31, "prob": None}},
-            "For a full hand tally, use the ballot polling audit type.",
+            "For a full hand tally, use the ballot polling or batch comparison audit type.",
         ),
     ]
     for bad_sample_size, expected_error in bad_sample_sizes:

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -434,14 +434,6 @@ def test_batch_comparison_custom_sample_size_validation(
             {contest_id: {"key": "custom", "size": 25, "prob": None}},
             "Sample size for contest Contest 1 must be less than or equal to: 15 (the total number of batches in the contest)",
         ),
-        (
-            {contest_id: {"key": "custom", "size": 15, "prob": None}},
-            "For a full hand tally, use the ballot polling audit type.",
-        ),
-        (
-            {contest_id: {"key": "macro", "size": 16, "prob": None}},
-            "For a full hand tally, use the ballot polling audit type.",
-        ),
     ]
     for bad_sample_size, expected_error in bad_sample_sizes:
         rv = post_json(
@@ -557,52 +549,49 @@ def test_batch_comparison_batches_sampled_multiple_times(
     assert_match_report(rv.data, snapshot)
 
 
-# TODO this test no longer applies, since we don't allow batch comparison full
-# hand tallies But the logic it tests is still there, so leaving the test as a
-# reminder to either remove the logic or find a different way to test it.
-# def test_batch_comparison_sample_all_batches(
-#     client: FlaskClient,
-#     election_id: str,
-#     jurisdiction_ids: List[str],
-#     contest_id: str,
-#     election_settings,  # pylint: disable=unused-argument
-#     manifests,  # pylint: disable=unused-argument
-#     batch_tallies,  # pylint: disable=unused-argument
-# ):
-#     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-#
-#     sample_size = (
-#         Batch.query.join(Jurisdiction).filter_by(election_id=election_id).count() - 1
-#     )
-#     rv = post_json(
-#         client,
-#         f"/api/election/{election_id}/round",
-#         {
-#             "roundNum": 1,
-#             "sampleSizes": {
-#                 contest_id: {"key": "custom", "size": sample_size, "prob": None}
-#             },
-#         },
-#     )
-#     assert_ok(rv)
-#
-#     rv = client.get(f"/api/election/{election_id}/round")
-#     rounds = json.loads(rv.data)["rounds"]
-#     round_1_id = rounds[0]["id"]
-#
-#     set_logged_in_user(
-#         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
-#     )
-#     all_batches = []
-#     for jurisdiction_id in jurisdiction_ids[:2]:
-#         rv = client.get(
-#             f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_1_id}/batches"
-#         )
-#         assert rv.status_code == 200
-#         all_batches += json.loads(rv.data)["batches"]
-#
-#     # Every batch should get sampled exactly once
-#     assert len(all_batches) == sample_size
+def test_batch_comparison_sample_all_batches(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_id: str,
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    batch_tallies,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+
+    sample_size = (
+        Batch.query.join(Jurisdiction).filter_by(election_id=election_id).count()
+    )
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 1,
+            "sampleSizes": {
+                contest_id: {"key": "custom", "size": sample_size, "prob": None}
+            },
+        },
+    )
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/round")
+    rounds = json.loads(rv.data)["rounds"]
+    round_1_id = rounds[0]["id"]
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    all_batches = []
+    for jurisdiction_id in jurisdiction_ids[:2]:
+        rv = client.get(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_1_id}/batches"
+        )
+        assert rv.status_code == 200
+        all_batches += json.loads(rv.data)["batches"]
+
+    # Every batch should get sampled exactly once
+    assert len(all_batches) == sample_size
 
 
 def test_batch_comparison_undo_start_round_1(

--- a/server/tests/hybrid/test_hybrid.py
+++ b/server/tests/hybrid/test_hybrid.py
@@ -859,7 +859,7 @@ def test_hybrid_invalid_sample_size(
                 "sizeNonCvr": 20,
                 "prob": None,
             },
-            "For a full hand tally, use the ballot polling audit type.",
+            "For a full hand tally, use the ballot polling or batch comparison audit type.",
         ),
         (
             {
@@ -869,7 +869,7 @@ def test_hybrid_invalid_sample_size(
                 "sizeNonCvr": 21,
                 "prob": None,
             },
-            "For a full hand tally, use the ballot polling audit type.",
+            "For a full hand tally, use the ballot polling or batch comparison audit type.",
         ),
     ]
     for invalid_sample_size, expected_error in invalid_sample_sizes:


### PR DESCRIPTION
We decided to show a warning but not disallow starting batch comparison audits that sample all batches.