### PR TITLE
Remove CSV streaming obstacles

### DIFF
--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -124,7 +124,6 @@ def process_ballot_manifest_file(
         num_batches = 0
         num_ballots = 0
         for row in manifest_csv:
-            print(row)
             batch = Batch(
                 id=str(uuid.uuid4()),
                 name=row[BATCH_NAME],
@@ -200,7 +199,6 @@ def validate_ballot_manifest_upload(request: Request):
     if "manifest" not in request.files:
         raise BadRequest("Missing required file parameter 'manifest'")
 
-    print(request.files["manifest"].content_type)
     validate_csv_mimetype(request.files["manifest"])
 
 

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -181,6 +181,16 @@ def hybrid_contest_choice_vote_counts(
     }
 
 
+def csv_reader_for_cvr(file_contents: str) -> CSVIterator:
+    # Temporarily wrap file contents in a buffer so we can "stream" it until
+    # we have actual file streaming from storage
+    cvr_file = io.BytesIO(file_contents.encode("utf-8"))
+    validate_not_empty(cvr_file)
+    text_file = decode_csv(cvr_file)
+    validate_comma_delimited(text_file)
+    return csv.reader(text_file, delimiter=",")
+
+
 def get_header_indices(headers_row: List[str]) -> Dict[str, int]:
     return {header: i for i, header in enumerate(headers_row)}
 
@@ -278,16 +288,6 @@ def parse_clearballot_cvrs(
         )
 
     return contests_metadata, (parse_cvr_row(row, i) for i, row in enumerate(cvrs))
-
-
-def csv_reader_for_cvr(file_contents: str) -> CSVIterator:
-    # Temporarily wrap file contents in a buffer so we can "stream" it until
-    # we have actual file streaming from storage
-    cvr_file = io.BytesIO(file_contents.encode("utf-8"))
-    validate_not_empty(cvr_file)
-    text_file = decode_csv(cvr_file)
-    validate_comma_delimited(text_file)
-    return csv.reader(text_file, delimiter=",")
 
 
 def parse_dominion_cvrs(

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -13,6 +13,8 @@ from werkzeug.exceptions import BadRequest, NotFound, Conflict
 from sqlalchemy import func, and_
 from sqlalchemy.orm import Session
 
+from server.util.csv_parse import decode_csv_file
+
 from . import api
 from ..database import db_session, engine as db_engine
 from ..models import *  # pylint: disable=wildcard-import
@@ -25,7 +27,7 @@ from ..worker.tasks import (
 )
 from ..util.file import serialize_file, serialize_file_processing
 from ..util.csv_download import csv_response
-from ..util.csv_parse import decode_csv_file
+from ..util.csv_parse import decode_csv_file, validate_csv_mimetype
 from ..util.jsonschema import JSONDict
 from ..audit_math.suite import HybridPair
 from ..activity_log.activity_log import UploadFile, activity_base, record_activity
@@ -563,6 +565,8 @@ def validate_cvr_upload(
 
     if "cvrs" not in request.files:
         raise BadRequest("Missing required file parameter 'cvrs'")
+
+    validate_csv_mimetype(request.files["cvrs"])
 
     if request.form.get("cvrFileType") not in [
         cvr_file_type.value for cvr_file_type in CvrFileType

--- a/server/tests/api/test_activity.py
+++ b/server/tests/api/test_activity.py
@@ -347,10 +347,7 @@ def test_file_upload_errors(
 
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (io.BytesIO(b"bad,\ndominion,\nfile,\nheaders,"), "cvrs.csv"),
-            "cvrFileType": "DOMINION",
-        },
+        data={"cvrs": (io.BytesIO(b""), "cvrs.csv"), "cvrFileType": "DOMINION",},
     )
     assert_ok(rv)
 
@@ -391,7 +388,7 @@ def test_file_upload_errors(
                 "info": {
                     **expected_activity["info"],
                     "file_type": "cvrs",
-                    "error": "Invalid contest name: dominion. Contest names should have this format: Contest Name (Vote For=1).",
+                    "error": "CSV cannot be empty.",
                 },
             },
             {

--- a/server/tests/api/test_activity.py
+++ b/server/tests/api/test_activity.py
@@ -347,7 +347,10 @@ def test_file_upload_errors(
 
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={"cvrs": (io.BytesIO(b""), "cvrs.csv"), "cvrFileType": "DOMINION"},
+        data={
+            "cvrs": (io.BytesIO(b"bad,\ndominion,\nfile,\nheaders,"), "cvrs.csv"),
+            "cvrFileType": "DOMINION",
+        },
     )
     assert_ok(rv)
 
@@ -388,7 +391,7 @@ def test_file_upload_errors(
                 "info": {
                     **expected_activity["info"],
                     "file_type": "cvrs",
-                    "error": "CVR file cannot be empty.",
+                    "error": "Invalid contest name: dominion. Contest names should have this format: Contest Name (Vote For=1).",
                 },
             },
             {

--- a/server/tests/util/test_csv_parse.py
+++ b/server/tests/util/test_csv_parse.py
@@ -2,13 +2,16 @@ from typing import Union, List
 import os, io, pytest
 from werkzeug.exceptions import BadRequest
 from werkzeug.datastructures import FileStorage
+
 from ...api.jurisdictions import JURISDICTIONS_COLUMNS
 from ...util.csv_parse import (
-    parse_csv,
+    decode_csv,
+    parse_csv as parse_csv_binary,
     decode_csv_file,
     CSVParseError,
     CSVColumnType,
     CSVValueType,
+    validate_csv_mimetype,
 )
 
 BALLOT_MANIFEST_COLUMNS = [
@@ -23,6 +26,12 @@ BALLOT_MANIFEST_COLUMNS_COMPOSITE_KEY = [
     CSVColumnType("Number of Ballots", CSVValueType.NUMBER),
     CSVColumnType("Tabulator", CSVValueType.TEXT, unique=True),
 ]
+
+
+# Quick wrapper function so we can write the tests with regular strings, not byte strings
+def parse_csv(csv_string: str, columns: List[CSVColumnType]):
+    return parse_csv_binary(io.BytesIO(csv_string.encode("utf-8")), columns)
+
 
 # Happy path
 def test_parse_csv_happy_path():
@@ -888,57 +897,62 @@ def test_parse_csv_real_world_examples():
         assert len(parsed) == expected_rows
 
 
-def test_decode_windows_csv_mimetype():
-    assert (
-        decode_csv_file(
-            FileStorage(io.BytesIO(b"a,b,c"), content_type="application/vnd.ms-excel")
-        )
-        == "a,b,c"
-    )
+def test_validate_csv_mimetype():
+    validate_csv_mimetype(FileStorage(b"", content_type="text/csv"))
+    validate_csv_mimetype(FileStorage(b"", content_type="application/vnd.ms-excel"))
+
+    for invalid_mimetype in [
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/pdf",
+        "text/plain",
+    ]:
+        with pytest.raises(BadRequest) as error:
+            validate_csv_mimetype(
+                FileStorage(
+                    b"",
+                    content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            )
+            assert error.value.description == (
+                "Please submit a valid CSV."
+                " If you are working with an Excel spreadsheet,"
+                " make sure you export it as a .csv file before uploading"
+            )
 
 
-def test_decode_excel_file():
+def test_parse_csv_excel_file():
     excel_file_path = os.path.join(
         os.path.dirname(__file__), "test-ballot-manifest.xlsx"
     )
     with open(excel_file_path, "rb") as excel_file:
-        with pytest.raises(BadRequest) as error:
-            decode_csv_file(
-                FileStorage(
-                    excel_file,
-                    content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                )
-            )
-        assert error.value.description == (
+        with pytest.raises(CSVParseError) as error:
+            parse_csv_binary(excel_file, [])
+        assert str(error.value) == (
             "Please submit a valid CSV."
             " If you are working with an Excel spreadsheet,"
             " make sure you export it as a .csv file before uploading"
         )
 
 
-def test_decode_pdf_file():
-    with pytest.raises(BadRequest) as error:
-        decode_csv_file(
-            FileStorage(
-                io.BytesIO(
-                    b"%PDF-1.4\r%\xe2\xe3\xcf\xd3\r\n7222 0 obj\r<</Linearized 1/L 10747310/O 7225/E 11059/N 2320/T 10602748/H [ 616 3649]>>\rendobj\r    \r\nxref\r\n7222 16\r\n0000000016 00000 n\r\n0000004265 00000 n\r\n0000004349 00000 n\r\n0000004387 00000 n\r\n0000004657 00000 n\r\n0000004748 00000 n\r\n0000005220 00000 n\r\n0000005380 00000 n\r\n0000006551 00000 n\r\n0000007201 00000 n\r\n0000007850 00000 n\r\n0000008480 00000 n\r\n0000009139 00000 n\r\n0000009801 00000 n\r\n0000010446 00000 n\r\n0000000616 00000 n\r\n"
-                ),
-                content_type="application/pdf",
-            )
+def test_parse_csv_pdf_file():
+    with pytest.raises(CSVParseError) as error:
+        parse_csv_binary(
+            io.BytesIO(
+                b"%PDF-1.4\r%\xe2\xe3\xcf\xd3\r\n7222 0 obj\r<</Linearized 1/L 10747310/O 7225/E 11059/N 2320/T 10602748/H [ 616 3649]>>\rendobj\r    \r\nxref\r\n7222 16\r\n0000000016 00000 n\r\n0000004265 00000 n\r\n0000004349 00000 n\r\n0000004387 00000 n\r\n0000004657 00000 n\r\n0000004748 00000 n\r\n0000005220 00000 n\r\n0000005380 00000 n\r\n0000006551 00000 n\r\n0000007201 00000 n\r\n0000007850 00000 n\r\n0000008480 00000 n\r\n0000009139 00000 n\r\n0000009801 00000 n\r\n0000010446 00000 n\r\n0000000616 00000 n\r\n"
+            ),
+            [],
         )
-    assert error.value.description == (
-        "Please submit a valid CSV."
-        " If you are working with an Excel spreadsheet,"
-        " make sure you export it as a .csv file before uploading"
+    assert str(error.value) == (
+        "Please submit a valid CSV file with columns separated by commas."
     )
 
 
-def test_decode_cant_detect_encoding():
+def test_parse_csv_cant_detect_encoding():
     undetectable_file_path = os.path.join(os.path.dirname(__file__), "undetectable.pdf")
     with open(undetectable_file_path, "rb") as file:
-        with pytest.raises(BadRequest) as error:
-            decode_csv_file(FileStorage(file, content_type="text/csv",))
-    assert error.value.description == (
+        with pytest.raises(CSVParseError) as error:
+            parse_csv_binary(file, [])
+    assert str(error.value) == (
         "Please submit a valid CSV."
         " If you are working with an Excel spreadsheet,"
         " make sure you export it as a .csv file before uploading"

--- a/server/tests/util/test_csv_parse.py
+++ b/server/tests/util/test_csv_parse.py
@@ -5,7 +5,6 @@ from werkzeug.datastructures import FileStorage
 
 from ...api.jurisdictions import JURISDICTIONS_COLUMNS
 from ...util.csv_parse import (
-    decode_csv,
     parse_csv as parse_csv_binary,
     decode_csv_file,
     CSVParseError,
@@ -907,12 +906,7 @@ def test_validate_csv_mimetype():
         "text/plain",
     ]:
         with pytest.raises(BadRequest) as error:
-            validate_csv_mimetype(
-                FileStorage(
-                    b"",
-                    content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                )
-            )
+            validate_csv_mimetype(FileStorage(b"", content_type=invalid_mimetype,))
             assert error.value.description == (
                 "Please submit a valid CSV."
                 " If you are working with an Excel spreadsheet,"

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -93,7 +93,10 @@ def decode_csv(file: BinaryIO) -> TextIO:
 # TODO remove this once we decode all CSV files using decode_csv
 def decode_csv_file(file: FileStorage) -> str:
     try:
-        return decode_csv(io.BytesIO(file.read())).read()
+        contents = file.read()
+        if contents == b"":
+            return ""
+        return decode_csv(io.BytesIO(contents)).read()
     except CSVParseError as err:
         raise BadRequest(INVALID_CSV_ERROR) from err
 
@@ -354,4 +357,3 @@ def convert_rows_to_dicts(csv: CSVIterator) -> CSVDictIterator:
 
 def pluralize(word: str, num: int) -> str:
     return word if num == 1 else f"{word}s"
-

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -91,7 +91,7 @@ def decode_csv(file: BinaryIO) -> TextIO:
 
 
 # TODO remove this once we decode all CSV files using decode_csv
-def decode_csv_file(file: FileStorage) -> str:
+def decode_csv_file(file: FileStorage) -> str:  # pragma: no cover
     try:
         contents = file.read()
         if contents == b"":

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -1,7 +1,7 @@
 # pylint: disable=stop-iteration-return
 from collections import defaultdict
 from enum import Enum
-from typing import List, Iterator, Dict, Any, NamedTuple, Tuple
+from typing import BinaryIO, List, Iterator, Dict, Any, NamedTuple, TextIO, Tuple
 import csv as py_csv
 import io, re, locale, chardet
 from werkzeug.exceptions import BadRequest
@@ -36,14 +36,21 @@ CSVRow = List[str]
 CSVIterator = Iterator[CSVRow]
 CSVDictIterator = Iterator[Dict[str, Any]]
 
+INVALID_CSV_ERROR = (
+    "Please submit a valid CSV."
+    " If you are working with an Excel spreadsheet,"
+    " make sure you export it as a .csv file before uploading"
+)
+
+
 # Robust CSV parsing
 # "Be conservative in what you do, be liberal in what you accept from others"
 # https://en.wikipedia.org/wiki/Robustness_principle
-def parse_csv(csv_string: str, columns: List[CSVColumnType]) -> CSVDictIterator:
-    validate_is_csv(csv_string)
-    csv: CSVIterator = py_csv.reader(
-        io.StringIO(csv_string, newline=None), delimiter=","
-    )
+def parse_csv(file: BinaryIO, columns: List[CSVColumnType]) -> CSVDictIterator:
+    validate_not_empty(file)
+    text_file = decode_csv(file)
+    validate_comma_delimited(text_file)
+    csv: CSVIterator = py_csv.reader(text_file, delimiter=",")
     csv = strip_whitespace(csv)
     csv = reject_no_rows(csv)
     csv = skip_empty_trailing_columns(csv)
@@ -61,14 +68,48 @@ def parse_csv(csv_string: str, columns: List[CSVColumnType]) -> CSVDictIterator:
     return dict_csv
 
 
-def validate_is_csv(csv: str):
-    lines = csv.splitlines()
-    if len(lines) == 0:
+def validate_csv_mimetype(file: FileStorage) -> None:
+    # In Windows, CSVs have mimetype application/vnd.ms-excel
+    if file.mimetype not in ["text/csv", "application/vnd.ms-excel"]:
+        raise BadRequest(INVALID_CSV_ERROR)
+
+
+def decode_csv(file: BinaryIO) -> TextIO:
+    detector = chardet.UniversalDetector()
+    for i, line in enumerate(file.readlines()):
+        detector.feed(line)
+        if detector.done or i > 500:
+            break
+    detector.close()
+    if not detector.result["encoding"]:
+        raise CSVParseError(INVALID_CSV_ERROR)
+    encoding = detector.result["encoding"]
+    if encoding == "ascii":
+        encoding = "utf-8"
+    file.seek(0)
+    return io.TextIOWrapper(file, encoding=encoding, newline=None)
+
+
+# TODO remove this once we decode all CSV files using decode_csv
+def decode_csv_file(file: FileStorage) -> str:
+    try:
+        return decode_csv(io.BytesIO(file.read())).read()
+    except CSVParseError as err:
+        raise BadRequest(INVALID_CSV_ERROR) from err
+
+
+def validate_not_empty(file: BinaryIO):
+    if file.read(1) == b"":
         raise CSVParseError("CSV cannot be empty.")
+
+
+def validate_comma_delimited(file: TextIO):
+    line = file.readline()
+    file.seek(0)
 
     dialect = None
     try:
-        dialect = py_csv.Sniffer().sniff(lines[0])
+        dialect = py_csv.Sniffer().sniff(line)
         if dialect.delimiter == "," or dialect.delimiter == "i":
             return
     except Exception:
@@ -314,25 +355,3 @@ def convert_rows_to_dicts(csv: CSVIterator) -> CSVDictIterator:
 def pluralize(word: str, num: int) -> str:
     return word if num == 1 else f"{word}s"
 
-
-def decode_csv_file(file: FileStorage) -> str:
-    user_error = BadRequest(
-        "Please submit a valid CSV."
-        " If you are working with an Excel spreadsheet,"
-        " make sure you export it as a .csv file before uploading"
-    )
-    # In Windows, CSVs have mimetype application/vnd.ms-excel
-    if file.mimetype not in ["text/csv", "application/vnd.ms-excel"]:
-        raise user_error
-
-    try:
-        file_bytes = file.read()
-        return str(file_bytes.decode("utf-8-sig"))
-    except UnicodeDecodeError as err:
-        try:
-            detect_result = chardet.detect(file_bytes)
-            if not detect_result["encoding"]:
-                raise user_error from err
-            return str(file_bytes.decode(detect_result["encoding"]))
-        except Exception:
-            raise user_error from err

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -91,13 +91,13 @@ def decode_csv(file: BinaryIO) -> TextIO:
 
 
 # TODO remove this once we decode all CSV files using decode_csv
-def decode_csv_file(file: FileStorage) -> str:  # pragma: no cover
+def decode_csv_file(file: FileStorage) -> str:
     try:
         contents = file.read()
         if contents == b"":
             return ""
         return decode_csv(io.BytesIO(contents)).read()
-    except CSVParseError as err:
+    except CSVParseError as err:  # pragma: no cover
         raise BadRequest(INVALID_CSV_ERROR) from err
 
 

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -1,7 +1,17 @@
 # pylint: disable=stop-iteration-return
 from collections import defaultdict
 from enum import Enum
-from typing import BinaryIO, List, Iterator, Dict, Any, NamedTuple, TextIO, Tuple
+from typing import (
+    BinaryIO,
+    Iterable,
+    List,
+    Iterator,
+    Dict,
+    Any,
+    NamedTuple,
+    TextIO,
+    Tuple,
+)
 import csv as py_csv
 import io, re, locale, chardet
 from werkzeug.exceptions import BadRequest
@@ -74,10 +84,18 @@ def validate_csv_mimetype(file: FileStorage) -> None:
         raise BadRequest(INVALID_CSV_ERROR)
 
 
+def read_chunks(file: BinaryIO, chunk_size: int) -> Iterable[bytes]:
+    while True:
+        chunk = file.read(chunk_size)
+        if not chunk:
+            break
+        yield chunk
+
+
 def decode_csv(file: BinaryIO) -> TextIO:
     detector = chardet.UniversalDetector()
-    for i, line in enumerate(file.readlines()):
-        detector.feed(line)
+    for i, chunk in enumerate(read_chunks(file, 64)):
+        detector.feed(chunk)
         if detector.done or i > 500:
             break
     detector.close()

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -122,6 +122,7 @@ def decode_csv_file(file: FileStorage) -> str:
 def validate_not_empty(file: BinaryIO):
     if file.read(1) == b"":
         raise CSVParseError("CSV cannot be empty.")
+    file.seek(0)
 
 
 def validate_comma_delimited(file: TextIO):


### PR DESCRIPTION
While most of our CSV parsing code already uses a streaming framework, there were a few places where we cheated and loaded the whole file into memory, namely:
- Decoding
- Validating that the file is not empty
- Tracking parsing progress (getting the total lines)

This PR changes each of these pieces to be streaming-compatible (but doesn't actually stream the file contents, since there's no way to stream it out of one field in the database). This sets us up for streaming file contents from external storage.