### PR TITLE
Bump findByText timeout to decrease test flakiness

### DIFF
--- a/client/src/components/AuditAdmin/Setup/Participants/Participants.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Participants/Participants.test.tsx
@@ -376,7 +376,9 @@ describe('Audit Setup > Participants', () => {
       )
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
       await screen.findByText(/Uploaded/)
-      await screen.findByText('something went wrong')
+      await screen.findByText('something went wrong', undefined, {
+        timeout: 2000,
+      })
     })
   })
 
@@ -405,7 +407,9 @@ describe('Audit Setup > Participants', () => {
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
 
       await screen.findByText(/Uploaded/)
-      await screen.findByText('something went wrong')
+      await screen.findByText('something went wrong', undefined, {
+        timeout: 2000,
+      })
     })
   })
 })


### PR DESCRIPTION
We have a test that sporadically fails in CircleCI. Jonah has also seen it fail locally.

<img width="800" alt="test" src="https://user-images.githubusercontent.com/12616928/169082459-ec105e6c-2b36-497c-86f4-de6b84b11d20.png">

Our best theory right now is that the default `findByText` timeout (1000ms) is too short for one of the lookups in the test. Dropping the timeout to 500ms, I was able to consistently repro the error locally, giving credence to this theory!

I'm bumping the relevant timeout in this test (and another very similar test to be safe) to 2000ms accordingly.