### PR TITLE
Pass options through to jsPDF mock

### DIFF
--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
@@ -35,11 +35,10 @@ jest.mock('axios')
 const mockSavePDF = jest.fn()
 jest.mock('jspdf', () => {
   const { jsPDF } = jest.requireActual('jspdf')
-  const mockjspdf = new jsPDF({ format: 'letter' })
-  // eslint-disable-next-line func-names
-  return function() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function mockJsPDF(options?: any) {
     return {
-      ...mockjspdf,
+      ...new jsPDF(options),
       addImage: jest.fn(),
       save: mockSavePDF,
     }

--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -22,11 +22,10 @@ import { queryClient } from '../../../App'
 const mockSavePDF = jest.fn()
 jest.mock('jspdf', () => {
   const { jsPDF } = jest.requireActual('jspdf')
-  const mockjspdf = new jsPDF({ format: 'letter' })
-  // eslint-disable-next-line func-names
-  return function() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function mockJsPDF(options?: any) {
     return {
-      ...mockjspdf,
+      ...new jsPDF(options),
       addImage: jest.fn(),
       save: mockSavePDF,
     }

--- a/client/src/components/JurisdictionAdmin/RoundManagement.test.tsx
+++ b/client/src/components/JurisdictionAdmin/RoundManagement.test.tsx
@@ -31,9 +31,11 @@ import {
 const mockSavePDF = jest.fn()
 jest.mock('jspdf', () => {
   const { jsPDF } = jest.requireActual('jspdf')
-  return function mockJsPDF() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function mockJsPDF(options?: any) {
     return {
-      ...new jsPDF({ format: 'letter' }),
+      ...new jsPDF(options),
+      addImage: jest.fn(),
       save: mockSavePDF,
     }
   }

--- a/client/src/components/JurisdictionAdmin/generateSheets.test.tsx
+++ b/client/src/components/JurisdictionAdmin/generateSheets.test.tsx
@@ -52,11 +52,10 @@ function constructContestChoices(numChoices: number): ICandidate[] {
 const mockSavePDF = jest.fn()
 jest.mock('jspdf', () => {
   const { jsPDF } = jest.requireActual('jspdf')
-  // eslint-disable-next-line func-names, @typescript-eslint/no-explicit-any
-  return function(options: any) {
-    const mockjspdf = new jsPDF(options)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function mockJsPDF(options?: any) {
     return {
-      ...mockjspdf,
+      ...new jsPDF(options),
       addImage: jest.fn(),
       save: mockSavePDF,
     }


### PR DESCRIPTION
We've been seeing console errors during tests that cover our use of jspdf-autotable.

<img width="820" alt="errors" src="https://user-images.githubusercontent.com/12616928/169126941-2fddd711-8222-4376-a7d2-78f724d3a827.png">

Despite the above error, our PDF tables are fitting on the page and rendering fine.

This is because we aren't always passing options through to the jsPDF mock used by tests. So while we're [using pt units when creating batch tally sheets](https://github.com/votingworks/arlo/blob/2d90eb4dc394a2f77c7607ba59925a4a55f55843/client/src/components/JurisdictionAdmin/generateSheets.ts#L217), some tests are [using the default mm units](https://github.com/votingworks/arlo/blob/2d90eb4dc394a2f77c7607ba59925a4a55f55843/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx#L38). Our [table cell min width of 100](https://github.com/votingworks/arlo/blob/2d90eb4dc394a2f77c7607ba59925a4a55f55843/client/src/components/JurisdictionAdmin/generateSheets.ts#L236) fits fine on the page in pt but not always in mm (1mm = 2.83pt).

This PR accordingly makes sure that we pass options through to the jsPDF mock. The above console errors are no more!


