### PR TITLE
Update Hart CVR parsing to handle scanned ballot information CSVs

### DIFF
--- a/client/src/components/Atoms/CSVForm.tsx
+++ b/client/src/components/Atoms/CSVForm.tsx
@@ -91,6 +91,10 @@ const CSVFile = ({
               {title && <H4>{title}</H4>}
               <FormSectionDescription>
                 {description}
+                {values.cvrFileType === CvrFileType.HART &&
+                  ' ' +
+                    'For Hart, you can also provide an optional scanned ballot information CSV. ' +
+                    'If provided, the unique identifiers in the CSV will be used as imprinted IDs.'}
                 {sampleFileLink && (
                   <>
                     <br />
@@ -127,15 +131,19 @@ const CSVFile = ({
               <>
                 <FormSection>
                   <FileInput
-                    inputProps={
-                      values.cvrFileType === CvrFileType.HART
-                        ? { accept: '.zip', name: 'zip' }
-                        : {
-                            accept: '.csv',
-                            name: 'csv',
-                            multiple: values.cvrFileType === CvrFileType.ESS,
-                          }
-                    }
+                    inputProps={{
+                      // While this component is named CSVFile, it can accept zip files in the case
+                      // of Hart CVRs
+                      // TODO: Consider renaming the component and its internals accordingly
+                      accept:
+                        values.cvrFileType === CvrFileType.HART
+                          ? '.zip,.csv'
+                          : '.csv',
+                      name: 'csv',
+                      multiple:
+                        values.cvrFileType === CvrFileType.ESS ||
+                        values.cvrFileType === CvrFileType.HART,
+                    }}
                     onInputChange={e => {
                       const { files } = e.currentTarget
                       setFieldValue(
@@ -145,7 +153,12 @@ const CSVFile = ({
                     }}
                     hasSelection={!!values.csv}
                     text={(() => {
-                      if (!values.csv) return 'Select a file...'
+                      if (!values.csv) {
+                        return values.cvrFileType === CvrFileType.ESS ||
+                          values.cvrFileType === CvrFileType.HART
+                          ? 'Select files...'
+                          : 'Select a file...'
+                      }
                       if (values.csv.length === 1) return values.csv[0].name
                       return `${values.csv.length} files selected`
                     })()}

--- a/client/src/components/Atoms/FileUpload.test.tsx
+++ b/client/src/components/Atoms/FileUpload.test.tsx
@@ -47,7 +47,7 @@ const TestFileUpload = ({
     deleteFile: () => deleteFile.mutateAsync(),
     downloadFileUrl: '/test/download',
   }
-  return <FileUpload {...fileUpload} acceptFileType="csv" {...props} />
+  return <FileUpload {...fileUpload} acceptFileTypes={['csv']} {...props} />
 }
 
 const render = (element: React.ReactElement) =>

--- a/client/src/components/Atoms/FileUpload.tsx
+++ b/client/src/components/Atoms/FileUpload.tsx
@@ -12,7 +12,7 @@ const ErrorP = styled.p`
 `
 
 export interface IFileUploadProps extends IFileUpload {
-  acceptFileType: 'csv' | 'zip'
+  acceptFileTypes: ('csv' | 'zip')[]
   allowMultipleFiles?: boolean
   disabled?: boolean
 }
@@ -23,7 +23,7 @@ const FileUpload = ({
   uploadProgress,
   deleteFile,
   downloadFileUrl,
-  acceptFileType,
+  acceptFileTypes,
   allowMultipleFiles = false,
   disabled = false,
 }: IFileUploadProps) => {
@@ -55,7 +55,7 @@ const FileUpload = ({
         <p>
           <FileInput
             inputProps={{
-              accept: `.${acceptFileType}`,
+              accept: acceptFileTypes.map(fileType => `.${fileType}`).join(','),
               name: 'files',
               multiple: allowMultipleFiles,
               ref: register(),

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
@@ -90,7 +90,7 @@ const JurisdictionDetail = ({
             <H6>Ballot Manifest</H6>
             <FileUpload
               {...ballotManifestUpload}
-              acceptFileType="csv"
+              acceptFileTypes={['csv']}
               disabled={!!round}
             />
           </StatusCard>
@@ -99,7 +99,7 @@ const JurisdictionDetail = ({
               <H6>Candidate Totals by Batch</H6>
               <FileUpload
                 {...batchTalliesUpload}
-                acceptFileType="csv"
+                acceptFileTypes={['csv']}
                 disabled={!!round || !isManifestUploaded}
               />
             </StatusCard>
@@ -175,10 +175,13 @@ const CvrsFileUpload = ({
       <FileUpload
         {...cvrsUpload}
         uploadFiles={uploadFiles}
-        acceptFileType={
-          selectedCvrFileType === CvrFileType.HART ? 'zip' : 'csv'
+        acceptFileTypes={
+          selectedCvrFileType === CvrFileType.HART ? ['zip', 'csv'] : ['csv']
         }
-        allowMultipleFiles={selectedCvrFileType === CvrFileType.ESS}
+        allowMultipleFiles={
+          selectedCvrFileType === CvrFileType.ESS ||
+          selectedCvrFileType === CvrFileType.HART
+        }
         disabled={disabled || (!cvrs.file && !selectedCvrFileType)}
       />
     </>

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
@@ -383,7 +383,6 @@ describe('JA setup', () => {
       userEvent.upload(fileSelect, [cvrsZip])
       await screen.findByLabelText('cvrs.zip')
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
-
       await screen.findByText('Uploaded at 11/18/2020, 9:39:14 PM.')
     })
   })
@@ -420,7 +419,6 @@ describe('JA setup', () => {
       },
       jaApiCalls.getCVRSfile(cvrsMocks.processed),
     ]
-
     await withMockFetch(expectedCalls, async () => {
       renderView()
       await screen.findByText('Audit Source Data')
@@ -436,7 +434,6 @@ describe('JA setup', () => {
       const fileSelect = screen.getByLabelText('Select files...')
       userEvent.upload(fileSelect, [cvrsZip, scannedBallotInformationCsv])
       await screen.findByLabelText('2 files selected')
-
       userEvent.click(screen.getByRole('button', { name: 'Upload File' }))
       await screen.findByText('Uploaded at 11/18/2020, 9:39:14 PM.')
     })

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -868,8 +868,7 @@ def parse_hart_cvrs(
                 header_indices,
                 file_name="scanned ballot information CSV",
             )
-            if cvr_guid != "" and unique_identifier != "":
-                cvr_guid_to_unique_identifier_mapping[cvr_guid] = unique_identifier
+            cvr_guid_to_unique_identifier_mapping[cvr_guid] = unique_identifier
 
         return cvr_guid_to_unique_identifier_mapping
 

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -52,6 +52,7 @@ from ..util.csv_download import csv_response
 from ..util.csv_parse import (
     CSVIterator,
     decode_csv,
+    does_file_have_csv_mimetype,
     validate_comma_delimited,
     validate_csv_mimetype,
     validate_not_empty,
@@ -782,20 +783,93 @@ def parse_ess_cvrs(
 def parse_hart_cvrs(
     jurisdiction: Jurisdiction,
 ) -> Tuple[CVR_CONTESTS_METADATA, Iterable[CvrBallot]]:
-    # Hart CVRs consist of a zip file containing an individual XML file for each
-    # ballot's CVR. Our parsing steps:
-    # 1. Unzip the files
-    # 2. First, parse out the contest and choice names. We have to do this in
-    #    a separate pass since our storage scheme for interpretations requires
-    #    knowing all of the contest and choice names up front.
-    # 3. Next, parse out the interpretations.
+    # Hart CVRs consist of a ZIP file containing an individual XML file for each ballot's CVR.
+    # Separate from this ZIP file, an optional scanned ballot information CSV can be provided. If
+    # the latter is provided, the `UniqueIdentifier`s in it will be used as imprinted IDs.
+    # Otherwise, `CvrGuid`s will be used.
+    #
+    # Our parsing steps:
+    # 1. Unzip the wrapper ZIP file.
+    # 2. Expect either [ another ZIP file ] or [ another ZIP file and a CSV ].
+    # 3. If a CSV is found, parse it as a scanned ballot information CSV.
+    # 4. Unzip the CVRs ZIP file.
+    # 5. Parse out the contest and choice names. We have to do this in a separate pass since our
+    #    storage scheme for interpretations requires knowing all of the contest and choice names up
+    #    front.
+    # 3. Then, parse out the interpretations.
 
-    zip_file = retrieve_file(jurisdiction.cvr_file.storage_path)
-    files = unzip_files(zip_file)
-    zip_file.close()
+    wrapper_zip_file = retrieve_file(jurisdiction.cvr_file.storage_path)
+    files = unzip_files(wrapper_zip_file)
+    wrapper_zip_file.close()
+
+    cvrs_zip_file: Union[BinaryIO, None] = None
+    scanned_ballot_information_file: Union[BinaryIO, None] = None
+    for name, file in files.items():
+        if name.lower().endswith(".zip"):
+            cvrs_zip_file = file
+        if name.lower().endswith(".csv"):
+            scanned_ballot_information_file = file
+
+    if cvrs_zip_file is None:
+        raise UserError("Expected a file with a .zip extension.")
+
+    def construct_cvr_guid_to_unique_identifier_mapping(
+        scanned_ballot_information_file: BinaryIO,
+    ) -> Dict[str, str]:
+        validate_not_empty(scanned_ballot_information_file)
+        text_file = decode_csv(scanned_ballot_information_file)
+
+        # Determine whether the scanned ballot information CSV has a format version row and skip it
+        # if so
+        has_format_version_row = False
+        first_line = text_file.readline()
+        if first_line.startswith("#FormatVersion") or "," not in first_line:
+            has_format_version_row = True
+            validate_comma_delimited(text_file)
+            # validate_comma_delimited resets the cursor to the start of the file so skip the
+            # format version row again
+            text_file.readline()
+        else:
+            text_file.seek(0)
+            validate_comma_delimited(text_file)
+        reader = csv.reader(text_file, delimiter=",")
+
+        headers = next(reader)
+        if "CvrId" not in headers:
+            raise UserError("Scanned ballot information CSV missing CvrId column.")
+        if "UniqueIdentifier" not in headers:
+            raise UserError(
+                "Scanned ballot information CSV missing UniqueIdentifier column."
+            )
+
+        cvr_guid_index = headers.index("CvrId")
+        unique_identifier_index = headers.index("UniqueIdentifier")
+
+        cvr_guid_to_unique_identifier_mapping: Dict[str, str] = {}
+        for i, row in enumerate(reader):
+            row_number = i + 2  # Account for zero indexing and header row
+            if has_format_version_row:
+                row_number += 1
+            if len(row) != len(headers):
+                raise UserError(f"Wrong number of cells in row {row_number}")
+            cvr_guid = row[cvr_guid_index]
+            unique_identifier = row[unique_identifier_index]
+            if cvr_guid != "" and unique_identifier != "":
+                cvr_guid_to_unique_identifier_mapping[cvr_guid] = unique_identifier
+        return cvr_guid_to_unique_identifier_mapping
+
+    cvr_guid_to_unique_identifier_mapping = (
+        construct_cvr_guid_to_unique_identifier_mapping(scanned_ballot_information_file)
+        if scanned_ballot_information_file is not None
+        else {}
+    )
+
+    cvr_files = unzip_files(cvrs_zip_file)
 
     # Remove excess files (e.g. WriteIn directory)
-    files = {name: file for name, file in files.items() if name.endswith(".xml")}
+    cvr_files = {
+        name: file for name, file in cvr_files.items() if name.lower().endswith(".xml")
+    }
 
     namespace = "http://tempuri.org/CVRDesign.xsd"
 
@@ -827,7 +901,7 @@ def parse_hart_cvrs(
     # Parse contests and choice names
     # { contest_name: choice_names }
     contest_choices = defaultdict(set)
-    for file in files.values():
+    for file in cvr_files.values():
         cvr_xml = ET.parse(file)
         for contest, choice_names in parse_contest_results(cvr_xml).items():
             contest_choices[contest].update(choice_names)
@@ -899,7 +973,7 @@ def parse_hart_cvrs(
         )
 
     def parse_cvr_ballots() -> Iterable[CvrBallot]:
-        for file_name, file in files.items():
+        for file_name, file in cvr_files.items():
             file.seek(0)
             cvr_xml = ET.parse(file)
             cvr_guid = find(cvr_xml, "CvrGuid").text
@@ -915,11 +989,16 @@ def parse_hart_cvrs(
                 )
 
             db_batch = batches_by_key.get(batch_number)
+            imprinted_id = (
+                cvr_guid_to_unique_identifier_mapping[cvr_guid]
+                if cvr_guid in cvr_guid_to_unique_identifier_mapping
+                else cvr_guid
+            )
             if db_batch:
                 yield CvrBallot(
                     batch=db_batch,
                     record_id=int(batch_sequence),
-                    imprinted_id=cvr_guid,
+                    imprinted_id=imprinted_id,
                     interpretations=parse_interpretations(cvr_xml),
                 )
             else:
@@ -1156,10 +1235,20 @@ def validate_cvr_upload(
     if cvr_file_type not in [cvr_file_type.value for cvr_file_type in CvrFileType]:
         raise BadRequest("Invalid file type")
 
-    file = request.files["cvrs"]
     if cvr_file_type == CvrFileType.HART:
-        if file.mimetype not in ["application/zip", "application/x-zip-compressed"]:
+        files = request.files.getlist("cvrs")
+        if len(files) != 1 and len(files) != 2:
+            raise BadRequest(f"Expected 1 or 2 files but received {len(files)}.")
+        if not any(
+            file.mimetype in ["application/zip", "application/x-zip-compressed"]
+            for file in files
+        ):
             raise BadRequest("Please submit a ZIP file export.")
+        if len(files) == 2:
+            if not any(does_file_have_csv_mimetype(file) for file in files):
+                raise BadRequest(
+                    "Please submit either a ZIP file export or a ZIP file export and a CSV."
+                )
     else:
         validate_csv_mimetype(request.files["cvrs"])
 
@@ -1185,7 +1274,7 @@ def upload_cvrs(
     validate_cvr_upload(request, election, jurisdiction)
     clear_cvr_data(jurisdiction)
 
-    if request.form["cvrFileType"] == CvrFileType.ESS:
+    if request.form["cvrFileType"] in [CvrFileType.ESS, CvrFileType.HART]:
         file_name = "cvr-files.zip"
         zip_file = zip_files(
             {file.filename: file.stream for file in request.files.getlist("cvrs")}
@@ -1197,9 +1286,7 @@ def upload_cvrs(
         )
     else:
         file_name = request.files["cvrs"].filename
-        file_extension = (
-            "zip" if request.form["cvrFileType"] == CvrFileType.HART else "csv"
-        )
+        file_extension = "csv"
         storage_path = store_file(
             request.files["cvrs"].stream,
             f"audits/{election.id}/jurisdictions/{jurisdiction.id}/"

--- a/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
@@ -996,3 +996,369 @@ snapshots["test_hart_cvr_upload 2"] = {
         "votes_allowed": 1,
     },
 }
+
+snapshots["test_hart_cvr_upload_with_scanned_ballot_information 1"] = [
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH1",
+        "imprinted_id": "unique-identifier-01",
+        "interpretations": "0,1,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH1",
+        "imprinted_id": "unique-identifier-02",
+        "interpretations": "1,0,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH1",
+        "imprinted_id": "unique-identifier-03",
+        "interpretations": "0,1,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH2",
+        "imprinted_id": "unique-identifier-04",
+        "interpretations": "1,0,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH2",
+        "imprinted_id": "unique-identifier-05",
+        "interpretations": "0,1,0,1,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH2",
+        "imprinted_id": "unique-identifier-06",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH3",
+        "imprinted_id": "unique-identifier-07",
+        "interpretations": "1,0,0,1,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH3",
+        "imprinted_id": "unique-identifier-08",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH3",
+        "imprinted_id": "unique-identifier-09",
+        "interpretations": "1,0,0,1,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-10",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-11",
+        "interpretations": "1,1,1,1,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-12",
+        "interpretations": ",,1,0,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 4,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-13",
+        "interpretations": ",,1,0,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 5,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-14",
+        "interpretations": ",,0,0,0,1",
+        "tabulator": "TABULATOR2",
+    },
+]
+
+snapshots["test_hart_cvr_upload_with_scanned_ballot_information 2"] = {
+    "Contest 1": {
+        "choices": {
+            "Choice 1-1": {"column": 0, "num_votes": 7},
+            "Choice 1-2": {"column": 1, "num_votes": 3},
+        },
+        "total_ballots_cast": 11,
+        "votes_allowed": 1,
+    },
+    "Contest 2": {
+        "choices": {
+            "Choice 2-1": {"column": 2, "num_votes": 6},
+            "Choice 2-2": {"column": 3, "num_votes": 3},
+            "Choice 2-3": {"column": 4, "num_votes": 3},
+            "Write-In": {"column": 5, "num_votes": 1},
+        },
+        "total_ballots_cast": 14,
+        "votes_allowed": 1,
+    },
+}
+
+snapshots["test_hart_cvr_upload_with_scanned_ballot_information 3"] = [
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH1",
+        "imprinted_id": "1-1-1",
+        "interpretations": "0,1,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH1",
+        "imprinted_id": "1-1-3",
+        "interpretations": "0,1,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-2-2",
+        "interpretations": "0,1,0,1,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH3",
+        "imprinted_id": "1-3-1",
+        "interpretations": "1,0,0,1,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH3",
+        "imprinted_id": "1-3-3",
+        "interpretations": "1,0,0,1,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH4",
+        "imprinted_id": "1-4-2",
+        "interpretations": "1,1,1,1,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 4,
+        "batch_name": "BATCH4",
+        "imprinted_id": "1-4-5",
+        "interpretations": ",,1,0,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH1",
+        "imprinted_id": "unique-identifier-02",
+        "interpretations": "1,0,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH2",
+        "imprinted_id": "unique-identifier-04",
+        "interpretations": "1,0,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH2",
+        "imprinted_id": "unique-identifier-06",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH3",
+        "imprinted_id": "unique-identifier-08",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-10",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-12",
+        "interpretations": ",,1,0,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 5,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-14",
+        "interpretations": ",,0,0,0,1",
+        "tabulator": "TABULATOR2",
+    },
+]
+
+snapshots["test_hart_cvr_upload_with_scanned_ballot_information 4"] = {
+    "Contest 1": {
+        "choices": {
+            "Choice 1-1": {"column": 0, "num_votes": 7},
+            "Choice 1-2": {"column": 1, "num_votes": 3},
+        },
+        "total_ballots_cast": 11,
+        "votes_allowed": 1,
+    },
+    "Contest 2": {
+        "choices": {
+            "Choice 2-1": {"column": 2, "num_votes": 6},
+            "Choice 2-2": {"column": 3, "num_votes": 3},
+            "Choice 2-3": {"column": 4, "num_votes": 3},
+            "Write-In": {"column": 5, "num_votes": 1},
+        },
+        "total_ballots_cast": 14,
+        "votes_allowed": 1,
+    },
+}
+
+snapshots["test_hart_cvr_upload_with_scanned_ballot_information 5"] = [
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH1",
+        "imprinted_id": "1-1-3",
+        "interpretations": "0,1,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-2-1",
+        "interpretations": "1,0,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-2-2",
+        "interpretations": "0,1,0,1,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-2-3",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH3",
+        "imprinted_id": "1-3-1",
+        "interpretations": "1,0,0,1,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH3",
+        "imprinted_id": "1-3-2",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH3",
+        "imprinted_id": "1-3-3",
+        "interpretations": "1,0,0,1,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH4",
+        "imprinted_id": "1-4-1",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH4",
+        "imprinted_id": "1-4-2",
+        "interpretations": "1,1,1,1,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH4",
+        "imprinted_id": "1-4-4",
+        "interpretations": ",,1,0,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 4,
+        "batch_name": "BATCH4",
+        "imprinted_id": "1-4-5",
+        "interpretations": ",,1,0,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 5,
+        "batch_name": "BATCH4",
+        "imprinted_id": "1-4-6",
+        "interpretations": ",,0,0,0,1",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH1",
+        "imprinted_id": "unique-identifier-01",
+        "interpretations": "0,1,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH1",
+        "imprinted_id": "unique-identifier-02",
+        "interpretations": "1,0,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+]
+
+snapshots["test_hart_cvr_upload_with_scanned_ballot_information 6"] = {
+    "Contest 1": {
+        "choices": {
+            "Choice 1-1": {"column": 0, "num_votes": 7},
+            "Choice 1-2": {"column": 1, "num_votes": 3},
+        },
+        "total_ballots_cast": 11,
+        "votes_allowed": 1,
+    },
+    "Contest 2": {
+        "choices": {
+            "Choice 2-1": {"column": 2, "num_votes": 6},
+            "Choice 2-2": {"column": 3, "num_votes": 3},
+            "Choice 2-3": {"column": 4, "num_votes": 3},
+            "Write-In": {"column": 5, "num_votes": 1},
+        },
+        "total_ballots_cast": 14,
+        "votes_allowed": 1,
+    },
+}

--- a/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
@@ -1123,6 +1123,128 @@ snapshots["test_hart_cvr_upload_with_scanned_ballot_information 3"] = [
     {
         "ballot_position": 1,
         "batch_name": "BATCH1",
+        "imprinted_id": "unique-identifier-01",
+        "interpretations": "0,1,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH1",
+        "imprinted_id": "unique-identifier-02",
+        "interpretations": "1,0,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH1",
+        "imprinted_id": "unique-identifier-03",
+        "interpretations": "0,1,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH2",
+        "imprinted_id": "unique-identifier-04",
+        "interpretations": "1,0,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH2",
+        "imprinted_id": "unique-identifier-05",
+        "interpretations": "0,1,0,1,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH2",
+        "imprinted_id": "unique-identifier-06",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH3",
+        "imprinted_id": "unique-identifier-07",
+        "interpretations": "1,0,0,1,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH3",
+        "imprinted_id": "unique-identifier-08",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH3",
+        "imprinted_id": "unique-identifier-09",
+        "interpretations": "1,0,0,1,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-10",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-11",
+        "interpretations": "1,1,1,1,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-12",
+        "interpretations": ",,1,0,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 4,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-13",
+        "interpretations": ",,1,0,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 5,
+        "batch_name": "BATCH4",
+        "imprinted_id": "unique-identifier-14",
+        "interpretations": ",,0,0,0,1",
+        "tabulator": "TABULATOR2",
+    },
+]
+
+snapshots["test_hart_cvr_upload_with_scanned_ballot_information 4"] = {
+    "Contest 1": {
+        "choices": {
+            "Choice 1-1": {"column": 0, "num_votes": 7},
+            "Choice 1-2": {"column": 1, "num_votes": 3},
+        },
+        "total_ballots_cast": 11,
+        "votes_allowed": 1,
+    },
+    "Contest 2": {
+        "choices": {
+            "Choice 2-1": {"column": 2, "num_votes": 6},
+            "Choice 2-2": {"column": 3, "num_votes": 3},
+            "Choice 2-3": {"column": 4, "num_votes": 3},
+            "Write-In": {"column": 5, "num_votes": 1},
+        },
+        "total_ballots_cast": 14,
+        "votes_allowed": 1,
+    },
+}
+
+snapshots["test_hart_cvr_upload_with_scanned_ballot_information 5"] = [
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH1",
         "imprinted_id": "1-1-1",
         "interpretations": "0,1,1,0,0,0",
         "tabulator": "TABULATOR1",
@@ -1217,128 +1339,6 @@ snapshots["test_hart_cvr_upload_with_scanned_ballot_information 3"] = [
         "imprinted_id": "unique-identifier-14",
         "interpretations": ",,0,0,0,1",
         "tabulator": "TABULATOR2",
-    },
-]
-
-snapshots["test_hart_cvr_upload_with_scanned_ballot_information 4"] = {
-    "Contest 1": {
-        "choices": {
-            "Choice 1-1": {"column": 0, "num_votes": 7},
-            "Choice 1-2": {"column": 1, "num_votes": 3},
-        },
-        "total_ballots_cast": 11,
-        "votes_allowed": 1,
-    },
-    "Contest 2": {
-        "choices": {
-            "Choice 2-1": {"column": 2, "num_votes": 6},
-            "Choice 2-2": {"column": 3, "num_votes": 3},
-            "Choice 2-3": {"column": 4, "num_votes": 3},
-            "Write-In": {"column": 5, "num_votes": 1},
-        },
-        "total_ballots_cast": 14,
-        "votes_allowed": 1,
-    },
-}
-
-snapshots["test_hart_cvr_upload_with_scanned_ballot_information 5"] = [
-    {
-        "ballot_position": 3,
-        "batch_name": "BATCH1",
-        "imprinted_id": "1-1-3",
-        "interpretations": "0,1,1,0,0,0",
-        "tabulator": "TABULATOR1",
-    },
-    {
-        "ballot_position": 1,
-        "batch_name": "BATCH2",
-        "imprinted_id": "1-2-1",
-        "interpretations": "1,0,1,0,0,0",
-        "tabulator": "TABULATOR1",
-    },
-    {
-        "ballot_position": 2,
-        "batch_name": "BATCH2",
-        "imprinted_id": "1-2-2",
-        "interpretations": "0,1,0,1,0,0",
-        "tabulator": "TABULATOR1",
-    },
-    {
-        "ballot_position": 3,
-        "batch_name": "BATCH2",
-        "imprinted_id": "1-2-3",
-        "interpretations": "1,0,0,0,1,0",
-        "tabulator": "TABULATOR1",
-    },
-    {
-        "ballot_position": 1,
-        "batch_name": "BATCH3",
-        "imprinted_id": "1-3-1",
-        "interpretations": "1,0,0,1,0,0",
-        "tabulator": "TABULATOR2",
-    },
-    {
-        "ballot_position": 2,
-        "batch_name": "BATCH3",
-        "imprinted_id": "1-3-2",
-        "interpretations": "1,0,0,0,1,0",
-        "tabulator": "TABULATOR2",
-    },
-    {
-        "ballot_position": 3,
-        "batch_name": "BATCH3",
-        "imprinted_id": "1-3-3",
-        "interpretations": "1,0,0,1,0,0",
-        "tabulator": "TABULATOR2",
-    },
-    {
-        "ballot_position": 1,
-        "batch_name": "BATCH4",
-        "imprinted_id": "1-4-1",
-        "interpretations": "1,0,0,0,1,0",
-        "tabulator": "TABULATOR2",
-    },
-    {
-        "ballot_position": 2,
-        "batch_name": "BATCH4",
-        "imprinted_id": "1-4-2",
-        "interpretations": "1,1,1,1,1,0",
-        "tabulator": "TABULATOR2",
-    },
-    {
-        "ballot_position": 3,
-        "batch_name": "BATCH4",
-        "imprinted_id": "1-4-4",
-        "interpretations": ",,1,0,0,0",
-        "tabulator": "TABULATOR2",
-    },
-    {
-        "ballot_position": 4,
-        "batch_name": "BATCH4",
-        "imprinted_id": "1-4-5",
-        "interpretations": ",,1,0,0,0",
-        "tabulator": "TABULATOR2",
-    },
-    {
-        "ballot_position": 5,
-        "batch_name": "BATCH4",
-        "imprinted_id": "1-4-6",
-        "interpretations": ",,0,0,0,1",
-        "tabulator": "TABULATOR2",
-    },
-    {
-        "ballot_position": 1,
-        "batch_name": "BATCH1",
-        "imprinted_id": "unique-identifier-01",
-        "interpretations": "0,1,1,0,0,0",
-        "tabulator": "TABULATOR1",
-    },
-    {
-        "ballot_position": 2,
-        "batch_name": "BATCH1",
-        "imprinted_id": "unique-identifier-02",
-        "interpretations": "1,0,1,0,0,0",
-        "tabulator": "TABULATOR1",
     },
 ]
 

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -699,7 +699,7 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortio
 TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
 TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1
 """,
-            "Missing required column CvrNumber",
+            "Missing required column CvrNumber.",
             "DOMINION",
         ),
         (
@@ -709,7 +709,7 @@ TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1
 CvrNumber,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
 1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1
 """,
-            "Missing required column TabulatorNum",
+            "Missing required column TabulatorNum.",
             "DOMINION",
         ),
         (
@@ -719,7 +719,7 @@ CvrNumber,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,
 CvrNumber,TabulatorNum,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
 1,TABULATOR1,1,1-1-1,Election Day,12345,COUNTY,0,1
 """,
-            "Missing required column BatchId",
+            "Missing required column BatchId.",
             "DOMINION",
         ),
         (
@@ -729,7 +729,7 @@ CvrNumber,TabulatorNum,RecordId,ImprintedId,CountingGroup,PrecinctPortion,Ballot
 CvrNumber,TabulatorNum,BatchId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
 1,TABULATOR1,BATCH1,1-1-1,Election Day,12345,COUNTY,0,1
 """,
-            "Missing required column RecordId",
+            "Missing required column RecordId.",
             "DOMINION",
         ),
         (
@@ -739,7 +739,7 @@ CvrNumber,TabulatorNum,BatchId,ImprintedId,CountingGroup,PrecinctPortion,BallotT
 CvrNumber,TabulatorNum,BatchId,RecordId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
 1,TABULATOR1,BATCH1,1,Election Day,12345,COUNTY,0,1
 """,
-            "Missing required column ImprintedId",
+            "Missing required column ImprintedId.",
             "DOMINION",
         ),
         (
@@ -829,35 +829,35 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,UniqueVotingIdentifier,REP,D
             """BoxID,BoxPosition,BallotID,PrecinctID,BallotStyleID,PrecinctStyleName,ScanComputerName,Status,Remade,Choice_1_1:Contest 1:Vote For 1:Choice 1-1:Non-Partisan,Choice_210_1:Contest 1:Vote For 1:Choice 1-2:Non-Partisan,Choice_34_1:Contest 2:Vote For 2:Choice 2-1:Non-Partisan,Choice_4_1:Contest 2:Vote For 2:Choice 2-2:Non-Partisan,Choice_173_1:Contest 2:Vote For 2:Choice 2-3:Non-Partisan
 BATCH1,1,1-1-1,p,bs,ps,TABULATOR1,s,r,0,1,1,1,0
 """,
-            "Missing required column RowNumber",
+            "Missing required column RowNumber.",
             "CLEARBALLOT",
         ),
         (
             """RowNumber,BoxPosition,BallotID,PrecinctID,BallotStyleID,PrecinctStyleName,ScanComputerName,Status,Remade,Choice_1_1:Contest 1:Vote For 1:Choice 1-1:Non-Partisan,Choice_210_1:Contest 1:Vote For 1:Choice 1-2:Non-Partisan,Choice_34_1:Contest 2:Vote For 2:Choice 2-1:Non-Partisan,Choice_4_1:Contest 2:Vote For 2:Choice 2-2:Non-Partisan,Choice_173_1:Contest 2:Vote For 2:Choice 2-3:Non-Partisan
 1,1,1-1-1,p,bs,ps,TABULATOR1,s,r,0,1,1,1,0
 """,
-            "Missing required column BoxID",
+            "Missing required column BoxID.",
             "CLEARBALLOT",
         ),
         (
             """RowNumber,BoxID,BallotID,PrecinctID,BallotStyleID,PrecinctStyleName,ScanComputerName,Status,Remade,Choice_1_1:Contest 1:Vote For 1:Choice 1-1:Non-Partisan,Choice_210_1:Contest 1:Vote For 1:Choice 1-2:Non-Partisan,Choice_34_1:Contest 2:Vote For 2:Choice 2-1:Non-Partisan,Choice_4_1:Contest 2:Vote For 2:Choice 2-2:Non-Partisan,Choice_173_1:Contest 2:Vote For 2:Choice 2-3:Non-Partisan
 1,BATCH1,1-1-1,p,bs,ps,TABULATOR1,s,r,0,1,1,1,0
 """,
-            "Missing required column BoxPosition",
+            "Missing required column BoxPosition.",
             "CLEARBALLOT",
         ),
         (
             """RowNumber,BoxID,BoxPosition,PrecinctID,BallotStyleID,PrecinctStyleName,ScanComputerName,Status,Remade,Choice_1_1:Contest 1:Vote For 1:Choice 1-1:Non-Partisan,Choice_210_1:Contest 1:Vote For 1:Choice 1-2:Non-Partisan,Choice_34_1:Contest 2:Vote For 2:Choice 2-1:Non-Partisan,Choice_4_1:Contest 2:Vote For 2:Choice 2-2:Non-Partisan,Choice_173_1:Contest 2:Vote For 2:Choice 2-3:Non-Partisan
 1,BATCH1,1,p,bs,ps,TABULATOR1,s,r,0,1,1,1,0
 """,
-            "Missing required column BallotID",
+            "Missing required column BallotID.",
             "CLEARBALLOT",
         ),
         (
             """RowNumber,BoxID,BoxPosition,BallotID,PrecinctID,BallotStyleID,PrecinctStyleName,Status,Remade,Choice_1_1:Contest 1:Vote For 1:Choice 1-1:Non-Partisan,Choice_210_1:Contest 1:Vote For 1:Choice 1-2:Non-Partisan,Choice_34_1:Contest 2:Vote For 2:Choice 2-1:Non-Partisan,Choice_4_1:Contest 2:Vote For 2:Choice 2-2:Non-Partisan,Choice_173_1:Contest 2:Vote For 2:Choice 2-3:Non-Partisan
 1,BATCH1,1,1-1-1,p,bs,ps,s,r,0,1,1,1,0
 """,
-            "Missing required column ScanComputerName",
+            "Missing required column ScanComputerName.",
             "CLEARBALLOT",
         ),
         (
@@ -1431,7 +1431,7 @@ def test_ess_cvr_invalid(
                 ),
                 (io.BytesIO(ESS_BALLOTS_2.encode()), "ess_ballots_2.csv",),
             ],
-            "ess_cvr.csv: Missing required column Cast Vote Record",
+            "ess_cvr.csv: Missing required column Cast Vote Record.",
         ),
         (
             [
@@ -1821,27 +1821,27 @@ def test_hart_cvr_upload_with_scanned_ballot_information(
             "expected_processing_work_progress": manifest_num_ballots,
         },
         {
-            "scanned_ballot_information_file_contents": "CvrId,UniqueId\n",
+            "scanned_ballot_information_file_contents": "CvrId,UniqueId\ncvr-id-1,unique-identifier-1\n",
             "expected_processing_status": ProcessingStatus.ERRORED,
-            "expected_processing_error": "Scanned ballot information CSV missing UniqueIdentifier column.",
+            "expected_processing_error": "Missing required column UniqueIdentifier in scanned ballot information CSV.",
             "expected_processing_work_progress": 0,
         },
         {
-            "scanned_ballot_information_file_contents": "CvrGuid,UniqueIdentifier\n",
+            "scanned_ballot_information_file_contents": "CvrGuid,UniqueIdentifier\ncvr-id-1,unique-identifier-1\n",
             "expected_processing_status": ProcessingStatus.ERRORED,
-            "expected_processing_error": "Scanned ballot information CSV missing CvrId column.",
+            "expected_processing_error": "Missing required column CvrId in scanned ballot information CSV.",
             "expected_processing_work_progress": 0,
         },
         {
-            "scanned_ballot_information_file_contents": "#FormatVersion 1\nCvrId,UniqueId\n",
+            "scanned_ballot_information_file_contents": "#FormatVersion 1\nCvrId,UniqueId\ncvr-id-1,unique-identifier-1\n",
             "expected_processing_status": ProcessingStatus.ERRORED,
-            "expected_processing_error": "Scanned ballot information CSV missing UniqueIdentifier column.",
+            "expected_processing_error": "Missing required column UniqueIdentifier in scanned ballot information CSV.",
             "expected_processing_work_progress": 0,
         },
         {
-            "scanned_ballot_information_file_contents": "#FormatVersion 1\nCvrGuid,UniqueIdentifier\n",
+            "scanned_ballot_information_file_contents": "#FormatVersion 1\nCvrGuid,UniqueIdentifier\ncvr-id-1,unique-identifier-1\n",
             "expected_processing_status": ProcessingStatus.ERRORED,
-            "expected_processing_error": "Scanned ballot information CSV missing CvrId column.",
+            "expected_processing_error": "Missing required column CvrId in scanned ballot information CSV.",
             "expected_processing_work_progress": 0,
         },
         {

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1662,40 +1662,66 @@ HART_CVRS = [
     build_hart_cvr("BATCH4", "6", "1-4-6", ",,1,0,0", add_write_in=True),
 ]
 
-HART_SCANNED_BALLOT_INFORMATION = """CvrId,UniqueIdentifier
-1-1-1,unique-identifier-01
-1-1-2,unique-identifier-02
-1-1-3,unique-identifier-03
-1-2-1,unique-identifier-04
-1-2-2,unique-identifier-05
-1-2-3,unique-identifier-06
-1-3-1,unique-identifier-07
-1-3-2,unique-identifier-08
-1-3-3,unique-identifier-09
-1-4-1,unique-identifier-10
-1-4-2,unique-identifier-11
-1-4-4,unique-identifier-12
-1-4-5,unique-identifier-13
-1-4-6,unique-identifier-14
-"""
-
-HART_SCANNED_BALLOT_INFORMATION_MISSING_RECORDS = """CvrId,UniqueIdentifier
-1-1-2,unique-identifier-02
-1-2-1,unique-identifier-04
-1-2-3,unique-identifier-06
-1-3-2,unique-identifier-08
-1-4-1,unique-identifier-10
-1-4-4,unique-identifier-12
-1-4-6,unique-identifier-14
-"""
-
 # Modeled after a real scanned ballot information CSV
-HART_SCANNED_BALLOT_INFORMATION_WITH_FORMAT_VERSION_ROW = """#FormatVersion 1
+HART_SCANNED_BALLOT_INFORMATION = """#FormatVersion 1
 #BatchId,Workstation,VotingType,VotingMethod,ScanSequence,Precinct,PageNumber,UniqueIdentifier,VariationNumber,Language,Party,Status,RejectReason,VoterIntentIssues,vDriveDeviceDataId,CvrId
-1,"A0123456789","Absentee Voting","Paper",1,"101",1,"unique-identifier-01",0,"English",,"Scanned",,False,"ABCD(1234[ABCD-1234*AB","1-1-1"
-1,"A0123456789","Absentee Voting","Paper",1,"101",2,"unique-identifier-01",0,"English",,"Scanned",,False,"ABCD(1234[ABCD-1234*AB","1-1-1"
-1,"A0123456789","Absentee Voting","Paper",2,"102",1,"unique-identifier-02",0,"Spanish",,"Scanned",,False,"ABCD(1234[ABCD-1234*AB","1-1-2"
-1,"A0123456789","Absentee Voting","Paper",2,"102",2,"unique-identifier-02",0,"Spanish",,"Scanned",,False,"ABCD(1234[ABCD-1234*AB","1-1-2"
+1,"A0123456789","Absentee Voting","Paper",1,"001",1,"unique-identifier-01",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-1-1"
+1,"A0123456789","Absentee Voting","Paper",1,"001",2,"unique-identifier-01",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-1-1"
+1,"A0123456789","Absentee Voting","Paper",2,"001",1,"unique-identifier-02",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-1-2"
+1,"A0123456789","Absentee Voting","Paper",2,"001",2,"unique-identifier-02",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-1-2"
+1,"A0123456789","Absentee Voting","Paper",3,"001",1,"unique-identifier-03",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-1-3"
+1,"A0123456789","Absentee Voting","Paper",3,"001",2,"unique-identifier-03",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-1-3"
+1,"A0123456789","Absentee Voting","Paper",4,"001",1,"unique-identifier-04",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-2-1"
+1,"A0123456789","Absentee Voting","Paper",4,"001",2,"unique-identifier-04",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-2-1"
+1,"A0123456789","Absentee Voting","Paper",5,"001",1,"unique-identifier-05",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-2-2"
+1,"A0123456789","Absentee Voting","Paper",5,"001",2,"unique-identifier-05",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-2-2"
+1,"A0123456789","Absentee Voting","Paper",6,"001",1,"unique-identifier-06",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-2-3"
+1,"A0123456789","Absentee Voting","Paper",6,"001",2,"unique-identifier-06",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-2-3"
+1,"A0123456789","Absentee Voting","Paper",7,"001",1,"unique-identifier-07",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-3-1"
+1,"A0123456789","Absentee Voting","Paper",7,"001",2,"unique-identifier-07",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-3-1"
+1,"A0123456789","Absentee Voting","Paper",8,"001",1,"unique-identifier-08",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-3-2"
+1,"A0123456789","Absentee Voting","Paper",8,"001",2,"unique-identifier-08",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-3-2"
+1,"A0123456789","Absentee Voting","Paper",9,"001",1,"unique-identifier-09",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-3-3"
+1,"A0123456789","Absentee Voting","Paper",9,"001",2,"unique-identifier-09",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-3-3"
+1,"A0123456789","Absentee Voting","Paper",10,"001",1,"unique-identifier-10",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-4-1"
+1,"A0123456789","Absentee Voting","Paper",10,"001",2,"unique-identifier-10",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-4-1"
+1,"A0123456789","Absentee Voting","Paper",11,"001",1,"unique-identifier-11",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-4-2"
+1,"A0123456789","Absentee Voting","Paper",11,"001",2,"unique-identifier-11",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-4-2"
+1,"A0123456789","Absentee Voting","Paper",12,"001",1,"unique-identifier-12",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-4-4"
+1,"A0123456789","Absentee Voting","Paper",12,"001",2,"unique-identifier-12",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-4-4"
+1,"A0123456789","Absentee Voting","Paper",13,"001",1,"unique-identifier-13",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-4-5"
+1,"A0123456789","Absentee Voting","Paper",13,"001",2,"unique-identifier-13",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-4-5"
+1,"A0123456789","Absentee Voting","Paper",14,"001",1,"unique-identifier-14",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-4-6"
+1,"A0123456789","Absentee Voting","Paper",14,"001",2,"unique-identifier-14",0,"English",,"Scanned",,False,"ABCD-1234(ABCD[1234*AB","1-4-6"
+"""
+
+HART_SCANNED_BALLOT_INFORMATION_MINIMAL = """#FormatVersion 1
+#CvrId,UniqueIdentifier
+"1-1-1","unique-identifier-01"
+"1-1-2","unique-identifier-02"
+"1-1-3","unique-identifier-03"
+"1-2-1","unique-identifier-04"
+"1-2-2","unique-identifier-05"
+"1-2-3","unique-identifier-06"
+"1-3-1","unique-identifier-07"
+"1-3-2","unique-identifier-08"
+"1-3-3","unique-identifier-09"
+"1-4-1","unique-identifier-10"
+"1-4-2","unique-identifier-11"
+"1-4-4","unique-identifier-12"
+"1-4-5","unique-identifier-13"
+"1-4-6","unique-identifier-14"
+"""
+
+HART_SCANNED_BALLOT_INFORMATION_MISSING_RECORDS = """#FormatVersion 1
+#CvrId,UniqueIdentifier
+"1-1-2","unique-identifier-02"
+"1-2-1","unique-identifier-04"
+"1-2-3","unique-identifier-06"
+"1-3-2","unique-identifier-08"
+"1-4-1","unique-identifier-10"
+"1-4-4","unique-identifier-12"
+"1-4-6","unique-identifier-14"
 """
 
 
@@ -1809,39 +1835,27 @@ def test_hart_cvr_upload_with_scanned_ballot_information(
             "expected_processing_work_progress": manifest_num_ballots,
         },
         {
+            "scanned_ballot_information_file_contents": HART_SCANNED_BALLOT_INFORMATION_MINIMAL,
+            "expected_processing_status": ProcessingStatus.PROCESSED,
+            "expected_processing_error": None,
+            "expected_processing_work_progress": manifest_num_ballots,
+        },
+        {
             "scanned_ballot_information_file_contents": HART_SCANNED_BALLOT_INFORMATION_MISSING_RECORDS,
             "expected_processing_status": ProcessingStatus.PROCESSED,
             "expected_processing_error": None,
             "expected_processing_work_progress": manifest_num_ballots,
         },
         {
-            "scanned_ballot_information_file_contents": HART_SCANNED_BALLOT_INFORMATION_WITH_FORMAT_VERSION_ROW,
-            "expected_processing_status": ProcessingStatus.PROCESSED,
-            "expected_processing_error": None,
-            "expected_processing_work_progress": manifest_num_ballots,
-        },
-        {
-            "scanned_ballot_information_file_contents": "CvrId,UniqueId\ncvr-id-1,unique-identifier-1\n",
+            "scanned_ballot_information_file_contents": "",
             "expected_processing_status": ProcessingStatus.ERRORED,
-            "expected_processing_error": "Missing required column UniqueIdentifier in scanned ballot information CSV.",
+            "expected_processing_error": "CSV cannot be empty.",
             "expected_processing_work_progress": 0,
         },
         {
-            "scanned_ballot_information_file_contents": "CvrGuid,UniqueIdentifier\ncvr-id-1,unique-identifier-1\n",
+            "scanned_ballot_information_file_contents": "CvrId,UniqueIdentifier\n",
             "expected_processing_status": ProcessingStatus.ERRORED,
-            "expected_processing_error": "Missing required column CvrId in scanned ballot information CSV.",
-            "expected_processing_work_progress": 0,
-        },
-        {
-            "scanned_ballot_information_file_contents": "#FormatVersion 1\nCvrId,UniqueId\ncvr-id-1,unique-identifier-1\n",
-            "expected_processing_status": ProcessingStatus.ERRORED,
-            "expected_processing_error": "Missing required column UniqueIdentifier in scanned ballot information CSV.",
-            "expected_processing_work_progress": 0,
-        },
-        {
-            "scanned_ballot_information_file_contents": "#FormatVersion 1\nCvrGuid,UniqueIdentifier\ncvr-id-1,unique-identifier-1\n",
-            "expected_processing_status": ProcessingStatus.ERRORED,
-            "expected_processing_error": "Missing required column CvrId in scanned ballot information CSV.",
+            "expected_processing_error": "Expected first line of scanned ballot information CSV to contain '#FormatVersion'.",
             "expected_processing_work_progress": 0,
         },
         {
@@ -1851,9 +1865,21 @@ def test_hart_cvr_upload_with_scanned_ballot_information(
             "expected_processing_work_progress": 0,
         },
         {
-            "scanned_ballot_information_file_contents": "",
+            "scanned_ballot_information_file_contents": "#FormatVersion 1\nCvrId,UniqueIdentifier\n",
             "expected_processing_status": ProcessingStatus.ERRORED,
-            "expected_processing_error": "CSV cannot be empty.",
+            "expected_processing_error": "CSV must contain at least one row after headers.",
+            "expected_processing_work_progress": 0,
+        },
+        {
+            "scanned_ballot_information_file_contents": "#FormatVersion 1\nCvrGuid,UniqueIdentifier\ncvr-id-1,unique-identifier-1\n",
+            "expected_processing_status": ProcessingStatus.ERRORED,
+            "expected_processing_error": "Missing required column CvrId in scanned ballot information CSV.",
+            "expected_processing_work_progress": 0,
+        },
+        {
+            "scanned_ballot_information_file_contents": "#FormatVersion 1\nCvrId,UniqueId\ncvr-id-1,unique-identifier-1\n",
+            "expected_processing_status": ProcessingStatus.ERRORED,
+            "expected_processing_error": "Missing required column UniqueIdentifier in scanned ballot information CSV.",
             "expected_processing_work_progress": 0,
         },
     ]

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -1,3 +1,4 @@
+import io
 import uuid, json, re
 from datetime import datetime
 from typing import Any, List, Union, Tuple, Optional
@@ -333,3 +334,9 @@ def find_log(caplog, level: int, message: str) -> Optional[logging.LogRecord]:
         ),
         None,
     )
+
+
+def string_to_bytes_io(string: str) -> io.BytesIO:
+    string_io = io.StringIO(string)
+    bytes_io = io.BytesIO(string_io.read().encode("utf-8"))
+    return bytes_io

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -79,9 +79,13 @@ def parse_csv(file: BinaryIO, columns: List[CSVColumnType]) -> CSVDictIterator:
     return dict_csv
 
 
-def validate_csv_mimetype(file: FileStorage) -> None:
+def does_file_have_csv_mimetype(file: FileStorage) -> bool:
     # In Windows, CSVs have mimetype application/vnd.ms-excel
-    if file.mimetype not in ["text/csv", "application/vnd.ms-excel"]:
+    return file.mimetype in ["text/csv", "application/vnd.ms-excel"]
+
+
+def validate_csv_mimetype(file: FileStorage) -> None:
+    if not does_file_have_csv_mimetype(file):
         raise BadRequest(INVALID_CSV_ERROR)
 
 

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -92,7 +92,7 @@ def zip_files(files: Dict[str, BinaryIO]) -> IO[bytes]:
     return zip_file
 
 
-def unzip_files(zip_file: BinaryIO) -> Dict[str, IO[bytes]]:
+def unzip_files(zip_file: BinaryIO) -> Dict[str, BinaryIO]:
     extract_dir = tempfile.TemporaryDirectory()
     with ZipFile(zip_file, "r") as zip_archive:
         zip_archive.extractall(extract_dir.name)


### PR DESCRIPTION
_Commit-by-commit reviewing recommended_

# Overview

Issue link: https://github.com/votingworks/arlo/issues/1505

This PR updates Hart CVR parsing to handle scanned ballot information CSVs for Washington and potentially others down the road. Lots of additional context can be found in the linked issue!

As you can see in these screencaptures, providing a scanned ballot information CSV is optional. In the first upload, we provide both a CVRs ZIP and a scanned ballot information CSV. In the second upload, we only provide a CVRs ZIP. And in the third upload, we only provide a scanned ballot information CSV, which results in an error. Both jurisdiction managers and audit admins can upload scanned ballot information CSVs.

_Jurisdiction manager UI_

https://user-images.githubusercontent.com/12616928/180813935-76a1b681-f157-42ab-a031-830041886b7f.mov

_Audit admin UI_

https://user-images.githubusercontent.com/12616928/180884235-fc252b61-7ce7-41df-98cb-fcd41e0c49f2.mov

# Testing

- [x] Added automated tests for both client-side and server-side logic, including error cases
- [x] Tested success and error flows manually