### PR TITLE
Add support user button for logging in to audit directly as arbitrary audit admin

### DIFF
--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -638,7 +638,7 @@ describe('Support Tools', () => {
     })
   })
 
-  it('audit screen shows a list of jurisdictions', async () => {
+  it('audit screen shows login button and list of jurisdictions', async () => {
     const expectedCalls = [
       supportApiCalls.getUser,
       apiCalls.getElection(mockElection),
@@ -648,11 +648,22 @@ describe('Support Tools', () => {
       const { history } = renderRoute('/support/audits/election-id-1')
 
       await screen.findByRole('heading', { name: 'Audit 1' })
+
+      const loginButton = screen.getByRole('button', {
+        name: /Log in as audit admin/,
+      })
+      expect(loginButton).toHaveAttribute(
+        'href',
+        '/api/support/elections/election-id-1/login'
+      )
+
       screen.getByText('Ballot Polling')
 
-      // List of jurisdictions
+      const jurisdictionButton = screen.getByRole('button', {
+        name: 'Jurisdiction 1',
+      })
       screen.getByRole('button', { name: 'Jurisdiction 2' })
-      userEvent.click(screen.getByRole('button', { name: 'Jurisdiction 1' }))
+      userEvent.click(jurisdictionButton)
 
       await screen.findByRole('heading', { name: 'Jurisdiction 1' })
       expect(history.location.pathname).toEqual(

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -393,16 +393,23 @@ const Audit = ({ electionId }: { electionId: string }) => {
 
   if (!election.isSuccess) return null
 
-  const { auditName, auditType, jurisdictions, rounds } = election.data
+  const { id, auditName, auditType, jurisdictions, rounds } = election.data
 
   return (
     <Column>
       <H2>{auditName}</H2>
-      <Tag large style={{ marginBottom: '15px' }}>
+      <div style={{ marginBottom: '10px' }}>
+        <AnchorButton href={`/api/support/elections/${id}/login`} icon="log-in">
+          Log in as audit admin
+        </AnchorButton>
+      </div>
+      <Tag large style={{ marginBottom: '10px' }}>
         {prettyAuditType(auditType)}
       </Tag>
-      <RoundsTable electionId={electionId} rounds={rounds} />
-      <H3 style={{ marginTop: '10px' }}>Jurisdictions</H3>
+      <div style={{ marginBottom: '10px' }}>
+        <RoundsTable electionId={electionId} rounds={rounds} />
+      </div>
+      <H3>Jurisdictions</H3>
       <ButtonList>
         {jurisdictions.map(jurisdiction => (
           <LinkButton

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -396,32 +396,44 @@ const Audit = ({ electionId }: { electionId: string }) => {
   const { id, auditName, auditType, jurisdictions, rounds } = election.data
 
   return (
-    <Column>
+    <div>
       <H2>{auditName}</H2>
-      <div style={{ marginBottom: '10px' }}>
-        <AnchorButton href={`/api/support/elections/${id}/login`} icon="log-in">
-          Log in as audit admin
-        </AnchorButton>
-      </div>
-      <Tag large style={{ marginBottom: '10px' }}>
-        {prettyAuditType(auditType)}
-      </Tag>
-      <div style={{ marginBottom: '10px' }}>
-        <RoundsTable electionId={electionId} rounds={rounds} />
-      </div>
-      <H3>Jurisdictions</H3>
-      <ButtonList>
-        {jurisdictions.map(jurisdiction => (
-          <LinkButton
-            key={jurisdiction.id}
-            to={`/support/jurisdictions/${jurisdiction.id}`}
-            intent={Intent.PRIMARY}
+      <Column>
+        <div
+          style={{
+            alignItems: 'center',
+            display: 'flex',
+            marginBottom: '10px',
+          }}
+        >
+          <Tag large style={{ marginRight: '10px' }}>
+            {prettyAuditType(auditType)}
+          </Tag>
+          <AnchorButton
+            href={`/api/support/elections/${id}/login`}
+            icon="log-in"
+            intent="primary"
           >
-            {jurisdiction.name}
-          </LinkButton>
-        ))}
-      </ButtonList>
-    </Column>
+            Log in as audit admin
+          </AnchorButton>
+        </div>
+        <div style={{ marginBottom: '10px' }}>
+          <RoundsTable electionId={electionId} rounds={rounds} />
+        </div>
+        <H3>Jurisdictions</H3>
+        <ButtonList>
+          {jurisdictions.map(jurisdiction => (
+            <LinkButton
+              key={jurisdiction.id}
+              to={`/support/jurisdictions/${jurisdiction.id}`}
+              intent={Intent.PRIMARY}
+            >
+              {jurisdiction.name}
+            </LinkButton>
+          ))}
+        </ButtonList>
+      </Column>
+    </div>
   )
 }
 

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -407,6 +407,24 @@ def log_in_as_jurisdiction_admin(email: str):
     return redirect("/")
 
 
+@api.route(
+    "/support/elections/<election_id>/login", methods=["GET"],
+)
+@restrict_access_support
+def log_in_to_audit_as_audit_admin(election_id: str):
+    election = get_or_404(Election, election_id)
+    audit_admins = [
+        audit_administration.user
+        for audit_administration in election.organization.audit_administrations
+    ]
+    if len(audit_admins) == 0:
+        raise Conflict("Organization has no audit admins.")
+    set_loggedin_user(
+        session, UserType.AUDIT_ADMIN, audit_admins[0].email, from_support_user=True
+    )
+    return redirect(f"/election/{election_id}")
+
+
 @api.route("/support/rounds/<round_id>", methods=["DELETE"])
 @restrict_access_support
 def support_undo_round_start(round_id: str):

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -472,6 +472,24 @@ def test_support_log_in_as_jurisdiction_admin(
         assert session["_last_request_at"] != original_last_request_at
 
 
+def test_support_log_in_to_audit_as_audit_admin(client: FlaskClient, election_id: str):
+    set_support_user(client, SUPPORT_EMAIL)
+
+    with client.session_transaction() as session:  # type: ignore
+        original_created_at = session["_created_at"]
+        original_last_request_at = session["_last_request_at"]
+
+    rv = client.get(f"/api/support/elections/{election_id}/login")
+    assert rv.status_code == 302
+    assert urlparse(rv.location).path == f"/election/{election_id}"
+
+    with client.session_transaction() as session:  # type: ignore
+        assert session["_user"]["type"] == UserType.AUDIT_ADMIN
+        assert session["_user"]["key"] == DEFAULT_AA_EMAIL
+        assert session["_created_at"] == original_created_at
+        assert session["_last_request_at"] != original_last_request_at
+
+
 def test_support_clear_audit_boards(
     client: FlaskClient,
     contest_ids: List[str],


### PR DESCRIPTION
## Overview

One of many support user improvements that we're considering for https://github.com/votingworks/arlo/issues/1433, this PR adds a support user button for logging in to an audit directly as an arbitrary audit admin. (Ginny has confirmed that picking any arbitrary audit admin in the relevant organization is fine and even desirable.)

Prior to this PR, there was no login button on the individual audit screen for support users, and support users still had to select an audit after logging in as an audit admin, making a number of support user flows clunky.

<img width="1030" alt="log-in-as" src="https://user-images.githubusercontent.com/12616928/188958678-17c252aa-ae77-43ab-9e33-44071344396d.png">

https://user-images.githubusercontent.com/12616928/188958673-b7483ce1-250a-49c8-a94f-dc619ccedc6b.mov

## Testing

- [x] Added automated tests
- [x] Tested manually