### PR TITLE
Enable streaming for CSV download endpoints

### DIFF
--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -270,7 +270,8 @@ def download_ballot_manifest_file(
         return NotFound()
 
     return csv_response(
-        jurisdiction.manifest_file.contents, jurisdiction.manifest_file.name
+        io.StringIO(jurisdiction.manifest_file.contents),
+        jurisdiction.manifest_file.name,
     )
 
 

--- a/server/api/ballots.py
+++ b/server/api/ballots.py
@@ -1,5 +1,5 @@
 import io, csv
-from typing import Optional
+from typing import Optional, TextIO
 from sqlalchemy import func, literal_column, and_
 from sqlalchemy.orm import contains_eager, joinedload
 from sqlalchemy.dialects.postgresql import aggregate_order_by
@@ -14,7 +14,7 @@ from ..util.csv_download import csv_response, jurisdiction_timestamp_name
 from ..util.jsonschema import JSONDict, validate
 
 
-def ballot_retrieval_list(jurisdiction: Jurisdiction, round: Round) -> str:
+def ballot_retrieval_list(jurisdiction: Jurisdiction, round: Round) -> TextIO:
     previous_ballots = set(
         SampledBallotDraw.query.join(Round)
         .filter(Round.round_num < round.round_num)
@@ -111,7 +111,8 @@ def ballot_retrieval_list(jurisdiction: Jurisdiction, round: Round) -> str:
             [value for value, should_show in values_to_show if should_show]
         )
 
-    return csv_io.getvalue()
+    csv_io.seek(0)
+    return csv_io
 
 
 @api.route(

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -214,7 +214,8 @@ def download_batch_tallies_file(
         return NotFound()
 
     return csv_response(
-        jurisdiction.batch_tallies_file.contents, jurisdiction.batch_tallies_file.name
+        io.StringIO(jurisdiction.batch_tallies_file.contents),
+        jurisdiction.batch_tallies_file.name,
     )
 
 

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -58,8 +58,9 @@ def get_batch_retrieval_list(
     retrieval_list_writer = csv.writer(csv_io)
     retrieval_list_writer.writerows(retrieval_list_rows)
 
+    csv_io.seek(0)
     return csv_response(
-        csv_io.getvalue(),
+        csv_io,
         filename=f"batch-retrieval-{jurisdiction_timestamp_name(election, jurisdiction)}.csv",
     )
 

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -648,7 +648,9 @@ def download_cvr_file(
     if not jurisdiction.cvr_file:
         return NotFound()
 
-    return csv_response(jurisdiction.cvr_file.contents, jurisdiction.cvr_file.name)
+    return csv_response(
+        io.StringIO(jurisdiction.cvr_file.contents), jurisdiction.cvr_file.name
+    )
 
 
 @api.route(

--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -517,7 +517,8 @@ def download_jurisdictions_file(election: Election):
         return NotFound()
 
     return csv_response(
-        election.jurisdictions_file.contents, election.jurisdictions_file.name
+        io.StringIO(election.jurisdictions_file.contents),
+        election.jurisdictions_file.name,
     )
 
 

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -755,18 +755,18 @@ def audit_admin_audit_report(election: Election):
     ]
     row_sets = [row_set for row_set in row_sets if row_set]
 
-    with io.StringIO() as csv_io:
-        report = csv.writer(csv_io)
+    csv_io = io.StringIO()
+    report = csv.writer(csv_io)
 
-        for row_set in row_sets[:-1]:
-            report.writerows(row_set)
-            report.writerow([])
-        report.writerows(row_sets[-1])
+    for row_set in row_sets[:-1]:
+        report.writerows(row_set)
+        report.writerow([])
+    report.writerows(row_sets[-1])
 
-        return csv_response(
-            csv_io.getvalue(),
-            filename=f"audit-report-{election_timestamp_name(election)}.csv",
-        )
+    csv_io.seek(0)
+    return csv_response(
+        csv_io, filename=f"audit-report-{election_timestamp_name(election)}.csv",
+    )
 
 
 @api.route(
@@ -774,16 +774,17 @@ def audit_admin_audit_report(election: Election):
 )
 @restrict_access([UserType.JURISDICTION_ADMIN])
 def jursdiction_admin_audit_report(election: Election, jurisdiction: Jurisdiction):
-    with io.StringIO() as csv_io:
-        report = csv.writer(csv_io)
+    csv_io = io.StringIO()
+    report = csv.writer(csv_io)
 
-        report.writerows(
-            sampled_batch_rows(election, jurisdiction)
-            if election.audit_type == AuditType.BATCH_COMPARISON
-            else sampled_ballot_rows(election, jurisdiction),
-        )
+    report.writerows(
+        sampled_batch_rows(election, jurisdiction)
+        if election.audit_type == AuditType.BATCH_COMPARISON
+        else sampled_ballot_rows(election, jurisdiction),
+    )
 
-        return csv_response(
-            csv_io.getvalue(),
-            filename=f"audit-report-{jurisdiction_timestamp_name(election, jurisdiction)}.csv",
-        )
+    csv_io.seek(0)
+    return csv_response(
+        csv_io,
+        filename=f"audit-report-{jurisdiction_timestamp_name(election, jurisdiction)}.csv",
+    )

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -164,6 +164,6 @@ def download_standardized_contests_file(election: Election):
         return NotFound()
 
     return csv_response(
-        election.standardized_contests_file.contents,
+        io.StringIO(election.standardized_contests_file.contents),
         election.standardized_contests_file.name,
     )

--- a/server/util/csv_download.py
+++ b/server/util/csv_download.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime
+from typing import IO
 from flask import Response
 
 from ..models import *  # pylint: disable=wildcard-import
@@ -20,9 +21,9 @@ def jurisdiction_timestamp_name(election: Election, jurisdiction: Jurisdiction) 
     return f"{jurisdiction_name}-{election_name}-{now}"
 
 
-def csv_response(csv_text: str, filename: str) -> Response:
+def csv_response(csv_file: IO, filename: str) -> Response:
     return Response(
-        csv_text,
+        csv_file,
         mimetype="text/csv",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )


### PR DESCRIPTION
Prep work for external file storage. Change our CSV download endpoint helper to take a stream (even though we just use an in-memory buffer for the time being).