### PR TITLE
Use react-query for useJurisdictions hook on progress screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .mypy_cache
 .pytest_cache
 .coverage*
+.vscode/*.log
 
 # vim temp files
 *~

--- a/client/src/components/AuditAdmin/AuditAdminView.test.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { waitFor, fireEvent, render, screen } from '@testing-library/react'
+import { waitFor, fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   BrowserRouter as Router,
   Router as RegularRouter,
   useParams,
+  Route,
 } from 'react-router-dom'
+import { QueryClientProvider } from 'react-query'
 import AuditAdminView from './AuditAdminView'
 import {
   jurisdictionFileMocks,
@@ -13,7 +15,11 @@ import {
   auditSettings,
   roundMocks,
 } from './useSetupMenuItems/_mocks'
-import { routerTestProps, withMockFetch } from '../testUtilities'
+import {
+  routerTestProps,
+  withMockFetch,
+  renderWithRouter,
+} from '../testUtilities'
 import AuthDataProvider, { useAuthDataContext } from '../UserContext'
 import getJurisdictionFileStatus from './useSetupMenuItems/getJurisdictionFileStatus'
 import getRoundStatus from './useSetupMenuItems/getRoundStatus'
@@ -23,20 +29,10 @@ import {
   jurisdictionErrorFile,
   standardizedContestsFile,
 } from './Setup/Participants/_mocks'
+import { queryClient } from '../../App'
 
 const getJurisdictionFileStatusMock = getJurisdictionFileStatus as jest.Mock
 const getRoundStatusMock = getRoundStatus as jest.Mock
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
-  useRouteMatch: jest.fn(),
-  useParams: jest.fn(),
-}))
-const paramsMock = useParams as jest.Mock
-paramsMock.mockReturnValue({
-  electionId: '1',
-  view: 'setup',
-})
 
 jest.mock('./useSetupMenuItems/getJurisdictionFileStatus')
 jest.mock('./useSetupMenuItems/getRoundStatus')
@@ -45,21 +41,28 @@ getRoundStatusMock.mockReturnValue(false)
 
 jest.mock('axios')
 
-afterEach(() => {
-  paramsMock.mockReturnValue({
-    electionId: '1',
-    view: 'setup',
-  })
-})
+// AuditAdminView will only be rendered once the user is logged in, so
+// we simulate that.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const AuditAdminViewWithAuth = (props: any) => {
+  const auth = useAuthDataContext()
+  return auth ? <AuditAdminView {...props} /> : null
+}
+
+const render = (view: string = 'setup') =>
+  renderWithRouter(
+    <QueryClientProvider client={queryClient}>
+      <AuthDataProvider>
+        <Route
+          path="/election/:electionId/:view?"
+          render={routeProps => <AuditAdminViewWithAuth {...routeProps} />}
+        />
+      </AuthDataProvider>
+    </QueryClientProvider>,
+    { route: `/election/1/${view}` }
+  )
 
 describe('AA setup flow', () => {
-  // AuditAdminView will only be rendered once the user is logged in, so
-  // we simulate that.
-  const AuditAdminViewWithAuth: React.FC = () => {
-    const auth = useAuthDataContext()
-    return auth ? <AuditAdminView /> : null
-  }
-
   const loadEach = [
     aaApiCalls.getRounds([]),
     aaApiCalls.getJurisdictions,
@@ -74,17 +77,11 @@ describe('AA setup flow', () => {
       ...loadEach,
       aaApiCalls.getSettings(auditSettings.all),
       aaApiCalls.getJurisdictionFile,
-      aaApiCalls.getSettings(auditSettings.all),
       ...loadEach,
+      aaApiCalls.getSettings(auditSettings.all),
     ]
     await withMockFetch(expectedCalls, async () => {
-      const { queryAllByText, getByText } = render(
-        <AuthDataProvider>
-          <Router>
-            <AuditAdminViewWithAuth />
-          </Router>
-        </AuthDataProvider>
-      )
+      const { queryAllByText, getByText } = render()
 
       await waitFor(() => {
         expect(queryAllByText('Participants').length).toBe(2)
@@ -107,13 +104,7 @@ describe('AA setup flow', () => {
       aaApiCalls.getJurisdictionFile,
     ]
     await withMockFetch(expectedCalls, async () => {
-      const { container, queryAllByText } = render(
-        <AuthDataProvider>
-          <Router>
-            <AuditAdminViewWithAuth />
-          </Router>
-        </AuthDataProvider>
-      )
+      const { container, queryAllByText } = render()
 
       await waitFor(() => {
         expect(queryAllByText('Participants').length).toBe(2)
@@ -131,13 +122,7 @@ describe('AA setup flow', () => {
       aaApiCalls.getJurisdictionFileWithResponse(jurisdictionFileMocks.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
-      const { queryAllByText } = render(
-        <AuthDataProvider>
-          <Router>
-            <AuditAdminViewWithAuth />
-          </Router>
-        </AuthDataProvider>
-      )
+      const { queryAllByText } = render()
 
       await waitFor(() => {
         expect(queryAllByText('Participants').length).toBe(2)
@@ -155,13 +140,7 @@ describe('AA setup flow', () => {
       aaApiCalls.getJurisdictionFile,
     ]
     await withMockFetch(expectedCalls, async () => {
-      const { queryByText, queryAllByText } = render(
-        <AuthDataProvider>
-          <Router>
-            <AuditAdminViewWithAuth />
-          </Router>
-        </AuthDataProvider>
-      )
+      const { queryByText, queryAllByText } = render()
 
       await waitFor(() => {
         expect(queryAllByText('Participants').length).toBe(2)
@@ -177,19 +156,14 @@ describe('AA setup flow', () => {
       ...loadEach,
       aaApiCalls.getSettings(auditSettings.blank),
       aaApiCalls.getJurisdictionFileWithResponse(jurisdictionFileMocks.empty),
+      aaApiCalls.getJurisdictions,
       aaApiCalls.putJurisdictionFile,
       aaApiCalls.getJurisdictionFileWithResponse(
         jurisdictionFileMocks.processed
       ),
     ]
     await withMockFetch(expectedCalls, async () => {
-      const { queryAllByText } = render(
-        <AuthDataProvider>
-          <Router>
-            <AuditAdminViewWithAuth />
-          </Router>
-        </AuthDataProvider>
-      )
+      const { queryAllByText } = render()
 
       await waitFor(() => {
         expect(queryAllByText('Participants').length).toBe(2)
@@ -214,17 +188,12 @@ describe('AA setup flow', () => {
       ...loadEach,
       aaApiCalls.getSettings(auditSettings.blank),
       aaApiCalls.getJurisdictionFileWithResponse(jurisdictionFileMocks.empty),
+      aaApiCalls.getJurisdictions,
       aaApiCalls.putJurisdictionErrorFile,
       aaApiCalls.getJurisdictionFileWithResponse(jurisdictionFileMocks.errored),
     ]
     await withMockFetch(expectedCalls, async () => {
-      const { queryAllByText } = render(
-        <AuthDataProvider>
-          <Router>
-            <AuditAdminViewWithAuth />
-          </Router>
-        </AuthDataProvider>
-      )
+      const { queryAllByText } = render()
 
       await waitFor(() => {
         expect(queryAllByText('Participants').length).toBe(2)
@@ -252,19 +221,14 @@ describe('AA setup flow', () => {
       aaApiCalls.getStandardizedContestsFileWithResponse(
         standardizedContestsFileMocks.empty
       ),
+      aaApiCalls.getJurisdictions,
       aaApiCalls.putStandardizedContestsFile,
       aaApiCalls.getStandardizedContestsFileWithResponse(
         standardizedContestsFileMocks.processed
       ),
     ]
     await withMockFetch(expectedCalls, async () => {
-      render(
-        <AuthDataProvider>
-          <Router>
-            <AuditAdminViewWithAuth />
-          </Router>
-        </AuthDataProvider>
-      )
+      render()
 
       // check file upload of jurisdiction
       await screen.findByText(/Uploaded/)
@@ -293,24 +257,12 @@ describe('AA setup flow', () => {
       ...loadAfterLaunch,
       ...loadAfterLaunch,
       ...loadAfterLaunch,
+      aaApiCalls.getMapData,
     ]
-    const routeProps = routerTestProps('/election/1', { electionId: '1' })
     await withMockFetch(expectedCalls, async () => {
-      paramsMock.mockReturnValue({
-        electionId: '1',
-        view: '',
-      })
-      render(
-        <AuthDataProvider>
-          <RegularRouter {...routeProps}>
-            <AuditAdminViewWithAuth />
-          </RegularRouter>
-        </AuthDataProvider>
-      )
+      const { history } = render('')
       await waitFor(() => {
-        expect(routeProps.history.location.pathname).toEqual(
-          '/election/1/progress'
-        )
+        expect(history.location.pathname).toEqual('/election/1/progress')
       })
     })
   })
@@ -336,13 +288,7 @@ describe('AA setup flow', () => {
       aaApiCalls.getRounds(roundMocks.empty),
     ]
     await withMockFetch(expectedCalls, async () => {
-      render(
-        <AuthDataProvider>
-          <Router>
-            <AuditAdminViewWithAuth />
-          </Router>
-        </AuthDataProvider>
-      )
+      render()
       await screen.findByRole('heading', {
         name: 'Arlo could not draw the sample',
       })

--- a/client/src/components/AuditAdmin/AuditAdminView.test.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.test.tsx
@@ -1,12 +1,7 @@
 import React from 'react'
 import { waitFor, fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {
-  BrowserRouter as Router,
-  Router as RegularRouter,
-  useParams,
-  Route,
-} from 'react-router-dom'
+import { Route } from 'react-router-dom'
 import { QueryClientProvider } from 'react-query'
 import AuditAdminView from './AuditAdminView'
 import {
@@ -15,11 +10,7 @@ import {
   auditSettings,
   roundMocks,
 } from './useSetupMenuItems/_mocks'
-import {
-  routerTestProps,
-  withMockFetch,
-  renderWithRouter,
-} from '../testUtilities'
+import { withMockFetch, renderWithRouter } from '../testUtilities'
 import AuthDataProvider, { useAuthDataContext } from '../UserContext'
 import getJurisdictionFileStatus from './useSetupMenuItems/getJurisdictionFileStatus'
 import getRoundStatus from './useSetupMenuItems/getRoundStatus'

--- a/client/src/components/AuditAdmin/AuditAdminView.test.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { waitFor, fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Route } from 'react-router-dom'
+import { Route, RouteProps } from 'react-router-dom'
 import { QueryClientProvider } from 'react-query'
 import AuditAdminView from './AuditAdminView'
 import {
@@ -34,8 +34,7 @@ jest.mock('axios')
 
 // AuditAdminView will only be rendered once the user is logged in, so
 // we simulate that.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const AuditAdminViewWithAuth = (props: any) => {
+const AuditAdminViewWithAuth = (props: RouteProps) => {
   const auth = useAuthDataContext()
   return auth ? <AuditAdminView {...props} /> : null
 }

--- a/client/src/components/AuditAdmin/AuditAdminView.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.tsx
@@ -7,7 +7,7 @@ import useRoundsAuditAdmin, {
   isDrawSampleComplete,
   drawSampleError,
 } from './useRoundsAuditAdmin'
-import useJurisdictions from '../useJurisdictions'
+import { useJurisdictions } from '../useJurisdictions'
 import useContests from '../useContests'
 import useAuditSettings from '../useAuditSettings'
 import { ElementType } from '../../types'
@@ -32,7 +32,7 @@ const AuditAdminView: React.FC = () => {
     electionId,
     refreshId
   )
-  const jurisdictions = useJurisdictions(electionId, refreshId)
+  const jurisdictionsQuery = useJurisdictions(electionId, refreshId)
   const [contests] = useContests(electionId, undefined, refreshId)
   const [auditSettings] = useAuditSettings(electionId, refreshId)
 
@@ -59,9 +59,10 @@ const AuditAdminView: React.FC = () => {
     rounds !== null && isAuditStarted(rounds),
   ])
 
-  if (!jurisdictions || !contests || !rounds || !auditSettings) return null // Still loading
+  if (!jurisdictionsQuery.isSuccess || !contests || !rounds || !auditSettings)
+    return null // Still loading
+  const jurisdictions = jurisdictionsQuery.data
 
-  // TODO support multiple contests in batch comparison audits
   const isBatch = auditSettings.auditType === 'BATCH_COMPARISON'
   const filteredMenuItems = menuItems.filter(({ id }) => {
     switch (id as ElementType<typeof setupStages>) {

--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -102,13 +102,10 @@ describe('Progress screen', () => {
   it('shows round status', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneComplete}
-          auditSettings={auditSettings.all}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.oneComplete,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -159,13 +156,10 @@ describe('Progress screen', () => {
   it('toggles between ballots and samples', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneComplete}
-          auditSettings={auditSettings.all}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.oneComplete,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -216,13 +210,10 @@ describe('Progress screen', () => {
   it('shows additional columns during setup for batch audits', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.twoManifestsOneTallies}
-          auditSettings={auditSettings.batchComparisonAll}
-          round={null}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.twoManifestsOneTallies,
+        auditSettings: auditSettings.batchComparisonAll,
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -269,13 +260,10 @@ describe('Progress screen', () => {
   it('shows additional columns during setup for ballot comparison audits', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.allManifestsSomeCVRs}
-          auditSettings={auditSettings.ballotComparisonAll}
-          round={null}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.allManifestsSomeCVRs,
+        auditSettings: auditSettings.ballotComparisonAll,
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -339,20 +327,17 @@ describe('Progress screen', () => {
         'href',
         '/api/election/1/jurisdiction/jurisdiction-id-2/cvrs/csv'
       )
-      within(cvrsCard).getByText('(ClearBallot)')
+      within(cvrsCard).getByText('ClearBallot')
     })
   })
 
   it('shows additional columns during setup for hybrid audits', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.hybridTwoManifestsOneCvr}
-          auditSettings={auditSettings.hybridAll}
-          round={null}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.hybridTwoManifestsOneCvr,
+        auditSettings: auditSettings.hybridAll,
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -404,13 +389,11 @@ describe('Progress screen', () => {
   it('shows a different toggle label for batch audits', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneComplete}
-          auditSettings={auditSettings.batchComparisonAll}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.oneComplete,
+        auditSettings: auditSettings.batchComparisonAll,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -439,13 +422,10 @@ describe('Progress screen', () => {
 
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneComplete}
-          auditSettings={auditSettings.all}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.oneComplete,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -476,13 +456,7 @@ describe('Progress screen', () => {
   it('filters by jurisdiction name', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneManifest}
-          auditSettings={auditSettings.all}
-          round={null}
-        />
-      )
+      const { container } = render()
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -508,13 +482,7 @@ describe('Progress screen', () => {
   it('sorts', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { rerender, container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneManifest}
-          auditSettings={auditSettings.all}
-          round={null}
-        />
-      )
+      const { container } = render()
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -540,7 +508,7 @@ describe('Progress screen', () => {
       within(rows[1]).getByRole('cell', { name: 'Jurisdiction 1' })
 
       // Toggle sorting by status
-      let statusHeader = screen.getByRole('columnheader', {
+      const statusHeader = screen.getByRole('columnheader', {
         name: 'Status',
       })
       userEvent.click(statusHeader)
@@ -556,21 +524,28 @@ describe('Progress screen', () => {
       within(rows[1]).getByRole('cell', {
         name: 'Manifest upload failed',
       })
+    })
+  })
 
-      // Toggle sorting by status once audit begins
-      rerender(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneComplete}
-          auditSettings={auditSettings.all}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+  it('sorts by status once the audit is in progress', async () => {
+    const expectedCalls = [aaApiCalls.getMapData]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.oneComplete,
+        round: roundMocks.singleIncomplete[0],
+      })
 
-      statusHeader = screen.getByRole('columnheader', {
+      expect(container.querySelectorAll('.d3-component').length).toBe(1)
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('.bp3-spinner').length).toBe(0)
+      })
+
+      const statusHeader = screen.getByRole('columnheader', {
         name: 'Status',
       })
       userEvent.click(statusHeader)
-      rows = screen.getAllByRole('row')
+      let rows = screen.getAllByRole('row')
       within(rows[1]).getByRole('cell', { name: 'Not started' })
 
       userEvent.click(statusHeader)
@@ -586,13 +561,7 @@ describe('Progress screen', () => {
   it('shows the detail modal before the audit starts', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneManifest}
-          auditSettings={auditSettings.all}
-          round={null}
-        />
-      )
+      const { container } = render()
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -667,13 +636,10 @@ describe('Progress screen', () => {
       jaApiCalls.getBallots(dummyBallots.ballots),
     ]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneComplete}
-          auditSettings={auditSettings.all}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.oneComplete,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -745,13 +711,10 @@ describe('Progress screen', () => {
       jaApiCalls.getBallotCount([]),
     ]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneComplete}
-          auditSettings={auditSettings.all}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.oneComplete,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -774,13 +737,10 @@ describe('Progress screen', () => {
       jaApiCalls.getBallotCount(dummyBallots.ballots),
     ]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneComplete}
-          auditSettings={auditSettings.all}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.noneStarted,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -801,13 +761,10 @@ describe('Progress screen', () => {
   it('shows status for ballot manifest and batch tallies for batch comparison audits', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.twoManifestsOneTallies}
-          auditSettings={auditSettings.batchComparisonAll}
-          round={null}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.twoManifestsOneTallies,
+        auditSettings: auditSettings.batchComparisonAll,
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -883,13 +840,11 @@ describe('Progress screen', () => {
       jaApiCalls.getBatches({ batches: [], resultsFinalizedAt: null }),
     ]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.oneComplete}
-          auditSettings={auditSettings.batchComparisonAll}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.oneComplete,
+        auditSettings: auditSettings.batchComparisonAll,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -913,13 +868,11 @@ describe('Progress screen', () => {
       jaApiCalls.unfinalizeBatchResults,
     ]
     await withMockFetch(expectedCalls, async () => {
-      render(
-        <Progress
-          jurisdictions={jurisdictionMocks.allComplete}
-          auditSettings={auditSettings.batchComparisonAll}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+      render({
+        jurisdictions: jurisdictionMocks.allComplete,
+        auditSettings: auditSettings.batchComparisonAll,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       userEvent.click(
         await screen.findByRole('button', { name: 'Jurisdiction 1' })
@@ -945,13 +898,10 @@ describe('Progress screen', () => {
   it('renders progress map with jurisdiction upload status', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
-        <Progress
-          jurisdictions={jurisdictionMocks.uploadingWithAlabamaJurisdictions}
-          auditSettings={auditSettings.batchComparisonAll}
-          round={null}
-        />
-      )
+      const { container } = render({
+        jurisdictions: jurisdictionMocks.uploadingWithAlabamaJurisdictions,
+        auditSettings: auditSettings.batchComparisonAll,
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -974,14 +924,11 @@ describe('Progress screen', () => {
   it('renders progress map with all completed jurisdictions', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
+      const { container } = render({
         // jurisdiction name also contains "County" name
-        <Progress
-          jurisdictions={jurisdictionMocks.allCompleteWithAlabamaJurisdictions}
-          auditSettings={auditSettings.all}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+        jurisdictions: jurisdictionMocks.allCompleteWithAlabamaJurisdictions,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -995,16 +942,12 @@ describe('Progress screen', () => {
   it('renders progress map with 2 matched & completed jurisdictions', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
+      const { container } = render({
         // jurisdiction name also contains "County" name
-        <Progress
-          jurisdictions={
-            jurisdictionMocks.allCompleteWithTwoMatchedAlabamaJurisdictions
-          }
-          auditSettings={auditSettings.all}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+        jurisdictions:
+          jurisdictionMocks.allCompleteWithTwoMatchedAlabamaJurisdictions,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
@@ -1021,16 +964,12 @@ describe('Progress screen', () => {
   it('does not render progress map with 1 matched & completed jurisdictions', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
-      const { container } = render(
+      const { container } = render({
         // jurisdiction name also contains "County" name
-        <Progress
-          jurisdictions={
-            jurisdictionMocks.allCompleteWithOneMatchedAlabamaJurisdictions
-          }
-          auditSettings={auditSettings.all}
-          round={roundMocks.singleIncomplete[0]}
-        />
-      )
+        jurisdictions:
+          jurisdictionMocks.allCompleteWithOneMatchedAlabamaJurisdictions,
+        round: roundMocks.singleIncomplete[0],
+      })
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -45,17 +45,17 @@ const totalFooter = <T extends object>(headerName: string) => (
   info: TableInstance<T>
 ) => sum(info.rows.map(row => row.values[headerName])).toLocaleString()
 
-interface IProps {
+export interface IProgressProps {
   jurisdictions: IJurisdiction[]
   auditSettings: IAuditSettings
   round: IRound | null
 }
 
-const Progress: React.FC<IProps> = ({
+const Progress: React.FC<IProgressProps> = ({
   jurisdictions,
   auditSettings,
   round,
-}: IProps) => {
+}: IProgressProps) => {
   const { electionId } = useParams<{ electionId: string }>()
   const [filter, setFilter] = useState<string>('')
   const [isShowingUnique, setIsShowingUnique] = useState<boolean>(true)

--- a/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
@@ -22,7 +22,7 @@ import FormButton from '../../../Atoms/Form/FormButton'
 import schema from './schema'
 import { ISidebarMenuItem } from '../../../Atoms/Sidebar'
 import useContests from '../../../useContests'
-import useJurisdictions from '../../../useJurisdictions'
+import { useJurisdictionsDeprecated } from '../../../useJurisdictions'
 import { IContest, ICandidate } from '../../../../types'
 import DropdownCheckboxList from './DropdownCheckboxList'
 import Card from '../../../Atoms/SpacedCard'
@@ -82,7 +82,7 @@ const ContestForm: React.FC<IProps> = ({
 
   const { electionId } = useParams<{ electionId: string }>()
   const [contests, updateContests] = useContests(electionId, auditType)
-  const jurisdictions = useJurisdictions(electionId)
+  const jurisdictions = useJurisdictionsDeprecated(electionId)
   const standardizedContests = useStandardizedContests(electionId)
 
   if ((isHybrid && !standardizedContests) || !jurisdictions || !contests)

--- a/client/src/components/AuditAdmin/Setup/Contests/ContestSelect.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/ContestSelect.tsx
@@ -10,7 +10,7 @@ import FormButtonBar from '../../../Atoms/Form/FormButtonBar'
 import FormButton from '../../../Atoms/Form/FormButton'
 import { ISidebarMenuItem } from '../../../Atoms/Sidebar'
 import useStandardizedContests from '../../../useStandardizedContests'
-import useJurisdictions from '../../../useJurisdictions'
+import { useJurisdictionsDeprecated } from '../../../useJurisdictions'
 import { Table, FilterInput } from '../../../Atoms/Table'
 import { IAuditSettings } from '../../../useAuditSettings'
 import useContestsBallotComparison, {
@@ -45,7 +45,7 @@ const ContestSelect: React.FC<IProps> = ({
   const standardizedContests = useStandardizedContests(electionId)
   const [contests, updateContests] = useContestsBallotComparison(electionId)
   const [filter, setFilter] = useState('')
-  const jurisdictions = useJurisdictions(electionId)
+  const jurisdictions = useJurisdictionsDeprecated(electionId)
 
   if (!standardizedContests || !jurisdictions || !contests) return null // Still loading
 

--- a/client/src/components/AuditAdmin/Setup/Review/Review.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.tsx
@@ -39,7 +39,10 @@ import { ErrorLabel } from '../../../Atoms/Form/_helpers'
 import { IContest } from '../../../../types'
 import { sum } from '../../../../utils/number'
 import useAuditSettings from '../../../useAuditSettings'
-import useJurisdictions, { IJurisdiction } from '../../../useJurisdictions'
+import {
+  useJurisdictionsDeprecated,
+  IJurisdiction,
+} from '../../../useJurisdictions'
 import {
   useJurisdictionsFile,
   useStandardizedContestsFile,
@@ -74,7 +77,7 @@ const Review: React.FC<IProps> = ({
 }: IProps) => {
   const { electionId } = useParams<{ electionId: string }>()
   const [auditSettings] = useAuditSettings(electionId)
-  const jurisdictions = useJurisdictions(electionId)
+  const jurisdictions = useJurisdictionsDeprecated(electionId)
   const [jurisdictionsFile] = useJurisdictionsFile(electionId)
   const [standardizedContestsFile] = useStandardizedContestsFile(
     electionId,

--- a/client/src/components/AuditAdmin/Setup/Setup.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Setup.test.tsx
@@ -8,7 +8,7 @@ import relativeStages from './_mocks'
 import { contestMocks } from './Contests/_mocks'
 import useContests from '../../useContests'
 import useAuditSettings from '../../useAuditSettings'
-import useJurisdictions from '../../useJurisdictions'
+import { useJurisdictionsDeprecated } from '../../useJurisdictions'
 
 const apiMock: jest.SpyInstance<
   ReturnType<typeof utilities.api>,
@@ -16,7 +16,7 @@ const apiMock: jest.SpyInstance<
 > = jest.spyOn(utilities, 'api').mockImplementation()
 apiMock.mockImplementation(async () => {})
 
-const useJurisdictionsMock = useJurisdictions as jest.Mock
+const useJurisdictionsMock = useJurisdictionsDeprecated as jest.Mock
 jest.mock('../../useJurisdictions')
 useJurisdictionsMock.mockImplementation(() => jurisdictionMocks.noManifests)
 

--- a/client/src/components/AuditAdmin/timers.test.tsx
+++ b/client/src/components/AuditAdmin/timers.test.tsx
@@ -15,6 +15,8 @@ import { renderWithRouter, withMockFetch } from '../testUtilities'
 import { aaApiCalls } from '../_mocks'
 import { auditSettings, roundMocks } from './useSetupMenuItems/_mocks'
 import { sampleSizeMock } from './Setup/Review/_mocks'
+import { queryClient } from '../../App'
+import { QueryClientProvider } from 'react-query'
 
 const getJurisdictionFileStatusMock = getJurisdictionFileStatus as jest.Mock
 const getRoundStatusMock = getRoundStatus as jest.Mock
@@ -33,9 +35,11 @@ const AuditAdminViewWithAuth: React.FC = () => {
 
 const renderWithRoute = (route: string, component: ReactElement) =>
   renderWithRouter(
-    <Route path="/election/:electionId/:view">
-      <AuthDataProvider>{component}</AuthDataProvider>
-    </Route>,
+    <QueryClientProvider client={queryClient}>
+      <Route path="/election/:electionId/:view">
+        <AuthDataProvider>{component}</AuthDataProvider>
+      </Route>
+    </QueryClientProvider>,
     {
       route,
     }
@@ -61,6 +65,7 @@ describe('timers', () => {
       ...loadEach,
       aaApiCalls.getMapData,
       ...loadEach,
+      aaApiCalls.getMapData,
     ]
     await withMockFetch(expectedCalls, async () => {
       renderWithRoute('/election/1/progress', <AuditAdminViewWithAuth />)
@@ -113,11 +118,11 @@ describe('timers', () => {
       ...loadEach,
       aaApiCalls.getSettings(auditSettings.all),
       aaApiCalls.getJurisdictionFile,
+      ...loadEach,
       aaApiCalls.getSettings(auditSettings.all),
       aaApiCalls.getJurisdictions,
       aaApiCalls.getJurisdictionFile,
       aaApiCalls.getContests,
-      ...loadEach,
       aaApiCalls.getSampleSizes,
       { ...aaApiCalls.getSampleSizes, response: sampleSizeMock.ballotPolling },
     ]

--- a/client/src/components/AuditAdmin/timers.test.tsx
+++ b/client/src/components/AuditAdmin/timers.test.tsx
@@ -7,6 +7,7 @@ import { screen, act } from '@testing-library/react'
 import { Route } from 'react-router-dom'
 import FakeTimers from '@sinonjs/fake-timers'
 import userEvent from '@testing-library/user-event'
+import { QueryClientProvider } from 'react-query'
 import getJurisdictionFileStatus from './useSetupMenuItems/getJurisdictionFileStatus'
 import getRoundStatus from './useSetupMenuItems/getRoundStatus'
 import AuthDataProvider, { useAuthDataContext } from '../UserContext'
@@ -16,7 +17,6 @@ import { aaApiCalls } from '../_mocks'
 import { auditSettings, roundMocks } from './useSetupMenuItems/_mocks'
 import { sampleSizeMock } from './Setup/Review/_mocks'
 import { queryClient } from '../../App'
-import { QueryClientProvider } from 'react-query'
 
 const getJurisdictionFileStatusMock = getJurisdictionFileStatus as jest.Mock
 const getRoundStatusMock = getRoundStatus as jest.Mock

--- a/client/src/components/useJurisdictions.ts
+++ b/client/src/components/useJurisdictions.ts
@@ -125,9 +125,13 @@ export const useJurisdictionsDeprecated = (
 }
 
 export const useJurisdictions = (electionId: string, refreshId?: string) => {
-  const url = `/api/election/${electionId}/jurisdiction`
-  return useQuery([url, refreshId], async () => {
-    const response: { jurisdictions: IJurisdiction[] } = await fetchApi(url)
-    return response && response.jurisdictions
-  })
+  return useQuery(
+    ['elections', electionId, 'jurisdictions', { refreshId }],
+    async () => {
+      const response: { jurisdictions: IJurisdiction[] } = await fetchApi(
+        `/api/election/${electionId}/jurisdiction`
+      )
+      return response && response.jurisdictions
+    }
+  )
 }

--- a/client/src/components/useJurisdictions.ts
+++ b/client/src/components/useJurisdictions.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
+import { useQuery } from 'react-query'
 import { api } from './utilities'
 import { IFileInfo, FileProcessingStatus } from './useCSV'
+import { fetchApi } from '../utils/api'
 
 export interface IBallotManifestInfo extends IFileInfo {
   numBallots: number | null
@@ -103,7 +105,7 @@ export const getJurisdictionStatus = (jurisdiction: IJurisdiction) => {
   return JurisdictionProgressStatus.AUDIT_NOT_STARTED
 }
 
-const useJurisdictions = (
+export const useJurisdictionsDeprecated = (
   electionId: string,
   refreshId?: string
 ): IJurisdiction[] | null => {
@@ -122,4 +124,10 @@ const useJurisdictions = (
   return jurisdictions
 }
 
-export default useJurisdictions
+export const useJurisdictions = (electionId: string, refreshId?: string) => {
+  const url = `/api/election/${electionId}/jurisdiction`
+  return useQuery([url, refreshId], async () => {
+    const response: { jurisdictions: IJurisdiction[] } = await fetchApi(url)
+    return response && response.jurisdictions
+  })
+}


### PR DESCRIPTION
This will enable file uploads/downloads on the progress screen (coming up in the next PR) to invalidate and reload the jurisdictions status using react-query's query invalidation functionality. It's also a step towards the bigger project of moving to react-query. In this case, to keep scope small, I only migrated the necessary component and left the old hook around but marked it deprecated.