### PR TITLE
Give support users buttons for undoing round starts and reopening rounds

### DIFF
--- a/client/src/components/Atoms/StatusBox.test.tsx
+++ b/client/src/components/Atoms/StatusBox.test.tsx
@@ -208,7 +208,7 @@ describe('StatusBox', () => {
         </Router>
       )
       screen.getByText('Round 1 of the audit is in progress')
-      screen.getByText('1 of 3 jurisdictions have completed Round 1')
+      screen.getByText('1 of 3 jurisdictions have completed round 1')
       screen.getByRole('button', { name: 'Undo Audit Launch' })
     })
 
@@ -226,7 +226,7 @@ describe('StatusBox', () => {
         </Router>
       )
       screen.getByText('Round 1 of the audit is in progress')
-      screen.getByText('1 of 3 jurisdictions have completed Round 1')
+      screen.getByText('1 of 3 jurisdictions have completed round 1')
       expect(screen.queryByRole('button')).not.toBeInTheDocument()
     })
 
@@ -403,7 +403,7 @@ describe('StatusBox', () => {
         </Router>
       )
       screen.getByText('Round 1 of the audit is in progress')
-      screen.getByText('1 of 3 jurisdictions have completed Round 1')
+      screen.getByText('1 of 3 jurisdictions have completed round 1')
       screen.getByText('Full hand tally required')
       screen.getByText(
         'One or more target contests require a full hand tally to complete the audit.'
@@ -545,7 +545,7 @@ describe('StatusBox', () => {
       )
       screen.getByText('Round 1 of the audit is in progress.')
       screen.getByText('1 of 1 audit boards complete.')
-      screen.getByText('Waiting for all jurisdictions to complete Round 1.')
+      screen.getByText('Waiting for all jurisdictions to complete round 1.')
     })
 
     it('renders no audit board status if offline', async () => {
@@ -567,7 +567,7 @@ describe('StatusBox', () => {
         </Router>
       )
       screen.getByText('Round 1 of the audit is in progress.')
-      screen.getByText('Waiting for all jurisdictions to complete Round 1.')
+      screen.getByText('Waiting for all jurisdictions to complete round 1.')
       await waitFor(() =>
         expect(
           screen.queryByText('1 of 1 audit boards complete.')

--- a/client/src/components/Atoms/StatusBox.tsx
+++ b/client/src/components/Atoms/StatusBox.tsx
@@ -239,7 +239,7 @@ export const AuditAdminStatusBox: React.FC<IAuditAdminProps> = ({
         headline={`Round ${roundNum} of the audit is in progress`}
         details={[
           `${numCompleted} of ${jurisdictions.length} jurisdictions` +
-            ` have completed Round ${roundNum}`,
+            ` have completed round ${roundNum}`,
         ]}
         auditName={auditSettings.auditName}
         buttonLabel={canUndoLaunch ? 'Undo Audit Launch' : undefined}
@@ -459,7 +459,7 @@ export const JurisdictionAdminStatusBox = ({
     }
     if (numCompleted === auditBoards.length)
       details.push(
-        `Waiting for all jurisdictions to complete Round ${roundNum}.`
+        `Waiting for all jurisdictions to complete round ${roundNum}.`
       )
     return (
       <StatusBox

--- a/client/src/components/SupportTools/RoundsTable.tsx
+++ b/client/src/components/SupportTools/RoundsTable.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { Button } from '@blueprintjs/core'
+import { toast } from 'react-toastify'
+
+import { Confirm, useConfirm } from '../Atoms/Confirm'
+import { IRound, useReopenCurrentRound, useUndoRoundStart } from './support-api'
+import { StyledTable } from '../Atoms/Table'
+import StatusTag from '../Atoms/StatusTag'
+
+interface IProps {
+  electionId: string
+  rounds: IRound[]
+}
+
+const RoundsTable = ({ electionId, rounds }: IProps) => {
+  if (rounds.length === 0) {
+    return (
+      <StyledTable style={{ tableLayout: 'auto' }}>
+        <thead>
+          <tr>
+            <th>Round</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Round 1</td>
+            <td>
+              <StatusTag>Not started</StatusTag>
+            </td>
+          </tr>
+        </tbody>
+      </StyledTable>
+    )
+  }
+
+  return (
+    <StyledTable style={{ tableLayout: 'auto' }}>
+      <thead>
+        <tr>
+          <th>Round</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rounds.map((round, i) => (
+          <tr key={round.id}>
+            <td>Round {round.roundNum}</td>
+            <td>
+              {round.endedAt ? (
+                <StatusTag intent="success">Completed</StatusTag>
+              ) : (
+                <StatusTag intent="warning">In progress</StatusTag>
+              )}
+            </td>
+            <td>
+              {i === rounds.length - 1 && (
+                <LastRoundAction electionId={electionId} round={round} />
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </StyledTable>
+  )
+}
+
+interface ILastRoundActionProps {
+  electionId: string
+  round: IRound
+}
+
+const LastRoundAction = ({ electionId, round }: ILastRoundActionProps) => {
+  const { confirm, confirmProps } = useConfirm()
+  const reopenCurrentRound = useReopenCurrentRound()
+  const undoRoundStart = useUndoRoundStart()
+
+  if (round.endedAt) {
+    return (
+      <>
+        <Button
+          onClick={() =>
+            confirm({
+              title: 'Confirm',
+              description: `Are you sure you want to reopen Round ${round.roundNum}?`,
+              yesButtonLabel: 'Reopen',
+              onYesClick: async () => {
+                await reopenCurrentRound.mutateAsync({ electionId })
+                toast.success(`Reopened Round ${round.roundNum}`)
+              },
+            })
+          }
+        >
+          Reopen
+        </Button>
+        <Confirm {...confirmProps} />
+      </>
+    )
+  }
+  return (
+    <>
+      <Button
+        onClick={() =>
+          confirm({
+            title: 'Confirm',
+            description: `Are you sure you want to undo the start of Round ${round.roundNum}?`,
+            yesButtonLabel: 'Undo Start',
+            onYesClick: async () => {
+              await undoRoundStart.mutateAsync({
+                electionId,
+                roundId: round.id,
+              })
+              toast.success(`Undid the start of Round ${round.roundNum}`)
+            },
+          })
+        }
+      >
+        Undo Start
+      </Button>
+      <Confirm {...confirmProps} />
+    </>
+  )
+}
+
+export default RoundsTable

--- a/client/src/components/SupportTools/RoundsTable.tsx
+++ b/client/src/components/SupportTools/RoundsTable.tsx
@@ -74,7 +74,7 @@ interface ILastRoundActionProps {
 const LastRoundAction = ({ electionId, round }: ILastRoundActionProps) => {
   const { confirm, confirmProps } = useConfirm()
   const reopenCurrentRound = useReopenCurrentRound()
-  const undoRoundStart = useUndoRoundStart()
+  const undoRoundStart = useUndoRoundStart(electionId)
 
   if (round.endedAt) {
     return (
@@ -107,10 +107,7 @@ const LastRoundAction = ({ electionId, round }: ILastRoundActionProps) => {
             description: `Are you sure you want to undo the start of Round ${round.roundNum}?`,
             yesButtonLabel: 'Undo Start',
             onYesClick: async () => {
-              await undoRoundStart.mutateAsync({
-                electionId,
-                roundId: round.id,
-              })
+              await undoRoundStart.mutateAsync({ roundId: round.id })
               toast.success(`Undid the start of Round ${round.roundNum}`)
             },
           })

--- a/client/src/components/SupportTools/RoundsTable.tsx
+++ b/client/src/components/SupportTools/RoundsTable.tsx
@@ -83,11 +83,11 @@ const LastRoundAction = ({ electionId, round }: ILastRoundActionProps) => {
           onClick={() =>
             confirm({
               title: 'Confirm',
-              description: `Are you sure you want to reopen Round ${round.roundNum}?`,
+              description: `Are you sure you want to reopen round ${round.roundNum}?`,
               yesButtonLabel: 'Reopen',
               onYesClick: async () => {
                 await reopenCurrentRound.mutateAsync({ electionId })
-                toast.success(`Reopened Round ${round.roundNum}`)
+                toast.success(`Reopened round ${round.roundNum}`)
               },
             })
           }
@@ -104,11 +104,11 @@ const LastRoundAction = ({ electionId, round }: ILastRoundActionProps) => {
         onClick={() =>
           confirm({
             title: 'Confirm',
-            description: `Are you sure you want to undo the start of Round ${round.roundNum}?`,
+            description: `Are you sure you want to undo the start of round ${round.roundNum}?`,
             yesButtonLabel: 'Undo Start',
             onYesClick: async () => {
               await undoRoundStart.mutateAsync({ roundId: round.id })
-              toast.success(`Undid the start of Round ${round.roundNum}`)
+              toast.success(`Undid the start of round ${round.roundNum}`)
             },
           })
         }

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -763,7 +763,7 @@ describe('Support Tools', () => {
         .getByRole('heading', { name: 'Confirm' })
         .closest('.bp3-dialog')! as HTMLElement
       within(confirmDialog).getByText(
-        'Are you sure you want to undo the start of Round 2?'
+        'Are you sure you want to undo the start of round 2?'
       )
       userEvent.click(
         within(confirmDialog).getByRole('button', { name: 'Undo Start' })
@@ -775,7 +775,7 @@ describe('Support Tools', () => {
         .getByRole('heading', { name: 'Confirm' })
         .closest('.bp3-dialog')! as HTMLElement
       within(confirmDialog).getByText(
-        'Are you sure you want to reopen Round 1?'
+        'Are you sure you want to reopen round 1?'
       )
       userEvent.click(
         within(confirmDialog).getByRole('button', { name: 'Reopen' })

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { screen, within } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ToastContainer } from 'react-toastify'
 import { QueryClientProvider } from 'react-query'
@@ -19,6 +19,7 @@ import {
   IElection,
   IJurisdictionBase,
   IJurisdiction,
+  IRound,
 } from './support-api'
 import { queryClient } from '../../App'
 
@@ -74,6 +75,7 @@ const mockElection: IElection = {
       name: 'Jurisdiction 2',
     },
   ],
+  rounds: [{ id: 'round-1', endedAt: null, roundNum: 1 }],
 }
 
 const mockJurisdiction: IJurisdiction = {
@@ -166,6 +168,16 @@ const apiCalls = {
   deleteOfflineResults: {
     url: '/api/support/jurisdictions/jurisdiction-id-1/results',
     options: { method: 'DELETE' },
+    response: { status: 'ok' },
+  },
+  undoRoundStart: {
+    url: '/api/support/rounds/round-2',
+    options: { method: 'DELETE' },
+    response: { status: 'ok' },
+  },
+  reopenCurrentRound: {
+    url: '/api/support/elections/election-id-1/reopen-current-round',
+    options: { method: 'PATCH' },
     response: { status: 'ok' },
   },
 }
@@ -646,6 +658,129 @@ describe('Support Tools', () => {
       expect(history.location.pathname).toEqual(
         '/support/jurisdictions/jurisdiction-id-1'
       )
+    })
+  })
+
+  const roundSummaryTestCases: {
+    rounds: IRound[]
+    expectedRoundsTableHead: string[]
+    expectedRoundsTableBody: {
+      round: string
+      status: string
+      action?: string
+    }[]
+  }[] = [
+    {
+      rounds: [],
+      expectedRoundsTableHead: ['Round', 'Status'],
+      expectedRoundsTableBody: [{ round: 'Round 1', status: 'Not started' }],
+    },
+    {
+      rounds: [{ id: 'round-1', endedAt: null, roundNum: 1 }],
+      expectedRoundsTableHead: ['Round', 'Status', 'Actions'],
+      expectedRoundsTableBody: [
+        { round: 'Round 1', status: 'In progress', action: 'Undo Start' },
+      ],
+    },
+    {
+      rounds: [
+        { id: 'round-1', endedAt: 'some-timestamp', roundNum: 1 },
+        { id: 'round-2', endedAt: null, roundNum: 2 },
+      ],
+      expectedRoundsTableHead: ['Round', 'Status', 'Actions'],
+      expectedRoundsTableBody: [
+        { round: 'Round 1', status: 'Completed' },
+        { round: 'Round 2', status: 'In progress', action: 'Undo Start' },
+      ],
+    },
+    {
+      rounds: [{ id: 'round-1', endedAt: 'some-timestamp', roundNum: 1 }],
+      expectedRoundsTableHead: ['Round', 'Status', 'Actions'],
+      expectedRoundsTableBody: [
+        { round: 'Round 1', status: 'Completed', action: 'Reopen' },
+      ],
+    },
+  ]
+  it.each(roundSummaryTestCases)(
+    'audit screen shows expected round summary',
+    async ({ rounds, expectedRoundsTableHead, expectedRoundsTableBody }) => {
+      const expectedCalls = [
+        supportApiCalls.getUser,
+        apiCalls.getElection({ ...mockElection, rounds }),
+      ]
+      await withMockFetch(expectedCalls, async () => {
+        renderRoute('/support/audits/election-id-1')
+
+        await screen.findByRole('heading', { name: 'Audit 1' })
+        expectedRoundsTableHead.forEach(header => {
+          screen.getByRole('columnheader', { name: header })
+        })
+        expectedRoundsTableBody.forEach(row => {
+          screen.getByRole('row', {
+            name: row.action
+              ? `${row.round} ${row.status} ${row.action}`
+              : `${row.round} ${row.status}`,
+          })
+          screen.getByRole('cell', { name: row.round })
+          screen.getByRole('cell', { name: row.status })
+          if (row.action) {
+            screen.getByRole('cell', { name: row.action })
+            screen.getByRole('button', { name: row.action })
+          }
+        })
+      })
+    }
+  )
+
+  it('audit screen supports undoing round starts and reopening rounds', async () => {
+    const expectedCalls = [
+      supportApiCalls.getUser,
+      apiCalls.getElection({
+        ...mockElection,
+        rounds: [
+          { id: 'round-1', endedAt: 'some-timestamp', roundNum: 1 },
+          { id: 'round-2', endedAt: null, roundNum: 2 },
+        ],
+      }),
+      apiCalls.undoRoundStart,
+      apiCalls.getElection({
+        ...mockElection,
+        rounds: [{ id: 'round-1', endedAt: 'some-timestamp', roundNum: 1 }],
+      }),
+      apiCalls.reopenCurrentRound,
+      apiCalls.getElection({
+        ...mockElection,
+        rounds: [{ id: 'round-1', endedAt: null, roundNum: 1 }],
+      }),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderRoute('/support/audits/election-id-1')
+
+      await screen.findByRole('heading', { name: 'Audit 1' })
+
+      userEvent.click(screen.getByText('Undo Start'))
+      let confirmDialog = screen
+        .getByRole('heading', { name: 'Confirm' })
+        .closest('.bp3-dialog')! as HTMLElement
+      within(confirmDialog).getByText(
+        'Are you sure you want to undo the start of Round 2?'
+      )
+      userEvent.click(
+        within(confirmDialog).getByRole('button', { name: 'Undo Start' })
+      )
+      await waitFor(() => expect(confirmDialog).not.toBeInTheDocument())
+
+      userEvent.click(screen.getByText('Reopen'))
+      confirmDialog = screen
+        .getByRole('heading', { name: 'Confirm' })
+        .closest('.bp3-dialog')! as HTMLElement
+      within(confirmDialog).getByText(
+        'Are you sure you want to reopen Round 1?'
+      )
+      userEvent.click(
+        within(confirmDialog).getByRole('button', { name: 'Reopen' })
+      )
+      await waitFor(() => expect(confirmDialog).not.toBeInTheDocument())
     })
   })
 

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -38,6 +38,7 @@ import {
 } from './support-api'
 import { useConfirm, Confirm } from '../Atoms/Confirm'
 import AuditBoardsTable from '../AuditAdmin/Progress/AuditBoardsTable'
+import RoundsTable from './RoundsTable'
 
 const SupportTools = () => {
   const auth = useAuthDataContext()
@@ -391,7 +392,7 @@ const Audit = ({ electionId }: { electionId: string }) => {
 
   if (!election.isSuccess) return null
 
-  const { auditName, auditType, jurisdictions } = election.data
+  const { auditName, auditType, jurisdictions, rounds } = election.data
 
   return (
     <Column>
@@ -399,7 +400,8 @@ const Audit = ({ electionId }: { electionId: string }) => {
       <Tag large style={{ marginBottom: '15px' }}>
         {prettyAuditType(auditType)}
       </Tag>
-      <H3>Jurisdictions</H3>
+      <RoundsTable electionId={electionId} rounds={rounds} />
+      <H3 style={{ marginTop: '10px' }}>Jurisdictions</H3>
       <ButtonList>
         {jurisdictions.map(jurisdiction => (
           <LinkButton

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -223,13 +223,8 @@ export const useClearOfflineResults = () => {
   })
 }
 
-export const useUndoRoundStart = () => {
-  const undoRoundStart = async ({
-    roundId,
-  }: {
-    electionId: string
-    roundId: string
-  }) =>
+export const useUndoRoundStart = (electionId: string) => {
+  const undoRoundStart = async ({ roundId }: { roundId: string }) =>
     fetchApi(`/api/support/rounds/${roundId}`, {
       method: 'DELETE',
     })
@@ -237,8 +232,8 @@ export const useUndoRoundStart = () => {
   const queryClient = useQueryClient()
 
   return useMutation(undoRoundStart, {
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries(['elections', variables.electionId])
+    onSuccess: () => {
+      queryClient.invalidateQueries(['elections', electionId])
     },
   })
 }

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -29,8 +29,15 @@ export interface IAuditAdmin {
   email: string
 }
 
+export interface IRound {
+  id: string
+  endedAt: string | null
+  roundNum: number
+}
+
 export interface IElection extends IElectionBase {
   jurisdictions: IJurisdictionBase[]
+  rounds: IRound[]
 }
 
 export interface IJurisdictionBase {
@@ -213,5 +220,40 @@ export const useClearOfflineResults = () => {
         'jurisdictions',
         variables.jurisdictionId,
       ]),
+  })
+}
+
+export const useUndoRoundStart = () => {
+  const undoRoundStart = async ({
+    roundId,
+  }: {
+    electionId: string
+    roundId: string
+  }) =>
+    fetchApi(`/api/support/rounds/${roundId}`, {
+      method: 'DELETE',
+    })
+
+  const queryClient = useQueryClient()
+
+  return useMutation(undoRoundStart, {
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries(['elections', variables.electionId])
+    },
+  })
+}
+
+export const useReopenCurrentRound = () => {
+  const reopenCurrentRound = async ({ electionId }: { electionId: string }) =>
+    fetchApi(`/api/support/elections/${electionId}/reopen-current-round`, {
+      method: 'PATCH',
+    })
+
+  const queryClient = useQueryClient()
+
+  return useMutation(reopenCurrentRound, {
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries(['elections', variables.electionId])
+    },
   })
 }

--- a/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
+++ b/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`Home screen redirects to audit screen if only one election exists for J
       class="sc-bdVaJa bKocXA"
     >
       <div
-        class="bp3-callout sc-hMqMXs gvJKSa"
+        class="bp3-callout sc-kEYyzF ejxvfy"
       >
         <div
           class="sc-bwzfXH jiphYj"
@@ -100,7 +100,7 @@ exports[`Home screen redirects to audit screen if only one election exists for J
             class="text"
           >
             <h3
-              class="bp3-heading sc-eNQAEJ xkxXg"
+              class="bp3-heading sc-hMqMXs iPDpyw"
             >
               Test Audit
             </h3>
@@ -116,19 +116,19 @@ exports[`Home screen redirects to audit screen if only one election exists for J
         </div>
       </div>
       <div
-        class="sc-bwzfXH sc-fMiknA gQUJtg"
+        class="sc-bwzfXH sc-dVhcbM jDwyKc"
       >
         <h2
-          class="bp3-heading sc-kEYyzF hZLToi"
+          class="bp3-heading sc-kkGfuU cPdmuO"
         >
           Audit Source Data
         </h2>
         <form>
           <div
-            class="sc-kkGfuU ivvpIi"
+            class="sc-iAyFgw dXmdgD"
           >
             <h2
-              class="bp3-heading sc-kEYyzF hZLToi"
+              class="bp3-heading sc-kkGfuU cPdmuO"
             />
             <div
               class="sc-bZQynM bGsEQi"

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -175,7 +175,8 @@ def get_election(election_id: str):
             for jurisdiction in election.jurisdictions
         ],
         rounds=[
-            dict(id=round.id, ended_at=round.ended_at) for round in election.rounds
+            dict(id=round.id, endedAt=round.ended_at, roundNum=round.round_num)
+            for round in election.rounds
         ],
         deletedAt=isoformat(election.deleted_at),
     )
@@ -308,6 +309,7 @@ def get_jurisdiction(jurisdiction_id: str):
             auditName=jurisdiction.election.audit_name,
             auditType=jurisdiction.election.audit_type,
             online=jurisdiction.election.online,
+            deletedAt=isoformat(jurisdiction.election.deleted_at),
         ),
         jurisdictionAdmins=sorted(
             [

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -151,7 +151,7 @@ def test_support_get_election(
                 {"id": jurisdiction_ids[1], "name": "J2",},
                 {"id": jurisdiction_ids[2], "name": "J3",},
             ],
-            "rounds": [{"id": round_1_id, "ended_at": None}],
+            "rounds": [{"id": round_1_id, "endedAt": None, "roundNum": 1}],
             "deletedAt": None,
         },
     )
@@ -418,6 +418,7 @@ def test_support_get_jurisdiction(
                 "auditName": "Test Audit test_support_get_jurisdiction",
                 "auditType": "BALLOT_POLLING",
                 "online": True,
+                "deletedAt": None,
             },
             "jurisdictionAdmins": [{"email": default_ja_email(election_id)}],
             "auditBoards": [
@@ -675,9 +676,9 @@ def test_support_undo_round_start(
     rounds = json.loads(rv.data)["rounds"]
     assert len(rounds) == 2
     assert rounds[0]["id"] == round_1_id
-    assert rounds[0]["ended_at"] is not None
+    assert rounds[0]["endedAt"] is not None
     assert rounds[1]["id"] == round_2_id
-    assert rounds[1]["ended_at"] is None
+    assert rounds[1]["endedAt"] is None
 
     rv = client.delete(f"/api/support/rounds/{round_1_id}")
     assert rv.status_code == 409
@@ -696,7 +697,7 @@ def test_support_undo_round_start(
     rounds = json.loads(rv.data)["rounds"]
     assert len(rounds) == 1
     assert rounds[0]["id"] == round_1_id
-    assert rounds[0]["ended_at"] is not None
+    assert rounds[0]["endedAt"] is not None
 
     rv = client.delete(f"/api/support/rounds/{round_1_id}")
     assert rv.status_code == 409
@@ -721,7 +722,7 @@ def test_support_reopen_current_round(
         round_from_db = Round.query.get(round_id)
 
         # Check what we can using the API and check the rest in the DB
-        return round["ended_at"] is not None and all(
+        return round["endedAt"] is not None and all(
             round_contest.end_p_value is not None
             and round_contest.is_complete is not None
             and len(round_contest.results) > 0


### PR DESCRIPTION
_Commit by commit reviewing recommended_

## Overview

The last in a series of PRs for https://github.com/votingworks/arlo/issues/1499!

This PR gives support users buttons for undoing round starts and reopening rounds through a new round summary table. This closes the loop on a flow for rolling back from round 2 to correct mistakes from round 1.

## Screenshots and screencaptures

_Round 2 started but not yet completed_

![undo-round-start](https://user-images.githubusercontent.com/12616928/187302090-d86e1644-0335-4e1d-8b81-34a3cb9d649c.png)

_Round 2 start undone, Round 1 not yet reopened_

![reopen-round](https://user-images.githubusercontent.com/12616928/187302081-0e324b91-2a6b-47fd-80ca-fe635ba61951.png)

_Audit not yet started_

![not-started](https://user-images.githubusercontent.com/12616928/187302077-8979faf7-50d6-4d3c-a283-14ba0bd96c13.png)

_In action, undoing Round 2 start and reopening Round 1_

https://user-images.githubusercontent.com/12616928/187302082-45fa46e7-33a9-45f9-a184-53ff25c6b8e5.mov

## Testing

- [x] Added automated tests
- [x] Tested manually