### PR TITLE
Fix flaky file upload tests

### DIFF
--- a/client/src/components/MultiJurisdictionAudit/index.test.tsx
+++ b/client/src/components/MultiJurisdictionAudit/index.test.tsx
@@ -534,17 +534,15 @@ describe('JA setup', () => {
       jaApiCalls.getUser,
       jaApiCalls.getSettings(auditSettings.batchComparisonAll),
       jaApiCalls.getRounds([]),
-      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getBallotManifestFile(manifestMocks.empty),
       jaApiCalls.getBatchTalliesFile(talliesMocks.processed),
       jaApiCalls.putManifest,
-      jaApiCalls.getBallotManifestFile(manifestMocks.processing),
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
       jaApiCalls.getBatchTalliesFile(talliesMocks.errored),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
       await screen.findByText('Audit Source Data')
-      expect(screen.getAllByText(/Uploaded/)).toHaveLength(2)
 
       // Upload a new manifest
       userEvent.click(
@@ -663,17 +661,15 @@ describe('JA setup', () => {
       jaApiCalls.getUser,
       jaApiCalls.getSettings(auditSettings.ballotComparisonAll),
       jaApiCalls.getRounds([]),
-      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getBallotManifestFile(manifestMocks.empty),
       jaApiCalls.getCVRSfile(cvrsMocks.processed),
       jaApiCalls.putManifest,
-      jaApiCalls.getBallotManifestFile(manifestMocks.processing),
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
       jaApiCalls.getCVRSfile(cvrsMocks.errored),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
       await screen.findByText('Audit Source Data')
-      expect(screen.getAllByText(/Uploaded/)).toHaveLength(2)
 
       // Upload a new manifest
       userEvent.click(


### PR DESCRIPTION
These tests were failing every once in a while. I'm not 100% sure why, but I think it had something to do with polling for file processing status. So I just modified the tests so that they don't have any polling loops (by changing the API response to not have a "processing" phase and skip straight to "processed"). The test should still test the same thing, but hopefully not flake out.