### PR TITLE
Add support user endpoint for reopening current round

### DIFF
--- a/server/api/support.py
+++ b/server/api/support.py
@@ -171,8 +171,11 @@ def get_election(election_id: str):
         auditType=election.audit_type,
         online=election.online,
         jurisdictions=[
-            dict(id=jurisdiction.id, name=jurisdiction.name,)
+            dict(id=jurisdiction.id, name=jurisdiction.name)
             for jurisdiction in election.jurisdictions
+        ],
+        rounds=[
+            dict(id=round.id, ended_at=round.ended_at) for round in election.rounds
         ],
         deletedAt=isoformat(election.deleted_at),
     )

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -421,7 +421,7 @@ def log_in_as_jurisdiction_admin(email: str):
     return redirect("/")
 
 
-@api.route("/support/elections/<election_id>/rounds/current/reopen", methods=["PATCH"])
+@api.route("/support/elections/<election_id>/reopen-current-round", methods=["PATCH"])
 @restrict_access_support
 def reopen_current_round(election_id: str):
     election = get_or_404(Election, election_id)

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -789,7 +789,7 @@ def test_reopen_current_round(
     run_audit_round(round_1_id, contest_ids[0], contest_ids, 0.55)
     assert is_round_completed(round_1_id)
 
-    rv = client.patch(f"/api/support/elections/{election_id}/rounds/current/reopen")
+    rv = client.patch(f"/api/support/elections/{election_id}/reopen-current-round")
     assert_ok(rv)
     assert not is_round_completed(round_1_id)
 
@@ -803,7 +803,7 @@ def test_reopen_current_round_when_audit_not_started(
 ):
     set_support_user(client, SUPPORT_EMAIL)
 
-    rv = client.patch(f"/api/support/elections/{election_id}/rounds/current/reopen")
+    rv = client.patch(f"/api/support/elections/{election_id}/reopen-current-round")
     assert rv.status_code == 409
     assert json.loads(rv.data) == {
         "errors": [{"errorType": "Conflict", "message": "Audit hasn't started yet.",}]
@@ -817,7 +817,7 @@ def test_reopen_current_round_when_round_in_progress(
 ):
     set_support_user(client, SUPPORT_EMAIL)
 
-    rv = client.patch(f"/api/support/elections/{election_id}/rounds/current/reopen")
+    rv = client.patch(f"/api/support/elections/{election_id}/reopen-current-round")
     assert rv.status_code == 409
     assert json.loads(rv.data) == {
         "errors": [{"errorType": "Conflict", "message": "Round is in progress.",}]


### PR DESCRIPTION
## Overview

Another step for https://github.com/votingworks/arlo/issues/1499, this PR adds a support user endpoint for reopening the current audit round. We currently only have [a script](https://github.com/votingworks/arlo/blob/main/scripts/reopen-round.py) for this.

## Testing

- [x] Added unit tests