### PR TITLE
Change JA file upload form copy to "file" instead of "csv"

### DIFF
--- a/client/src/components/Atoms/CSVForm.tsx
+++ b/client/src/components/Atoms/CSVForm.tsx
@@ -145,7 +145,7 @@ const CSVFile = ({
                     }}
                     hasSelection={!!values.csv}
                     text={(() => {
-                      if (!values.csv) return 'Select a CSV...'
+                      if (!values.csv) return 'Select a file...'
                       if (values.csv.length === 1) return values.csv[0].name
                       return `${values.csv.length} files selected`
                     })()}

--- a/client/src/components/AuditAdmin/AuditAdminView.test.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.test.tsx
@@ -141,7 +141,7 @@ describe('AA setup flow', () => {
 
       await waitFor(() => {
         expect(queryAllByText('Participants').length).toBe(2)
-        screen.getByLabelText('Select a CSV...')
+        screen.getByLabelText('Select a file...')
       })
     })
   })
@@ -194,7 +194,7 @@ describe('AA setup flow', () => {
       await waitFor(() => {
         expect(queryAllByText('Participants').length).toBe(2)
       })
-      const jurisdisctionInput = screen.getByLabelText('Select a CSV...')
+      const jurisdisctionInput = screen.getByLabelText('Select a file...')
       const jurisdictionButton = screen.getByRole('button', {
         name: 'Upload File',
       })
@@ -229,7 +229,7 @@ describe('AA setup flow', () => {
       await waitFor(() => {
         expect(queryAllByText('Participants').length).toBe(2)
       })
-      const jurisdisctionInput = screen.getByLabelText('Select a CSV...')
+      const jurisdisctionInput = screen.getByLabelText('Select a file...')
       const jurisdictionButton = screen.getByRole('button', {
         name: 'Upload File',
       })
@@ -268,7 +268,7 @@ describe('AA setup flow', () => {
 
       // check file upload of jurisdiction
       await screen.findByText(/Uploaded/)
-      const standardizedContestInput = screen.getByLabelText('Select a CSV...')
+      const standardizedContestInput = screen.getByLabelText('Select a file...')
       const standardizedContestButton = screen.getByRole('button', {
         name: 'Upload File',
       })

--- a/client/src/components/AuditAdmin/Setup/Participants/Participants.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Participants/Participants.test.tsx
@@ -144,7 +144,7 @@ describe('Audit Setup > Participants', () => {
 
       // Upload a file
       userEvent.upload(
-        screen.getByLabelText('Select a CSV...'),
+        screen.getByLabelText('Select a file...'),
         jurisdictionFile
       )
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
@@ -158,7 +158,7 @@ describe('Audit Setup > Participants', () => {
 
       // Replace the file in the input
       userEvent.click(screen.getByRole('button', { name: 'Replace File' }))
-      userEvent.upload(screen.getByLabelText('Select a CSV...'), anotherFile)
+      userEvent.upload(screen.getByLabelText('Select a file...'), anotherFile)
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
       await screen.findByText('Current file:')
 
@@ -193,7 +193,7 @@ describe('Audit Setup > Participants', () => {
         // eslint-disable-next-line prefer-const
         jurisdictionsFileInput,
         standardizedContestsFileInput,
-      ] = screen.getAllByLabelText('Select a CSV...')
+      ] = screen.getAllByLabelText('Select a file...')
       let [
         // eslint-disable-next-line prefer-const
         jurisdictionsFileUploadButton,
@@ -210,7 +210,7 @@ describe('Audit Setup > Participants', () => {
       await screen.findByText('Current file:')
       screen.getByText('file name')
 
-      standardizedContestsFileInput = screen.getByLabelText('Select a CSV...')
+      standardizedContestsFileInput = screen.getByLabelText('Select a file...')
       standardizedContestsFileUploadButton = screen.getByRole('button', {
         name: 'Upload File',
       })
@@ -250,7 +250,7 @@ describe('Audit Setup > Participants', () => {
         // eslint-disable-next-line prefer-const
         jurisdictionsFileInput,
         standardizedContestsFileInput,
-      ] = screen.getAllByLabelText('Select a CSV...')
+      ] = screen.getAllByLabelText('Select a file...')
       let [
         // eslint-disable-next-line prefer-const
         jurisdictionsFileUploadButton,
@@ -267,7 +267,7 @@ describe('Audit Setup > Participants', () => {
       await screen.findByText('Current file:')
       screen.getByText('file name')
 
-      standardizedContestsFileInput = screen.getByLabelText('Select a CSV...')
+      standardizedContestsFileInput = screen.getByLabelText('Select a file...')
       standardizedContestsFileUploadButton = screen.getByRole('button', {
         name: 'Upload File',
       })
@@ -296,7 +296,7 @@ describe('Audit Setup > Participants', () => {
       screen.getByText('something went wrong')
 
       const standardizedContestsFileInput = screen.getByLabelText(
-        'Select a CSV...'
+        'Select a file...'
       )
       const standardizedContestsFileUploadButton = screen.getByRole('button', {
         name: 'Upload File',
@@ -320,7 +320,7 @@ describe('Audit Setup > Participants', () => {
       screen.getByText('something went wrong')
 
       const standardizedContestsFileInput = screen.getByLabelText(
-        'Select a CSV...'
+        'Select a file...'
       )
       const standardizedContestsFileUploadButton = screen.getByRole('button', {
         name: 'Upload File',
@@ -371,7 +371,7 @@ describe('Audit Setup > Participants', () => {
         })[1]
       )
       userEvent.upload(
-        await screen.findByLabelText('Select a CSV...'),
+        await screen.findByLabelText('Select a file...'),
         contestsFile
       )
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
@@ -399,7 +399,7 @@ describe('Audit Setup > Participants', () => {
         screen.getAllByRole('button', { name: 'Replace File' })[0]
       )
       userEvent.upload(
-        screen.getByLabelText('Select a CSV...'),
+        screen.getByLabelText('Select a file...'),
         jurisdictionErrorFile
       )
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))

--- a/client/src/components/AuditAdmin/Setup/__snapshots__/Setup.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/__snapshots__/Setup.test.tsx.snap
@@ -3036,7 +3036,7 @@ exports[`Setup renders Participants stage 1`] = `
             <span
               class="bp3-file-upload-input"
             >
-              Select a CSV...
+              Select a file...
             </span>
           </label>
           <div
@@ -3122,7 +3122,7 @@ exports[`Setup renders Participants stage with locked next stage 1`] = `
             <span
               class="bp3-file-upload-input"
             >
-              Select a CSV...
+              Select a file...
             </span>
           </label>
           <div
@@ -3210,7 +3210,7 @@ exports[`Setup renders Participants stage with processing next stage 1`] = `
             <span
               class="bp3-file-upload-input"
             >
-              Select a CSV...
+              Select a file...
             </span>
           </label>
           <div

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
@@ -88,7 +88,7 @@ describe('JA setup', () => {
       userEvent.click(uploadButton)
       await screen.findByText('You must upload a file')
 
-      userEvent.upload(screen.getByLabelText('Select a CSV...'), manifestFile)
+      userEvent.upload(screen.getByLabelText('Select a file...'), manifestFile)
       userEvent.click(uploadButton)
       await screen.findByText('Uploaded at 6/8/2020, 9:39:14 PM.')
 
@@ -99,7 +99,7 @@ describe('JA setup', () => {
       })
       userEvent.click(deleteButton)
       await screen.findByRole('button', { name: 'Upload File' })
-      screen.getByLabelText('Select a CSV...')
+      screen.getByLabelText('Select a file...')
     })
   })
 
@@ -116,7 +116,7 @@ describe('JA setup', () => {
     await withMockFetch(expectedCalls, async () => {
       renderView()
       await screen.findByText('Audit Source Data')
-      const talliesInput = screen.getByLabelText('Select a CSV...')
+      const talliesInput = screen.getByLabelText('Select a file...')
       const talliesButton = screen.getByRole('button', { name: 'Upload File' })
 
       userEvent.click(talliesButton)
@@ -140,7 +140,7 @@ describe('JA setup', () => {
     await withMockFetch(expectedCalls, async () => {
       renderView()
       await screen.findByText('Audit Source Data')
-      userEvent.upload(screen.getByLabelText('Select a CSV...'), talliesFile)
+      userEvent.upload(screen.getByLabelText('Select a file...'), talliesFile)
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
       const toast = await screen.findByRole('alert')
       expect(toast).toHaveTextContent('something went wrong: putTallies')
@@ -169,7 +169,7 @@ describe('JA setup', () => {
         })[1]
       )
       userEvent.upload(
-        await screen.findByLabelText('Select a CSV...'),
+        await screen.findByLabelText('Select a file...'),
         talliesFile
       )
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
@@ -197,7 +197,7 @@ describe('JA setup', () => {
         screen.getAllByRole('button', { name: 'Replace File' })[0]
       )
       userEvent.upload(
-        await screen.findByLabelText('Select a CSV...'),
+        await screen.findByLabelText('Select a file...'),
         manifestFile
       )
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
@@ -230,7 +230,7 @@ describe('JA setup', () => {
         screen.getByRole('option', { name: 'ClearBallot' })
       )
 
-      const cvrsInput = screen.getByLabelText('Select a CSV...')
+      const cvrsInput = screen.getByLabelText('Select a file...')
       const cvrsButton = screen.getByRole('button', { name: 'Upload File' })
 
       userEvent.click(cvrsButton)
@@ -269,7 +269,7 @@ describe('JA setup', () => {
       await screen.findByText('Uploaded at 6/8/2020, 9:39:14 PM.')
       screen.getByRole('option', { name: 'ClearBallot', selected: true })
       userEvent.click(screen.getAllByRole('button', { name: 'Delete File' })[1])
-      await screen.findByText('Select a CSV...')
+      await screen.findByText('Select a file...')
       screen.getByRole('option', { name: 'ClearBallot', selected: true })
     })
   })
@@ -296,7 +296,7 @@ describe('JA setup', () => {
         })[1]
       )
       userEvent.upload(
-        await screen.findByLabelText('Select a CSV...'),
+        await screen.findByLabelText('Select a file...'),
         cvrsFile
       )
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
@@ -340,7 +340,7 @@ describe('JA setup', () => {
         screen.getByRole('option', { name: 'ES&S' })
       )
 
-      const fileSelect = screen.getByLabelText('Select a CSV...')
+      const fileSelect = screen.getByLabelText('Select a file...')
       userEvent.upload(fileSelect, [cvrsFile1, cvrsFile2])
       await screen.findByLabelText('2 files selected')
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
@@ -379,7 +379,7 @@ describe('JA setup', () => {
         screen.getByRole('option', { name: 'Hart' })
       )
 
-      const fileSelect = screen.getByLabelText('Select a CSV...')
+      const fileSelect = screen.getByLabelText('Select a file...')
       userEvent.upload(fileSelect, cvrsZip)
       await screen.findByLabelText('cvrs.zip')
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
@@ -408,7 +408,7 @@ describe('JA setup', () => {
         screen.getAllByRole('button', { name: 'Replace File' })[0]
       )
       userEvent.upload(
-        await screen.findByLabelText('Select a CSV...'),
+        await screen.findByLabelText('Select a file...'),
         manifestFile
       )
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
@@ -432,7 +432,7 @@ describe('JA setup', () => {
       renderView()
       await screen.findByText('Audit Source Data')
       const [manifestInput, talliesInput] = screen.getAllByLabelText(
-        'Select a CSV...'
+        'Select a file...'
       )
       const [manifestButton, talliesButton] = screen.getAllByRole('button', {
         name: 'Upload File',
@@ -466,10 +466,10 @@ describe('JA setup', () => {
 
       const replaceButton = await screen.findByText('Replace File')
       userEvent.click(replaceButton)
-      const inputFiles = await screen.findAllByText('Select a CSV...')
+      const inputFiles = await screen.findAllByText('Select a file...')
       expect(inputFiles).toHaveLength(2)
 
-      const [manifestInput] = screen.getAllByLabelText('Select a CSV...')
+      const [manifestInput] = screen.getAllByLabelText('Select a file...')
       const [manifestButton] = screen.getAllByRole('button', {
         name: 'Upload File',
       })

--- a/client/src/components/JurisdictionAdmin/__snapshots__/JurisdictionAdminView.test.tsx.snap
+++ b/client/src/components/JurisdictionAdmin/__snapshots__/JurisdictionAdminView.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`JA setup renders initial state 1`] = `
               <span
                 class="bp3-file-upload-input"
               >
-                Select a CSV...
+                Select a file...
               </span>
             </label>
             <div
@@ -151,7 +151,7 @@ exports[`JA setup renders initial state 1`] = `
               <span
                 class="bp3-file-upload-input"
               >
-                Select a CSV...
+                Select a file...
               </span>
             </label>
             <div

--- a/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
+++ b/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`Home screen redirects to audit screen if only one election exists for J
                 <span
                   class="bp3-file-upload-input"
                 >
-                  Select a CSV...
+                  Select a file...
                 </span>
               </label>
               <div


### PR DESCRIPTION
Previously, all files uploaded were CSVs, now for Hart CVRs, we also
accept a zip, so we just change the copy to be generic.