### PR TITLE
Move Minerva doctests to test file to use approx

### DIFF
--- a/server/audit_math/minerva.py
+++ b/server/audit_math/minerva.py
@@ -177,15 +177,6 @@ def collect_risks(
 
     Outputs:
         risks - Mapping of (winner, loser) pairs to their risk levels
-
-    >>> c3 = make_arlo_contest({"a": 600, "b": 400, "c": 100, "_undervote_": 100})
-    >>> collect_risks(0.1, c3, [120], make_sample_results(c3, [[56, 40, 3]]))
-    {('winner', 'loser'): 0.0933945799801079}
-    >>> collect_risks(0.1, c3, [83], make_sample_results(c3, [[40, 40, 3]]))
-    {('winner', 'loser'): 0.5596434615209632}
-    >>> collect_risks(0.1, c3, [82], make_sample_results(c3, [[40, 40, 3]]))
-    Traceback (most recent call last):
-    ValueError: Incorrect number of valid ballots entered
     """
 
     logging.debug(
@@ -242,12 +233,6 @@ def compute_risk(
         measurements:   the p-value of the hypotheses that the election
                         result is correct based on the sample
         confirmed:      a boolean indicating whether the audit can stop
-
-    >>> c3 = make_arlo_contest({"a": 600, "b": 400, "c": 100, "_undervote_": 100})
-    >>> compute_risk(10, c3, make_sample_results(c3, [[56, 40, 3]]), {1: 100, 2: 150})
-    ({('winner', 'loser'): 0.0933945799801079}, True)
-    >>> compute_risk(10, c3, make_sample_results(c3, [[40, 40, 3]]), {1: 100, 2: 150})
-    ({('winner', 'loser'): 0.5596434615209632}, False)
     """
 
     alpha = risk_limit / 100

--- a/server/tests/audit_math/test_minerva.py
+++ b/server/tests/audit_math/test_minerva.py
@@ -152,6 +152,22 @@ def test_get_sample_size_2win():
     }
 
 
+def test_collect_risks():
+    c3 = minerva.make_arlo_contest({"a": 600, "b": 400, "c": 100, "_undervote_": 100})
+    res = minerva.collect_risks(
+        0.1, c3, [120], minerva.make_sample_results(c3, [[56, 40, 3]])
+    )
+    assert res == {("winner", "loser"): approx(0.0933945799801079)}
+    res = minerva.collect_risks(
+        0.1, c3, [83], minerva.make_sample_results(c3, [[40, 40, 3]])
+    )
+    assert res == {("winner", "loser"): pytest.approx(0.5596434615209632)}
+    with pytest.raises(ValueError, match="Incorrect number of valid ballots entered"):
+        minerva.collect_risks(
+            0.1, c3, [82], minerva.make_sample_results(c3, [[40, 40, 3]])
+        )
+
+
 def test_compute_risk_delta():
     c = minerva.make_arlo_contest(
         {
@@ -205,9 +221,13 @@ def test_compute_risk_2win_2_2r():
 def test_compute_risk():
     c3 = minerva.make_arlo_contest({"a": 600, "b": 400, "c": 100, "_undervote_": 100})
     res = minerva.compute_risk(
-        10, c3, minerva.make_sample_results(c3, [[56, 40, 3]]), {1: 100}
+        10, c3, minerva.make_sample_results(c3, [[56, 40, 3]]), {1: 100, 2: 150}
     )
     assert res == ({("winner", "loser"): approx(0.0933945799801079)}, True)
+    res = minerva.compute_risk(
+        10, c3, minerva.make_sample_results(c3, [[40, 40, 3]]), {1: 100, 2: 150}
+    )
+    assert res == ({("winner", "loser"): approx(0.5596434615209632)}, False)
 
 
 def test_compute_risk_close_narrow():


### PR DESCRIPTION
Some Minerva doctests need pytest.approx to account for precision issues. Doctests don't support this, so we move them to the test_minerva.py test file.