### PR TITLE
Documenting outdated uses of api mocking

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/Contests/index.test.tsx
@@ -13,6 +13,8 @@ import { IJurisdiction } from '../../useJurisdictions'
 import { IContest } from '../../../../types'
 import { jurisdictionMocks } from '../../useSetupMenuItems/_mocks'
 
+// TODO update to withMockFetch instead of apiMock
+
 const toastSpy = jest.spyOn(toast, 'error').mockImplementation()
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,

--- a/client/src/components/MultiJurisdictionAudit/AASetup/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/AASetup/index.test.tsx
@@ -10,6 +10,8 @@ import useContests from '../useContests'
 import useAuditSettings from '../useAuditSettings'
 import useJurisdictions from '../useJurisdictions'
 
+// TODO update to withMockFetch instead of apiMock
+
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
   Parameters<typeof utilities.api>

--- a/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/StatusBox/index.test.tsx
@@ -14,6 +14,8 @@ import { contestMocks } from '../AASetup/Contests/_mocks'
 import * as utilities from '../../utilities'
 import { IAuditSettings } from '../useAuditSettings'
 
+// TODO update to withMockFetch instead of apiMock
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
   useRouteMatch: jest.fn(),

--- a/client/src/components/MultiJurisdictionAudit/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.test.tsx
@@ -65,6 +65,8 @@ jest.mock('./useSetupMenuItems/getRoundStatus')
 getJurisdictionFileStatusMock.mockReturnValue('PROCESSED')
 getRoundStatusMock.mockReturnValue(false)
 
+// TODO investigate to see if mocking axios can be replaced with a more full use of withMockFetch
+
 jest.mock('axios')
 
 afterEach(() => {

--- a/client/src/components/MultiJurisdictionAudit/useAuditSettings.test.ts
+++ b/client/src/components/MultiJurisdictionAudit/useAuditSettings.test.ts
@@ -4,6 +4,8 @@ import * as utilities from '../utilities'
 import useAuditSettings from './useAuditSettings'
 import { auditSettings } from './useSetupMenuItems/_mocks'
 
+// TODO update to withMockFetch instead of apiMock
+
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
   Parameters<typeof utilities.api>

--- a/client/src/components/MultiJurisdictionAudit/useSetupMenuItems.test.ts
+++ b/client/src/components/MultiJurisdictionAudit/useSetupMenuItems.test.ts
@@ -11,6 +11,8 @@ import { IRound } from './useRoundsAuditAdmin'
 
 jest.unmock('./useSetupMenuItems/index')
 
+// TODO update to withMockFetch instead of apiMock
+
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
   Parameters<typeof utilities.api>

--- a/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/getJurisdictionFileStatus.test.ts
+++ b/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/getJurisdictionFileStatus.test.ts
@@ -3,6 +3,8 @@ import getJurisdictionFileStatus, {
 } from './getJurisdictionFileStatus'
 import * as utilities from '../../utilities'
 
+// TODO update to withMockFetch instead of apiMock
+
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
   Parameters<typeof utilities.api>

--- a/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/getRoundStatus.test.ts
+++ b/client/src/components/MultiJurisdictionAudit/useSetupMenuItems/getRoundStatus.test.ts
@@ -1,6 +1,8 @@
 import getRoundStatus from './getRoundStatus'
 import * as utilities from '../../utilities'
 
+// TODO update to withMockFetch instead of apiMock
+
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
   Parameters<typeof utilities.api>


### PR DESCRIPTION
**Description**

Went through and found all the instances where we are still using the old `apiMock` format instead of the new `withMockFetch` helper so it can be easily refactored in future.