### PR TITLE
Support Tools: button to permanently delete audit

### DIFF
--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -35,6 +35,8 @@ import {
   useDeleteOrganization,
   useRenameOrganization,
   useRemoveAuditAdmin,
+  useDeleteElection,
+  IElectionBase,
 } from './support-api'
 import { useConfirm, Confirm } from '../Atoms/Confirm'
 
@@ -90,6 +92,7 @@ const ButtonList = styled(ButtonGroup).attrs({
       border-top: 1px solid ${Colors.LIGHT_GRAY3};
     }
   }
+  margin-bottom: 30px;
 `
 
 const Organizations = () => {
@@ -168,6 +171,7 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
   const removeAuditAdmin = useRemoveAuditAdmin(organizationId)
   const deleteOrganization = useDeleteOrganization(organizationId)
   const renameOrganization = useRenameOrganization(organizationId)
+  const deleteElection = useDeleteElection()
   const { confirm, confirmProps } = useConfirm()
 
   const {
@@ -235,6 +239,18 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
       }),
     })
 
+  const onClickPermanentlyDeleteAudit = ({ auditName, id }: IElectionBase) => {
+    confirm({
+      title: 'Confirm',
+      description: `Are you sure you want to permanently delete ${auditName}?`,
+      yesButtonLabel: 'Delete',
+      onYesClick: async () => {
+        await deleteElection.mutateAsync({ electionId: id, organizationId })
+        toast.success(`Deleted ${auditName}`)
+      },
+    })
+  }
+
   return (
     <div style={{ width: '100%' }}>
       <div style={{ display: 'flex', alignItems: 'baseline' }}>
@@ -261,16 +277,40 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
         <Column>
           <H3>Audits</H3>
           <ButtonList>
-            {elections.map(election => (
-              <LinkButton
-                key={election.id}
-                to={`/support/audits/${election.id}`}
-                intent={Intent.PRIMARY}
-              >
-                {election.auditName}
-              </LinkButton>
-            ))}
+            {elections
+              .filter(election => !election.deletedAt)
+              .map(election => (
+                <LinkButton
+                  key={election.id}
+                  to={`/support/audits/${election.id}`}
+                  intent={Intent.PRIMARY}
+                >
+                  {election.auditName}
+                </LinkButton>
+              ))}
           </ButtonList>
+          <H3>Deleted Audits</H3>
+          <Table striped>
+            <tbody>
+              {elections
+                .filter(election => !election.deletedAt)
+                .map(election => (
+                  <tr key={election.id}>
+                    <td>{election.auditName}</td>
+                    <td>
+                      <Button
+                        icon="delete"
+                        intent={Intent.DANGER}
+                        onClick={() => onClickPermanentlyDeleteAudit(election)}
+                        minimal
+                      >
+                        Permanently Delete
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </Table>
         </Column>
         <Column>
           <H3>Audit Admins</H3>

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -39,6 +39,7 @@ export interface IElectionBase {
     | 'BATCH_COMPARISON'
     | 'HYBRID'
   online: boolean
+  deletedAt: string
 }
 
 export interface IAuditAdmin {
@@ -166,6 +167,26 @@ export const useElection = (electionId: string) =>
   useQuery<IElection, Error>(['elections', electionId], () =>
     fetchApi(`/api/support/elections/${electionId}`)
   )
+
+export const useDeleteElection = () => {
+  const deleteElection = async ({
+    electionId,
+  }: {
+    electionId: string
+    organizationId: string
+  }) =>
+    fetchApi(`/api/support/elections/${electionId}`, {
+      method: 'DELETE',
+    })
+
+  const queryClient = useQueryClient()
+
+  return useMutation(deleteElection, {
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries(['organizations', variables.organizationId])
+    },
+  })
+}
 
 export const useJurisdiction = (jurisdictionId: string) =>
   useQuery<IJurisdiction, Error>(['jurisdictions', jurisdictionId], () =>

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -8,6 +8,7 @@ from auth0.v3.management import Auth0
 from auth0.v3.exceptions import Auth0Error
 from werkzeug.exceptions import BadRequest, Conflict
 
+
 from . import api
 from ..models import *  # pylint: disable=wildcard-import
 from ..database import db_session
@@ -24,6 +25,7 @@ from ..config import (
 )
 from ..util.jsonschema import validate
 from ..util.isoformat import isoformat
+from ..util.file import delete_file
 from .rounds import get_current_round
 
 AUTH0_DOMAIN = urlparse(AUDITADMIN_AUTH0_BASE_URL).hostname
@@ -163,6 +165,7 @@ def rename_organization(organization_id: str):
 def get_election(election_id: str):
     election = get_or_404(Election, election_id)
     return jsonify(
+        organizationId=election.organization_id,
         id=election.id,
         auditName=election.audit_name,
         auditType=election.audit_type,
@@ -171,7 +174,37 @@ def get_election(election_id: str):
             dict(id=jurisdiction.id, name=jurisdiction.name,)
             for jurisdiction in election.jurisdictions
         ],
+        deletedAt=isoformat(election.deleted_at),
     )
+
+
+@api.route("/support/elections/<election_id>", methods=["DELETE"])
+def permanently_delete_election(election_id: str):
+    election = get_or_404(Election, election_id)
+
+    election_file_ids = [
+        election.jurisdictions_file_id,
+        election.standardized_contests_file_id,
+    ]
+    jurisdiction_file_ids = [
+        file_id
+        for jurisdiction in election.jurisdictions
+        for file_id in [
+            jurisdiction.manifest_file_id,
+            jurisdiction.cvr_file_id,
+            jurisdiction.batch_tallies_file_id,
+        ]
+    ]
+    all_file_ids = [
+        file_id for file_id in election_file_ids + jurisdiction_file_ids if file_id
+    ]
+    file_paths = File.query.filter(File.id.in_(all_file_ids)).values(File.storage_path)
+    for (file_path,) in file_paths:
+        delete_file(file_path)
+
+    db_session.delete(election)
+    db_session.commit()
+    return jsonify(status="ok")
 
 
 AUDIT_ADMIN_SCHEMA = {

--- a/server/migrations/versions/593823da406d_fix_delete_cascades.py
+++ b/server/migrations/versions/593823da406d_fix_delete_cascades.py
@@ -1,0 +1,48 @@
+# pylint: disable=invalid-name
+"""Fix delete cascades
+
+Revision ID: 593823da406d
+Revises: f63ba2f2da22
+Create Date: 2022-03-08 01:17:04.936981+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "593823da406d"
+down_revision = "dd3f3330aee2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint(
+        "ballot_interpretation_contest_choice_contest_choice_id__60bf",
+        "ballot_interpretation_contest_choice",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "ballot_interpretation_contest_choice_ballot_id_contest_id_fkey",
+        "ballot_interpretation_contest_choice",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("ballot_interpretation_contest_choice_contest_choice_id_contest_id_fkey"),
+        "ballot_interpretation_contest_choice",
+        "contest_choice",
+        ["contest_choice_id", "contest_id"],
+        ["id", "contest_id"],
+        ondelete="cascade",
+    )
+    op.create_foreign_key(
+        op.f("ballot_interpretation_contest_choice_ballot_id_contest_id_fkey"),
+        "ballot_interpretation_contest_choice",
+        "ballot_interpretation",
+        ["ballot_id", "contest_id"],
+        ["ballot_id", "contest_id"],
+        ondelete="cascade",
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -155,6 +155,7 @@ class Election(BaseModel):
         "Jurisdiction",
         back_populates="election",
         uselist=True,
+        cascade="all, delete-orphan",
         passive_deletes=True,
         order_by="Jurisdiction.name",
     )
@@ -170,6 +171,7 @@ class Election(BaseModel):
         "Round",
         back_populates="election",
         uselist=True,
+        cascade="all, delete-orphan",
         passive_deletes=True,
         order_by="Round.round_num",
     )
@@ -654,6 +656,10 @@ class BallotInterpretation(BaseModel):
         "ContestChoice",
         uselist=True,
         secondary="ballot_interpretation_contest_choice",
+        primaryjoin="and_("
+        + "ballot_interpretation.c.ballot_id == ballot_interpretation_contest_choice.c.ballot_id,"
+        + "ballot_interpretation.c.contest_id == ballot_interpretation_contest_choice.c.contest_id)",
+        cascade="all, delete",
         order_by="ContestChoice.created_at",
     )
     comment = Column(Text)
@@ -674,10 +680,12 @@ ballot_interpretation_contest_choice = Table(
     ForeignKeyConstraint(
         ["ballot_id", "contest_id"],
         ["ballot_interpretation.ballot_id", "ballot_interpretation.contest_id"],
+        ondelete="cascade",
     ),
     ForeignKeyConstraint(
         ["contest_choice_id", "contest_id"],
         ["contest_choice.id", "contest_choice.contest_id"],
+        ondelete="cascade",
     ),
 )
 

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -1,3 +1,4 @@
+import os.path
 from unittest.mock import Mock, patch
 from urllib.parse import urlparse
 from flask.testing import FlaskClient
@@ -148,6 +149,29 @@ def test_support_get_election(
             ],
         },
     )
+
+
+def test_support_permanently_delete_election(
+    client: FlaskClient, election_id: str, round_2_id: str
+):
+    election = Election.query.get(election_id)
+    jurisdictions_file_path = election.jurisdictions_file.storage_path
+    manifest_file_path = election.jurisdictions[0].manifest_file.storage_path
+
+    set_support_user(client, SUPPORT_EMAIL)
+    rv = client.delete(f"/api/support/elections/{election_id}")
+    assert_ok(rv)
+
+    rv = client.get(f"/api/support/elections/{election_id}")
+    assert rv.status_code == 404
+
+    assert not os.path.exists(jurisdictions_file_path)
+    assert not os.path.exists(manifest_file_path)
+
+    assert Election.query.get(election_id) is None
+    assert Jurisdiction.query.filter_by(election_id=election_id).count() == 0
+    assert Contest.query.filter_by(election_id=election_id).count() == 0
+    assert Round.query.filter_by(election_id=election_id).count() == 0
 
 
 @patch("server.api.support.GetToken")

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -71,6 +71,17 @@ def retrieve_file(storage_path: str) -> BinaryIO:
         return open(storage_path, "rb")
 
 
+def delete_file(storage_path: str):
+    if config.FILE_UPLOAD_STORAGE_PATH.startswith("s3://"):
+        assert storage_path.startswith("s3://")
+        parsed_path = urlparse(storage_path)
+        bucket_name = parsed_path.netloc
+        key = parsed_path.path[1:]
+        s3().delete_object(bucket_name, key)
+    else:
+        return os.remove(storage_path)
+
+
 def zip_files(files: Dict[str, BinaryIO]) -> IO[bytes]:
     zip_file = tempfile.TemporaryFile()
     with ZipFile(zip_file, "w") as zip_archive:


### PR DESCRIPTION
- Add a button for deleted ("archived") audits to be permanently deleted by Support Users
- Also reorganize audits into two sections: active and deleted