### PR TITLE
Allow Windows zip mimetype for Hart CVR uploads

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -1116,7 +1116,7 @@ def validate_cvr_upload(
 
     file = request.files["cvrs"]
     if cvr_file_type == CvrFileType.HART:
-        if file.mimetype != "application/zip":
+        if file.mimetype not in ["application/zip", "application/x-zip-compressed"]:
             raise BadRequest("Please submit a ZIP file export.")
     else:
         validate_csv_mimetype(request.files["cvrs"])

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1787,6 +1787,22 @@ def test_hart_cvrs_invalid_zip_mimetype(
         ]
     }
 
+    # Make sure that the Windows zip mimetype does work
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
+        data={
+            "cvrs": [
+                (
+                    zip_hart_cvrs(HART_CVRS),
+                    "cvr-files.zip",
+                    "application/x-zip-compressed",
+                )
+            ],
+            "cvrFileType": "HART",
+        },
+    )
+    assert_ok(rv)
+
 
 def test_cvrs_unexpected_error(
     election_id: str,


### PR DESCRIPTION
Windows seems to use mimetype `application/x-zip-compressed` instead of `application/zip`.