### PR TITLE
ESS CVRs: sort ballots files

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -519,18 +519,18 @@ def parse_ess_cvrs(
         headers = next(ballots_csv)
         header_indices = get_header_indices(headers)
 
-        ballots_csv = (row for row in ballots_csv if not row[0].startswith("Total"))
+        ballot_rows = (row for row in ballots_csv if not row[0].startswith("Total"))
 
         # The rows may not be in order, but we need them sorted in order to
         # concatenate and merge the files. For now, sort them in memory, though
         # we may need to change this if it becomes a memory bottleneck.
-        ballots_csv = sorted(
-            ballots_csv, key=lambda row: int(row[header_indices["Cast Vote Record"]])
+        sorted_ballot_rows = sorted(
+            ballot_rows, key=lambda row: int(row[header_indices["Cast Vote Record"]])
         )
 
         tabulator_regex = re.compile(r"^(\d{4})(\d{6})$")
 
-        for row_index, row in enumerate(ballots_csv):
+        for row_index, row in enumerate(sorted_ballot_rows):
             cvr_number = column_value(
                 row, "Cast Vote Record", row_index + 1, header_indices
             )

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -519,11 +519,18 @@ def parse_ess_cvrs(
         headers = next(ballots_csv)
         header_indices = get_header_indices(headers)
 
+        ballots_csv = (row for row in ballots_csv if not row[0].startswith("Total"))
+
+        # The rows may not be in order, but we need them sorted in order to
+        # concatenate and merge the files. For now, sort them in memory, though
+        # we may need to change this if it becomes a memory bottleneck.
+        ballots_csv = sorted(
+            ballots_csv, key=lambda row: int(row[header_indices["Cast Vote Record"]])
+        )
+
         tabulator_regex = re.compile(r"^(\d{4})(\d{6})$")
 
         for row_index, row in enumerate(ballots_csv):
-            if row[0].startswith("Total"):
-                continue
             cvr_number = column_value(
                 row, "Cast Vote Record", row_index + 1, header_indices
             )

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1172,19 +1172,21 @@ ESS_CVR = """Cast Vote Record,Precinct,Ballot Style,Contest 1,Contest 2
 15,p,bs,Choice 1-1,Choice 2-3
 """
 
+# ESS ballots files may or may not be ordered by Cast Vote Record, so here we
+# simulate one unordered and one ordered
 ESS_BALLOTS_1 = """Ballots,,,,,,,,,
 GEN2111,,,,,,,,,
 "Test County,Test State",,,,,,,,,
 "November 5, 2021",,,,,,,,,
 ,,,,,,,,,
 Cast Vote Record,Batch,Ballot Status,Original Ballot Exception,Remaining Ballot Exception,Write-in Type,Results Report,Reporting Group,Tabulator CVR,Precinct ID
+5,BATCH1,Not Reviewed,,,,N,Election Day,0002003172,p
+6,BATCH1,Not Reviewed,,,,N,Election Day,0002003173,p
+7,BATCH2,Not Reviewed,,,,N,Election Day,0001000415,p
 1,BATCH1,Not Reviewed,,,,N,Election Day,0001013415,p
 2,BATCH1,Not Reviewed,,,,N,Election Day,0001013416,p
 3,BATCH1,Not Reviewed,Undervote,,,N,Election Day,0001013417,p
 4,BATCH1,Not Reviewed,Overvote,,,N,Election Day,0002003171,p
-5,BATCH1,Not Reviewed,,,,N,Election Day,0002003172,p
-6,BATCH1,Not Reviewed,,,,N,Election Day,0002003173,p
-7,BATCH2,Not Reviewed,,,,N,Election Day,0001000415,p
 Total : 7,,,,,,,,,
 """
 


### PR DESCRIPTION
Task: #1421 

We previously assumed the ballots files would be ordered by the "Cast Vote Record" column, but it turns out that's not true. So we sort each one in memory for now, since the files we've seen so far seem to be small enough that it's not an issue.