### PR TITLE
Parse updated ES&S ballots files

### DIFF
--- a/scripts/fix-ess-cvr-quotes.py
+++ b/scripts/fix-ess-cvr-quotes.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name
 import sys
 import re
 
@@ -10,60 +11,78 @@ def split_attach_sep(pattern, str):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
+    if len(sys.argv) != 4:
         print(
-            "Usage: python -m scripts.fix-ess-cvr-quotes <in-cvr-path> <out-cvr-path>"
+            "Usage: python -m scripts.fix-ess-cvr-quotes file-type <in-cvr-path> <out-cvr-path>"
         )
         sys.exit(1)
 
     # TODO it seems like the rows still aren't ending up all the same length,
     # probably because the REP ballots are not padded with empty cells like the
     # DEM ballots (and headers) are
-    with open(sys.argv[1], "r") as in_file, open(sys.argv[2], "w") as out_file:
-        for row in in_file:
-            row = row.replace("\n", "")
+    with open(sys.argv[2], "r") as in_file, open(sys.argv[3], "w") as out_file:
+        file_type = sys.argv[1]
+        if file_type == "ballots":
+            # In ballots files, we've seen misquoting in the Original Ballot Exception column.
+            # It seems like they contain a list of values separated by a comma
+            # and a space, so we look for that pattern and try to quote it.
+            #
+            # Example: ... Approved with Changes,Undervote, Overvote,Undervote,,Y, ...
+            misquoting_regex = re.compile(r",([a-zA-Z ]+(?:, [a-zA-Z ]+)+),")
+            for row in in_file:
+                row = re.sub(misquoting_regex, r',"\1",', row)
+                # Sub twice in case they overlap
+                row = re.sub(misquoting_regex, r',"\1",', row)
+                out_file.write(row)
 
-            # Split off first 5 columns that don't have candidates
-            [_, metadata_columns, contest_columns] = re.split(
-                r"(^(?:[\w \-]+,){5})", row
-            )
+        elif file_type == "cvr":
+            for row in in_file:
+                row = row.replace("\n", "")
 
-            # Example contest_columns:
-            # ,SMITH, "JOHN ""JOHNNY"" (CND0001)",,DOE, JANE (CND0002)
-            # What we want:
-            # "","SMITH, JOHN ""JOHNNY" (CND0001)","","DOE, JANE (CND0002)"
-
-            # We're going to take advantage of the fact that every candidate
-            # name and contest name ends with its id in parens.
-
-            # First, put in a placeholder for empty columns that ends in a paren
-            # re.sub only replaces non-overlapping occurrences, so we have to do this twice
-            contest_columns = re.sub(r",,", ",EMPTY),", contest_columns)
-            contest_columns = re.sub(r",,", ",EMPTY),", contest_columns)
-            # Also handle the edges
-            contest_columns = re.sub(r",$", ",EMPTY)", contest_columns)
-            contest_columns = re.sub(r"^,", "EMPTY),", contest_columns)
-
-            # Next, make undervotes and overvotes also end in a paren
-            contest_columns = re.sub(r"undervote", "undervote)", contest_columns)
-            contest_columns = re.sub(r"overvote", "overvote)", contest_columns)
-
-            # Split on ), or )",
-            candidates = split_attach_sep(r'(\))"?,', contest_columns)
-            fixed_candidates = []
-            for candidate in candidates:
-                # Remove any internal misquoting (e.g. "JOHN) in example above
-                candidate = candidate.replace(',"', ",")
-                # Put the empties, undervotes, and overvotes back
-                candidate = (
-                    candidate.replace("EMPTY)", "")
-                    .replace("undervote)", "undervote")
-                    .replace("overvote)", "overvote")
+                # Split off first 5 columns that don't have candidates
+                [_, metadata_columns, contest_columns] = re.split(
+                    r"(^(?:[\w \-]+,){5})", row
                 )
-                # Properly quote
-                fixed_candidates.append('"' + candidate + '"')
 
-            # Rejoin the row
-            fixed_row = metadata_columns + ",".join(fixed_candidates)
+                # Example contest_columns:
+                # ,SMITH, "JOHN ""JOHNNY"" (CND0001)",,DOE, JANE (CND0002)
+                # What we want:
+                # "","SMITH, JOHN ""JOHNNY" (CND0001)","","DOE, JANE (CND0002)"
 
-            out_file.write(fixed_row + "\n")
+                # We're going to take advantage of the fact that every candidate
+                # name and contest name ends with its id in parens.
+
+                # First, put in a placeholder for empty columns that ends in a paren
+                # re.sub only replaces non-overlapping occurrences, so we have to do this twice
+                contest_columns = re.sub(r",,", ",EMPTY),", contest_columns)
+                contest_columns = re.sub(r",,", ",EMPTY),", contest_columns)
+                # Also handle the edges
+                contest_columns = re.sub(r",$", ",EMPTY)", contest_columns)
+                contest_columns = re.sub(r"^,", "EMPTY),", contest_columns)
+
+                # Next, make undervotes and overvotes also end in a paren
+                contest_columns = re.sub(r"undervote", "undervote)", contest_columns)
+                contest_columns = re.sub(r"overvote", "overvote)", contest_columns)
+
+                # Split on ), or )",
+                candidates = split_attach_sep(r'(\))"?,', contest_columns)
+                fixed_candidates = []
+                for candidate in candidates:
+                    # Remove any internal misquoting (e.g. "JOHN) in example above
+                    candidate = candidate.replace(',"', ",")
+                    # Put the empties, undervotes, and overvotes back
+                    candidate = (
+                        candidate.replace("EMPTY)", "")
+                        .replace("undervote)", "undervote")
+                        .replace("overvote)", "overvote")
+                    )
+                    # Properly quote
+                    fixed_candidates.append('"' + candidate + '"')
+
+                # Rejoin the row
+                fixed_row = metadata_columns + ",".join(fixed_candidates)
+
+                out_file.write(fixed_row + "\n")
+
+        else:
+            raise Exception('File type must be "ballots" or "cvr"')

--- a/scripts/fix-ess-cvr-quotes.py
+++ b/scripts/fix-ess-cvr-quotes.py
@@ -1,0 +1,69 @@
+import sys
+import re
+
+
+# Splits a string based on a separator pattern containing capture groups. Then
+# attaches the captured separator back onto the previous portion of the string.
+def split_attach_sep(pattern, str):
+    split = re.split(pattern, str)
+    return ["".join(split[i : i + 2]) for i in range(0, len(split), 2)]
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(
+            "Usage: python -m scripts.fix-ess-cvr-quotes <in-cvr-path> <out-cvr-path>"
+        )
+        sys.exit(1)
+
+    # TODO it seems like the rows still aren't ending up all the same length,
+    # probably because the REP ballots are not padded with empty cells like the
+    # DEM ballots (and headers) are
+    with open(sys.argv[1], "r") as in_file, open(sys.argv[2], "w") as out_file:
+        for row in in_file:
+            row = row.replace("\n", "")
+
+            # Split off first 5 columns that don't have candidates
+            [_, metadata_columns, contest_columns] = re.split(
+                r"(^(?:[\w \-]+,){5})", row
+            )
+
+            # Example contest_columns:
+            # ,SMITH, "JOHN ""JOHNNY"" (CND0001)",,DOE, JANE (CND0002)
+            # What we want:
+            # "","SMITH, JOHN ""JOHNNY" (CND0001)","","DOE, JANE (CND0002)"
+
+            # We're going to take advantage of the fact that every candidate
+            # name and contest name ends with its id in parens.
+
+            # First, put in a placeholder for empty columns that ends in a paren
+            # re.sub only replaces non-overlapping occurrences, so we have to do this twice
+            contest_columns = re.sub(r",,", ",EMPTY),", contest_columns)
+            contest_columns = re.sub(r",,", ",EMPTY),", contest_columns)
+            # Also handle the edges
+            contest_columns = re.sub(r",$", ",EMPTY)", contest_columns)
+            contest_columns = re.sub(r"^,", "EMPTY),", contest_columns)
+
+            # Next, make undervotes and overvotes also end in a paren
+            contest_columns = re.sub(r"undervote", "undervote)", contest_columns)
+            contest_columns = re.sub(r"overvote", "overvote)", contest_columns)
+
+            # Split on ), or )",
+            candidates = split_attach_sep(r'(\))"?,', contest_columns)
+            fixed_candidates = []
+            for candidate in candidates:
+                # Remove any internal misquoting (e.g. "JOHN) in example above
+                candidate = candidate.replace(',"', ",")
+                # Put the empties, undervotes, and overvotes back
+                candidate = (
+                    candidate.replace("EMPTY)", "")
+                    .replace("undervote)", "undervote")
+                    .replace("overvote)", "overvote")
+                )
+                # Properly quote
+                fixed_candidates.append('"' + candidate + '"')
+
+            # Rejoin the row
+            fixed_row = metadata_columns + ",".join(fixed_candidates)
+
+            out_file.write(fixed_row + "\n")

--- a/scripts/manifest-for-cvr.py
+++ b/scripts/manifest-for-cvr.py
@@ -64,10 +64,8 @@ if __name__ == "__main__":
         # Expects type 2 ES&S ballots file (more on this in server/api/cvrs.py)
         elif cvr_file_type == "ESS":
             headers = next(cvr)
-            print(headers)
             header_indices = {header: i for i, header in enumerate(headers)}
             for row in cvr:
-                print(row)
                 tabulator = row[header_indices["Machine"]]
                 batch_name = row[header_indices["Batch"]]
                 batch_counts[(tabulator, batch_name)] += 1

--- a/scripts/manifest-for-cvr.py
+++ b/scripts/manifest-for-cvr.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
                 ] = row[:first_contest_column]
                 batch_counts[(scan_computer_name, box_id)] += 1
 
-        # Expects type 2 ES&S ballots file
+        # Expects type 2 ES&S ballots file (more on this in server/api/cvrs.py)
         elif cvr_file_type == "ESS":
             headers = next(cvr)
             print(headers)

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -515,7 +515,7 @@ def parse_ess_cvrs(
         # around this, we find and quote the example of this we've seen.
         misquoting_regex = re.compile(r", (Overvote|Undervote),,")
         ballots_file_lines = (
-            re.sub(misquoting_regex, '," \1,",', line) for line in ballots_file
+            re.sub(misquoting_regex, r'," \1,",', line) for line in ballots_file
         )
 
         ballots_csv = csv.reader(ballots_file_lines, delimiter=",")

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -509,16 +509,7 @@ def parse_ess_cvrs(
         ballots_file: TextIO,
     ) -> Iterator[Tuple[str, CvrBallot]]:  # (CVR number, ballot)
         validate_comma_delimited(ballots_file)
-
-        # We've seen malformed ballots CSVs to lack of field quoting, leading to
-        # commas in field values being parsed as extra columns. To hackily work
-        # around this, we find and quote the example of this we've seen.
-        misquoting_regex = re.compile(r", (Overvote|Undervote),,")
-        ballots_file_lines = (
-            re.sub(misquoting_regex, r'," \1,",', line) for line in ballots_file
-        )
-
-        ballots_csv = csv.reader(ballots_file_lines, delimiter=",")
+        ballots_csv = csv.reader(ballots_file, delimiter=",")
 
         # There are two formats of the ballots file that we support based on
         # different versions of the ES&S system

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -513,10 +513,9 @@ def parse_ess_cvrs(
         # We've seen malformed ballots CSVs to lack of field quoting, leading to
         # commas in field values being parsed as extra columns. To hackily work
         # around this, we find and quote the example of this we've seen.
-        overvote_misquoting_regex = re.compile(r", Overvote,,")
+        misquoting_regex = re.compile(r", (Overvote|Undervote),,")
         ballots_file_lines = (
-            re.sub(overvote_misquoting_regex, '," Overvote,",', line)
-            for line in ballots_file
+            re.sub(misquoting_regex, '," \1,",', line) for line in ballots_file
         )
 
         ballots_csv = csv.reader(ballots_file_lines, delimiter=",")
@@ -592,7 +591,7 @@ def parse_ess_cvrs(
                     record_id = int(ballot_number)
                 else:
                     # Convert 16-character hex to a small-ish int that fits in
-                    # the db Based on the data we've seen, this creates a large
+                    # the db. Based on the data we've seen, this creates a large
                     # enough gap between ids to order them without creating any
                     # duplicates.
                     record_id = floor(int(tabulator_cvr, 16) / 10 ** 10)

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -1,3 +1,4 @@
+from math import floor
 import uuid
 import tempfile
 import csv
@@ -476,7 +477,7 @@ def parse_ess_cvrs(
     def is_ballots_file(file: TextIO):
         first_line = file.readline()
         file.seek(0)
-        return first_line.startswith("Ballots")
+        return first_line.startswith("Ballots") or "Tabulator CVR" in first_line
 
     ballots_files = {
         name: file for name, file in text_files.items() if is_ballots_file(file)
@@ -508,17 +509,35 @@ def parse_ess_cvrs(
         ballots_file: TextIO,
     ) -> Iterator[Tuple[str, CvrBallot]]:  # (CVR number, ballot)
         validate_comma_delimited(ballots_file)
-        ballots_csv = csv.reader(ballots_file, delimiter=",")
 
-        # Skip some metadata rows
+        # We've seen malformed ballots CSVs to lack of field quoting, leading to
+        # commas in field values being parsed as extra columns. To hackily work
+        # around this, we find and quote the example of this we've seen.
+        overvote_misquoting_regex = re.compile(r", Overvote,,")
+        ballots_file_lines = (
+            re.sub(overvote_misquoting_regex, '," Overvote,",', line)
+            for line in ballots_file
+        )
+
+        ballots_csv = csv.reader(ballots_file_lines, delimiter=",")
+
+        # There are two formats of the ballots file that we support based on
+        # different versions of the ES&S system
         # pylint: disable=stop-iteration-return
-        _ballots_header = next(ballots_csv)
-        _gen_tag = next(ballots_csv)
-        _county_name = next(ballots_csv)
-        _date = next(ballots_csv)
-        _empty_row = next(ballots_csv)
+        first_row = next(ballots_csv)
+        # One format starts with metadata rows before the headers, which we want to skip
+        if first_row[0] == "Ballots":
+            _gen_tag = next(ballots_csv)
+            _county_name = next(ballots_csv)
+            _date = next(ballots_csv)
+            _empty_row = next(ballots_csv)
+            headers = next(ballots_csv)
+            ballots_file_type = "type1"
+        # The other has headers in the first row
+        else:
+            headers = first_row
+            ballots_file_type = "type2"
 
-        headers = next(ballots_csv)
         header_indices = get_header_indices(headers)
 
         ballot_rows = (row for row in ballots_csv if not row[0].startswith("Total"))
@@ -530,7 +549,7 @@ def parse_ess_cvrs(
             ballot_rows, key=lambda row: int(row[header_indices["Cast Vote Record"]])
         )
 
-        tabulator_regex = re.compile(r"^(\d{4})(\d{6})$")
+        ten_digit_tabulator_cvr_regex = re.compile(r"^(\d{4})(\d{6})$")
 
         for row_index, row in enumerate(sorted_ballot_rows):
             cvr_number = column_value(
@@ -541,23 +560,49 @@ def parse_ess_cvrs(
                 row, "Tabulator CVR", cvr_number, header_indices
             )
 
-            match = tabulator_regex.match(tabulator_cvr)
-            if not match:
-                raise UserError(
-                    "Tabulator CVR should be a ten-digit number."
-                    f" Got {tabulator_cvr} for Cast Vote Record {cvr_number}."
-                    " Make sure any leading zeros have not been stripped from this field."
+            # In type 1 ballots files, Tabulator CVR is a 10-digit string. The
+            # first four digits are the tabulator ID, the last six are the
+            # ballot number within the batch. We use this full value as an
+            # imprinted ID even though it's not imprinted on the ballots.
+            if ballots_file_type == "type1":
+                match = ten_digit_tabulator_cvr_regex.match(tabulator_cvr)
+                if not match:
+                    raise UserError(
+                        "Tabulator CVR should be a ten-digit number."
+                        f" Got {tabulator_cvr} for Cast Vote Record {cvr_number}."
+                        " Make sure any leading zeros have not been stripped from this field."
+                    )
+                tabulator_number, ballot_number = match.groups()
+                imprinted_id = tabulator_cvr
+                record_id = int(ballot_number)
+
+            # In type 2 ballots files, we use the Machine column as the
+            # tabulator ID. Tabulator CVR has either the 10-digit string or a
+            # 16-character hex id, the latter of which is actually imprinted on
+            # the ballots. For the hex case, we attempt to use it as a ballot
+            # number, even though we don't know if it corresponds to ballot order.
+            elif ballots_file_type == "type2":
+                tabulator_number = column_value(
+                    row, "Machine", cvr_number, header_indices
                 )
-            tabulator_number, ballot_number = match.groups()
+                imprinted_id = tabulator_cvr
+                match = ten_digit_tabulator_cvr_regex.match(tabulator_cvr)
+                if match:
+                    _, ballot_number = match.groups()
+                    record_id = int(ballot_number)
+                else:
+                    # Convert 16-character hex to a small-ish int that fits in
+                    # the db Based on the data we've seen, this creates a large
+                    # enough gap between ids to order them without creating any
+                    # duplicates.
+                    record_id = floor(int(tabulator_cvr, 16) / 10 ** 10)
 
             db_batch = batches_by_key.get((tabulator_number, batch_name))
             if db_batch:
                 yield (
                     cvr_number,
                     CvrBallot(
-                        batch=db_batch,
-                        record_id=int(ballot_number),
-                        imprinted_id=tabulator_cvr,
+                        batch=db_batch, record_id=record_id, imprinted_id=imprinted_id,
                     ),
                 )
             else:

--- a/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
@@ -633,6 +633,127 @@ snapshots["test_dominion_cvr_upload 2"] = {
     },
 }
 
+snapshots["test_ess_cvr_type_2_upload 1"] = [
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0002000171",
+        "interpretations": "1,0,0,1,0",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0002000172",
+        "interpretations": "0,1,0,1,0",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0002000173",
+        "interpretations": "1,0,0,1,0",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 4,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0002000174",
+        "interpretations": "0,1,0,0,1",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 5,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0002000175",
+        "interpretations": "1,0,0,0,1",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH1",
+        "imprinted_id": "0002003172",
+        "interpretations": "0,1,1,0,0",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH1",
+        "imprinted_id": "0002003173",
+        "interpretations": "1,0,1,0,0",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH1",
+        "imprinted_id": "02bc1dc7bc1e7774",
+        "interpretations": "0,1,1,0,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH1",
+        "imprinted_id": "039b31b93d9a8099",
+        "interpretations": "1,0,1,0,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH1",
+        "imprinted_id": "06348ce7b6d146d2",
+        "interpretations": "u,u,1,0,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 4,
+        "batch_name": "BATCH1",
+        "imprinted_id": "09809965339bad95",
+        "interpretations": "o,o,1,0,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH2",
+        "imprinted_id": "19882855d197f6c2",
+        "interpretations": "0,1,1,0,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1dd6b0ff8462558c",
+        "interpretations": "1,0,1,0,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1f781b866b83de9b",
+        "interpretations": "0,1,0,1,0",
+        "tabulator": "0001",
+    },
+]
+
+snapshots["test_ess_cvr_type_2_upload 2"] = {
+    "Contest 1": {
+        "choices": {
+            "Choice 1-1": {"column": 0, "num_votes": 6},
+            "Choice 1-2": {"column": 1, "num_votes": 6},
+        },
+        "total_ballots_cast": 14,
+        "votes_allowed": 1,
+    },
+    "Contest 2": {
+        "choices": {
+            "Choice 2-1": {"column": 2, "num_votes": 8},
+            "Choice 2-2": {"column": 3, "num_votes": 4},
+            "Choice 2-3": {"column": 4, "num_votes": 2},
+        },
+        "total_ballots_cast": 14,
+        "votes_allowed": 1,
+    },
+}
+
 snapshots["test_ess_cvr_upload 1"] = [
     {
         "ballot_position": 1,

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1485,12 +1485,11 @@ def test_ess_cvr_invalid(
         )
 
 
-# In CVR rows 3 and 4, we simulate a malformed CSV row due to bad quoting of the Remaining Ballot Exception field.
 ESS_TYPE_2_BALLOTS = """Cast Vote Record,Batch,Ballot Status,Original Ballot Exception,Remaining Ballot Exception,Write-in Type,Results Report,Ballot Style,Reporting Group,Tabulator CVR,Audit Number,Type,Poll Place,Poll Place ID,Precinct,Precinct ID,Machine,Adjudicated By,
 1,BATCH1,Not Reviewed,,,,N,REP 405,Election Day,02bc1dc7bc1e7774,7074480632,Card,Election Day,28,405,21,0001,
 2,BATCH1,Not Reviewed,,,,N,REP 405,Election Day,039b31b93d9a8099,7074480632,Card,Election Day,28,405,21,0001,
-3,BATCH1,Not Reviewed,Undervote, Overvote,,,N,REP 405,Election Day,06348ce7b6d146d2,7074480632,Card,Election Day,28,405,21,0001,
-4,BATCH1,Not Reviewed,Overvote, Undervote,,,N,REP 405,Election Day,09809965339bad95,7074480632,Card,Election Day,28,405,21,0001,
+3,BATCH1,Not Reviewed,"Undervote, Overvote",,,N,REP 405,Election Day,06348ce7b6d146d2,7074480632,Card,Election Day,28,405,21,0001,
+4,BATCH1,Not Reviewed,Overvote,,,N,REP 405,Election Day,09809965339bad95,7074480632,Card,Election Day,28,405,21,0001,
 5,BATCH1,Not Reviewed,,,,N,REP 405,Election Day,0002003172,7074480632,Card,Election Day,28,405,21,0002,
 6,BATCH1,Not Reviewed,,,,N,REP 405,Election Day,0002003173,7074480632,Card,Election Day,28,405,21,0002,
 7,BATCH2,Not Reviewed,,,,N,REP 405,Election Day,19882855d197f6c2,7074480632,Card,Election Day,28,405,21,0001,

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1485,12 +1485,12 @@ def test_ess_cvr_invalid(
         )
 
 
-# In CVR row 4, we simulate a malformed CSV row due to bad quoting of the Remaining Ballot Exception field.
+# In CVR rows 3 and 4, we simulate a malformed CSV row due to bad quoting of the Remaining Ballot Exception field.
 ESS_TYPE_2_BALLOTS = """Cast Vote Record,Batch,Ballot Status,Original Ballot Exception,Remaining Ballot Exception,Write-in Type,Results Report,Ballot Style,Reporting Group,Tabulator CVR,Audit Number,Type,Poll Place,Poll Place ID,Precinct,Precinct ID,Machine,Adjudicated By,
 1,BATCH1,Not Reviewed,,,,N,REP 405,Election Day,02bc1dc7bc1e7774,7074480632,Card,Election Day,28,405,21,0001,
 2,BATCH1,Not Reviewed,,,,N,REP 405,Election Day,039b31b93d9a8099,7074480632,Card,Election Day,28,405,21,0001,
-3,BATCH1,Not Reviewed,Undervote,,,N,REP 405,Election Day,06348ce7b6d146d2,7074480632,Card,Election Day,28,405,21,0001,
-4,BATCH1,Not Reviewed,Overvote, Overvote,,,N,REP 405,Election Day,09809965339bad95,7074480632,Card,Election Day,28,405,21,0001,
+3,BATCH1,Not Reviewed,Undervote, Overvote,,,N,REP 405,Election Day,06348ce7b6d146d2,7074480632,Card,Election Day,28,405,21,0001,
+4,BATCH1,Not Reviewed,Overvote, Undervote,,,N,REP 405,Election Day,09809965339bad95,7074480632,Card,Election Day,28,405,21,0001,
 5,BATCH1,Not Reviewed,,,,N,REP 405,Election Day,0002003172,7074480632,Card,Election Day,28,405,21,0002,
 6,BATCH1,Not Reviewed,,,,N,REP 405,Election Day,0002003173,7074480632,Card,Election Day,28,405,21,0002,
 7,BATCH2,Not Reviewed,,,,N,REP 405,Election Day,19882855d197f6c2,7074480632,Card,Election Day,28,405,21,0001,


### PR DESCRIPTION
A new version of ES&S creates different ballots files than we previously expected. This PR updates the CVR parsing to handle this new file format.

Also adds a script to fix misquoted fields in ES&S ballots and CVR files.