### PR TITLE
Hybrid: validate CVR votes aren't more than contest settings votes

### DIFF
--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -93,6 +93,12 @@ def validate_hybrid_manifests_and_cvrs(contest: Contest):
             f" times the number of votes allowed ({contest.votes_allowed})"
         )
 
+    if any(count.non_cvr < 0 for count in vote_counts.values()):
+        raise UserError(
+            f"For contest {contest.name}, the CVRs contain more votes"
+            " than were entered in the contest settings."
+        )
+
 
 def sample_size_options(election: Election) -> Dict[str, Dict[str, SampleSizeOption]]:
     if not election.contests:

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -93,10 +93,20 @@ def validate_hybrid_manifests_and_cvrs(contest: Contest):
             f" times the number of votes allowed ({contest.votes_allowed})"
         )
 
-    if any(count.non_cvr < 0 for count in vote_counts.values()):
+    choices_by_id = {choice.id: choice for choice in contest.choices}
+    invalid_count = next(
+        (
+            (choices_by_id[choice_id], count)
+            for choice_id, count in vote_counts.items()
+            if count.cvr > choices_by_id[choice_id].num_votes
+        ),
+        None,
+    )
+    if invalid_count:
+        choice, count = invalid_count
         raise UserError(
-            f"For contest {contest.name}, the CVRs contain more votes"
-            " than were entered in the contest settings."
+            f"For contest {contest.name}, the CVRs contain more votes for choice {choice.name} ({count.cvr})"
+            f" than were entered in the contest settings ({choice.num_votes})."
         )
 
 

--- a/server/tests/hybrid/test_hybrid.py
+++ b/server/tests/hybrid/test_hybrid.py
@@ -757,7 +757,7 @@ def test_hybrid_manifest_validation_too_many_cvr_votes(
                 "status": "ERRORED",
                 "startedAt": assert_is_date,
                 "completedAt": assert_is_date,
-                "error": "For contest Contest 1, the CVRs contain more votes than were entered in the contest settings.",
+                "error": "For contest Contest 1, the CVRs contain more votes for choice Choice 1-1 (14) than were entered in the contest settings (13).",
             },
         },
     )

--- a/server/tests/hybrid/test_hybrid.py
+++ b/server/tests/hybrid/test_hybrid.py
@@ -720,6 +720,49 @@ def test_hybrid_manifest_validation_few_non_cvr_ballots(
     )
 
 
+def test_hybrid_manifest_validation_too_many_cvr_votes(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    cvrs,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    contests = [
+        {
+            "id": str(uuid.uuid4()),
+            "name": "Contest 1",
+            "isTargeted": True,
+            "choices": [
+                {"id": str(uuid.uuid4()), "name": "Choice 1-1", "numVotes": 13},
+                {"id": str(uuid.uuid4()), "name": "Choice 1-2", "numVotes": 10},
+            ],
+            "numWinners": 1,
+            "votesAllowed": 2,
+            "jurisdictionIds": jurisdiction_ids[:2],
+        },
+    ]
+    rv = put_json(client, f"/api/election/{election_id}/contest", contests)
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
+    assert rv.status_code == 200
+    compare_json(
+        json.loads(rv.data),
+        {
+            "sampleSizes": None,
+            "selected": None,
+            "task": {
+                "status": "ERRORED",
+                "startedAt": assert_is_date,
+                "completedAt": assert_is_date,
+                "error": "For contest Contest 1, the CVRs contain more votes than were entered in the contest settings.",
+            },
+        },
+    )
+
+
 def test_hybrid_filter_cvrs(
     client: FlaskClient,
     election_id: str,


### PR DESCRIPTION
If the audit admin enters total vote counts for a contest choice that are less than the number of votes for that choice in the CVRs, something is wrong!