### PR TITLE
Create utils/api

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,11 +14,11 @@ import AuthDataProvider, {
   useAuthDataContext,
 } from './components/UserContext'
 import SupportTools from './components/SupportTools'
-import { ApiError } from './components/SupportTools/support-api'
 import JurisdictionAdminView from './components/JurisdictionAdmin/JurisdictionAdminView'
 import AuditAdminView from './components/AuditAdmin/AuditAdminView'
 import ActivityLog from './components/AuditAdmin/ActivityLog'
 import AuditBoardView from './components/AuditBoard/AuditBoardView'
+import { ApiError } from './utils/api'
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/client/src/components/AuditAdmin/ActivityLog.tsx
+++ b/client/src/components/AuditAdmin/ActivityLog.tsx
@@ -4,7 +4,7 @@ import { HTMLSelect, H3 } from '@blueprintjs/core'
 import { IOrganization, useAuthDataContext, IAuditAdmin } from '../UserContext'
 import { Wrapper, Inner } from '../Atoms/Wrapper'
 import { StyledTable, DownloadCSVButton } from '../Atoms/Table'
-import { fetchApi } from '../SupportTools/support-api'
+import { fetchApi } from '../../utils/api'
 
 interface IActivity {
   id: string

--- a/client/src/components/AuditAdmin/Setup/Contests/Contests.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/Contests.test.tsx
@@ -18,10 +18,6 @@ const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
   Parameters<typeof utilities.api>
 > = jest.spyOn(utilities, 'api').mockImplementation()
-const checkAndToastMock: jest.SpyInstance<
-  ReturnType<typeof utilities.checkAndToast>,
-  Parameters<typeof utilities.checkAndToast>
-> = jest.spyOn(utilities, 'checkAndToast').mockReturnValue(false)
 
 const generateApiMock = (
   contestsReturn: { contests: IContest[] } | Error | { status: 'ok' },
@@ -49,8 +45,6 @@ const generateApiMock = (
 apiMock.mockImplementation(
   generateApiMock(contestMocks.emptyTargeted, { jurisdictions: [] })
 )
-
-checkAndToastMock.mockReturnValue(false)
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
@@ -85,7 +79,6 @@ function regexify(contest: IContestNumbered) {
 afterEach(() => {
   ;(nextStage.activate as jest.Mock).mockClear()
   apiMock.mockClear()
-  checkAndToastMock.mockClear()
   toastSpy.mockClear()
 })
 

--- a/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
@@ -5,7 +5,6 @@ import { useParams } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import relativeStages from '../_mocks'
 import Review from './Review'
-import * as utilities from '../../../utilities'
 import { settingsMock, sampleSizeMock } from './_mocks'
 import { contestMocks } from '../Contests/_mocks'
 import {

--- a/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
@@ -89,10 +89,6 @@ const apiCalls = {
   }),
 }
 
-const checkAndToastMock: jest.SpyInstance<
-  ReturnType<typeof utilities.checkAndToast>,
-  Parameters<typeof utilities.checkAndToast>
-> = jest.spyOn(utilities, 'checkAndToast').mockReturnValue(false)
 const toastSpy = jest.spyOn(toast, 'error').mockImplementation()
 
 jest.mock('react-router-dom', () => ({
@@ -128,7 +124,6 @@ beforeEach(() => {
   refreshMock.mockClear()
   startNextRoundMock.mockClear()
   toastSpy.mockClear()
-  checkAndToastMock.mockClear()
   routeMock.mockClear()
   ;(prevStage.activate as jest.Mock).mockClear()
 })

--- a/client/src/components/AuditAdmin/Setup/Setup.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Setup.test.tsx
@@ -14,10 +14,6 @@ const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
   Parameters<typeof utilities.api>
 > = jest.spyOn(utilities, 'api').mockImplementation()
-const checkAndToastMock: jest.SpyInstance<
-  ReturnType<typeof utilities.checkAndToast>,
-  Parameters<typeof utilities.checkAndToast>
-> = jest.spyOn(utilities, 'checkAndToast').mockReturnValue(false)
 apiMock.mockImplementation(async () => {})
 
 const useJurisdictionsMock = useJurisdictions as jest.Mock
@@ -34,8 +30,6 @@ useContestsMock.mockImplementation(() => [
 const useAuditSettingsMock = useAuditSettings as jest.Mock
 jest.mock('../../useAuditSettings')
 useAuditSettingsMock.mockImplementation(() => [auditSettings.all, jest.fn()])
-
-checkAndToastMock.mockReturnValue(false)
 
 const mockHistoryPush = jest.fn()
 jest.mock('react-router-dom', () => ({
@@ -54,7 +48,6 @@ routeMock.mockReturnValue({
 
 afterEach(() => {
   apiMock.mockClear()
-  checkAndToastMock.mockClear()
 })
 
 describe('Setup', () => {

--- a/client/src/components/HomeScreen.tsx
+++ b/client/src/components/HomeScreen.tsx
@@ -24,7 +24,7 @@ import {
   IOrganization,
   IAuditAdmin,
 } from './UserContext'
-import { parseApiError, addCSRFToken } from './utilities'
+import { parseApiError } from './utilities'
 import LinkButton from './Atoms/LinkButton'
 import FormSection from './Atoms/Form/FormSection'
 import FormButton from './Atoms/Form/FormButton'
@@ -34,7 +34,7 @@ import { groupBy, sortBy } from '../utils/array'
 import { IAuditSettings } from './useAuditSettings'
 import { useConfirm, Confirm } from './Atoms/Confirm'
 import { ErrorLabel } from './Atoms/Form/_helpers'
-import { fetchApi } from './SupportTools/support-api'
+import { addCSRFToken, fetchApi } from '../utils/api'
 
 const HomeScreen: React.FC = () => {
   const auth = useAuthDataContext()

--- a/client/src/components/JurisdictionAdmin/useBatchResults.ts
+++ b/client/src/components/JurisdictionAdmin/useBatchResults.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query'
-import { fetchApi } from '../SupportTools/support-api'
+import { fetchApi } from '../../utils/api'
 
 export interface IBatchResults {
   [choiceId: string]: number

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -1,24 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query'
 import { useHistory } from 'react-router-dom'
-import { tryJson, addCSRFToken } from '../utilities'
-
-export class ApiError extends Error {
-  public statusCode: number
-
-  public constructor(message: string, statusCode: number) {
-    super(message)
-    this.statusCode = statusCode
-  }
-}
-
-export const fetchApi = async (url: string, options?: RequestInit) => {
-  const response = await fetch(url, addCSRFToken(options))
-  if (response.ok) return response.json()
-  const text = await response.text()
-  const { errors } = tryJson(text)
-  const error = errors && errors.length && errors[0].message
-  throw new ApiError(error || text, response.status)
-}
+import { fetchApi } from '../../utils/api'
 
 export interface IOrganizationBase {
   id: string

--- a/client/src/components/useCSV.ts
+++ b/client/src/components/useCSV.ts
@@ -1,8 +1,9 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import { toast } from 'react-toastify'
 import { useEffect, useState } from 'react'
-import { api, useInterval, addCSRFToken } from './utilities'
+import { api, useInterval } from './utilities'
 import { IAuditSettings } from './useAuditSettings'
+import { addCSRFToken } from '../utils/api'
 
 export enum FileProcessingStatus {
   READY_TO_PROCESS = 'READY_TO_PROCESS',

--- a/client/src/components/utilities.test.ts
+++ b/client/src/components/utilities.test.ts
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react'
 import { toast } from 'react-toastify'
-import { api, testNumber, poll, checkAndToast, downloadFile } from './utilities'
+import { api, testNumber, poll, downloadFile } from './utilities'
 
 const response = () =>
   new Response(new Blob([JSON.stringify({ success: true })]))
@@ -193,24 +193,6 @@ describe('utilities.ts', () => {
       await waitFor(() => {
         expect(result.message).toBe('error')
       })
-    })
-  })
-
-  describe('checkAndToast', () => {
-    it('toasts errors', () => {
-      expect(checkAndToast({ errors: [{ message: 'error' }] })).toBeTruthy()
-      expect(toastSpy).toBeCalledTimes(1)
-    })
-
-    it('returns false without errors', () => {
-      expect(checkAndToast({})).toBeFalsy()
-      expect(toastSpy).toBeCalledTimes(0)
-    })
-
-    it('handles falsy input and nonobject inputs', () => {
-      expect(checkAndToast(null)).toBeFalsy()
-      expect(checkAndToast('')).toBeFalsy()
-      expect(toastSpy).toBeCalledTimes(0)
     })
   })
 

--- a/client/src/components/utilities.ts
+++ b/client/src/components/utilities.ts
@@ -161,37 +161,6 @@ export const asyncForEach = async <T>(
   }
 }
 
-const getErrorsFromResponse = (
-  response: unknown
-): { message: string }[] | undefined => {
-  if (typeof response !== 'object' || !response) {
-    return undefined
-  }
-
-  const { errors } = response as { [key: string]: unknown }
-
-  if (!Array.isArray(errors)) {
-    return undefined
-  }
-
-  return errors
-}
-
-export const checkAndToast = (
-  response: unknown
-): response is IErrorResponse => {
-  const errors = getErrorsFromResponse(response)
-  if (errors) {
-    toast.error(
-      `There was a server error regarding: ${errors
-        .map(({ message }) => message)
-        .join(', ')}`
-    )
-    return true
-  }
-  return false
-}
-
 // https://overreacted.io/making-setinterval-declarative-with-react-hooks/
 /* istanbul ignore next */
 export const useInterval = (

--- a/client/src/components/utilities.ts
+++ b/client/src/components/utilities.ts
@@ -1,35 +1,7 @@
 import { useRef, useEffect } from 'react'
 import { toast } from 'react-toastify'
-import { AxiosRequestConfig } from 'axios'
 import number from '../utils/number-schema'
-import { IErrorResponse } from '../types'
-
-const parseCookies = () =>
-  Object.fromEntries(
-    document.cookie.split(';').map(pair => pair.trim().split('='))
-  )
-
-export const addCSRFToken = (options?: RequestInit | AxiosRequestConfig) => {
-  const token = parseCookies()._csrf_token
-  if (
-    token &&
-    options &&
-    ['POST', 'PUT', 'PATCH', 'DELETE'].includes(options.method!)
-  )
-    return {
-      ...options,
-      headers: { ...options.headers, 'X-CSRFToken': token },
-    }
-  return options
-}
-
-export const tryJson = (responseText: string) => {
-  try {
-    return JSON.parse(responseText)
-  } catch (err) {
-    return {}
-  }
-}
+import { addCSRFToken, tryJson } from '../utils/api'
 
 export const parseApiError = async (response: Response) => {
   const responseText = await response.text()
@@ -39,6 +11,7 @@ export const parseApiError = async (response: Response) => {
   return { ...error, responseText, response }
 }
 
+// Deprecated - use utils/api.fetchApi with react-query
 export const api = async <T>(
   endpoint: string,
   options?: RequestInit
@@ -100,6 +73,7 @@ export const downloadFile = (fileBlob: Blob, fileName?: string) => {
   document.body.removeChild(a)
 }
 
+// Deprecated - use react-query's refetch interval
 export const poll = (
   condition: () => Promise<boolean>,
   callback: () => void,

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -1,0 +1,45 @@
+import { AxiosRequestConfig } from 'axios'
+
+const parseCookies = () =>
+  Object.fromEntries(
+    document.cookie.split(';').map(pair => pair.trim().split('='))
+  )
+
+export const addCSRFToken = (options?: RequestInit | AxiosRequestConfig) => {
+  const token = parseCookies()._csrf_token
+  if (
+    token &&
+    options &&
+    ['POST', 'PUT', 'PATCH', 'DELETE'].includes(options.method!)
+  )
+    return {
+      ...options,
+      headers: { ...options.headers, 'X-CSRFToken': token },
+    }
+  return options
+}
+
+export const tryJson = (responseText: string) => {
+  try {
+    return JSON.parse(responseText)
+  } catch (err) {
+    return {}
+  }
+}
+export class ApiError extends Error {
+  public statusCode: number
+
+  public constructor(message: string, statusCode: number) {
+    super(message)
+    this.statusCode = statusCode
+  }
+}
+
+export const fetchApi = async (url: string, options?: RequestInit) => {
+  const response = await fetch(url, addCSRFToken(options))
+  if (response.ok) return response.json()
+  const text = await response.text()
+  const { errors } = tryJson(text)
+  const error = errors && errors.length && errors[0].message
+  throw new ApiError(error || text, response.status)
+}


### PR DESCRIPTION
Create utils/api.ts for `fetchApi` and related functions.

This was originally created in support-api.ts to try out using react-query. Now that we're moving towards that as the standard approach, it should have its own file. I didn't bother moving over the deprecated `api `util function since it will eventually be phased out.

Also removes unused checkAndToast function.