### PR TITLE
CSV parse: don't detect total row for column that sums to 0

### DIFF
--- a/server/tests/util/test_csv_parse.py
+++ b/server/tests/util/test_csv_parse.py
@@ -382,6 +382,19 @@ def test_parse_csv_total_row():
         == "It looks like the last row in the CSV might be a total row. Please remove this row from the CSV."
     )
 
+    # Shouldn't raise an error for a column with all 0s
+    parsed = list(
+        parse_csv(
+            ("Batch Name,Number of Ballots\n" "Batch A,0\n" "Batch B,0\n" "XXX,0\n"),
+            BALLOT_MANIFEST_COLUMNS,
+        )
+    )
+    assert parsed == [
+        {"Batch Name": "Batch A", "Number of Ballots": 0},
+        {"Batch Name": "Batch B", "Number of Ballots": 0},
+        {"Batch Name": "XXX", "Number of Ballots": 0},
+    ]
+
 
 # Cases where we are lenient
 

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -339,7 +339,7 @@ def reject_final_total_row(csv: CSVDictIterator, columns: List[CSVColumnType]):
         yield row
 
     for values in column_values.values():
-        if sum(values[:-1]) == values[-1]:
+        if sum(values[:-1]) == values[-1] and values[-1] != 0:
             raise CSVParseError(
                 "It looks like the last row in the CSV might be a total row."
                 " Please remove this row from the CSV."


### PR DESCRIPTION
We have some logic to auto-detect total rows (which aren't allowed) if the last row in the CSV has a value that is the sum of all the other rows for that column. This logic shouldn't apply for columns with all 0s, since that doesn't indicate a total row. This case won't happen often (probably only for batch tallies where a candidate got 0 votes - very rare). But still good to guard against.