### PR TITLE
Fix ballot comparison round 2 sample size

### DIFF
--- a/server/tests/audit_math/test_supersimple.py
+++ b/server/tests/audit_math/test_supersimple.py
@@ -643,7 +643,7 @@ o2_stopping_size = {
     "Contest B": 60000,
     "Contest C": 36000,
     "Contest D": 15000,
-    "Contest E": 6,
+    "Contest E": 33,
     "Contest F": 15,
     "Two-winner Contest": 1000,
 }


### PR DESCRIPTION
`supersimple.nMin` expects the number of expected discrepancies, not the rate. We were passing the number of expected one-vote discrepancies but the rate of expected two-vote discrepancies.