### PR TITLE
chore: Add default formatter for python

### DIFF
--- a/arlo.code-workspace
+++ b/arlo.code-workspace
@@ -18,6 +18,9 @@
     "python.formatting.provider": "black",
     "typescript.tsdk": "client/node_modules/typescript/lib",
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "[python]": {
+      "editor.defaultFormatter": "ms-python.python"
+    }
   }
 }


### PR DESCRIPTION
For some reason, the existing setting of prettier as the default formatter all of a sudden made Python formatting stop working. This was the suggested fix.