### PR TITLE
Change store_file to take a stream instead of FileStorage

### DIFF
--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -208,7 +208,7 @@ def validate_ballot_manifest_upload(request: Request):
 
 def save_ballot_manifest_file(manifest, jurisdiction: Jurisdiction):
     storage_path = store_file(
-        manifest,
+        manifest.stream,
         f"audits/{jurisdiction.election_id}/jurisdictions/{jurisdiction.id}/"
         + timestamp_filename("manifest", "csv"),
     )

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -171,7 +171,7 @@ def upload_batch_tallies(
 
     batch_tallies = request.files["batchTallies"]
     storage_path = store_file(
-        batch_tallies,
+        batch_tallies.stream,
         f"audits/{jurisdiction.election_id}/jurisdictions/{jurisdiction.id}/"
         + timestamp_filename("batch_tallies", "csv"),
     )

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -630,7 +630,7 @@ def upload_cvrs(
     clear_cvr_data(jurisdiction)
 
     storage_path = store_file(
-        request.files["cvrs"],
+        request.files["cvrs"].stream,
         f"audits/{election.id}/jurisdictions/{jurisdiction.id}/"
         + timestamp_filename("cvrs", "csv"),
     )

--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -541,7 +541,7 @@ def update_jurisdictions_file(election: Election):
 
     jurisdictions_file = request.files["jurisdictions"]
     storage_path = store_file(
-        jurisdictions_file,
+        jurisdictions_file.stream,
         f"audits/{election.id}/"
         + timestamp_filename("participating_jurisdictions", "csv"),
     )

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -133,7 +133,7 @@ def upload_standardized_contests_file(election: Election):
     election.standardized_contests = None
     file = request.files["standardized-contests"]
     storage_path = store_file(
-        file,
+        file.stream,
         f"audits/{election.id}/" + timestamp_filename("standardized_contests", "csv"),
     )
     election.standardized_contests_file = File(

--- a/server/tests/util/test_file_storage.py
+++ b/server/tests/util/test_file_storage.py
@@ -15,7 +15,7 @@ def test_file_storage_s3(mock_boto_client):
     original_file_upload_storage_path = config.FILE_UPLOAD_STORAGE_PATH
     config.FILE_UPLOAD_STORAGE_PATH = "s3://test_bucket"
 
-    file = FileStorage(io.BytesIO(b"test file contents"))
+    file = io.BytesIO(b"test file contents")
     store_file(file, "test_dir/test_file.csv")
     mock_boto_client.assert_called_once_with(
         "s3",
@@ -47,7 +47,7 @@ def test_file_storage_local_file():
     original_file_upload_storage_path = config.FILE_UPLOAD_STORAGE_PATH
     config.FILE_UPLOAD_STORAGE_PATH = tempfile.TemporaryDirectory().name
 
-    file = FileStorage(io.BytesIO(b"test file contents"))
+    file = io.BytesIO(b"test file contents")
     path = f"test_dir/{datetime.now(timezone.utc).timestamp()}/test_file.csv"
     storage_path = store_file(file, path)
 

--- a/server/tests/util/test_file_storage.py
+++ b/server/tests/util/test_file_storage.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 import tempfile
 import io
 from unittest.mock import patch
-from werkzeug.datastructures import FileStorage
 
 from ...util.file import retrieve_file, store_file
 from ... import config

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import shutil
 import io
 from os import path
 import os
@@ -45,7 +46,7 @@ def s3():  # pylint: disable=invalid-name
     )
 
 
-def store_file(file: FileStorage, storage_path: str) -> str:
+def store_file(file: BinaryIO, storage_path: str) -> str:
     assert not path.isabs(storage_path)
     full_path = path.join(config.FILE_UPLOAD_STORAGE_PATH, storage_path)
     if config.FILE_UPLOAD_STORAGE_PATH.startswith("s3://"):
@@ -53,7 +54,8 @@ def store_file(file: FileStorage, storage_path: str) -> str:
         s3().upload_fileobj(file, bucket_name, storage_path)
     else:
         os.makedirs(os.path.dirname(full_path), exist_ok=True)
-        file.save(full_path)
+        with open(full_path, "wb") as system_file:
+            shutil.copyfileobj(file, system_file)
     return full_path
 
 

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -5,10 +5,7 @@ from os import path
 import os
 from typing import BinaryIO, Optional
 from urllib.parse import urlparse
-from werkzeug.datastructures import FileStorage
-
 import boto3
-
 
 from .. import config
 from ..models import *  # pylint: disable=wildcard-import


### PR DESCRIPTION
This is a more generic interface that matches retrieve_file. And it will be useful when we start zipping multiple uploaded files together before storing.