### PR TITLE
Allow audit admins to upload jurisdiction files

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,6 +33,10 @@ export const queryClient = new QueryClient({
       onError: (error: ApiError) => {
         toast.error(error.message)
       },
+      // When a file input dialog closes, it triggers a window focus event,
+      // which causes a refetch by default, so we turn that off to avoid confusion.
+      // https://github.com/tannerlinsley/react-query/issues/2960
+      refetchOnWindowFocus: false,
     },
     mutations: {
       onError: (error: ApiError) => {

--- a/client/src/components/Atoms/FileUpload.test.tsx
+++ b/client/src/components/Atoms/FileUpload.test.tsx
@@ -12,7 +12,7 @@ import {
 import FileUpload, { IFileUploadProps } from './FileUpload'
 import {
   withMockFetch,
-  mockOfType,
+  mocksOfType,
   serverError,
   findAndCloseToast,
 } from '../testUtilities'
@@ -55,7 +55,7 @@ const render = (element: React.ReactElement) =>
     <QueryClientProvider client={queryClient}>{element}</QueryClientProvider>
   )
 
-const fileInfoMocks = mockOfType<IFileInfo>()({
+const fileInfoMocks = mocksOfType<IFileInfo>()({
   empty: { file: null, processing: null },
   processing: {
     file: {

--- a/client/src/components/Atoms/FileUpload.test.tsx
+++ b/client/src/components/Atoms/FileUpload.test.tsx
@@ -1,0 +1,314 @@
+import React from 'react'
+import { render as testingLibraryRender, screen } from '@testing-library/react'
+import { QueryClientProvider } from 'react-query'
+import userEvent from '@testing-library/user-event'
+import { ToastContainer } from 'react-toastify'
+import {
+  useUploadedFile,
+  useUploadFiles,
+  useDeleteFile,
+  IFileUpload,
+} from '../useFileUpload'
+import FileUpload, { IFileUploadProps } from './FileUpload'
+import {
+  withMockFetch,
+  mockOfType,
+  serverError,
+  findAndCloseToast,
+} from '../testUtilities'
+import { queryClient } from '../../App'
+import { IFileInfo, FileProcessingStatus } from '../useCSV'
+
+jest.mock('axios')
+
+// Set up a test component that hooks up useFileUpload to FileUpload in the way
+// they are used together. We test them together because they are designed to be
+// used in concert, so testing their integration is more useful than testing
+// them in isolation.
+const TestFileUpload = ({
+  onFileChange,
+  ...props
+}: Partial<IFileUploadProps> & { onFileChange?: () => void }) => {
+  const uploadedFile = useUploadedFile(['test-key'], '/test', {
+    onFileChange: onFileChange || jest.fn(),
+  })
+  const uploadFiles = useUploadFiles(['test-key'], '/test')
+  const deleteFile = useDeleteFile(['test-key'], '/test')
+  const fileUpload: IFileUpload = {
+    uploadedFile,
+    uploadFiles: files => {
+      const formData = new FormData()
+      for (const file of files) {
+        formData.append('files', file, file.name)
+      }
+      return uploadFiles.mutateAsync(formData)
+    },
+    uploadProgress: uploadFiles.progress,
+    deleteFile: () => deleteFile.mutateAsync(),
+    downloadFileUrl: '/test/download',
+  }
+  return <FileUpload {...fileUpload} acceptFileType="csv" {...props} />
+}
+
+const render = (element: React.ReactElement) =>
+  testingLibraryRender(
+    <QueryClientProvider client={queryClient}>{element}</QueryClientProvider>
+  )
+
+const fileInfoMocks = mockOfType<IFileInfo>()({
+  empty: { file: null, processing: null },
+  processing: {
+    file: {
+      name: 'test-file.csv',
+      uploadedAt: '2020-06-08T21:39:05.765+00:00',
+    },
+    processing: {
+      status: FileProcessingStatus.PROCESSING,
+      startedAt: '2020-06-08T21:39:05.765+00:00',
+      completedAt: null,
+      error: null,
+      workProgress: 1,
+      workTotal: 2,
+    },
+  },
+  processed: {
+    file: {
+      name: 'test-file.csv',
+      uploadedAt: '2020-06-08T21:39:05.765+00:00',
+    },
+    processing: {
+      status: FileProcessingStatus.PROCESSED,
+      startedAt: '2020-06-08T21:39:05.765+00:00',
+      completedAt: '2020-06-08T21:40:05.765+00:00',
+      error: null,
+    },
+  },
+  errored: {
+    file: {
+      name: 'test-file.csv',
+      uploadedAt: '2020-06-08T21:39:05.765+00:00',
+    },
+    processing: {
+      status: FileProcessingStatus.ERRORED,
+      startedAt: '2020-06-08T21:39:05.765+00:00',
+      completedAt: '2020-06-08T21:40:05.765+00:00',
+      error: 'something went wrong',
+    },
+  },
+})
+
+const testFile = new File(['test content'], 'test-file.csv', {
+  type: 'text/csv',
+})
+const formData = new FormData()
+formData.append('files', testFile, testFile.name)
+
+describe('FileUpload + useFileUpload', () => {
+  it('when no file is uploaded, shows a form to upload a file', async () => {
+    const expectedCalls = [
+      { url: '/test', response: fileInfoMocks.empty },
+      {
+        url: '/test',
+        options: { method: 'PUT', body: formData },
+        response: { status: 'ok' },
+      },
+      { url: '/test', response: fileInfoMocks.processing },
+      { url: '/test', response: fileInfoMocks.processed },
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const onFileChange = jest.fn()
+      render(<TestFileUpload onFileChange={onFileChange} />)
+
+      await screen.findByText('No file uploaded')
+      expect(onFileChange).not.toHaveBeenCalled()
+      const uploadButton = screen.getByRole('button', { name: 'Upload File' })
+      expect(uploadButton).toBeDisabled()
+
+      const fileInput = screen.getByLabelText('Select a file...')
+      userEvent.upload(fileInput, testFile)
+      await screen.findByText('test-file.csv')
+
+      userEvent.click(uploadButton)
+
+      await screen.findByText('Uploading')
+      expect(uploadButton).toBeDisabled()
+
+      await screen.findByText('Processing')
+      expect(uploadButton).toBeDisabled()
+
+      await screen.findByText('Uploaded')
+      const fileLink = screen.getByRole('link', { name: 'test-file.csv' })
+      expect(fileLink).toHaveAttribute('href', '/test/download')
+      screen.getByRole('button', { name: 'Delete File' })
+      expect(onFileChange).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('when a file is uploaded, shows a delete file button', async () => {
+    const expectedCalls = [
+      { url: '/test', response: fileInfoMocks.processed },
+      {
+        url: '/test',
+        options: { method: 'DELETE' },
+        response: { status: 'ok' },
+      },
+      { url: '/test', response: fileInfoMocks.empty },
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const onFileChange = jest.fn()
+      render(<TestFileUpload onFileChange={onFileChange} />)
+
+      await screen.findByText('Uploaded')
+      expect(onFileChange).not.toHaveBeenCalled()
+      const deleteButton = screen.getByRole('button', { name: 'Delete File' })
+      userEvent.click(deleteButton)
+      expect(deleteButton).toBeDisabled()
+      await screen.findByText('No file uploaded')
+      expect(onFileChange).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('when a file uploaded fails, shows an error message', async () => {
+    const expectedCalls = [
+      { url: '/test', response: fileInfoMocks.empty },
+      {
+        url: '/test',
+        options: { method: 'PUT', body: formData },
+        response: { status: 'ok' },
+      },
+      { url: '/test', response: fileInfoMocks.errored },
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render(<TestFileUpload />)
+
+      await screen.findByText('No file uploaded')
+      const uploadButton = screen.getByRole('button', { name: 'Upload File' })
+      expect(uploadButton).toBeDisabled()
+
+      const fileInput = screen.getByLabelText('Select a file...')
+      userEvent.upload(fileInput, testFile)
+      await screen.findByText('test-file.csv')
+
+      userEvent.click(uploadButton)
+
+      await screen.findByText('Upload failed')
+      screen.getByText('something went wrong')
+      const fileLink = screen.getByRole('link', { name: 'test-file.csv' })
+      expect(fileLink).toHaveAttribute('href', '/test/download')
+      screen.getByRole('button', { name: 'Delete File' })
+    })
+  })
+
+  it('supports uploading multiple files', async () => {
+    const testFile2 = new File(['test content'], 'test-file-2.csv', {
+      type: 'text/csv',
+    })
+    const formData2 = new FormData()
+    formData2.append('files', testFile, testFile.name)
+    formData2.append('files', testFile2, testFile2.name)
+    const expectedCalls = [
+      { url: '/test', response: fileInfoMocks.empty },
+      {
+        url: '/test',
+        options: { method: 'PUT', body: formData2 },
+        response: { status: 'ok' },
+      },
+      { url: '/test', response: fileInfoMocks.processed },
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render(<TestFileUpload allowMultipleFiles />)
+
+      await screen.findByText('No file uploaded')
+      const uploadButton = screen.getByRole('button', { name: 'Upload Files' })
+      expect(uploadButton).toBeDisabled()
+
+      const fileInput = screen.getByLabelText('Select files...')
+      userEvent.upload(fileInput, [testFile, testFile2])
+      await screen.findByText('2 files selected')
+
+      userEvent.click(uploadButton)
+      await screen.findByText('Uploaded')
+    })
+  })
+
+  it('can be disabled when no file uploaded', async () => {
+    const expectedCalls = [{ url: '/test', response: fileInfoMocks.empty }]
+    await withMockFetch(expectedCalls, async () => {
+      render(<TestFileUpload disabled />)
+
+      await screen.findByText('No file uploaded')
+      expect(screen.getByLabelText('Select a file...')).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Upload File' })).toBeDisabled()
+    })
+  })
+
+  it('can be disabled when file is uploaded', async () => {
+    const expectedCalls = [{ url: '/test', response: fileInfoMocks.processed }]
+    await withMockFetch(expectedCalls, async () => {
+      render(<TestFileUpload disabled />)
+
+      await screen.findByText('Uploaded')
+      expect(screen.getByRole('button', { name: 'Delete File' })).toBeDisabled()
+    })
+  })
+
+  it('handles an API error on get', async () => {
+    const expectedCalls = [serverError('getFile', { url: '/test' })]
+    await withMockFetch(expectedCalls, async () => {
+      render(
+        <>
+          <TestFileUpload />
+          <ToastContainer />
+        </>
+      )
+      await findAndCloseToast('getFile')
+    })
+  })
+
+  it('handles an API error on put', async () => {
+    const expectedCalls = [
+      { url: '/test', response: fileInfoMocks.empty },
+      serverError('putFile', {
+        url: '/test',
+        options: {
+          method: 'PUT',
+          body: formData,
+        },
+      }),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render(
+        <>
+          <TestFileUpload />
+          <ToastContainer />
+        </>
+      )
+      await screen.findByText('No file uploaded')
+      userEvent.upload(screen.getByLabelText('Select a file...'), testFile)
+      await screen.findByText('test-file.csv')
+      userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
+      await findAndCloseToast('putFile')
+    })
+  })
+
+  it('handles an API error on delete', async () => {
+    const expectedCalls = [
+      { url: '/test', response: fileInfoMocks.processed },
+      serverError('deleteFile', {
+        url: '/test',
+        options: { method: 'DELETE' },
+      }),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render(
+        <>
+          <TestFileUpload />
+          <ToastContainer />
+        </>
+      )
+      await screen.findByText('Uploaded')
+      userEvent.click(screen.getByRole('button', { name: 'Delete File' }))
+      await findAndCloseToast('deleteFile')
+    })
+  })
+})

--- a/client/src/components/Atoms/FileUpload.tsx
+++ b/client/src/components/Atoms/FileUpload.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import { FileInput, Button, Colors, ProgressBar } from '@blueprintjs/core'
+import { useForm } from 'react-hook-form'
+import styled from 'styled-components'
+import StatusTag from './StatusTag'
+import { IFileUpload } from '../useFileUpload'
+import AsyncButton from './AsyncButton'
+
+const ErrorP = styled.p`
+  margin-top: 10px;
+  color: ${Colors.RED3};
+`
+
+export interface IFileUploadProps extends IFileUpload {
+  acceptFileType: 'csv' | 'zip'
+  allowMultipleFiles?: boolean
+  disabled?: boolean
+}
+
+const FileUpload = ({
+  uploadedFile,
+  uploadFiles,
+  uploadProgress,
+  deleteFile,
+  downloadFileUrl,
+  acceptFileType,
+  allowMultipleFiles = false,
+  disabled = false,
+}: IFileUploadProps) => {
+  const { register, handleSubmit, formState, watch } = useForm<{
+    files: FileList
+  }>({ mode: 'onTouched' })
+
+  if (!uploadedFile.isSuccess) return null
+
+  const { file, processing } = uploadedFile.data
+
+  if (!uploadProgress && !file) {
+    const onUpload = async ({ files }: { files: FileList }) => {
+      try {
+        await uploadFiles(Array.from(files))
+      } catch (error) {
+        // Do nothing - toasting handled by queryClient
+      }
+    }
+
+    const files = watch('files')
+    const numFiles = files ? files.length : 0
+
+    return (
+      <form onSubmit={handleSubmit(onUpload)}>
+        <p>
+          <StatusTag>No file uploaded</StatusTag>
+        </p>
+        <p>
+          <FileInput
+            inputProps={{
+              accept: `.${acceptFileType}`,
+              name: 'files',
+              multiple: allowMultipleFiles,
+              ref: register(),
+            }}
+            hasSelection={numFiles > 0}
+            text={(() => {
+              if (numFiles === 0)
+                return allowMultipleFiles
+                  ? 'Select files...'
+                  : 'Select a file...'
+              if (numFiles === 1) return files[0].name
+              return `${numFiles} files selected`
+            })()}
+            disabled={disabled || formState.isSubmitting}
+          />
+        </p>
+        <p>
+          <Button
+            type="submit"
+            intent="primary"
+            loading={formState.isSubmitting}
+            disabled={disabled || numFiles === 0}
+          >
+            {allowMultipleFiles ? 'Upload Files' : 'Upload File'}
+          </Button>
+        </p>
+      </form>
+    )
+  }
+
+  if (uploadProgress) {
+    return (
+      <form>
+        <p>
+          <StatusTag intent="warning">Uploading</StatusTag>
+        </p>
+        <ProgressBar
+          key="uploading"
+          stripes={false}
+          intent="warning"
+          value={uploadProgress}
+        />
+      </form>
+    )
+  }
+
+  /* istanbul ignore next */
+  if (!(file && processing)) {
+    throw new Error('Invalid state')
+  }
+
+  if (!processing.completedAt) {
+    return (
+      <form>
+        <p>
+          <StatusTag intent="primary">Processing</StatusTag>
+        </p>
+        {processing.workTotal && (
+          <ProgressBar
+            key="processing"
+            stripes={false}
+            intent="primary"
+            value={processing.workProgress! / processing.workTotal}
+          />
+        )}
+      </form>
+    )
+  }
+
+  const { error } = processing
+  return (
+    <form>
+      <p>
+        {error ? (
+          <StatusTag intent="danger">Upload failed</StatusTag>
+        ) : (
+          <StatusTag intent="success">Uploaded</StatusTag>
+        )}
+        <a
+          href={downloadFileUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ marginLeft: '15px' }}
+        >
+          {file.name}
+        </a>
+      </p>
+      {error && <ErrorP>{error}</ErrorP>}
+      <p>
+        <AsyncButton disabled={disabled} onClick={deleteFile}>
+          Delete File
+        </AsyncButton>
+      </p>
+    </form>
+  )
+}
+
+export default FileUpload

--- a/client/src/components/AuditAdmin/AuditAdminView.test.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.test.tsx
@@ -146,7 +146,6 @@ describe('AA setup flow', () => {
       ...loadEach,
       aaApiCalls.getSettings(auditSettings.blank),
       aaApiCalls.getJurisdictionFileWithResponse(jurisdictionFileMocks.empty),
-      aaApiCalls.getJurisdictions,
       aaApiCalls.putJurisdictionFile,
       aaApiCalls.getJurisdictionFileWithResponse(
         jurisdictionFileMocks.processed
@@ -178,7 +177,6 @@ describe('AA setup flow', () => {
       ...loadEach,
       aaApiCalls.getSettings(auditSettings.blank),
       aaApiCalls.getJurisdictionFileWithResponse(jurisdictionFileMocks.empty),
-      aaApiCalls.getJurisdictions,
       aaApiCalls.putJurisdictionErrorFile,
       aaApiCalls.getJurisdictionFileWithResponse(jurisdictionFileMocks.errored),
     ]
@@ -211,7 +209,6 @@ describe('AA setup flow', () => {
       aaApiCalls.getStandardizedContestsFileWithResponse(
         standardizedContestsFileMocks.empty
       ),
-      aaApiCalls.getJurisdictions,
       aaApiCalls.putStandardizedContestsFile,
       aaApiCalls.getStandardizedContestsFileWithResponse(
         standardizedContestsFileMocks.processed

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
@@ -414,7 +414,7 @@ describe('JurisdictionDetail', () => {
 
       userEvent.click(
         screen.getByRole('button', {
-          name: /Download Aggregated Ballot Retrieval List/,
+          name: /Download Ballot Retrieval List/,
         })
       )
       expect(window.open).toHaveBeenCalledWith(
@@ -479,7 +479,7 @@ describe('JurisdictionDetail', () => {
 
       await screen.findByRole('heading', { name: 'Round 1 Data Entry' })
       screen.getByRole('button', {
-        name: /Download Aggregated Ballot Retrieval List/,
+        name: /Download Ballot Retrieval List/,
       })
       screen.getByRole('button', { name: /Download Ballot Labels/ })
       screen.getByRole('button', { name: /Download Placeholder Sheets/ })
@@ -517,7 +517,7 @@ describe('JurisdictionDetail', () => {
 
       userEvent.click(
         screen.getByRole('button', {
-          name: /Download Aggregated Batch Retrieval List/,
+          name: /Download Batch Retrieval List/,
         })
       )
       expect(window.open).toHaveBeenCalledWith(

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
@@ -1,0 +1,640 @@
+import React from 'react'
+import {
+  render as testingLibraryRender,
+  screen,
+  within,
+  waitFor,
+} from '@testing-library/react'
+import { QueryClientProvider } from 'react-query'
+import userEvent from '@testing-library/user-event'
+import JurisdictionDetail, {
+  IJurisdictionDetailProps,
+} from './JurisdictionDetail'
+import {
+  jurisdictionMocks,
+  roundMocks,
+  auditSettings,
+  manifestMocks,
+  cvrsMocks,
+  auditBoardMocks,
+  talliesMocks,
+  manifestFile,
+  cvrsFile,
+  talliesFile,
+  contestMocks,
+} from '../useSetupMenuItems/_mocks'
+import { jaApiCalls } from '../../_mocks'
+import { withMockFetch } from '../../testUtilities'
+import { queryClient } from '../../../App'
+import { dummyBallots } from '../../AuditBoard/_mocks'
+import { batchesMocks } from '../../JurisdictionAdmin/_mocks'
+
+jest.mock('axios')
+
+// Borrowed from generateSheets.test.tsx
+const mockSavePDF = jest.fn()
+jest.mock('jspdf', () => {
+  const { jsPDF } = jest.requireActual('jspdf')
+  const mockjspdf = new jsPDF({ format: 'letter' })
+  // eslint-disable-next-line func-names
+  return function() {
+    return {
+      ...mockjspdf,
+      addImage: jest.fn(),
+      save: mockSavePDF,
+    }
+  }
+})
+window.URL.createObjectURL = jest.fn()
+window.open = jest.fn()
+
+const render = (props: Partial<IJurisdictionDetailProps>) =>
+  testingLibraryRender(
+    <QueryClientProvider client={queryClient}>
+      <JurisdictionDetail
+        handleClose={jest.fn()}
+        jurisdiction={jurisdictionMocks.noManifests[0]}
+        electionId="1"
+        round={null}
+        auditSettings={auditSettings.all}
+        {...props}
+      />
+    </QueryClientProvider>
+  )
+
+describe('JurisdictionDetail', () => {
+  it('before launch, shows manifest for ballot polling audit', async () => {
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.empty),
+      jaApiCalls.putManifest,
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.deleteManifest,
+      jaApiCalls.getBallotManifestFile(manifestMocks.empty),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({ jurisdiction: jurisdictionMocks.oneManifest[0] })
+
+      screen.getByRole('heading', { name: 'Jurisdiction Files' })
+
+      const manifestCard = screen
+        .getByRole('heading', { name: 'Ballot Manifest' })
+        .closest('div')!
+      await within(manifestCard).findByText('No file uploaded')
+
+      userEvent.upload(
+        within(manifestCard).getByLabelText('Select a file...'),
+        manifestFile
+      )
+      await within(manifestCard).findByText('manifest.csv')
+      userEvent.click(
+        within(manifestCard).getByRole('button', { name: 'Upload File' })
+      )
+
+      await within(manifestCard).findByText('Uploaded')
+      const manifestLink = within(manifestCard).getByRole('link', {
+        name: 'manifest.csv',
+      })
+      expect(manifestLink).toHaveAttribute(
+        'href',
+        '/api/election/1/jurisdiction/jurisdiction-id-1/ballot-manifest/csv'
+      )
+
+      userEvent.click(
+        within(manifestCard).getByRole('button', { name: 'Delete File' })
+      )
+      await within(manifestCard).findByText('No file uploaded')
+    })
+  })
+
+  it('before launch, shows manifest and cvrs for ballot comparison audit', async () => {
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.empty),
+      jaApiCalls.getCVRSfile(cvrsMocks.empty),
+      jaApiCalls.putManifest,
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getCVRSfile(cvrsMocks.empty),
+      jaApiCalls.putCVRs,
+      jaApiCalls.getCVRSfile(cvrsMocks.processed),
+      jaApiCalls.deleteManifest,
+      jaApiCalls.getBallotManifestFile(manifestMocks.empty),
+      jaApiCalls.getCVRSfile(cvrsMocks.processed),
+      jaApiCalls.putManifest,
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getCVRSfile(cvrsMocks.errored),
+      jaApiCalls.deleteCVRs,
+      jaApiCalls.getCVRSfile(cvrsMocks.empty),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: {
+          ...jurisdictionMocks.noManifests[0],
+          cvrs: cvrsMocks.empty,
+        },
+        auditSettings: auditSettings.ballotComparisonAll,
+      })
+
+      screen.getByRole('heading', { name: 'Jurisdiction Files' })
+
+      const manifestCard = screen
+        .getByRole('heading', { name: 'Ballot Manifest' })
+        .closest('div')!
+      await within(manifestCard).findByText('No file uploaded')
+
+      const cvrsCard = screen
+        .getByRole('heading', { name: 'Cast Vote Records (CVR)' })
+        .closest('div')!
+      await within(cvrsCard).findByText('No file uploaded')
+
+      // CVRs should be disabled until manifest uploaded
+      expect(within(cvrsCard).getByLabelText('Select a file...')).toBeDisabled()
+      expect(
+        within(cvrsCard).getByRole('button', { name: 'Upload File' })
+      ).toBeDisabled()
+      expect(within(cvrsCard).getByLabelText('CVR File Type:')).toBeDisabled()
+
+      // Upload manifest
+      userEvent.upload(
+        within(manifestCard).getByLabelText('Select a file...'),
+        manifestFile
+      )
+      await within(manifestCard).findByText('manifest.csv')
+      userEvent.click(
+        within(manifestCard).getByRole('button', { name: 'Upload File' })
+      )
+      await within(manifestCard).findByText('Uploaded')
+
+      // Now can upload CVRs
+      expect(within(cvrsCard).getByLabelText('Select a file...')).toBeDisabled()
+      userEvent.selectOptions(
+        within(cvrsCard).getByLabelText('CVR File Type:'),
+        'ClearBallot'
+      )
+      userEvent.upload(
+        within(cvrsCard).getByLabelText('Select a file...'),
+        cvrsFile
+      )
+      await within(cvrsCard).findByText('cvrs.csv')
+      userEvent.click(
+        within(cvrsCard).getByRole('button', { name: 'Upload File' })
+      )
+      await within(cvrsCard).findByText('Uploaded')
+      const cvrsLink = within(cvrsCard).getByRole('link', { name: 'cvrs.csv' })
+      expect(cvrsLink).toHaveAttribute(
+        'href',
+        '/api/election/1/jurisdiction/jurisdiction-id-1/cvrs/csv'
+      )
+      within(cvrsCard).getByText('ClearBallot')
+
+      // Now try changing the manifest, CVRs should be reloaded
+      userEvent.click(
+        within(manifestCard).getByRole('button', { name: 'Delete File' })
+      )
+      userEvent.upload(
+        await within(manifestCard).findByLabelText('Select a file...'),
+        manifestFile
+      )
+      await within(manifestCard).findByText('manifest.csv')
+      userEvent.click(
+        within(manifestCard).getByRole('button', { name: 'Upload File' })
+      )
+      await within(manifestCard).findByText('Uploaded')
+      await within(cvrsCard).findByText('Upload failed')
+
+      // Delete CVRs
+      userEvent.click(
+        within(cvrsCard).getByRole('button', { name: 'Delete File' })
+      )
+      await within(cvrsCard).findByText('No file uploaded')
+    })
+  })
+
+  it('before launch, accepts multiple files for ES&S CVR uploads', async () => {
+    const cvrsFormData: FormData = new FormData()
+    const cvrsFile1 = new File(['test cvr data'], 'cvrs1.csv', {
+      type: 'text/csv',
+    })
+    const cvrsFile2 = new File(['test cvr data'], 'cvrs2.csv', {
+      type: 'text/csv',
+    })
+    cvrsFormData.append('cvrs', cvrsFile1, cvrsFile1.name)
+    cvrsFormData.append('cvrs', cvrsFile2, cvrsFile2.name)
+    cvrsFormData.append('cvrFileType', 'ESS')
+
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getCVRSfile(cvrsMocks.empty),
+      {
+        ...jaApiCalls.putCVRs,
+        options: { ...jaApiCalls.putCVRs.options, body: cvrsFormData },
+      },
+      jaApiCalls.getCVRSfile(cvrsMocks.processed),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: {
+          ...jurisdictionMocks.allManifests[0],
+          cvrs: cvrsMocks.empty,
+        },
+        auditSettings: auditSettings.ballotComparisonAll,
+      })
+
+      const cvrsCard = screen
+        .getByRole('heading', { name: 'Cast Vote Records (CVR)' })
+        .closest('div')!
+      await within(cvrsCard).findByText('No file uploaded')
+      userEvent.selectOptions(
+        within(cvrsCard).getByLabelText('CVR File Type:'),
+        within(cvrsCard).getByRole('option', { name: 'ES&S' })
+      )
+      userEvent.upload(
+        await within(cvrsCard).findByLabelText('Select files...'),
+        [cvrsFile1, cvrsFile2]
+      )
+      await within(cvrsCard).findByText('2 files selected')
+      userEvent.click(screen.getByRole('button', { name: 'Upload Files' }))
+      await within(cvrsCard).findByText('Uploaded')
+    })
+  })
+
+  it('before launch, accepts zip files for Hart CVR uploads', async () => {
+    const cvrsFormData: FormData = new FormData()
+    const cvrsZip = new File(['test cvr data'], 'cvrs.zip', {
+      type: 'application/zip',
+    })
+    cvrsFormData.append('cvrs', cvrsZip, cvrsZip.name)
+    cvrsFormData.append('cvrFileType', 'HART')
+
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getCVRSfile(cvrsMocks.empty),
+      {
+        ...jaApiCalls.putCVRs,
+        options: { ...jaApiCalls.putCVRs.options, body: cvrsFormData },
+      },
+      jaApiCalls.getCVRSfile(cvrsMocks.processed),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: {
+          ...jurisdictionMocks.allManifests[0],
+          cvrs: cvrsMocks.empty,
+        },
+        auditSettings: auditSettings.ballotComparisonAll,
+      })
+
+      const cvrsCard = screen
+        .getByRole('heading', { name: 'Cast Vote Records (CVR)' })
+        .closest('div')!
+      await within(cvrsCard).findByText('No file uploaded')
+      userEvent.selectOptions(
+        within(cvrsCard).getByLabelText('CVR File Type:'),
+        within(cvrsCard).getByRole('option', { name: 'Hart' })
+      )
+      userEvent.upload(
+        await within(cvrsCard).findByLabelText('Select a file...'),
+        cvrsZip
+      )
+      await within(cvrsCard).findByText('cvrs.zip')
+      userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
+      await within(cvrsCard).findByText('Uploaded')
+    })
+  })
+
+  it('before launch, shows manifest and batch tallies for batch comparison audit', async () => {
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.empty),
+      jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
+      jaApiCalls.putManifest,
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
+      jaApiCalls.putTallies,
+      jaApiCalls.getBatchTalliesFile(talliesMocks.processed),
+      jaApiCalls.deleteManifest,
+      jaApiCalls.getBallotManifestFile(manifestMocks.empty),
+      jaApiCalls.getBatchTalliesFile(talliesMocks.processed),
+      jaApiCalls.putManifest,
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getBatchTalliesFile(talliesMocks.errored),
+      jaApiCalls.deleteTallies,
+      jaApiCalls.getBatchTalliesFile(talliesMocks.empty),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: jurisdictionMocks.noManifestsNoTallies[0],
+        auditSettings: auditSettings.batchComparisonAll,
+      })
+
+      screen.getByRole('heading', { name: 'Jurisdiction Files' })
+
+      const manifestCard = screen
+        .getByRole('heading', { name: 'Ballot Manifest' })
+        .closest('div')!
+      await within(manifestCard).findByText('No file uploaded')
+
+      const talliesCard = screen
+        .getByRole('heading', { name: 'Candidate Totals by Batch' })
+        .closest('div')!
+      await within(talliesCard).findByText('No file uploaded')
+
+      // Tallies should be disabled until manifest uploaded
+      expect(
+        within(talliesCard).getByLabelText('Select a file...')
+      ).toBeDisabled()
+      expect(
+        within(talliesCard).getByRole('button', { name: 'Upload File' })
+      ).toBeDisabled()
+
+      // Upload manifest
+      userEvent.upload(
+        within(manifestCard).getByLabelText('Select a file...'),
+        manifestFile
+      )
+      await within(manifestCard).findByText('manifest.csv')
+      userEvent.click(
+        within(manifestCard).getByRole('button', { name: 'Upload File' })
+      )
+      await within(manifestCard).findByText('Uploaded')
+
+      // Now can upload tallies
+      userEvent.upload(
+        within(talliesCard).getByLabelText('Select a file...'),
+        talliesFile
+      )
+      await within(talliesCard).findByText('tallies.csv')
+      userEvent.click(
+        within(talliesCard).getByRole('button', { name: 'Upload File' })
+      )
+      await within(talliesCard).findByText('Uploaded')
+      const talliesLink = within(talliesCard).getByRole('link', {
+        name: 'tallies.csv',
+      })
+      expect(talliesLink).toHaveAttribute(
+        'href',
+        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies/csv'
+      )
+
+      // Now try changing the manifest, tallies should be reloaded
+      userEvent.click(
+        within(manifestCard).getByRole('button', { name: 'Delete File' })
+      )
+      userEvent.upload(
+        await within(manifestCard).findByLabelText('Select a file...'),
+        manifestFile
+      )
+      await within(manifestCard).findByText('manifest.csv')
+      userEvent.click(
+        within(manifestCard).getByRole('button', { name: 'Upload File' })
+      )
+      await within(manifestCard).findByText('Uploaded')
+      await within(talliesCard).findByText('Upload failed')
+
+      // Delete tallies
+      userEvent.click(
+        within(talliesCard).getByRole('button', { name: 'Delete File' })
+      )
+      await within(talliesCard).findByText('No file uploaded')
+    })
+  })
+
+  it('after launch, shows round status for ballot polling audit', async () => {
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getAuditBoards(auditBoardMocks.unfinished),
+      jaApiCalls.getBallotCount(dummyBallots.ballots),
+      jaApiCalls.getBallots(dummyBallots.ballots),
+      jaApiCalls.getBallots(dummyBallots.ballots),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: jurisdictionMocks.noneStarted[0],
+        round: roundMocks.singleIncomplete[0],
+      })
+
+      await screen.findByRole('heading', { name: 'Round 1 Data Entry' })
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: /Download Aggregated Ballot Retrieval List/,
+        })
+      )
+      expect(window.open).toHaveBeenCalledWith(
+        '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/ballots/retrieval-list'
+      )
+
+      userEvent.click(
+        screen.getByRole('button', { name: /Download Placeholder Sheets/ })
+      )
+      await waitFor(() =>
+        expect(mockSavePDF).toHaveBeenCalledWith(
+          'Round 1 Placeholders - Jurisdiction 1 - Test Audit.pdf',
+          { returnPromise: true }
+        )
+      )
+      mockSavePDF.mockClear()
+      userEvent.click(
+        screen.getByRole('button', { name: /Download Ballot Labels/ })
+      )
+      await waitFor(() =>
+        expect(mockSavePDF).toHaveBeenCalledWith(
+          'Round 1 Labels - Jurisdiction 1 - Test Audit.pdf',
+          { returnPromise: true }
+        )
+      )
+      mockSavePDF.mockClear()
+      userEvent.click(
+        screen.getByRole('button', { name: /Download Audit Board Credentials/ })
+      )
+      await waitFor(() =>
+        expect(mockSavePDF).toHaveBeenCalledWith(
+          'Audit Board Credentials - Jurisdiction 1 - Test Audit.pdf',
+          { returnPromise: true }
+        )
+      )
+
+      // Manifest should still be shown for download, but form should be disabled
+      const manifestCard = screen
+        .getByRole('heading', { name: 'Ballot Manifest' })
+        .closest('div')!
+      await within(manifestCard).findByText('Uploaded')
+      within(manifestCard).getByRole('link', { name: 'manifest.csv' })
+      expect(
+        within(manifestCard).getByRole('button', { name: 'Delete File' })
+      ).toBeDisabled()
+    })
+  })
+
+  it('after launch, shows round status for ballot comparison audit', async () => {
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getCVRSfile(cvrsMocks.processed),
+      jaApiCalls.getAuditBoards(auditBoardMocks.unfinished),
+      jaApiCalls.getBallotCount(dummyBallots.ballots),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: jurisdictionMocks.noneStartedBallotComparison[0],
+        auditSettings: auditSettings.ballotComparisonAll,
+        round: roundMocks.singleIncomplete[0],
+      })
+
+      await screen.findByRole('heading', { name: 'Round 1 Data Entry' })
+      screen.getByRole('button', {
+        name: /Download Aggregated Ballot Retrieval List/,
+      })
+      screen.getByRole('button', { name: /Download Ballot Labels/ })
+      screen.getByRole('button', { name: /Download Placeholder Sheets/ })
+      screen.getByRole('button', { name: /Download Audit Board Credentials/ })
+
+      // CVRs should still be shown for download, but form should be disabled
+      const cvrsCard = screen
+        .getByRole('heading', { name: 'Cast Vote Records (CVR)' })
+        .closest('div')!
+      await within(cvrsCard).findByText('Uploaded')
+      within(cvrsCard).getByRole('link', { name: 'cvrs.csv' })
+      expect(
+        within(cvrsCard).getByRole('button', { name: 'Delete File' })
+      ).toBeDisabled()
+    })
+  })
+
+  it('after launch, shows round status for batch comparison audit', async () => {
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getBatchTalliesFile(talliesMocks.processed),
+      jaApiCalls.getAuditBoards(auditBoardMocks.unfinished),
+      jaApiCalls.getBatches(batchesMocks.emptyInitial),
+      jaApiCalls.getBatches(batchesMocks.emptyInitial),
+      jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: jurisdictionMocks.oneComplete[0],
+        auditSettings: auditSettings.batchComparisonAll,
+        round: roundMocks.singleIncomplete[0],
+      })
+
+      await screen.findByRole('heading', { name: 'Round 1 Data Entry' })
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: /Download Aggregated Batch Retrieval List/,
+        })
+      )
+      expect(window.open).toHaveBeenCalledWith(
+        '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/batches/retrieval-list'
+      )
+
+      userEvent.click(
+        screen.getByRole('button', { name: /Download Batch Tally Sheets/ })
+      )
+      await waitFor(() =>
+        expect(mockSavePDF).toHaveBeenCalledWith('Batch Tally Sheets.pdf', {
+          returnPromise: true,
+        })
+      )
+
+      // Batch tallies should still be shown for download, but form should be disabled
+      const talliesCard = screen
+        .getByRole('heading', { name: 'Candidate Totals by Batch' })
+        .closest('div')!
+      await within(talliesCard).findByText('Uploaded')
+      within(talliesCard).getByRole('link', { name: 'tallies.csv' })
+      expect(
+        within(talliesCard).getByRole('button', { name: 'Delete File' })
+      ).toBeDisabled()
+    })
+  })
+
+  it('after launch, shows a message when no ballots sampled', async () => {
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getAuditBoards(auditBoardMocks.unfinished),
+      jaApiCalls.getBallotCount([]),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: jurisdictionMocks.oneComplete[0],
+        round: roundMocks.singleIncomplete[0],
+      })
+      await screen.findByText('No ballots sampled')
+    })
+  })
+
+  it('after launch, shows a message in the detail modal when no audit boards set up', async () => {
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getAuditBoards([]),
+      jaApiCalls.getBallotCount(dummyBallots.ballots),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: jurisdictionMocks.noneStarted[0],
+        round: roundMocks.singleIncomplete[0],
+      })
+      await screen.findByText('Waiting for jurisdiction to set up audit boards')
+    })
+  })
+
+  it('after launch, shows a message when no batches sampled', async () => {
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getBatchTalliesFile(talliesMocks.processed),
+      jaApiCalls.getAuditBoards(auditBoardMocks.unfinished),
+      jaApiCalls.getBatches({ batches: [], resultsFinalizedAt: null }),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: jurisdictionMocks.oneComplete[0],
+        auditSettings: auditSettings.batchComparisonAll,
+        round: roundMocks.singleIncomplete[0],
+      })
+      await screen.findByText('No ballots sampled')
+    })
+  })
+
+  it('after launch, shows a message when auditing is complete', async () => {
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getAuditBoards(auditBoardMocks.finished),
+      jaApiCalls.getBallotCount(dummyBallots.ballots),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: jurisdictionMocks.allComplete[0],
+        auditSettings: auditSettings.all,
+        round: roundMocks.singleIncomplete[0],
+      })
+      await screen.findByText('Data entry complete')
+    })
+  })
+
+  it('after launch, shows a button to unfinalize batch results', async () => {
+    const expectedCalls = [
+      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+      jaApiCalls.getBatchTalliesFile(talliesMocks.processed),
+      jaApiCalls.getAuditBoards(auditBoardMocks.single),
+      jaApiCalls.getBatches(batchesMocks.complete),
+      jaApiCalls.unfinalizeBatchResults,
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render({
+        jurisdiction: jurisdictionMocks.allComplete[0],
+        auditSettings: auditSettings.batchComparisonAll,
+        round: roundMocks.singleIncomplete[0],
+      })
+
+      await screen.findByText('Results finalized')
+
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: { reload: jest.fn() },
+      })
+      userEvent.click(
+        screen.getByRole('button', { name: 'Unfinalize Results' })
+      )
+      await waitFor(() => {
+        expect(window.location.reload).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/client/src/components/AuditAdmin/Setup/Review/__snapshots__/Review.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Review/__snapshots__/Review.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`Audit Setup > Review & Launch custom sample size validation - ballot co
               Audit Board Data Entry:
             </td>
             <td>
-              Offline
+              Online
             </td>
           </tr>
         </tbody>

--- a/client/src/components/AuditAdmin/useSetupMenuItems/_mocks.ts
+++ b/client/src/components/AuditAdmin/useSetupMenuItems/_mocks.ts
@@ -770,6 +770,47 @@ export const jurisdictionMocks = {
       currentRoundStatus: null,
     },
   ],
+  noneStartedBallotComparison: [
+    {
+      id: 'jurisdiction-id-1',
+      name: 'Jurisdiction 1',
+      ballotManifest: manifestMocks.processed,
+      cvrs: cvrsMocks.processed,
+      currentRoundStatus: {
+        status: JurisdictionRoundStatus.NOT_STARTED,
+        numUniqueAudited: 0,
+        numUnique: 10,
+        numSamplesAudited: 0,
+        numSamples: 11,
+      },
+    },
+    {
+      id: 'jurisdiction-id-2',
+      name: 'Jurisdiction 2',
+      ballotManifest: manifestMocks.processed,
+      cvrs: cvrsMocks.processed,
+      currentRoundStatus: {
+        status: JurisdictionRoundStatus.NOT_STARTED,
+        numUniqueAudited: 0,
+        numUnique: 20,
+        numSamplesAudited: 0,
+        numSamples: 22,
+      },
+    },
+    {
+      id: 'jurisdiction-id-3',
+      name: 'Jurisdiction 3',
+      ballotManifest: manifestMocks.processed,
+      cvrs: cvrsMocks.processed,
+      currentRoundStatus: {
+        status: JurisdictionRoundStatus.COMPLETE,
+        numUniqueAudited: 30,
+        numUnique: 30,
+        numSamplesAudited: 31,
+        numSamples: 31,
+      },
+    },
+  ],
   // Hybrid
   hybridTwoManifestsOneCvr: [
     {

--- a/client/src/components/AuditAdmin/useSetupMenuItems/_mocks.ts
+++ b/client/src/components/AuditAdmin/useSetupMenuItems/_mocks.ts
@@ -124,7 +124,7 @@ export const auditSettings = mockOfType<IAuditSettings>()({
   ballotComparisonAll: {
     state: 'AL',
     electionName: 'Election Name',
-    online: false,
+    online: true,
     randomSeed: '12345',
     riskLimit: 10,
     auditType: 'BALLOT_COMPARISON',

--- a/client/src/components/AuditAdmin/useSetupMenuItems/_mocks.ts
+++ b/client/src/components/AuditAdmin/useSetupMenuItems/_mocks.ts
@@ -12,7 +12,7 @@ import { IAuditBoard } from '../../useAuditBoards'
 import { IRound } from '../useRoundsAuditAdmin'
 import { IAuditSettings } from '../../useAuditSettings'
 import { FileProcessingStatus, IFileInfo, CvrFileType } from '../../useCSV'
-import { mockOfType } from '../../testUtilities'
+import { mocksOfType } from '../../testUtilities'
 
 export const manifestFile = new File(
   [readFileSync(join(__dirname, './test_manifest.csv'), 'utf8')],
@@ -30,7 +30,7 @@ export const cvrsFile = new File(
   { type: 'text/csv' }
 )
 
-export const auditSettings = mockOfType<IAuditSettings>()({
+export const auditSettings = mocksOfType<IAuditSettings>()({
   blank: {
     state: null,
     electionName: null,
@@ -143,7 +143,7 @@ export const auditSettings = mockOfType<IAuditSettings>()({
   },
 })
 
-export const roundMocks = mockOfType<IRound[]>()({
+export const roundMocks = mocksOfType<IRound[]>()({
   empty: [],
   singleIncomplete: [
     {
@@ -1045,7 +1045,7 @@ export const contestMocks: {
   ],
 }
 
-export const fileProcessingMocks = mockOfType<IFileInfo['processing']>()({
+export const fileProcessingMocks = mocksOfType<IFileInfo['processing']>()({
   null: null,
   processed: {
     status: FileProcessingStatus.PROCESSED,
@@ -1061,7 +1061,7 @@ export const fileProcessingMocks = mockOfType<IFileInfo['processing']>()({
   },
 })
 
-export const auditBoardMocks = mockOfType<IAuditBoard[]>()({
+export const auditBoardMocks = mocksOfType<IAuditBoard[]>()({
   empty: [],
   unfinished: [
     {

--- a/client/src/components/AuditAdmin/useSetupMenuItems/_mocks.ts
+++ b/client/src/components/AuditAdmin/useSetupMenuItems/_mocks.ts
@@ -12,6 +12,7 @@ import { IAuditBoard } from '../../useAuditBoards'
 import { IRound } from '../useRoundsAuditAdmin'
 import { IAuditSettings } from '../../useAuditSettings'
 import { FileProcessingStatus, IFileInfo, CvrFileType } from '../../useCSV'
+import { mockOfType } from '../../testUtilities'
 
 export const manifestFile = new File(
   [readFileSync(join(__dirname, './test_manifest.csv'), 'utf8')],
@@ -29,9 +30,7 @@ export const cvrsFile = new File(
   { type: 'text/csv' }
 )
 
-export const auditSettings: {
-  [key: string]: IAuditSettings
-} = {
+export const auditSettings = mockOfType<IAuditSettings>()({
   blank: {
     state: null,
     electionName: null,
@@ -142,18 +141,9 @@ export const auditSettings: {
     auditMathType: 'SUITE',
     auditName: 'Test Audit',
   },
-}
+})
 
-export const roundMocks: {
-  [key in
-    | 'empty'
-    | 'singleIncomplete'
-    | 'twoIncomplete'
-    | 'singleComplete'
-    | 'needAnother'
-    | 'drawSampleInProgress'
-    | 'drawSampleErrored']: IRound[]
-} = {
+export const roundMocks = mockOfType<IRound[]>()({
   empty: [],
   singleIncomplete: [
     {
@@ -272,7 +262,7 @@ export const roundMocks: {
       },
     },
   ],
-}
+})
 
 export const jurisdictionFileMocks: { [key: string]: IFileInfo } = {
   empty: {
@@ -336,7 +326,7 @@ export const standardizedContestsFileMocks: { [key: string]: IFileInfo } = {
   },
 }
 
-export const manifestMocks: { [key: string]: IBallotManifestInfo } = {
+export const manifestMocks = {
   empty: {
     file: null,
     processing: null,
@@ -381,7 +371,7 @@ export const manifestMocks: { [key: string]: IBallotManifestInfo } = {
   },
 }
 
-export const talliesMocks: { [key: string]: IBatchTalliesFileInfo } = {
+export const talliesMocks = {
   empty: {
     file: null,
     processing: null,
@@ -476,7 +466,7 @@ export const cvrsMocks: { [key: string]: ICvrFileInfo } = {
   },
 }
 
-export const jurisdictionMocks: { [key: string]: IJurisdiction[] } = {
+export const jurisdictionMocks = {
   empty: [],
   // Setup - Ballot polling
   noManifests: [
@@ -1014,9 +1004,7 @@ export const contestMocks: {
   ],
 }
 
-export const fileProcessingMocks: {
-  [key in 'null' | 'processed' | 'errored']: IFileInfo['processing']
-} = {
+export const fileProcessingMocks = mockOfType<IFileInfo['processing']>()({
   null: null,
   processed: {
     status: FileProcessingStatus.PROCESSED,
@@ -1030,19 +1018,9 @@ export const fileProcessingMocks: {
     completedAt: '2019-07-18T16:35:07.000+00:00',
     error: 'something went wrong',
   },
-}
+})
 
-export const auditBoardMocks: {
-  [key in
-    | 'empty'
-    | 'unfinished'
-    | 'finished'
-    | 'single'
-    | 'double'
-    | 'noBallots'
-    | 'started'
-    | 'signedOff']: IAuditBoard[]
-} = {
+export const auditBoardMocks = mockOfType<IAuditBoard[]>()({
   empty: [],
   unfinished: [
     {
@@ -1148,4 +1126,4 @@ export const auditBoardMocks: {
       },
     },
   ],
-}
+})

--- a/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.test.tsx
@@ -267,17 +267,12 @@ describe('Batch comparison data entry', () => {
     const expectedCalls = [
       apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
       apiCalls.getBatches(batchesMocks.emptyInitial),
-      apiCalls.getBatches(batchesMocks.emptyInitial),
       apiCalls.putBatchResults('batch-1', [tallySheet1, tallySheet2]),
       apiCalls.getBatches({
         ...batchesMocks.emptyInitial,
         batches: batchesWithResults([tallySheet1, tallySheet2]),
       }),
       apiCalls.putBatchResults('batch-1', [tallySheet2]),
-      apiCalls.getBatches({
-        ...batchesMocks.emptyInitial,
-        batches: batchesWithResults([tallySheet2]),
-      }),
       apiCalls.getBatches({
         ...batchesMocks.emptyInitial,
         batches: batchesWithResults([tallySheet2]),

--- a/client/src/components/JurisdictionAdmin/_mocks.ts
+++ b/client/src/components/JurisdictionAdmin/_mocks.ts
@@ -5,7 +5,7 @@ import {
   IFullHandTallyBatchResults,
   IFullHandTallyBatchResult,
 } from './useFullHandTallyResults'
-import { mockOfType } from '../testUtilities'
+import { mocksOfType } from '../testUtilities'
 
 export interface INullResultValues {
   [contestId: string]: {
@@ -13,7 +13,7 @@ export interface INullResultValues {
   }
 }
 
-export const roundMocks = mockOfType<IRound>()({
+export const roundMocks = mocksOfType<IRound>()({
   incomplete: {
     id: 'round-1',
     roundNum: 1,
@@ -61,7 +61,7 @@ export const roundMocks = mockOfType<IRound>()({
   },
 })
 
-export const resultsMocks = mockOfType<INullResultValues>()({
+export const resultsMocks = mocksOfType<INullResultValues>()({
   emptyInitial: {
     'contest-id-1': {
       'choice-id-1': null,
@@ -84,7 +84,7 @@ export const resultsMocks = mockOfType<INullResultValues>()({
   },
 })
 
-export const batchResultsMocks = mockOfType<INullResultValues>()({
+export const batchResultsMocks = mocksOfType<INullResultValues>()({
   empty: {
     'batch-1': {
       'choice-id-1': null,
@@ -115,7 +115,7 @@ export const batchResultsMocks = mockOfType<INullResultValues>()({
   },
 })
 
-export const batchesMocks = mockOfType<IBatches>()({
+export const batchesMocks = mocksOfType<IBatches>()({
   emptyInitial: {
     batches: [
       {
@@ -203,7 +203,7 @@ export const batchesMocks = mockOfType<IBatches>()({
   },
 })
 
-export const fullHandTallyBatchResultMock = mockOfType<
+export const fullHandTallyBatchResultMock = mocksOfType<
   IFullHandTallyBatchResults
 >()({
   empty: {
@@ -272,7 +272,7 @@ export const fullHandTallyBatchResultMock = mockOfType<
   },
 })
 
-export const fullHandTallyBatchResultsMock = mockOfType<
+export const fullHandTallyBatchResultsMock = mocksOfType<
   IFullHandTallyBatchResult
 >()({
   empty: {

--- a/client/src/components/JurisdictionAdmin/_mocks.ts
+++ b/client/src/components/JurisdictionAdmin/_mocks.ts
@@ -5,6 +5,7 @@ import {
   IFullHandTallyBatchResults,
   IFullHandTallyBatchResult,
 } from './useFullHandTallyResults'
+import { mockOfType } from '../testUtilities'
 
 export interface INullResultValues {
   [contestId: string]: {
@@ -12,9 +13,7 @@ export interface INullResultValues {
   }
 }
 
-export const roundMocks: {
-  [key in 'incomplete' | 'complete' | 'fullHandTallyIncomplete']: IRound
-} = {
+export const roundMocks = mockOfType<IRound>()({
   incomplete: {
     id: 'round-1',
     roundNum: 1,
@@ -60,11 +59,9 @@ export const roundMocks: {
       error: null,
     },
   },
-}
+})
 
-export const resultsMocks: {
-  [key in 'emptyInitial' | 'complete']: INullResultValues
-} = {
+export const resultsMocks = mockOfType<INullResultValues>()({
   emptyInitial: {
     'contest-id-1': {
       'choice-id-1': null,
@@ -85,11 +82,9 @@ export const resultsMocks: {
       'choice-id-4': 2,
     },
   },
-}
+})
 
-export const batchResultsMocks: {
-  [key in 'empty' | 'complete']: INullResultValues
-} = {
+export const batchResultsMocks = mockOfType<INullResultValues>()({
   empty: {
     'batch-1': {
       'choice-id-1': null,
@@ -118,11 +113,9 @@ export const batchResultsMocks: {
       'choice-id-2': 2,
     },
   },
-}
+})
 
-export const batchesMocks: {
-  [key in 'emptyInitial' | 'complete']: IBatches
-} = {
+export const batchesMocks = mockOfType<IBatches>()({
   emptyInitial: {
     batches: [
       {
@@ -208,16 +201,11 @@ export const batchesMocks: {
     ],
     resultsFinalizedAt: '2020-09-14T17:35:19.482Z',
   },
-}
+})
 
-export const fullHandTallyBatchResultMock: {
-  [key in
-    | 'empty'
-    | 'complete'
-    | 'updated'
-    | 'finalized'
-    | 'completeWithMultipleBatch']: IFullHandTallyBatchResults
-} = {
+export const fullHandTallyBatchResultMock = mockOfType<
+  IFullHandTallyBatchResults
+>()({
   empty: {
     finalizedAt: '',
     results: [],
@@ -282,11 +270,11 @@ export const fullHandTallyBatchResultMock: {
       },
     ],
   },
-}
+})
 
-export const fullHandTallyBatchResultsMock: {
-  [key in 'empty' | 'complete' | 'updated']: IFullHandTallyBatchResult
-} = {
+export const fullHandTallyBatchResultsMock = mockOfType<
+  IFullHandTallyBatchResult
+>()({
   empty: {
     batchName: '',
     batchType: '',
@@ -308,4 +296,4 @@ export const fullHandTallyBatchResultsMock: {
       'choice-id-2': 20,
     },
   },
-}
+})

--- a/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
+++ b/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Home screen redirects to audit screen if only one election exists for J
     class="Toastify"
   />
   <div
-    class="sc-cQFLBn dufrvO"
+    class="sc-gojNiO cKHzrH"
   >
     <div
       class="bp3-navbar sc-bxivhb jwFLoW"

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -17,6 +17,7 @@ import { IBatches } from './JurisdictionAdmin/useBatchResults'
 import { IOrganization } from './UserContext'
 import mapTopology from '../../public/us-states-counties.json'
 import { contestMocks } from './AuditAdmin/Setup/Contests/_mocks'
+import { IContest } from '../types'
 
 const jurisdictionFormData: FormData = new FormData()
 jurisdictionFormData.append(
@@ -247,6 +248,17 @@ export const jaApiCalls = {
     },
     response: { status: 'ok' },
   },
+  deleteTallies: {
+    url: '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies',
+    options: {
+      method: 'DELETE',
+    },
+    response: { status: 'ok' },
+  },
+  getJurisdictionContests: (contests: IContest[]) => ({
+    url: `/api/election/1/jurisdiction/jurisdiction-id-1/contest`,
+    response: { contests },
+  }),
 }
 
 export const mockOrganizations = {

--- a/client/src/components/testUtilities.tsx
+++ b/client/src/components/testUtilities.tsx
@@ -207,3 +207,10 @@ export const findAndCloseToast = async (expectedContent: string) => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   )
 }
+
+// Enforces the value type for an object with values of type Mock, while
+// inferring the keys. This allows for good autocompletion of mocks in tests
+// while still enforcing their type.
+// Example: const mockNumbers = mockOfType<number>()({ 'one': 1, 'two': 2 })
+export const mockOfType = <T,>() => <Mock,>(mock: { [K in keyof Mock]: T }) =>
+  mock

--- a/client/src/components/testUtilities.tsx
+++ b/client/src/components/testUtilities.tsx
@@ -211,6 +211,6 @@ export const findAndCloseToast = async (expectedContent: string) => {
 // Enforces the value type for an object with values of type Mock, while
 // inferring the keys. This allows for good autocompletion of mocks in tests
 // while still enforcing their type.
-// Example: const mockNumbers = mockOfType<number>()({ 'one': 1, 'two': 2 })
-export const mockOfType = <T,>() => <Mock,>(mock: { [K in keyof Mock]: T }) =>
+// Example: const mockNumbers = mocksOfType<number>()({ 'one': 1, 'two': 2 })
+export const mocksOfType = <T,>() => <Mock,>(mock: { [K in keyof Mock]: T }) =>
   mock

--- a/client/src/components/useFileUpload.ts
+++ b/client/src/components/useFileUpload.ts
@@ -31,10 +31,6 @@ export const useUploadedFile = (
   const isProcessing = (fileInfo?: IFileInfo) =>
     fileInfo && fileInfo.processing && !fileInfo.processing.completedAt
   return useQuery<IFileInfo, ApiError>(key, () => fetchApi(url), {
-    // When a file input dialog closes, it triggers a window focus event,
-    // which causes a refetch by default, so we turn that off.
-    // https://github.com/tannerlinsley/react-query/issues/2960
-    refetchOnWindowFocus: false,
     refetchInterval: fileInfo => (isProcessing(fileInfo) ? 1000 : false),
     // Once a file is finished processing or is deleted, call onFileChange
     // (but don't call it the very first time we load the file)

--- a/client/src/components/useFileUpload.ts
+++ b/client/src/components/useFileUpload.ts
@@ -1,0 +1,202 @@
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  UseQueryResult,
+} from 'react-query'
+import axios, { AxiosRequestConfig } from 'axios'
+import { useState, useRef } from 'react'
+import { IFileInfo, CvrFileType } from './useCSV'
+import { fetchApi, ApiError, addCSRFToken } from '../utils/api'
+
+interface IUseFileUploadProps {
+  url: string
+  formKey: string
+}
+
+export interface IFileUpload {
+  uploadedFile: UseQueryResult<IFileInfo, ApiError>
+  uploadFiles: (files: File[]) => Promise<void>
+  uploadProgress?: number
+  deleteFile: () => Promise<void>
+  downloadFileUrl?: string
+}
+
+export const useUploadedFile = (
+  key: string[],
+  url: string,
+  options: { onFileChange?: () => void; enabled?: boolean } = {}
+) => {
+  const isFirstFetch = useRef(true)
+  const isProcessing = (fileInfo?: IFileInfo) =>
+    fileInfo && fileInfo.processing && !fileInfo.processing.completedAt
+  return useQuery<IFileInfo, ApiError>(key, () => fetchApi(url), {
+    // When a file input dialog closes, it triggers a window focus event,
+    // which causes a refetch by default, so we turn that off.
+    // https://github.com/tannerlinsley/react-query/issues/2960
+    refetchOnWindowFocus: false,
+    refetchInterval: fileInfo => (isProcessing(fileInfo) ? 1000 : false),
+    // Once a file is finished processing or is deleted, call onFileChange
+    // (but don't call it the very first time we load the file)
+    onSuccess: fileInfo => {
+      if (isFirstFetch.current) {
+        isFirstFetch.current = false
+        return
+      }
+      if (!isProcessing(fileInfo) && options.onFileChange) {
+        options.onFileChange()
+      }
+    },
+    enabled: options.enabled,
+  })
+}
+
+export const useUploadFiles = (key: string[], url: string) => {
+  const [progress, setProgress] = useState<number>()
+
+  const putFiles = async (formData: FormData) => {
+    try {
+      await axios(url, addCSRFToken({
+        method: 'PUT',
+        data: formData,
+        onUploadProgress: progressEvent =>
+          setProgress(progressEvent.loaded / progressEvent.total),
+      }) as AxiosRequestConfig)
+    } catch (error) {
+      const { errors } = error.response.data
+      const message =
+        errors && errors.length ? errors[0].message : error.response.statusText
+      throw new ApiError(message, error.response.status)
+    } finally {
+      setProgress(undefined)
+    }
+  }
+
+  const queryClient = useQueryClient()
+
+  return {
+    ...useMutation<void, ApiError, FormData>(putFiles, {
+      onSuccess: () => queryClient.invalidateQueries(key),
+    }),
+    progress,
+  }
+}
+
+export const useDeleteFile = (key: string[], url: string) => {
+  const deleteFile = () => fetchApi(url, { method: 'DELETE' })
+  const queryClient = useQueryClient()
+  return useMutation<void, ApiError, void>(deleteFile, {
+    onSuccess: () => queryClient.invalidateQueries(key),
+  })
+}
+
+export const useBallotManifest = (
+  electionId: string,
+  jurisdictionId: string
+): IFileUpload => {
+  const url = `/api/election/${electionId}/jurisdiction/${jurisdictionId}/ballot-manifest`
+  const key = ['jurisdictions', jurisdictionId, 'ballot-manifest']
+  const uploadFiles = useUploadFiles(key, url)
+  const deleteFile = useDeleteFile(key, url)
+  const queryClient = useQueryClient()
+  return {
+    uploadedFile: useUploadedFile(key, url, {
+      onFileChange: () => {
+        // When the manifest changes, batch tallies and cvrs are reprocessed
+        queryClient.invalidateQueries([
+          'jurisdictions',
+          jurisdictionId,
+          'batch-tallies',
+        ])
+        queryClient.invalidateQueries(['jurisdictions', jurisdictionId, 'cvrs'])
+        // We need to reload the jurisdictions list with new file upload status
+        queryClient.invalidateQueries([
+          'elections',
+          electionId,
+          'jurisdictions',
+        ])
+      },
+    }),
+    uploadFiles: files => {
+      const formData = new FormData()
+      formData.append('manifest', files[0], files[0].name)
+      return uploadFiles.mutateAsync(formData)
+    },
+    uploadProgress: uploadFiles.progress,
+    deleteFile: () => deleteFile.mutateAsync(),
+    downloadFileUrl: `${url}/csv`,
+  }
+}
+
+export const useBatchTallies = (
+  electionId: string,
+  jurisdictionId: string,
+  options: { enabled: boolean } = { enabled: true }
+): IFileUpload => {
+  const key = ['jurisdictions', jurisdictionId, 'batch-tallies']
+  const url = `/api/election/${electionId}/jurisdiction/${jurisdictionId}/batch-tallies`
+  const uploadFiles = useUploadFiles(key, url)
+  const deleteFile = useDeleteFile(key, url)
+  const queryClient = useQueryClient()
+  return {
+    uploadedFile: useUploadedFile(key, url, {
+      ...options,
+      onFileChange: () => {
+        // We need to reload the jurisdictions list with new file upload status
+        queryClient.invalidateQueries([
+          'elections',
+          electionId,
+          'jurisdictions',
+        ])
+      },
+    }),
+    uploadFiles: files => {
+      const formData = new FormData()
+      formData.append('batchTallies', files[0], files[0].name)
+      return uploadFiles.mutateAsync(formData)
+    },
+    uploadProgress: uploadFiles.progress,
+    deleteFile: () => deleteFile.mutateAsync(),
+    downloadFileUrl: `${url}/csv`,
+  }
+}
+
+interface ICvrsFileUpload extends Omit<IFileUpload, 'uploadFiles'> {
+  uploadFiles: (cvrs: File[], cvrFileType: CvrFileType) => Promise<void>
+}
+
+export const useCVRs = (
+  electionId: string,
+  jurisdictionId: string,
+  options: { enabled: boolean } = { enabled: true }
+): ICvrsFileUpload => {
+  const key = ['jurisdictions', jurisdictionId, 'cvrs']
+  const url = `/api/election/${electionId}/jurisdiction/${jurisdictionId}/cvrs`
+  const uploadFiles = useUploadFiles(key, url)
+  const deleteFile = useDeleteFile(key, url)
+  const queryClient = useQueryClient()
+  return {
+    uploadedFile: useUploadedFile(key, url, {
+      ...options,
+      onFileChange: () => {
+        // We need to reload the jurisdictions list with new file upload status
+        queryClient.invalidateQueries([
+          'elections',
+          electionId,
+          'jurisdictions',
+        ])
+      },
+    }),
+    uploadFiles: (files, cvrFileType) => {
+      const formData = new FormData()
+      for (const file of files) {
+        formData.append('cvrs', file, file.name)
+      }
+      formData.append('cvrFileType', cvrFileType)
+      return uploadFiles.mutateAsync(formData)
+    },
+    uploadProgress: uploadFiles.progress,
+    deleteFile: () => deleteFile.mutateAsync(),
+    downloadFileUrl: `${url}/csv`,
+  }
+}

--- a/client/src/components/useFileUpload.ts
+++ b/client/src/components/useFileUpload.ts
@@ -22,6 +22,14 @@ export interface IFileUpload {
   downloadFileUrl?: string
 }
 
+/**
+ * useUploadedFile loads the current uploaded file state from the server. If the
+ * file is processing, it will refetch the file status every second. It takes an
+ * optional argument options.onFileChange, which will be called whenever the
+ * uploaded file on the server changes (i.e. when a new file finishes processing
+ * or when a file is deleted). It is not called when the file state is first
+ * loaded from the server, nor when a file is processing.
+ */
 export const useUploadedFile = (
   key: string[],
   url: string,
@@ -32,8 +40,6 @@ export const useUploadedFile = (
     fileInfo && fileInfo.processing && !fileInfo.processing.completedAt
   return useQuery<IFileInfo, ApiError>(key, () => fetchApi(url), {
     refetchInterval: fileInfo => (isProcessing(fileInfo) ? 1000 : false),
-    // Once a file is finished processing or is deleted, call onFileChange
-    // (but don't call it the very first time we load the file)
     onSuccess: fileInfo => {
       if (isFirstFetch.current) {
         isFirstFetch.current = false

--- a/client/src/components/useJurisdictions.ts
+++ b/client/src/components/useJurisdictions.ts
@@ -132,10 +132,6 @@ export const useJurisdictions = (electionId: string, refreshId?: string) => {
         `/api/election/${electionId}/jurisdiction`
       )
       return response && response.jurisdictions
-    },
-    // When a file input dialog closes, it triggers a window focus event,
-    // which causes a refetch by default, so we turn that off.
-    // https://github.com/tannerlinsley/react-query/issues/2960
-    { refetchOnWindowFocus: false }
+    }
   )
 }

--- a/client/src/components/useJurisdictions.ts
+++ b/client/src/components/useJurisdictions.ts
@@ -132,6 +132,10 @@ export const useJurisdictions = (electionId: string, refreshId?: string) => {
         `/api/election/${electionId}/jurisdiction`
       )
       return response && response.jurisdictions
-    }
+    },
+    // When a file input dialog closes, it triggers a window focus event,
+    // which causes a refetch by default, so we turn that off.
+    // https://github.com/tannerlinsley/react-query/issues/2960
+    { refetchOnWindowFocus: false }
   )
 }

--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -241,7 +241,7 @@ def clear_ballot_manifest_file(jurisdiction: Jurisdiction):
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/ballot-manifest",
     methods=["PUT"],
 )
-@restrict_access([UserType.JURISDICTION_ADMIN])
+@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
 def upload_ballot_manifest(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):
@@ -256,7 +256,7 @@ def upload_ballot_manifest(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/ballot-manifest",
     methods=["GET"],
 )
-@restrict_access([UserType.JURISDICTION_ADMIN])
+@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
 def get_ballot_manifest(
     election: Election, jurisdiction: Jurisdiction  # pylint: disable=unused-argument
 ):
@@ -287,7 +287,7 @@ def download_ballot_manifest_file(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/ballot-manifest",
     methods=["DELETE"],
 )
-@restrict_access([UserType.JURISDICTION_ADMIN])
+@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
 def clear_ballot_manifest(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -161,7 +161,7 @@ def clear_batch_tallies_data(jurisdiction: Jurisdiction):
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/batch-tallies",
     methods=["PUT"],
 )
-@restrict_access([UserType.JURISDICTION_ADMIN])
+@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
 def upload_batch_tallies(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):
@@ -198,7 +198,7 @@ def upload_batch_tallies(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/batch-tallies",
     methods=["GET"],
 )
-@restrict_access([UserType.JURISDICTION_ADMIN])
+@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
 def get_batch_tallies(
     election: Election, jurisdiction: Jurisdiction  # pylint: disable=unused-argument
 ):
@@ -229,7 +229,7 @@ def download_batch_tallies_file(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/batch-tallies",
     methods=["DELETE"],
 )
-@restrict_access([UserType.JURISDICTION_ADMIN])
+@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
 def clear_batch_tallies(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -1143,7 +1143,7 @@ def clear_cvr_data(jurisdiction: Jurisdiction):
 @api.route(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/cvrs", methods=["PUT"],
 )
-@restrict_access([UserType.JURISDICTION_ADMIN])
+@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
 def upload_cvrs(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):
@@ -1193,7 +1193,7 @@ def upload_cvrs(
 @api.route(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/cvrs", methods=["GET"],
 )
-@restrict_access([UserType.JURISDICTION_ADMIN])
+@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
 def get_cvrs(
     election: Election, jurisdiction: Jurisdiction  # pylint: disable=unused-argument
 ):
@@ -1222,7 +1222,7 @@ def download_cvr_file(
 @api.route(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/cvrs", methods=["DELETE"],
 )
-@restrict_access([UserType.JURISDICTION_ADMIN])
+@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
 def clear_cvrs(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -175,6 +175,7 @@ def test_batch_tallies_clear(
     assert File.query.get(file_id) is None
     assert jurisdiction.batch_tallies is None
 
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies/csv"
     )

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -175,7 +175,6 @@ def test_batch_tallies_clear(
     assert File.query.get(file_id) is None
     assert jurisdiction.batch_tallies is None
 
-    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies/csv"
     )


### PR DESCRIPTION
Task: #1439 

Gives audit admins the ability to upload jurisdiction files in the jurisdiction detail modal on the progress screen.

Details of the changes are in each commit.

Demo video (seemed to be too large for Github): https://drive.google.com/file/d/1ovUio7uelbb7Or82N23IQb6RZk8IzowB/view?usp=sharing 
