### PR TITLE
Remove redundant "Aggregated" from batch/ballot retrieval list buttons

### DIFF
--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -690,7 +690,7 @@ describe('Progress screen', () => {
 
       userEvent.click(
         within(modal).getByRole('button', {
-          name: /Download Aggregated Ballot Retrieval List/,
+          name: /Download Ballot Retrieval List/,
         })
       )
 
@@ -764,7 +764,7 @@ describe('Progress screen', () => {
 
       userEvent.click(
         await within(modal).findByRole('button', {
-          name: /Download Aggregated Batch Retrieval List/,
+          name: /Download Batch Retrieval List/,
         })
       )
       expect(window.open).toHaveBeenCalledWith(

--- a/client/src/components/JurisdictionAdmin/RoundManagement.test.tsx
+++ b/client/src/components/JurisdictionAdmin/RoundManagement.test.tsx
@@ -165,7 +165,7 @@ describe('RoundManagement', () => {
         auditBoards: auditBoardMocks.unfinished,
         createAuditBoards: jest.fn(),
       })
-      await screen.findByText('Download Aggregated Ballot Retrieval List')
+      await screen.findByText('Download Ballot Retrieval List')
       expect(container).toMatchSnapshot()
     })
   })
@@ -184,7 +184,7 @@ describe('RoundManagement', () => {
         auditBoards: auditBoardMocks.unfinished,
         createAuditBoards: jest.fn(),
       })
-      await screen.findByText('Download Aggregated Ballot Retrieval List')
+      await screen.findByText('Download Ballot Retrieval List')
       expect(container).toMatchSnapshot()
     })
   })
@@ -206,7 +206,7 @@ describe('RoundManagement', () => {
       })
 
       await screen.findByRole('button', {
-        name: /Download Aggregated Batch Retrieval List/,
+        name: /Download Batch Retrieval List/,
       })
 
       userEvent.click(

--- a/client/src/components/JurisdictionAdmin/RoundManagement.tsx
+++ b/client/src/components/JurisdictionAdmin/RoundManagement.tsx
@@ -192,7 +192,7 @@ export const JAFileDownloadButtons = ({
           )
       }
     >
-      Download Aggregated{' '}
+      Download{' '}
       {auditSettings.auditType === 'BATCH_COMPARISON' ? 'Batch' : 'Ballot'}{' '}
       Retrieval List
     </Button>

--- a/client/src/components/JurisdictionAdmin/__snapshots__/RoundManagement.test.tsx.snap
+++ b/client/src/components/JurisdictionAdmin/__snapshots__/RoundManagement.test.tsx.snap
@@ -1423,7 +1423,7 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
           <span
             class="bp3-button-text"
           >
-            Download Aggregated
+            Download
              
             Ballot
              
@@ -1673,7 +1673,7 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
           <span
             class="bp3-button-text"
           >
-            Download Aggregated
+            Download
              
             Ballot
              


### PR DESCRIPTION
All in the PR title! We concluded that the "Aggregated" in the copy felt redundant

-----

_Before and after_

<img width="355" alt="before" src="https://user-images.githubusercontent.com/12616928/168904368-fbc110e1-ff72-4075-8283-90c18aad8d34.png">

<img width="270" alt="after" src="https://user-images.githubusercontent.com/12616928/168904367-0343e770-6d4c-472d-9c04-018b64f779b4.png">

-----

Made the same change to the ballot retrieval buttons for non-batch audits

```
$ git grep "Aggregated"
$
```