### PR TITLE
Fix audit board confirmation modal title wrapping

### DIFF
--- a/client/src/components/AuditBoard/Ballot.tsx
+++ b/client/src/components/AuditBoard/Ballot.tsx
@@ -84,7 +84,7 @@ const ConfirmationModalTitle = styled.span`
 const ConfirmationModalSubTitle = styled.span`
   font-size: 16px;
   font-weight: 400;
-  whitespace: normal; /* Allow long batch names to wrap */
+  white-space: normal; /* Allow long batch names to wrap */
 `
 
 interface IProps {


### PR DESCRIPTION
🤦

_Before and after_

<img width="300" alt="before" src="https://user-images.githubusercontent.com/12616928/168886858-c96aa486-d933-403e-8433-129fb27adcd4.png"> <img width="300" alt="after" src="https://user-images.githubusercontent.com/12616928/168886857-f8f92522-0087-4cd9-bb92-2c5b7c40aa33.png">
