### PR TITLE
Show sample sizes to audit admin in later rounds

### DIFF
--- a/client/src/components/Atoms/StatusBox.test.tsx
+++ b/client/src/components/Atoms/StatusBox.test.tsx
@@ -267,6 +267,10 @@ describe('StatusBox', () => {
           screen.getByRole('button', { name: 'Start Round 2' })
         ).toBeDisabled()
         await waitFor(() => expect(startNextRoundMock).toHaveBeenCalledTimes(1))
+        expect(startNextRoundMock).toHaveBeenCalledWith({
+          'contest-id':
+            sampleSizeMock.ballotComparison.sampleSizes['contest-id'][0],
+        })
       })
     })
 

--- a/client/src/components/Atoms/StatusBox.test.tsx
+++ b/client/src/components/Atoms/StatusBox.test.tsx
@@ -11,8 +11,11 @@ import {
   auditBoardMocks,
 } from '../AuditAdmin/useSetupMenuItems/_mocks'
 import { contestMocks } from '../AuditAdmin/Setup/Contests/_mocks'
-import * as utilities from '../utilities'
 import { IAuditSettings } from '../useAuditSettings'
+import { withMockFetch } from '../testUtilities'
+import { aaApiCalls } from '../_mocks'
+import { sampleSizeMock } from '../AuditAdmin/Setup/Review/_mocks'
+import { FileProcessingStatus } from '../useCSV'
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
@@ -24,15 +27,6 @@ paramsMock.mockReturnValue({
   electionId: '1',
   jurisdictionId: '1',
   view: 'setup',
-})
-
-const apiMock: jest.SpyInstance<
-  ReturnType<typeof utilities.api>,
-  Parameters<typeof utilities.api>
-> = jest.spyOn(utilities, 'api').mockImplementation()
-
-afterEach(() => {
-  apiMock.mockClear()
 })
 
 const cvrAuditTypes: IAuditSettings['auditType'][] = [
@@ -236,48 +230,110 @@ describe('StatusBox', () => {
       expect(screen.queryByRole('button')).not.toBeInTheDocument()
     })
 
-    it('renders round complete, need another round state', () => {
-      render(
-        <Router>
-          <AuditAdminStatusBox
-            rounds={roundMocks.needAnother}
-            startNextRound={jest.fn()}
-            undoRoundStart={jest.fn()}
-            jurisdictions={jurisdictionMocks.allComplete}
-            contests={contestMocks.filledTargeted.contests}
-            auditSettings={auditSettings.all}
-          />
-        </Router>
-      )
-      screen.getByText(
-        'Round 1 of the audit is complete - another round is needed'
-      )
-      screen.getByText('When you are ready, start Round 2')
-      screen.getByText('Start Round 2')
+    it('renders round complete, need another round state', async () => {
+      const expectedCalls = [
+        {
+          ...aaApiCalls.getSampleSizes,
+          url: '/api/election/1/sample-sizes/2',
+          response: sampleSizeMock.ballotComparison,
+        },
+      ]
+      await withMockFetch(expectedCalls, async () => {
+        const startNextRoundMock = jest.fn()
+        render(
+          <Router>
+            <AuditAdminStatusBox
+              rounds={roundMocks.needAnother}
+              startNextRound={startNextRoundMock}
+              undoRoundStart={jest.fn()}
+              jurisdictions={jurisdictionMocks.allComplete}
+              contests={contestMocks.filledTargeted.contests}
+              auditSettings={auditSettings.ballotComparisonAll}
+            />
+          </Router>
+        )
+        screen.getByText(
+          'Round 1 of the audit is complete - another round is needed'
+        )
+        screen.getByText('Loading sample sizes...')
+        screen.getByRole('button', { name: 'Start Round 2' })
+        await screen.findByText('Round 2 Sample Sizes')
+        screen.getByText(/Contest Name: 15 ballots/)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Start Round 2' }), {
+          bubbles: true,
+        })
+        expect(
+          screen.getByRole('button', { name: 'Start Round 2' })
+        ).toBeDisabled()
+        await waitFor(() => expect(startNextRoundMock).toHaveBeenCalledTimes(1))
+      })
     })
 
-    it('creates the next round', async () => {
-      const startNextRoundMock = jest.fn()
-      render(
-        <Router>
-          <AuditAdminStatusBox
-            rounds={roundMocks.needAnother}
-            startNextRound={startNextRoundMock}
-            undoRoundStart={jest.fn()}
-            jurisdictions={jurisdictionMocks.allComplete}
-            contests={contestMocks.filledTargeted.contests}
-            auditSettings={auditSettings.all}
-          />
-        </Router>
-      )
-      fireEvent.click(screen.getByRole('button', { name: 'Start Round 2' }), {
-        bubbles: true,
+    it('renders round complete, need another round state for batch comparison audits', async () => {
+      const expectedCalls = [
+        {
+          ...aaApiCalls.getSampleSizes,
+          url: '/api/election/1/sample-sizes/2',
+          response: sampleSizeMock.batchComparison,
+        },
+      ]
+      await withMockFetch(expectedCalls, async () => {
+        const startNextRoundMock = jest.fn()
+        render(
+          <Router>
+            <AuditAdminStatusBox
+              rounds={roundMocks.needAnother}
+              startNextRound={startNextRoundMock}
+              undoRoundStart={jest.fn()}
+              jurisdictions={jurisdictionMocks.allComplete}
+              contests={contestMocks.filledTargeted.contests}
+              auditSettings={auditSettings.batchComparisonAll}
+            />
+          </Router>
+        )
+        screen.getByText(
+          'Round 1 of the audit is complete - another round is needed'
+        )
+        await screen.findByText('Round 2 Sample Sizes')
+        screen.getByText(/Contest Name: 4 batches/)
       })
+    })
 
-      expect(
-        screen.getByRole('button', { name: 'Start Round 2' })
-      ).toBeDisabled()
-      await waitFor(() => expect(startNextRoundMock).toHaveBeenCalledTimes(1))
+    it('handles sample size errors in need another round state', async () => {
+      const expectedCalls = [
+        {
+          ...aaApiCalls.getSampleSizes,
+          url: '/api/election/1/sample-sizes/2',
+          response: {
+            sampleSizes: null,
+            selected: null,
+            task: {
+              status: FileProcessingStatus.ERRORED,
+              startedAt: '2019-07-18T16:34:07.000+00:00',
+              completedAt: '2019-07-18T16:35:07.000+00:00',
+              error: 'something went wrong',
+            },
+          },
+        },
+      ]
+      await withMockFetch(expectedCalls, async () => {
+        render(
+          <Router>
+            <AuditAdminStatusBox
+              rounds={roundMocks.needAnother}
+              startNextRound={jest.fn()}
+              undoRoundStart={jest.fn()}
+              jurisdictions={jurisdictionMocks.allComplete}
+              contests={contestMocks.filledTargeted.contests}
+              auditSettings={auditSettings.ballotComparisonAll}
+            />
+          </Router>
+        )
+        await screen.findByText(
+          'Error computing sample sizes: something went wrong'
+        )
+      })
     })
 
     it('renders audit completion state', () => {

--- a/client/src/components/Atoms/StatusBox.tsx
+++ b/client/src/components/Atoms/StatusBox.tsx
@@ -15,6 +15,7 @@ import {
 } from '../AuditAdmin/useRoundsAuditAdmin'
 import { IAuditBoard } from '../useAuditBoards'
 import { IContest } from '../../types'
+import useSampleSizes from '../AuditAdmin/Setup/Review/useSampleSizes'
 
 const SpacedH3 = styled(H3)`
   &.bp3-heading {
@@ -263,15 +264,13 @@ export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
   // Round complete, need another round
   if (!isAuditComplete) {
     return (
-      <StatusBox
-        headline={`Round ${roundNum} of the audit is complete - another round is needed`}
-        details={[`When you are ready, start Round ${roundNum + 1}`]}
-        buttonLabel={`Start Round ${roundNum + 1}`}
-        onButtonClick={startNextRound}
-        auditName={auditSettings.auditName}
-      >
-        {children}
-      </StatusBox>
+      <AuditAdminAnotherRoundStatusBox
+        electionId={electionId}
+        auditSettings={auditSettings}
+        contests={contests}
+        roundNum={roundNum}
+        startNextRound={startNextRound}
+      />
     )
   }
 
@@ -282,6 +281,62 @@ export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
       details={[]}
       buttonLabel="Download Audit Report"
       onButtonClick={async () => downloadAuditAdminReport(electionId)}
+      auditName={auditSettings.auditName}
+    >
+      {children}
+    </StatusBox>
+  )
+}
+
+interface IAuditAdminAnotherRoundStatusBoxProps {
+  electionId: string
+  auditSettings: IAuditSettings
+  contests: IContest[]
+  roundNum: number
+  startNextRound: () => Promise<boolean>
+  children?: ReactElement
+}
+
+const AuditAdminAnotherRoundStatusBox = ({
+  electionId,
+  auditSettings,
+  contests,
+  roundNum,
+  startNextRound,
+  children,
+}: IAuditAdminAnotherRoundStatusBoxProps) => {
+  const sampleSizesResponse = useSampleSizes(electionId, roundNum + 1, true)
+  const ballotsOrBatches =
+    auditSettings.auditType === 'BATCH_COMPARISON' ? 'batches' : 'ballots'
+
+  return (
+    <StatusBox
+      headline={`Round ${roundNum} of the audit is complete - another round is needed`}
+      details={(() => {
+        if (
+          sampleSizesResponse === null ||
+          sampleSizesResponse.task.completedAt === null
+        )
+          return ['Loading sample sizes...']
+        if (sampleSizesResponse.task.error !== null)
+          return [
+            `Error computing sample sizes: ${sampleSizesResponse.task.error}`,
+          ]
+        return [
+          `Round ${roundNum + 1} Sample Sizes`,
+          ...Object.entries(sampleSizesResponse.sampleSizes!).map(
+            ([contestId, options]) => {
+              const [option] = options // Backend should autoselect one option
+              const contestName = contests.find(
+                contest => contest.id === contestId
+              )!.name
+              return `• ${contestName}: ${option.size} ${ballotsOrBatches}`
+            }
+          ),
+        ]
+      })()}
+      buttonLabel={`Start Round ${roundNum + 1}`}
+      onButtonClick={startNextRound}
       auditName={auditSettings.auditName}
     >
       {children}

--- a/client/src/components/Atoms/StatusBox.tsx
+++ b/client/src/components/Atoms/StatusBox.tsx
@@ -309,7 +309,7 @@ const AuditAdminAnotherRoundStatusBox = ({
 }: IAuditAdminAnotherRoundStatusBoxProps) => {
   const sampleSizesResponse = useSampleSizes(electionId, roundNum + 1, true)
   // The server should autoselect one option per contest, so we pick the first
-  // item in the options array
+  // item in the options array for each contest
   const sampleSizes =
     sampleSizesResponse &&
     sampleSizesResponse.sampleSizes &&

--- a/client/src/components/AuditAdmin/AuditAdminView.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.tsx
@@ -18,7 +18,6 @@ import Sidebar from '../Atoms/Sidebar'
 import { RefreshTag } from '../Atoms/RefreshTag'
 import Setup, { setupStages } from './Setup/Setup'
 import Progress from './Progress/Progress'
-import useSampleSizes from './Setup/Review/useSampleSizes'
 
 interface IParams {
   electionId: string

--- a/client/src/components/AuditAdmin/AuditAdminView.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.tsx
@@ -18,6 +18,7 @@ import Sidebar from '../Atoms/Sidebar'
 import { RefreshTag } from '../Atoms/RefreshTag'
 import Setup, { setupStages } from './Setup/Setup'
 import Progress from './Progress/Progress'
+import useSampleSizes from './Setup/Review/useSampleSizes'
 
 interface IParams {
   electionId: string

--- a/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
@@ -27,7 +27,7 @@ const apiCalls = {
     response,
   }),
   getSampleSizeOptions: (response: ISampleSizesResponse) => ({
-    url: '/api/election/1/sample-sizes',
+    url: '/api/election/1/sample-sizes/1',
     response,
   }),
   getRounds: {

--- a/client/src/components/AuditAdmin/Setup/Review/Review.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.tsx
@@ -113,7 +113,11 @@ const Review: React.FC<IProps> = ({
     !!auditSettings &&
     isSetupComplete(jurisdictions, contests, auditSettings)
   const shouldLoadSampleSizes = setupComplete && standardizationComplete
-  const sampleSizesResponse = useSampleSizes(electionId, shouldLoadSampleSizes)
+  const sampleSizesResponse = useSampleSizes(
+    electionId,
+    1,
+    shouldLoadSampleSizes
+  )
 
   if (!jurisdictions || !contests || !auditSettings) return null // Still loading
 

--- a/client/src/components/AuditAdmin/Setup/Review/useSampleSizes.ts
+++ b/client/src/components/AuditAdmin/Setup/Review/useSampleSizes.ts
@@ -32,12 +32,14 @@ export interface ISampleSizesResponse {
 }
 
 const getSampleSizeOptions = async (
-  electionId: string
+  electionId: string,
+  roundNumber: number
 ): Promise<ISampleSizesResponse | null> =>
-  api(`/election/${electionId}/sample-sizes`)
+  api(`/election/${electionId}/sample-sizes/${roundNumber}`)
 
 const useSampleSizes = (
   electionId: string,
+  roundNumber: number,
   shouldFetch: boolean
 ): ISampleSizesResponse | null => {
   const [
@@ -48,7 +50,7 @@ const useSampleSizes = (
   useEffect(() => {
     ;(async () => {
       const isComplete = async () => {
-        const response = await getSampleSizeOptions(electionId)
+        const response = await getSampleSizeOptions(electionId, roundNumber)
         if (response && response.task.completedAt !== null) {
           setSampleSizeOptions(response)
           return true
@@ -63,7 +65,7 @@ const useSampleSizes = (
           5 * 60 * 1000 // Time out loading sample sizes after 5 minutes
         )
     })()
-  }, [electionId, shouldFetch])
+  }, [electionId, roundNumber, shouldFetch])
 
   return sampleSizeOptions
 }

--- a/client/src/components/AuditAdmin/useRoundsAuditAdmin.ts
+++ b/client/src/components/AuditAdmin/useRoundsAuditAdmin.ts
@@ -34,7 +34,7 @@ const getRounds = async (electionId: string): Promise<IRound[] | null> => {
 const postRound = async (
   electionId: string,
   roundNum: number,
-  sampleSizes?: ISampleSizes
+  sampleSizes: ISampleSizes
 ) => {
   const response = await api(`/election/${electionId}/round`, {
     method: 'POST',
@@ -70,12 +70,12 @@ const useRoundsAuditAdmin = (
   refreshId?: string
 ): [
   IRound[] | null,
-  (sampleSizes?: ISampleSizes) => Promise<boolean>,
+  (sampleSizes: ISampleSizes) => Promise<boolean>,
   () => Promise<boolean>
 ] => {
   const [rounds, setRounds] = useState<IRound[] | null>(null)
 
-  const startNextRound = async (sampleSizes?: ISampleSizes) => {
+  const startNextRound = async (sampleSizes: ISampleSizes) => {
     if (rounds === null)
       throw new Error('Cannot start next round until rounds are loaded')
     const nextRoundNum =

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -425,7 +425,7 @@ export const aaApiCalls = {
     response: { status: 'ok' },
   }),
   getSampleSizes: {
-    url: '/api/election/1/sample-sizes',
+    url: '/api/election/1/sample-sizes/1',
     response: {
       sampleSizes: null,
       selected: null,

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -713,23 +713,11 @@ def draw_sample(round_id: str, election_id: str):
     # For rounds after the first round, automatically select a sample size
     if round.round_num > 1:
 
-        def select_sample_size(options):
-            audit_type = AuditType(election.audit_type)
-            if audit_type == AuditType.BALLOT_POLLING:
-                return options.get("0.9", options.get("asn"))
-            elif audit_type == AuditType.BATCH_COMPARISON:
-                return options["macro"]
-            elif audit_type == AuditType.BALLOT_COMPARISON:
-                return options["supersimple"]
-            else:
-                assert audit_type == AuditType.HYBRID
-                return options["suite"]
-
         sample_size_options = sample_sizes_module.sample_size_options(election)
         for round_contest in round.round_contests:
             if round_contest.contest_id in sample_size_options:
-                round_contest.sample_size = select_sample_size(
-                    sample_size_options[round_contest.contest_id]
+                round_contest.sample_size = sample_sizes_module.autoselect_sample_size(
+                    sample_size_options[round_contest.contest_id], election.audit_type
                 )
 
     contest_sample_sizes = [

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -185,18 +185,10 @@ def sample_size_options(election: Election) -> Dict[str, Dict[str, SampleSizeOpt
                 }
             }
 
-    targeted_contests = Contest.query.filter_by(
-        election_id=election.id, is_targeted=True
-    )
-    targeted_contests_that_havent_met_risk_limit = (
-        targeted_contests.all()
-        if len(list(election.rounds)) == 0
-        else targeted_contests.join(RoundContest).filter_by(is_complete=False).all()
-    )
     try:
         return {
             contest.id: sample_sizes_for_contest(contest)
-            for contest in targeted_contests_that_havent_met_risk_limit
+            for contest in rounds.active_targeted_contests(election)
         }
     except ValueError as exc:
         raise UserError(exc) from exc

--- a/server/tests/api/snapshots/snap_test_sample_sizes.py
+++ b/server/tests/api/snapshots/snap_test_sample_sizes.py
@@ -31,10 +31,5 @@ snapshots["test_sample_sizes_round_2 2"] = {
 }
 
 snapshots["test_sample_sizes_round_2 3"] = {
-    "Contest 1": [
-        {"key": "asn", "prob": 0.51, "size": 250},
-        {"key": "0.7", "prob": 0.7, "size": 341},
-        {"key": "0.8", "prob": 0.8, "size": 415},
-        {"key": "0.9", "prob": 0.9, "size": 539},
-    ]
+    "Contest 1": [{"key": "0.9", "prob": 0.9, "size": 539}]
 }

--- a/server/tests/api/snapshots/snap_test_sample_sizes.py
+++ b/server/tests/api/snapshots/snap_test_sample_sizes.py
@@ -29,3 +29,12 @@ snapshots["test_sample_sizes_round_2 2"] = {
     "Contest 1": {"key": "asn", "prob": 0.52, "size": 119},
     "Contest 2": None,
 }
+
+snapshots["test_sample_sizes_round_2 3"] = {
+    "Contest 1": [
+        {"key": "asn", "prob": 0.51, "size": 250},
+        {"key": "0.7", "prob": 0.7, "size": 341},
+        {"key": "0.8", "prob": 0.8, "size": 415},
+        {"key": "0.9", "prob": 0.9, "size": 539},
+    ]
+}

--- a/server/tests/api/test_ballots.py
+++ b/server/tests/api/test_ballots.py
@@ -1124,7 +1124,7 @@ def test_ballots_human_sort_order(
 
     # Start round 1
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     rv = post_json(
         client,

--- a/server/tests/api/test_jurisdictions.py
+++ b/server/tests/api/test_jurisdictions.py
@@ -308,7 +308,7 @@ def test_jurisdictions_round_status_offline(
     rv = put_json(client, f"/api/election/{election_id}/settings", settings)
     assert_ok(rv)
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     rv = post_json(
         client,

--- a/server/tests/api/test_rounds.py
+++ b/server/tests/api/test_rounds.py
@@ -33,7 +33,7 @@ def test_rounds_create_one(
     manifests,  # pylint: disable=unused-argument
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     sample_size = sample_size_options[contest_ids[0]][0]
     rv = post_json(

--- a/server/tests/api/test_sample_sizes.py
+++ b/server/tests/api/test_sample_sizes.py
@@ -94,7 +94,7 @@ def test_sample_sizes_round_2(
         },
     )
 
-    # Requesting round 2 sizes should return new sample sizes
+    # Requesting round 2 sizes should auto-select a sample size
     rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
     response = json.loads(rv.data)
     snapshot.assert_match(

--- a/server/tests/api/test_sample_sizes.py
+++ b/server/tests/api/test_sample_sizes.py
@@ -9,7 +9,7 @@ from ... import config
 
 
 def test_sample_sizes_without_contests(client: FlaskClient, election_id: str):
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -31,7 +31,7 @@ def test_sample_sizes_without_risk_limit(
     election_id: str,
     contest_ids: List[str],  # pylint: disable=unused-argument
 ):
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -55,7 +55,7 @@ def test_sample_sizes_round_1(
     election_settings,  # pylint: disable=unused-argument
     snapshot,
 ):
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     response = json.loads(rv.data)
     contest_id_to_name = dict(Contest.query.values(Contest.id, Contest.name))
     snapshot.assert_match(
@@ -67,13 +67,16 @@ def test_sample_sizes_round_1(
 def test_sample_sizes_round_2(
     client: FlaskClient,
     election_id: str,
+    contest_ids: List[str],
     round_1_id: str,  # pylint: disable=unused-argument
     snapshot,
 ):
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    run_audit_round(round_1_id, contest_ids[0], contest_ids, 0.5)
+
+    # Requesting round 1 sizes should return previous sample sizes
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     response = json.loads(rv.data)
     contest_id_to_name = dict(Contest.query.values(Contest.id, Contest.name))
-    # Should still return round 1 sample sizes
     snapshot.assert_match(
         {contest_id_to_name[id]: sizes for id, sizes in response["sampleSizes"].items()}
     )
@@ -91,6 +94,28 @@ def test_sample_sizes_round_2(
         },
     )
 
+    # Requesting round 2 sizes should return new sample sizes
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    response = json.loads(rv.data)
+    snapshot.assert_match(
+        {contest_id_to_name[id]: sizes for id, sizes in response["sampleSizes"].items()}
+    )
+    assert response["selected"] is None
+
+
+def test_samples_sizes_invalid_round_num(
+    client: FlaskClient,
+    election_id: str,
+    contest_ids: List[str],  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
+):
+    for invalid_round_num in [0, 2]:
+        rv = client.get(f"/api/election/{election_id}/sample-sizes/{invalid_round_num}")
+        assert rv.status_code == 400
+        assert json.loads(rv.data) == {
+            "errors": [{"message": "Invalid round number", "errorType": "Bad Request"}]
+        }
+
 
 def test_sample_sizes_background(
     client: FlaskClient,
@@ -103,7 +128,7 @@ def test_sample_sizes_background(
 
     # When we first request sample sizes, we expect a background task to get
     # created, but no sample sizes returned yet
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert json.loads(rv.data) == {
         "sampleSizes": None,
         "selected": None,
@@ -123,7 +148,7 @@ def test_sample_sizes_background(
     sample_sizes.task.started_at = started_at
     db_session.commit()
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert json.loads(rv.data) == {
         "sampleSizes": None,
         "selected": None,
@@ -146,7 +171,7 @@ def test_sample_sizes_background(
     sample_sizes.task.completed_at = completed_at
     db_session.commit()
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert json.loads(rv.data) == {
         "sampleSizes": {contest_ids[0]: [{"key": "asn", "size": 1, "prob": 0.5}]},
         "selected": None,
@@ -167,7 +192,7 @@ def test_sample_sizes_background(
     sample_sizes.task.completed_at = completed_at
     db_session.commit()
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert json.loads(rv.data) == {
         "sampleSizes": None,
         "selected": None,

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -545,7 +545,19 @@ def test_support_reopen_audit_board(
 
     # Start round 2
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2},)
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
     assert_ok(rv)
 
     rv = client.get(f"/api/election/{election_id}/round",)

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -629,7 +629,7 @@ def test_support_clear_offline_results_ballot_polling(
 
     # Start the round
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_sizes = json.loads(rv.data)["sampleSizes"]
     rv = post_json(
         client,

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -649,7 +649,19 @@ def test_ballot_comparison_two_rounds(
     check_discrepancies(rv.data, audit_results)
 
     # Start a second round
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2},)
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
     assert_ok(rv)
 
     rv = client.get(f"/api/election/{election_id}/round",)
@@ -948,7 +960,19 @@ def test_ballot_comparison_multiple_targeted_contests_sample_size(
     end_round(round.election, round)
     db_session.commit()
 
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2})
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
     assert_ok(rv)
 
     rv = client.get(f"/api/election/{election_id}/round",)

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -302,7 +302,7 @@ def test_require_cvr_uploads(
 
     # AA tries to select a sample size - should get an error because CVRs have
     # to be uploaded first
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -345,7 +345,7 @@ def test_require_manifest_uploads(
 
     # AA tries to select a sample size - should get an error because manifests have
     # to be uploaded first
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -383,7 +383,7 @@ def test_contest_names_dont_match_cvr_contests(
     rv = put_json(client, f"/api/election/{election_id}/contest", contests)
     assert_ok(rv)
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -576,7 +576,7 @@ def test_ballot_comparison_two_rounds(
     target_contest_id = contests[0]["id"]
     opportunistic_contest_id = contests[1]["id"]
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     assert len(sample_size_options) == 1
     sample_size = sample_size_options[target_contest_id][0]
@@ -656,7 +656,7 @@ def test_ballot_comparison_two_rounds(
     round_2_id = json.loads(rv.data)["rounds"][1]["id"]
 
     # Sample sizes endpoint should still return round 1 sample size
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     assert len(sample_size_options) == 1
     assert sample_size_options[target_contest_id][0] == sample_size
@@ -909,7 +909,7 @@ def test_ballot_comparison_multiple_targeted_contests_sample_size(
     )
     assert_ok(rv)
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
 
     rv = post_json(
@@ -1073,7 +1073,7 @@ def test_ballot_comparison_union_choice_names(
         ],
     )
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     assert len(sample_size_options) == 1
     sample_size = sample_size_options[target_contest["id"]][0]

--- a/server/tests/ballot_comparison/test_ballot_comparison_manifests.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison_manifests.py
@@ -153,7 +153,7 @@ def test_ballot_comparison_container_manifest(
     contests = json.loads(rv.data)["contests"]
     target_contest_id = contests[0]["id"]
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     assert len(sample_size_options) == 1
     sample_size = sample_size_options[target_contest_id][0]

--- a/server/tests/ballot_comparison/test_contest_name_standardizations.py
+++ b/server/tests/ballot_comparison/test_contest_name_standardizations.py
@@ -80,7 +80,7 @@ def test_standardize_contest_names(
 
     # Try to get the sample sizes - should fail because we haven't standardized
     # all targeted contest names
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -129,7 +129,7 @@ def test_standardize_contest_names(
     db_session.commit()
 
     # Now sample sizes should work
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     response = json.loads(rv.data)
     assert response["task"]["status"] == "PROCESSED"
@@ -256,7 +256,7 @@ def test_standardize_contest_names_cvr_change(
 
     # Try to get the sample sizes - should fail because we haven't standardized
     # all targeted contest names
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -334,7 +334,7 @@ def test_standardize_contest_names_contest_change(
 
     # Try to get the sample sizes - should fail because we haven't standardized
     # all targeted contest names
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),

--- a/server/tests/ballot_polling/test_minerva_ballot_polling.py
+++ b/server/tests/ballot_polling/test_minerva_ballot_polling.py
@@ -284,7 +284,19 @@ def test_minerva_ballot_polling_two_rounds(
     assert_match_report(rv.data, snapshot)
 
     # Start a second round
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2},)
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
     assert_ok(rv)
 
     rv = client.get(f"/api/election/{election_id}/round",)

--- a/server/tests/ballot_polling/test_minerva_ballot_polling.py
+++ b/server/tests/ballot_polling/test_minerva_ballot_polling.py
@@ -39,7 +39,7 @@ def test_minerva_sample_size(
     snapshot,
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
 
     sample_size_options = json.loads(rv.data)["sampleSizes"][contest_ids[0]]

--- a/server/tests/batch_comparison/conftest.py
+++ b/server/tests/batch_comparison/conftest.py
@@ -146,7 +146,7 @@ def round_1_id(
     batch_tallies,  # pylint: disable=unused-argument
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     sample_size = sample_size_options[contest_id][0]

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -61,7 +61,7 @@ def test_batch_comparison_sample_size(
     snapshot,
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     assert len(sample_size_options) == 1
@@ -77,7 +77,7 @@ def test_batch_comparison_without_all_batch_tallies(
     manifests,  # pylint: disable=unused-argument
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -120,7 +120,7 @@ def test_batch_comparison_too_many_votes(
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     assert rv.status_code == 200
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     compare_json(
         json.loads(rv.data),
         {

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -360,7 +360,19 @@ def test_batch_comparison_round_2(
     snapshot.assert_match(jurisdictions[1]["currentRoundStatus"])
 
     # Start a second round
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2})
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
     assert_ok(rv)
 
     rv = client.get(f"/api/election/{election_id}/round")

--- a/server/tests/batch_comparison/test_batches.py
+++ b/server/tests/batch_comparison/test_batches.py
@@ -256,7 +256,19 @@ def test_record_batch_results(
 
     # Start a new round to test round 2
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2})
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
     assert_ok(rv)
 
     set_logged_in_user(
@@ -558,7 +570,19 @@ def test_record_batch_results_bad_round(
         assert_ok(rv)
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2})
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
     assert_ok(rv)
 
     rv = client.get(f"/api/election/{election_id}/round")

--- a/server/tests/batch_comparison/test_batches.py
+++ b/server/tests/batch_comparison/test_batches.py
@@ -728,7 +728,7 @@ def test_batches_human_sort_order(
 
     # Start round 1
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     rv = post_json(
         client,

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -199,7 +199,7 @@ def round_1_id(
     manifests,  # pylint: disable=unused-argument
 ) -> str:
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     rv = post_json(
         client,

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -226,7 +226,20 @@ def round_2_id(
     run_audit_round(round_1_id, contest_ids[0], contest_ids, 0.55)
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2},)
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
     assert_ok(rv)
 
     rv = client.get(f"/api/election/{election_id}/round",)

--- a/server/tests/hybrid/snapshots/snap_test_hybrid.py
+++ b/server/tests/hybrid/snapshots/snap_test_hybrid.py
@@ -7,6 +7,10 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots["test_hybrid_sample_size 1"] = [
+    {"key": "suite", "prob": None, "size": 23, "sizeCvr": 14, "sizeNonCvr": 9}
+]
+
 snapshots[
     "test_hybrid_two_rounds 1"
 ] = """Tabulator,Batch Name,Ballot Number,Imprinted ID,Ticket Numbers,Already Audited,Audit Board
@@ -46,7 +50,7 @@ J2,Audit Board #1,,,,\r
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Audited Votes: CVR,Audited Votes: Non CVR\r
-1,Contest 1,Targeted,23,No,0.4278843891,DATETIME,DATETIME,Choice 1-1: 14; Choice 1-2: 6,Choice 1-1: 6; Choice 1-2: 5,Choice 1-1: 8; Choice 1-2: 1\r
+1,Contest 1,Targeted,23,No,0.1394502521,DATETIME,DATETIME,Choice 1-1: 14; Choice 1-2: 8,Choice 1-1: 7; Choice 1-2: 6,Choice 1-1: 7; Choice 1-2: 2\r
 1,Contest 2,Opportunistic,,No,1.0,DATETIME,DATETIME,Choice 2-1: 10; Choice 2-2: 5; Choice 2-3: 3,Choice 2-1: 5; Choice 2-2: 4; Choice 2-3: 3,Choice 2-1: 5; Choice 2-2: 1; Choice 2-3: 0\r
 \r
 ######## SAMPLED BALLOTS ########\r
@@ -64,16 +68,16 @@ J1,TABULATOR3,BATCH1,5,,Round 1: 0.072664791498577026,AUDITED,Choice 1-1,,,Choic
 J1,TABULATOR3,BATCH1,9,,Round 1: 0.293674693309260219,AUDITED,Choice 1-1,,,Choice 2-1,,\r
 J1,TABULATOR3,BATCH1,10,,Round 1: 0.199742518299743122,AUDITED,Choice 1-1,,,Choice 2-2,,\r
 J2,TABULATOR1,BATCH1,3,1-1-3,Round 1: 0.242392535590495322,AUDITED,Choice 1-2,Choice 1-2,,"Choice 2-1, Choice 2-2",,\r
-J2,TABULATOR1,BATCH2,1,1-2-1,Round 1: 0.200269401620671924,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3",,\r
-J2,TABULATOR2,BATCH1,1,2-1-1,Round 1: 0.174827909206366766,NOT_FOUND,,Choice 1-1,2,,,\r
+J2,TABULATOR1,BATCH2,1,1-2-1,Round 1: 0.200269401620671924,AUDITED,"Choice 1-1, Choice 1-2",Choice 1-1,1,"Choice 2-1, Choice 2-3",,\r
+J2,TABULATOR2,BATCH1,1,2-1-1,Round 1: 0.174827909206366766,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-2",,\r
 J2,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.185417954749015145,AUDITED,Choice 1-1,Choice 1-1,,"Choice 2-1, Choice 2-3",,\r
 J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,"Choice 2-1, Choice 2-2, Choice 2-3",,\r
 J2,TABULATOR2,BATCH2,3,2-2-4,Round 1: 0.179114059650472941,AUDITED,CONTEST_NOT_ON_BALLOT,,,"Choice 2-1, Choice 2-3",,\r
 J2,TABULATOR3,BATCH1,1,,Round 1: 0.052129356711674929,AUDITED,Choice 1-1,,,CONTEST_NOT_ON_BALLOT,,\r
-J2,TABULATOR3,BATCH1,5,,Round 1: 0.037027823153316024,AUDITED,Choice 1-1,,,CONTEST_NOT_ON_BALLOT,,\r
+J2,TABULATOR3,BATCH1,5,,Round 1: 0.037027823153316024,AUDITED,Choice 1-2,,,CONTEST_NOT_ON_BALLOT,,\r
 J2,TABULATOR3,BATCH1,10,,Round 1: 0.087764767095634400,AUDITED,Choice 1-2,,,CONTEST_NOT_ON_BALLOT,,\r
 """
 
-snapshots["test_sample_size 1"] = [
-    {"key": "suite", "prob": None, "size": 23, "sizeCvr": 14, "sizeNonCvr": 9}
+snapshots["test_hybrid_two_rounds 3"] = [
+    {"key": "suite", "prob": None, "size": 33, "sizeCvr": 20, "sizeNonCvr": 13}
 ]

--- a/server/tests/hybrid/test_hybrid.py
+++ b/server/tests/hybrid/test_hybrid.py
@@ -146,7 +146,7 @@ def test_sample_size(
     snapshot,
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_sizes = json.loads(rv.data)["sampleSizes"]
     assert len(sample_sizes) == 1
     snapshot.assert_match(sample_sizes[contest_ids[0]])
@@ -165,7 +165,7 @@ def test_sample_size(
     assert_ok(rv)
 
     # Sample sizes endpoint shoudl still return round 1 options after audit launch
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert json.loads(rv.data)["sampleSizes"] == sample_sizes
 
 
@@ -177,7 +177,7 @@ def test_sample_size_before_manifest(
     election_settings,  # pylint: disable=unused-argument
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -203,7 +203,7 @@ def test_sample_size_before_cvrs(
     manifests,  # pylint: disable=unused-argument
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -247,7 +247,7 @@ def test_contest_names_dont_match_cvrs(
     rv = put_json(client, f"/api/election/{election_id}/contest", contests)
     assert_ok(rv)
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -296,7 +296,7 @@ def test_contest_choices_dont_match_cvrs(
     rv = put_json(client, f"/api/election/{election_id}/contest", contests)
     assert_ok(rv)
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -329,7 +329,7 @@ def test_hybrid_two_rounds(
 ):
     # AA selects a sample size and launches the audit
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_sizes = json.loads(rv.data)["sampleSizes"]
 
     rv = post_json(
@@ -488,7 +488,7 @@ def test_hybrid_two_rounds(
     )
 
     # Sample sizes endpoint should still return round 1 sample size
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     assert len(sample_size_options) == 1
     assert sample_size_options[target_contest_id][0] == sample_size
@@ -550,7 +550,7 @@ def test_hybrid_manifest_validation_too_many_votes(
     rv = put_json(client, f"/api/election/{election_id}/contest", contests)
     assert_ok(rv)
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -623,7 +623,7 @@ def test_hybrid_manifest_validation_too_few_cvr_ballots(
         assert_ok(rv)
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),
@@ -696,7 +696,7 @@ def test_hybrid_manifest_validation_few_non_cvr_ballots(
         assert_ok(rv)
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     compare_json(
         json.loads(rv.data),

--- a/server/tests/hybrid/test_hybrid.py
+++ b/server/tests/hybrid/test_hybrid.py
@@ -483,7 +483,17 @@ def test_hybrid_two_rounds(
     snapshot.assert_match(round_2_sample_sizes[contest_ids[0]])
 
     # Try to start a second round
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2})
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in round_2_sample_sizes.items()
+            },
+        },
+    )
     assert_ok(rv)
 
     rv = client.get(f"/api/election/{election_id}/round",)

--- a/server/tests/test_full_hand_tally.py
+++ b/server/tests/test_full_hand_tally.py
@@ -83,7 +83,7 @@ def test_all_ballots_sample_size(
     election_settings,  # pylint: disable=unused-argument
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     options = sample_size_options[contest_ids[0]]
     # We only expect the all-ballots sample size option when the margin is
@@ -107,7 +107,7 @@ def test_all_ballots_audit(
     rv = client.get(f"/api/election/{election_id}/settings")
     assert json.loads(rv.data)["online"] is True
 
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_sizes = json.loads(rv.data)["sampleSizes"]
     selected_sample_sizes = {contest_id: sample_sizes[contest_id][0]}
 

--- a/server/tests/test_multi_winner_contest.py
+++ b/server/tests/test_multi_winner_contest.py
@@ -119,7 +119,17 @@ def test_multi_winner_two_rounds(
     rv = client.get(f"/api/election/{election_id}/round")
     assert json.loads(rv.data)["rounds"][0]["isAuditComplete"] is False
 
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2},)
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {contest_id: sample_size_options[contest_id][0]},
+        },
+    )
     assert_ok(rv)
 
     rv = client.get(f"/api/election/{election_id}/round")

--- a/server/tests/test_multi_winner_contest.py
+++ b/server/tests/test_multi_winner_contest.py
@@ -40,7 +40,7 @@ def test_multi_winner_sample_size(
     snapshot,
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_size_options = json.loads(rv.data)["sampleSizes"]
     options = sample_size_options[contest_ids[0]]
     # We only expect the asn sample size option for multi-winner contests
@@ -100,7 +100,7 @@ def test_multi_winner_two_rounds(
     contest_id = contest_ids[0]
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_sizes = json.loads(rv.data)["sampleSizes"]
     selected_sample_sizes = {contest_id: sample_sizes[contest_id][0]}
 

--- a/server/tests/test_multiple_targeted_contests.py
+++ b/server/tests/test_multiple_targeted_contests.py
@@ -66,7 +66,7 @@ def test_sample_size_round_1(
     snapshot,
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_sizes = json.loads(rv.data)["sampleSizes"]
     contest_id_to_name = dict(Contest.query.values(Contest.id, Contest.name))
     snapshot.assert_match(
@@ -84,7 +84,7 @@ def test_multiple_targeted_contests_two_rounds(
     snapshot,
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes")
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     sample_sizes = json.loads(rv.data)["sampleSizes"]
     selected_sample_sizes = {
         contest_id: sizes[0] for contest_id, sizes in sample_sizes.items()

--- a/server/tests/test_multiple_targeted_contests.py
+++ b/server/tests/test_multiple_targeted_contests.py
@@ -144,7 +144,21 @@ def test_multiple_targeted_contests_two_rounds(
         }
     )
 
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2})
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    print(sample_size_options)
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
     assert_ok(rv)
 
     rv = client.get(f"/api/election/{election_id}/round")

--- a/server/tests/test_offline_data_entry.py
+++ b/server/tests/test_offline_data_entry.py
@@ -287,7 +287,19 @@ def test_offline_results_bad_round(
         assert_ok(rv)
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = post_json(client, f"/api/election/{election_id}/round", {"roundNum": 2})
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
     assert_ok(rv)
 
     set_logged_in_user(


### PR DESCRIPTION
Task: #1438 

Best reviewed commit-by-commit.

- First, we add the ability for the /sample-sizes endpoint to compute later round sample sizes
- Second, we use that new ability to show the sample sizes in the AA status box before starting another round
- Last, we remove the code in the backend that computed and chose the sample size for later rounds while drawing the sample, instead sending it from the frontend (this matches the round 1 sample size data flow and also sets us up to allow the user to modify later round sample sizes if we ever want that)

Due to some constraints with what the StatusBox component currently supports, I didn't do much fancy design for now. Ultimately, I think it would make sense to rethink this UI entirely so that viewing/editing sample sizes looks the same in the first round and later rounds, so I didn't think it was worth putting too much effort in here.
<img width="1099" alt="Screen Shot 2022-04-26 at 3 57 21 PM" src="https://user-images.githubusercontent.com/530106/165406147-c69290bf-28f0-480f-b134-327f099998bc.png">

