### PR TITLE
Increase default Cypress timeout

### DIFF
--- a/client/cypress.json
+++ b/client/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "http://localhost:3000",
   "integrationFolder": "cypress/end-to-end",
   "viewportWidth": 1000,
-  "viewportHeight": 1000
+  "viewportHeight": 1000,
+  "defaultCommandTimeout": 10000
 }


### PR DESCRIPTION
Default timeout is 4 seconds, increasing to 10 seconds. It seemed like there were some intermittent failures related to file uploads, which might take a few seconds.