### PR TITLE
Macro: Compute p-value using sample order

### DIFF
--- a/server/audit_math/macro.py
+++ b/server/audit_math/macro.py
@@ -288,7 +288,6 @@ def compute_risk(
 
     # Computing U without the sample preserves conservative-ness
     U = compute_U(reported_results, cast(Dict, {}), contest)
-    print("U", U)
 
     for _, batch in sorted(
         sample_ticket_numbers.items(), key=lambda entry: entry[0]  # ticket_number

--- a/server/audit_math/macro.py
+++ b/server/audit_math/macro.py
@@ -11,8 +11,10 @@ https://papers.ssrn.com/sol3/papers.cfm?abstract_id=1443314 for the
 publication).
 """
 from decimal import Decimal, ROUND_CEILING
-from typing import Dict, Tuple, Any, TypedDict, Optional, List
+from typing import Dict, Tuple, TypeVar, TypedDict, Optional, List, cast
 from .sampler_contest import Contest
+
+BatchKey = TypeVar("BatchKey")
 
 
 class BatchError(TypedDict):
@@ -129,8 +131,8 @@ def compute_max_error(
 
 
 def compute_U(
-    reported_results: Dict[Tuple[Any, Any], Dict[str, Dict[str, int]]],
-    sample_results: Dict[Tuple[Any, Any], Dict[str, Dict[str, int]]],
+    reported_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
+    sample_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
     contest: Contest,
 ) -> Decimal:
     """
@@ -171,8 +173,8 @@ def compute_U(
 def get_sample_sizes(
     risk_limit: int,
     contest: Contest,
-    reported_results: Dict[Any, Dict[str, Dict[str, int]]],
-    sample_results: Dict[Any, Dict[str, Dict[str, int]]],
+    reported_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
+    sample_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
 ) -> int:
     """
     Computes initial sample sizes parameterized by likelihood that the
@@ -241,9 +243,9 @@ def get_sample_sizes(
 def compute_risk(
     risk_limit: int,
     contest: Contest,
-    reported_results: Dict[Any, Dict[str, Dict[str, int]]],
-    sample_results: Dict[Any, Dict[str, Dict[str, int]]],
-    times_sampled: Dict[Any, int],
+    reported_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
+    sample_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
+    sample_ticket_numbers: Dict[str, BatchKey],
 ) -> Tuple[float, bool]:
     """
     Computes the risk-value of <sample_results> based on results in <contest>.
@@ -264,11 +266,11 @@ def compute_risk(
                                }
                                ...
                            }
-        sample_results - if a sample has already been drawn, this will
-                         contain its results, of the same form as
-                         reported_results
-        times_sampled - a mapping from batch id to the number of times the batch
-                        was sampled
+        sample_results   - if a sample has already been drawn, this will
+                           contain its results, of the same form as
+                           reported_results
+        sample_ticket_numbers - a mapping from ticket numbers to the batch
+                           keys in sample_results
     Outputs:
         measurements    - the p-value of the hypotheses that the election
                           result is correct based on the sample for each
@@ -285,9 +287,15 @@ def compute_risk(
     p = Decimal(1.0)
 
     # Computing U without the sample preserves conservative-ness
-    U = compute_U(reported_results, {}, contest)
+    U = compute_U(reported_results, cast(Dict, {}), contest)
+    print("U", U)
 
-    for batch in sample_results:
+    for _, batch in sorted(
+        sample_ticket_numbers.items(), key=lambda entry: entry[0]  # ticket_number
+    ):
+        if contest.name not in sample_results[batch]:
+            continue
+
         error = compute_error(reported_results[batch], sample_results[batch], contest)
         e_p = error["weighted_error"] if error else Decimal(0)
 
@@ -302,7 +310,7 @@ def compute_risk(
         if taint == 1:
             p = Decimal("inf")  # Our p-value blows up
         else:
-            p *= ((1 - 1 / U) / (1 - taint)) ** times_sampled[batch]
+            p *= (1 - 1 / U) / (1 - taint)
 
         if p <= alpha:
             return float(p), True

--- a/server/audit_math/sampler.py
+++ b/server/audit_math/sampler.py
@@ -113,7 +113,7 @@ def draw_ppeb_sample(
     int_seed = int(consistent_sampler.sha256_hex(seed), 16)  # type: ignore
     generator = default_rng(int_seed)
 
-    U = macro.compute_U(batch_results, {}, contest)
+    U = macro.compute_U(batch_results, cast(Dict, {}), contest)
 
     # This can only be the case if we've already recounted
     if U == 0:

--- a/server/tests/audit_math/test_macro.py
+++ b/server/tests/audit_math/test_macro.py
@@ -420,14 +420,14 @@ def test_compute_risk_uses_sample_order(contests, batches) -> None:
         sample["Batch {}".format(i)] = {
             "Contest A": {"winner": 200, "loser": 180,},
         }
-        sample_ticket_numbers[str(i)] = "Batch {}".format(i)
+        sample_ticket_numbers[str(i).zfill(3)] = "Batch {}".format(i)
 
     # Draws with taint of 0.0952
     for i in range(100, 110):
         sample["Batch {}".format(i)] = {
             "Contest A": {"winner": 180, "loser": 200,},
         }
-        sample_ticket_numbers[str(i)] = "Batch {}".format(i)
+        sample_ticket_numbers[str(i).zfill(3)] = "Batch {}".format(i)
 
     # In the original sample order, we should reach the risk limit before
     # hitting the tainted draws
@@ -444,7 +444,7 @@ def test_compute_risk_uses_sample_order(contests, batches) -> None:
     # Now reorder the sample so the tainted draws come first - the taint should
     # be too large to ever hit the risk limit
     sample_ticket_numbers = {
-        str(len(sample_ticket_numbers) - i): batch
+        str(len(sample_ticket_numbers) - i).zfill(3): batch
         for i, batch in enumerate(sample_ticket_numbers.values())
     }
     computed_p, result = macro.compute_risk(
@@ -472,7 +472,7 @@ def test_tied_contest() -> None:
 
     batches = {}
     for i in range(100):
-        batches[i] = {
+        batches[str(i)] = {
             "Tied Contest": {
                 "winner": 500,
                 "loser": 500,
@@ -507,9 +507,9 @@ def test_tied_contest() -> None:
     assert not res
 
     # Now do a full hand recount
-    sampled_ticket_numbers = {str(i): batch for i, batch in enumerate(batches.keys())}
+    sample_ticket_numbers = {str(i): batch for i, batch in enumerate(batches.keys())}
     computed_p, res = macro.compute_risk(
-        RISK_LIMIT, contest, batches, batches, sampled_ticket_numbers
+        RISK_LIMIT, contest, batches, batches, sample_ticket_numbers
     )
 
     assert not computed_p


### PR DESCRIPTION
Task: #1371 

Change `macro.compute_risk` to take an ordering of the sampled batches by ticket number instead of just the number of times each batch got sampled. Compute the p-value by evaluating batch taints in sample order, bailing once we get below the risk limit.

Also added type checking to test_macro.py by adding a `None` return type to the test functions.