### PR TITLE
Bugfix: Don't return 0 sample size from BRAVO math

### DIFF
--- a/server/audit_math/bravo.py
+++ b/server/audit_math/bravo.py
@@ -421,7 +421,8 @@ def get_sample_size(
 
     for quant in quants:
         size = bravo_sample_sizes(alpha, p_w, p_l, sample_w, sample_l, quant)
-        samples[str(quant)] = {"type": None, "size": size, "prob": quant}
+        if size != 0:
+            samples[str(quant)] = {"type": None, "size": size, "prob": quant}
 
     # If the computed sample size is a good chunk of the ballots, recommend
     # auditing all ballots, since this is actually less work than auditing a
@@ -430,6 +431,7 @@ def get_sample_size(
     all_ballots_threshold = num_ballots * 0.25
     if (
         num_ballots > large_election_threshold
+        and "0.9" in samples
         and samples["0.9"]["size"] >= all_ballots_threshold
     ):
         return {

--- a/server/tests/audit_math/test_bravo.py
+++ b/server/tests/audit_math/test_bravo.py
@@ -552,6 +552,31 @@ def test_ballot_polling_not_found_ballots(snapshot):
     snapshot.assert_match(not_found_p_values)
 
 
+def test_bravo_no_90_percent_prob_sample_size():
+    contest = Contest(
+        "Contest",
+        {
+            "K": 228713,
+            "J": 124297,
+            "D": 115776,
+            "P": 43710,
+            "C": 41809,
+            "G": 41688,
+            "B": 13720,
+            "ballots": 672912,
+            "numWinners": 1,
+            "votesAllowed": 1,
+        },
+    )
+    sample_results = {
+        "round1": {"K": 50, "J": 21, "D": 30, "P": 8, "C": 10, "G": 10, "B": 1}
+    }
+    sample_sizes = bravo.get_sample_size(
+        RISK_LIMIT, contest, sample_results, {"round1": 135}
+    )
+    assert "0.9" not in sample_sizes
+
+
 bravo_contests = {
     "test1": {
         "cand1": 600,


### PR DESCRIPTION
If any of the bravo sample sizes is 0, we shouldn't return it. That way, we never end up in a broken state with a 0 sample size.