### PR TITLE
Fix S3 migration script

### DIFF
--- a/scripts/migrate-files-to-s3.py
+++ b/scripts/migrate-files-to-s3.py
@@ -15,8 +15,9 @@ def migrate_file(file, path):
         return storage_path
     else:
         print("Already migrated")
-        stored_file = retrieve_file(file.storage_path)
-        assert stored_file.read() == contents
+        if len(contents) > 0:
+            stored_file = retrieve_file(file.storage_path)
+            assert stored_file.read() == contents
         return None
 
 


### PR DESCRIPTION
Don't try to compare file contents in S3 and the database for files that were written after the first S3 deploy and therefore were never stored in the db.
