### PR TITLE
ES&S CVRs: ensure ballots files are parsed in order of CVR number

### DIFF
--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1217,9 +1217,9 @@ def test_ess_cvr_upload(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={
             "cvrs": [
-                (io.BytesIO(ESS_BALLOTS_1.encode()), "ess_ballots_1.csv",),
                 (io.BytesIO(ESS_CVR.encode()), "ess_cvr.csv",),
                 (io.BytesIO(ESS_BALLOTS_2.encode()), "ess_ballots_2.csv",),
+                (io.BytesIO(ESS_BALLOTS_1.encode()), "ess_ballots_1.csv",),
             ],
             "cvrFileType": "ESS",
         },

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1368,6 +1368,13 @@ def test_ess_cvr_invalid(
         ),
         (
             [
+                (io.BytesIO(ESS_CVR.encode()), "ess_cvr.csv",),
+                (io.BytesIO(b"Ballots"), "ess_ballots_1.csv",),
+            ],
+            "ess_ballots_1.csv: Please submit a valid CSV file with columns separated by commas.",
+        ),
+        (
+            [
                 (io.BytesIO(ESS_BALLOTS_1.encode()), "ess_ballots_1.csv",),
                 (io.BytesIO(ESS_CVR.encode()), "ess_cvr.csv",),
                 (


### PR DESCRIPTION
Previously, we just concatenated the ballots files in the order they were uploaded. Instead, we should order the files by the first CVR number in each file (since the ballots are ordered by CVR number within the file).