### PR TITLE
Fix AA uploading jurisdiction files form state bug

### DIFF
--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
@@ -176,6 +176,9 @@ describe('JurisdictionDetail', () => {
       userEvent.click(
         within(cvrsCard).getByRole('button', { name: 'Upload File' })
       )
+      await waitFor(() =>
+        expect(within(cvrsCard).getByLabelText('CVR File Type:')).toBeDisabled()
+      )
       await within(cvrsCard).findByText('Uploaded')
       const cvrsLink = within(cvrsCard).getByRole('link', { name: 'cvrs.csv' })
       expect(cvrsLink).toHaveAttribute(
@@ -204,6 +207,9 @@ describe('JurisdictionDetail', () => {
         within(cvrsCard).getByRole('button', { name: 'Delete File' })
       )
       await within(cvrsCard).findByText('No file uploaded')
+      const cvrFileTypeInput = within(cvrsCard).getByLabelText('CVR File Type:')
+      expect(cvrFileTypeInput).toBeEnabled()
+      expect(cvrFileTypeInput).toHaveValue('CLEARBALLOT')
     })
   })
 

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -59,10 +59,9 @@ const Progress: React.FC<IProgressProps> = ({
   const { electionId } = useParams<{ electionId: string }>()
   const [filter, setFilter] = useState<string>('')
   const [isShowingUnique, setIsShowingUnique] = useState<boolean>(true)
-  const [
-    jurisdictionDetail,
-    setJurisdictionDetail,
-  ] = useState<IJurisdiction | null>(null)
+  const [jurisdictionDetailId, setJurisdictionDetailId] = useState<
+    string | null
+  >(null)
 
   // gives prop validation error if used as auditSettings.auditType
   const { auditType } = auditSettings
@@ -80,7 +79,7 @@ const Progress: React.FC<IProgressProps> = ({
           small
           intent="primary"
           minimal
-          onClick={() => setJurisdictionDetail(jurisdiction)}
+          onClick={() => setJurisdictionDetailId(jurisdiction.id)}
         >
           {jurisdiction.name}
         </Button>
@@ -97,7 +96,7 @@ const Progress: React.FC<IProgressProps> = ({
           <StatusTag
             {...props}
             interactive
-            onClick={() => setJurisdictionDetail(jurisdiction)}
+            onClick={() => setJurisdictionDetailId(jurisdiction.id)}
           />
         )
 
@@ -338,12 +337,16 @@ const Progress: React.FC<IProgressProps> = ({
         columns={columns}
         id="progress-table"
       />
-      {jurisdictionDetail && (
+      {jurisdictionDetailId && (
         <JurisdictionDetail
-          jurisdiction={jurisdictionDetail}
+          jurisdiction={
+            jurisdictions.find(
+              jurisdiction => jurisdiction.id === jurisdictionDetailId
+            )!
+          }
           electionId={electionId}
           round={round}
-          handleClose={() => setJurisdictionDetail(null)}
+          handleClose={() => setJurisdictionDetailId(null)}
           auditSettings={auditSettings}
         />
       )}

--- a/client/src/components/useFileUpload.ts
+++ b/client/src/components/useFileUpload.ts
@@ -163,7 +163,7 @@ export const useBatchTallies = (
   }
 }
 
-interface ICvrsFileUpload extends Omit<IFileUpload, 'uploadFiles'> {
+export interface ICvrsFileUpload extends Omit<IFileUpload, 'uploadFiles'> {
   uploadFiles: (cvrs: File[], cvrFileType: CvrFileType) => Promise<void>
 }
 


### PR DESCRIPTION
There was a small bug where after deleting a CVR file/reuploading a new
CVR file, the latest file state wasn't showing up in the detail modal, which
was causing the CVR file type dropdown to be incorrectly
enabled/disabled.

The root cause of this was that the jurisdiction progress screen was
storing the entire jurisdiction object in state for whichever
jurisdiction's detail modal was open. When the jurisdictions list was
refetched, that stale object was sticking around. I fixed that by
switching to only storing the jurisdiction id in state.

Then, I realized that it would be snappier to not even use that
jurisdiction list data in the modal, but to instead rely entirely on the
useCVRs response (which updates quicker). This is also cleaner and
better matches the data pattern we use for the other file uploads
(manifest, tallies). So I changed that as well.