### PR TITLE
Add batch name and ballot number to audit board confirmation modal header

### DIFF
--- a/client/src/components/AuditBoard/AuditBoardView.test.tsx
+++ b/client/src/components/AuditBoard/AuditBoardView.test.tsx
@@ -272,7 +272,8 @@ describe('AuditBoardView', () => {
           })
         )
         const dialog = (await screen.findByRole('heading', {
-          name: /Confirm the Ballot Selections/,
+          name:
+            'Confirm the Ballot Selections Batch 0003-04-Precinct 19 (Jonesboro Fire Department) · Ballot Number 2112',
         })).closest('.bp3-dialog')! as HTMLElement
         expect(within(dialog).getAllByText('Ballot Not Found').length).toBe(1)
         userEvent.click(
@@ -320,7 +321,8 @@ describe('AuditBoardView', () => {
         )
 
         const dialog = (await screen.findByRole('heading', {
-          name: /Confirm the Ballot Selections/,
+          name:
+            'Confirm the Ballot Selections Batch 0003-04-Precinct 19 (Jonesboro Fire Department) · Ballot Number 2112',
         })).closest('.bp3-dialog')! as HTMLElement
         within(dialog).getByText('Contest 1')
         within(dialog).getByText('Choice One')
@@ -401,7 +403,8 @@ describe('AuditBoardView', () => {
         )
 
         const dialog = (await screen.findByRole('heading', {
-          name: /Confirm the Ballot Selections/,
+          name:
+            'Confirm the Ballot Selections Batch 0003-04-Precinct 19 (Jonesboro Fire Department) · Ballot Number 2112',
         })).closest('.bp3-dialog')! as HTMLElement
         within(dialog).getByText('Contest 1')
         within(dialog).getByText('Choice One')
@@ -457,7 +460,8 @@ describe('AuditBoardView', () => {
         )
 
         const dialog = (await screen.findByRole('heading', {
-          name: /Confirm the Ballot Selections/,
+          name:
+            'Confirm the Ballot Selections Batch 0003-04-Precinct 19 (Jonesboro Fire Department) · Ballot Number 2112',
         })).closest('.bp3-dialog')! as HTMLElement
         within(dialog).getByText('Contest 1')
         within(dialog).getByText('Choice Three')
@@ -523,7 +527,8 @@ describe('AuditBoardView', () => {
 
         // Confirm
         const dialog = (await screen.findByRole('heading', {
-          name: /Confirm the Ballot Selections/,
+          name:
+            'Confirm the Ballot Selections Batch 0003-04-Precinct 19 (Jonesboro Fire Department) · Ballot Number 2112',
         })).closest('.bp3-dialog')! as HTMLElement
         within(dialog).getByText('Ballot Not Found')
         userEvent.click(
@@ -568,7 +573,8 @@ describe('AuditBoardView', () => {
           screen.getByRole('button', { name: 'Submit Selections' })
         )
         const dialog1 = (await screen.findByRole('heading', {
-          name: /Confirm the Ballot Selections/,
+          name:
+            'Confirm the Ballot Selections Batch 0003-04-Precinct 19 (Jonesboro Fire Department) · Ballot Number 2112',
         })).closest('.bp3-dialog')! as HTMLElement
         userEvent.click(
           within(dialog1).getByRole('button', { name: 'Change Selections' })
@@ -589,7 +595,8 @@ describe('AuditBoardView', () => {
 
         // Confirm
         const dialog2 = (await screen.findByRole('heading', {
-          name: /Confirm the Ballot Selections/,
+          name:
+            'Confirm the Ballot Selections Batch 0003-04-Precinct 19 (Jonesboro Fire Department) · Ballot Number 2112',
         })).closest('.bp3-dialog')! as HTMLElement
         within(dialog2).getByText('Ballot Not Found')
         userEvent.click(

--- a/client/src/components/AuditBoard/AuditBoardView.test.tsx
+++ b/client/src/components/AuditBoard/AuditBoardView.test.tsx
@@ -507,11 +507,11 @@ describe('AuditBoardView', () => {
         screen.getByRole('heading', { name: 'Contest 2' })
         userEvent.click(
           screen.getAllByRole('checkbox', {
-            name: 'Blank vote',
+            name: 'Blank Vote',
           })[1]
         )
         expect(
-          screen.getAllByRole('checkbox', { name: 'Blank vote' })[1]
+          screen.getAllByRole('checkbox', { name: 'Blank Vote' })[1]
         ).toBeChecked()
 
         // Verify that all choices are cleared when "Ballot Not Found" is selected
@@ -522,7 +522,7 @@ describe('AuditBoardView', () => {
           screen.getByRole('checkbox', { name: 'Choice One' })
         ).not.toBeChecked()
         expect(
-          screen.getAllByRole('checkbox', { name: 'Blank vote' })[1]
+          screen.getAllByRole('checkbox', { name: 'Blank Vote' })[1]
         ).not.toBeChecked()
 
         // Confirm

--- a/client/src/components/AuditBoard/Ballot.test.tsx
+++ b/client/src/components/AuditBoard/Ballot.test.tsx
@@ -100,7 +100,7 @@ describe('Ballot', () => {
     expect(container).toMatchSnapshot()
   })
 
-  const buttonLabels = ['Blank vote', 'Not on Ballot']
+  const buttonLabels = ['Blank Vote', 'Not on Ballot']
   buttonLabels.forEach(buttonLabel => {
     it(`selects ${buttonLabel}`, async () => {
       const { container, getByLabelText } = render(

--- a/client/src/components/AuditBoard/Ballot.tsx
+++ b/client/src/components/AuditBoard/Ballot.tsx
@@ -75,6 +75,18 @@ const InstructionsList = styled(OL)`
   }
 `
 
+const ConfirmationModalTitle = styled.span`
+  display: inline-block;
+  margin-top: 10px;
+  margin-bottom: 10px;
+`
+
+const ConfirmationModalSubTitle = styled.span`
+  font-size: 16px;
+  font-weight: 400;
+  whitespace: normal; /* Allow long batch names to wrap */
+`
+
 interface IProps {
   home: string
   boardName: string
@@ -108,6 +120,10 @@ const Ballot: React.FC<IProps> = ({
 
   const { confirm, confirmProps } = useConfirm()
 
+  if (!ballot) {
+    return <Redirect to={home} />
+  }
+
   const renderInterpretation = (
     { interpretation, choiceIds }: IBallotInterpretation,
     contest: IContest
@@ -130,9 +146,20 @@ const Ballot: React.FC<IProps> = ({
     }
   }
 
+  const confirmationModalTitle = (
+    <ConfirmationModalTitle>
+      Confirm the Ballot Selections
+      <br />
+      <ConfirmationModalSubTitle>
+        Batch <b>{ballot.batch.name}</b> · Ballot Number{' '}
+        <b>{ballot.position}</b>
+      </ConfirmationModalSubTitle>
+    </ConfirmationModalTitle>
+  )
+
   const confirmSelections = (newInterpretations: IBallotInterpretation[]) => {
     confirm({
-      title: 'Confirm the Ballot Selections',
+      title: confirmationModalTitle,
       description: (
         <>
           {contests.map((contest, i) => (
@@ -165,7 +192,7 @@ const Ballot: React.FC<IProps> = ({
 
   const confirmBallotNotFound = async () => {
     confirm({
-      title: 'Confirm the Ballot Selections',
+      title: confirmationModalTitle,
       description: (
         <div>
           <h3>Ballot Not Found</h3>
@@ -180,9 +207,7 @@ const Ballot: React.FC<IProps> = ({
     })
   }
 
-  return !ballot ? (
-    <Redirect to={home} />
-  ) : (
+  return (
     <div>
       <Inner>
         <Wrapper>

--- a/client/src/components/AuditBoard/Ballot.tsx
+++ b/client/src/components/AuditBoard/Ballot.tsx
@@ -137,7 +137,7 @@ const Ballot: React.FC<IProps> = ({
           ) : null
         )
       case Interpretation.BLANK:
-        return <h3>Blank vote</h3>
+        return <h3>Blank Vote</h3>
       case Interpretation.CONTEST_NOT_ON_BALLOT:
         return <h3>Not on Ballot</h3>
       // case Interpretation.CANT_AGREE: (we do not support this case now)

--- a/client/src/components/AuditBoard/BallotAudit.tsx
+++ b/client/src/components/AuditBoard/BallotAudit.tsx
@@ -259,7 +259,7 @@ const BallotAuditContest = ({
           <BlockCheckbox
             handleChange={onCheckboxClick(Interpretation.BLANK)}
             checked={interpretation.interpretation === Interpretation.BLANK}
-            label="Blank vote"
+            label="Blank Vote"
             small
           />
           <BlockCheckbox

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                               <span
                                 class="checkbox-text"
                               >
-                                Blank vote
+                                Blank Vote
                               </span>
                             </span>
                           </label>
@@ -334,7 +334,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                               <span
                                 class="checkbox-text"
                               >
-                                Blank vote
+                                Blank Vote
                               </span>
                             </span>
                           </label>

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
     class="sc-htpNat cBZqYS"
   >
     <div
-      class="bp3-navbar sc-kgAjT dAgMgI"
+      class="bp3-navbar sc-ksYbfQ QHGZm"
     >
       <div
-        class="sc-bxivhb sc-ksYbfQ eaOcCd"
+        class="sc-bxivhb sc-frDJqD dfcocX"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -451,10 +451,10 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
     class="sc-htpNat cBZqYS"
   >
     <div
-      class="bp3-navbar sc-kgAjT dAgMgI"
+      class="bp3-navbar sc-ksYbfQ QHGZm"
     >
       <div
-        class="sc-bxivhb sc-ksYbfQ eaOcCd"
+        class="sc-bxivhb sc-frDJqD dfcocX"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -2732,10 +2732,10 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
     class="sc-htpNat cBZqYS"
   >
     <div
-      class="bp3-navbar sc-kgAjT dAgMgI"
+      class="bp3-navbar sc-ksYbfQ QHGZm"
     >
       <div
-        class="sc-bxivhb sc-ksYbfQ eaOcCd"
+        class="sc-bxivhb sc-frDJqD dfcocX"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -4635,10 +4635,10 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
     class="sc-htpNat cBZqYS"
   >
     <div
-      class="bp3-navbar sc-kgAjT dAgMgI"
+      class="bp3-navbar sc-ksYbfQ QHGZm"
     >
       <div
-        class="sc-bxivhb sc-ksYbfQ eaOcCd"
+        class="sc-bxivhb sc-frDJqD dfcocX"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -4959,10 +4959,10 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
     class="sc-htpNat cBZqYS"
   >
     <div
-      class="bp3-navbar sc-kgAjT dAgMgI"
+      class="bp3-navbar sc-ksYbfQ QHGZm"
     >
       <div
-        class="sc-bxivhb sc-ksYbfQ eaOcCd"
+        class="sc-bxivhb sc-frDJqD dfcocX"
       >
         <div
           class="bp3-navbar-group bp3-align-left"

--- a/client/src/components/AuditBoard/__snapshots__/Ballot.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/Ballot.test.tsx.snap
@@ -189,7 +189,7 @@ exports[`Ballot renders correctly with an audited ballot 1`] = `
                             <span
                               class="checkbox-text"
                             >
-                              Blank vote
+                              Blank Vote
                             </span>
                           </span>
                         </label>
@@ -485,7 +485,7 @@ exports[`Ballot renders correctly with an unaudited ballot 1`] = `
                             <span
                               class="checkbox-text"
                             >
-                              Blank vote
+                              Blank Vote
                             </span>
                           </span>
                         </label>
@@ -595,7 +595,7 @@ exports[`Ballot renders correctly with an unaudited ballot 1`] = `
 </div>
 `;
 
-exports[`Ballot selects Blank vote 1`] = `
+exports[`Ballot selects Blank Vote 1`] = `
 <div>
   <div>
     <div
@@ -781,7 +781,7 @@ exports[`Ballot selects Blank vote 1`] = `
                             <span
                               class="checkbox-text"
                             >
-                              Blank vote
+                              Blank Vote
                             </span>
                           </span>
                         </label>
@@ -1075,7 +1075,7 @@ exports[`Ballot selects Not on Ballot 1`] = `
                             <span
                               class="checkbox-text"
                             >
-                              Blank vote
+                              Blank Vote
                             </span>
                           </span>
                         </label>
@@ -1369,7 +1369,7 @@ exports[`Ballot switches audit and review views 1`] = `
                             <span
                               class="checkbox-text"
                             >
-                              Blank vote
+                              Blank Vote
                             </span>
                           </span>
                         </label>

--- a/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
+++ b/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Home screen redirects to audit screen if only one election exists for J
     class="Toastify"
   />
   <div
-    class="sc-iujRgT jTfiFp"
+    class="sc-exAgwC gHrCj"
   >
     <div
       class="bp3-navbar sc-bxivhb jwFLoW"


### PR DESCRIPTION
# Overview

Issue link: https://github.com/votingworks/arlo/issues/1434

This PR adds batch name and ballot number to the audit board confirmation modal header, allowing audit board users to confirm not only contest selections but also that they've entered information for the correct ballot.

_Before (left) and after (right)_

<img width="400" alt="before" src="https://user-images.githubusercontent.com/12616928/166058635-0b86ea55-eabe-468e-87ab-f5a885162209.png"> <img width="400" alt="after" src="https://user-images.githubusercontent.com/12616928/166058642-33687a82-77a6-4e60-8bb2-f840772bbae1.png">

_With a long batch name_

<img width="400" alt="long-batch-name" src="https://user-images.githubusercontent.com/12616928/166058794-65900e25-dc72-44e0-b08c-5e6a4e0e5488.png">

Confirmed with Ginny that we're happy with this design! 🎨 ✅

While I was at it, I also made an unrelated tweak to the "Blank vote" button, switching it to title case ("Blank Vote") for consistency with other buttons and instructional copy.

# Testing

- [x] Updated unit tests
- [x] Tested manually, including with long batch names