### PR TITLE
Verify that Clear Ballot CVR file has contest columns

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -249,6 +249,12 @@ def parse_clearballot_cvrs(
     cvr_file = retrieve_file(jurisdiction.cvr_file.storage_path)
     cvrs = csv_reader_for_cvr(cvr_file)
     headers = next(cvrs)
+
+    if not any(header.startswith("Choice_") for header in headers):
+        raise UserError(
+            "CVR file should have at least one column beginning with 'Choice_'"
+        )
+
     first_contest_column = next(
         i for i, header in enumerate(headers) if header.startswith("Choice_")
     )

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1085,8 +1085,11 @@ CLEARBALLOT_CVRS = """RowNumber,BoxID,BoxPosition,BallotID,PrecinctID,BallotStyl
 14,BATCH2,6,2-2-6,p,bs,ps,TABULATOR2,s,r,,,1,0,1
 """
 
-CLEARBALLOT_CVRS_MISSING_CONTEST_COLUMNS = """RowNumber,BoxID,BoxPosition,BallotID,PrecinctID,BallotStyleID,PrecinctStyleName,ScanComputerName,Status,Remade
-1,BATCH1,1,1-1-1,p,bs,ps,TABULATOR1,s,r
+# This file is based on a real file that we once received, probably exported by Clear Ballot but
+# not a Clear Ballot CVR file
+CLEARBALLOT_CVRS_INVALID = """ChoiceID,ContestID,ChoiceName
+1,1,Mike Wazowski
+2,1,James 'Sulley' Sullivan
 """
 
 
@@ -1164,7 +1167,7 @@ def test_clearballot_cvr_upload(
     )
 
 
-def test_clearballot_cvr_upload_missing_contest_columns(
+def test_clearballot_cvr_upload_invalid(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],
@@ -1177,10 +1180,7 @@ def test_clearballot_cvr_upload_missing_contest_columns(
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={
-            "cvrs": (
-                io.BytesIO(CLEARBALLOT_CVRS_MISSING_CONTEST_COLUMNS.encode()),
-                "cvrs.csv",
-            ),
+            "cvrs": (io.BytesIO(CLEARBALLOT_CVRS_INVALID.encode()), "cvrs.csv",),
             "cvrFileType": "CLEARBALLOT",
         },
     )

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1068,7 +1068,7 @@ def test_cvr_reprocess_after_manifest_reupload(
     assert Jurisdiction.query.get(jurisdiction_ids[0]).cvr_contests_metadata is not None
 
 
-CLEARBALLOT_CVR = """RowNumber,BoxID,BoxPosition,BallotID,PrecinctID,BallotStyleID,PrecinctStyleName,ScanComputerName,Status,Remade,Choice_1_1:Contest 1:Vote For 1:Choice 1-1:Non-Partisan,Choice_210_1:Contest 1:Vote For 1:Choice 1-2:Non-Partisan,Choice_34_1:Contest 2:Vote For 2:Choice 2-1:Non-Partisan,Choice_4_1:Contest 2:Vote For 2:Choice 2-2:Non-Partisan,Choice_173_1:Contest 2:Vote For 2:Choice 2-3:Non-Partisan
+CLEARBALLOT_CVRS = """RowNumber,BoxID,BoxPosition,BallotID,PrecinctID,BallotStyleID,PrecinctStyleName,ScanComputerName,Status,Remade,Choice_1_1:Contest 1:Vote For 1:Choice 1-1:Non-Partisan,Choice_210_1:Contest 1:Vote For 1:Choice 1-2:Non-Partisan,Choice_34_1:Contest 2:Vote For 2:Choice 2-1:Non-Partisan,Choice_4_1:Contest 2:Vote For 2:Choice 2-2:Non-Partisan,Choice_173_1:Contest 2:Vote For 2:Choice 2-3:Non-Partisan
 1,BATCH1,1,1-1-1,p,bs,ps,TABULATOR1,s,r,0,1,1,1,0
 2,BATCH1,2,1-1-2,p,bs,ps,TABULATOR1,s,r,1,0,1,0,1
 3,BATCH1,3,1-1-3,p,bs,ps,TABULATOR1,s,r,0,1,1,1,0
@@ -1083,6 +1083,10 @@ CLEARBALLOT_CVR = """RowNumber,BoxID,BoxPosition,BallotID,PrecinctID,BallotStyle
 12,BATCH2,4,2-2-4,p,bs,ps,TABULATOR2,s,r,,,1,0,1
 13,BATCH2,5,2-2-5,p,bs,ps,TABULATOR2,s,r,,,1,1,0
 14,BATCH2,6,2-2-6,p,bs,ps,TABULATOR2,s,r,,,1,0,1
+"""
+
+CLEARBALLOT_CVRS_MISSING_CONTEST_COLUMNS = """RowNumber,BoxID,BoxPosition,BallotID,PrecinctID,BallotStyleID,PrecinctStyleName,ScanComputerName,Status,Remade
+1,BATCH1,1,1-1-1,p,bs,ps,TABULATOR1,s,r
 """
 
 
@@ -1100,7 +1104,7 @@ def test_clearballot_cvr_upload(
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
         data={
-            "cvrs": (io.BytesIO(CLEARBALLOT_CVR.encode()), "cvrs.csv",),
+            "cvrs": (io.BytesIO(CLEARBALLOT_CVRS.encode()), "cvrs.csv",),
             "cvrFileType": "CLEARBALLOT",
         },
     )
@@ -1157,6 +1161,59 @@ def test_clearballot_cvr_upload(
     )
     snapshot.assert_match(
         Jurisdiction.query.get(jurisdiction_ids[0]).cvr_contests_metadata
+    )
+
+
+def test_clearballot_cvr_upload_missing_contest_columns(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    manifests,  # pylint: disable=unused-argument
+):
+    # Upload CVRs
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
+        data={
+            "cvrs": (
+                io.BytesIO(CLEARBALLOT_CVRS_MISSING_CONTEST_COLUMNS.encode()),
+                "cvrs.csv",
+            ),
+            "cvrFileType": "CLEARBALLOT",
+        },
+    )
+    assert_ok(rv)
+
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/jurisdiction")
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+    manifest_num_ballots = jurisdictions[0]["ballotManifest"]["numBallots"]
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs"
+    )
+    compare_json(
+        json.loads(rv.data),
+        {
+            "file": {
+                "cvrFileType": "CLEARBALLOT",
+                "name": "cvrs.csv",
+                "uploadedAt": assert_is_date,
+            },
+            "processing": {
+                "status": ProcessingStatus.ERRORED,
+                "startedAt": assert_is_date,
+                "completedAt": assert_is_date,
+                "error": "CVR file should have at least one column beginning with 'Choice_'",
+                "workProgress": 0,
+                "workTotal": manifest_num_ballots,
+            },
+        },
     )
 
 


### PR DESCRIPTION
# Overview

This PR addresses an alert for a Clear Ballot CVR file that actually turned out not to be a Clear Ballot CVR file at all. More specifically, the file had no contest columns (columns beginning with `"Choice_"`), resulting in this "find" operation raising a `StopIteration` exception:

```python
first_contest_column = next(
    i for i, header in enumerate(headers) if header.startswith("Choice_")
)
```

There's a broader bucket of errors here: uploading the wrong file. We typically catch these errors downstream and surface them as user errors. Once in a while, though, a wrong file triggers a non-user error, as happened here. It's not yet clear to me what a generalized fix for this would look like. We could as a matter of habit encode more assumptions about headers for each CVR file type upfront.

# Testing

- [x] Tested manually with the file that triggered PagerDuty
- [x] Added an automated test