### PR TITLE
Allow AAs to reopen audit boards before all have signed off

### DIFF
--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
@@ -699,28 +699,35 @@ describe('JurisdictionDetail', () => {
     })
   })
 
-  it('after launch of an audit with online audit boards, shows a table of audit boards', async () => {
-    const expectedCalls = [
-      jaApiCalls.getBallotManifestFile(manifestMocks.processed),
-      jaApiCalls.getAuditBoards(auditBoardMocks.double),
-      jaApiCalls.getBallotCount(dummyBallots.ballots),
-    ]
-    await withMockFetch(expectedCalls, async () => {
-      render({
-        auditSettings: auditSettings.all,
-        jurisdiction: jurisdictionMocks.allComplete[0],
-        round: roundMocks.singleIncomplete[0],
-      })
+  it.each([
+    jurisdictionMocks.oneComplete[0], // Jurisdiction status = in progress
+    jurisdictionMocks.allComplete[0], // Jurisdiction status = complete
+  ])(
+    'after launch of an audit with online audit boards, shows a table of audit boards',
+    async jurisdiction => {
+      const expectedCalls = [
+        jaApiCalls.getBallotManifestFile(manifestMocks.processed),
+        jaApiCalls.getAuditBoards(auditBoardMocks.double),
+        jaApiCalls.getBallotCount(dummyBallots.ballots),
+      ]
+      await withMockFetch(expectedCalls, async () => {
+        render({
+          auditSettings: auditSettings.all,
+          jurisdiction,
+          round: roundMocks.singleIncomplete[0],
+        })
 
-      await screen.findByText('Data entry complete')
-      screen.getByText('Audit Board #01')
-      screen.getByText('Audit Board #02')
-      const reopenButtons = screen.getAllByRole('button', { name: 'Reopen' })
-      expect(reopenButtons).toHaveLength(2)
-      expect(reopenButtons[0]).toBeDisabled()
-      expect(reopenButtons[1]).toBeDisabled()
-    })
-  })
+        await screen.findByRole('columnheader', { name: 'Audit Board' })
+        screen.getByRole('columnheader', { name: 'Actions' })
+        screen.getByRole('cell', { name: 'Audit Board #01' })
+        screen.getByRole('cell', { name: 'Audit Board #02' })
+        const reopenButtons = screen.getAllByRole('button', { name: 'Reopen' })
+        expect(reopenButtons).toHaveLength(2)
+        expect(reopenButtons[0]).toBeDisabled()
+        expect(reopenButtons[1]).toBeDisabled()
+      })
+    }
+  )
 
   it('after launch of an audit with online audit boards, allows reopening of audit boards that have signed off', async () => {
     const expectedCalls = [

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
@@ -283,6 +283,19 @@ const RoundStatusSection = ({
   const status = (() => {
     const jurisdictionStatus =
       jurisdiction.currentRoundStatus && jurisdiction.currentRoundStatus.status
+    const auditBoardsTable = (
+      <AuditBoardsTable
+        auditBoards={auditBoards}
+        reopenAuditBoard={auditBoard =>
+          reopenAuditBoard({
+            auditBoardId: auditBoard.id,
+            electionId,
+            jurisdictionId: jurisdiction.id,
+            roundId: round.id,
+          })
+        }
+      />
+    )
 
     if (round.isFullHandTally) {
       if (jurisdictionStatus === JurisdictionRoundStatus.COMPLETE)
@@ -318,7 +331,9 @@ const RoundStatusSection = ({
       )
     }
 
-    if (sampleCount.ballots === 0) return <p>No ballots sampled</p>
+    if (sampleCount.ballots === 0) {
+      return <p>No ballots sampled</p>
+    }
     if (jurisdictionStatus === JurisdictionRoundStatus.COMPLETE) {
       if (auditSettings.auditType === 'BATCH_COMPARISON') {
         return (
@@ -342,19 +357,7 @@ const RoundStatusSection = ({
       return (
         <div>
           <p>Data entry complete</p>
-          {auditSettings.online && (
-            <AuditBoardsTable
-              auditBoards={auditBoards}
-              reopenAuditBoard={auditBoard =>
-                reopenAuditBoard({
-                  auditBoardId: auditBoard.id,
-                  electionId,
-                  jurisdictionId: jurisdiction.id,
-                  roundId: round.id,
-                })
-              }
-            />
-          )}
+          {auditSettings.online && auditBoardsTable}
         </div>
       )
     }
@@ -362,14 +365,19 @@ const RoundStatusSection = ({
       return <p>Waiting for jurisdiction to set up audit boards</p>
     }
     return (
-      <JAFileDownloadButtons
-        electionId={electionId}
-        jurisdictionId={jurisdiction.id}
-        jurisdictionName={jurisdiction.name}
-        round={round}
-        auditSettings={auditSettings}
-        auditBoards={auditBoards}
-      />
+      <>
+        <JAFileDownloadButtons
+          electionId={electionId}
+          jurisdictionId={jurisdiction.id}
+          jurisdictionName={jurisdiction.name}
+          round={round}
+          auditSettings={auditSettings}
+          auditBoards={auditBoards}
+        />
+        {auditSettings.online && (
+          <div style={{ marginTop: '10px' }}>{auditBoardsTable}</div>
+        )}
+      </>
     )
   })()
 


### PR DESCRIPTION
I recently realized that https://github.com/votingworks/arlo/pull/1573, which moved the ability to reopen audit boards from support users to audit admins, resulted in a loss of functionality, namely the ability to reopen audit boards _before_ all audit boards in a jurisdiction have signed off. This PR restores that ability!

![audit-boards-table](https://user-images.githubusercontent.com/12616928/187951138-c771d3bd-5ab8-4325-b17d-8aa5e76cf862.png)