### PR TITLE
Set up scaffolding for public Arlo pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,6 +19,7 @@ import AuditAdminView from './components/AuditAdmin/AuditAdminView'
 import ActivityLog from './components/AuditAdmin/ActivityLog'
 import AuditBoardView from './components/AuditBoard/AuditBoardView'
 import { ApiError } from './utils/api'
+import PublicPages from './components/PublicPages/PublicPages'
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -113,6 +114,9 @@ const App: React.FC = () => {
               />
               <Route path="/support">
                 <SupportTools />
+              </Route>
+              <Route path="/public">
+                <PublicPages />
               </Route>
               <Route>
                 <Wrapper>404 Not Found</Wrapper>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -115,11 +115,8 @@ const App: React.FC = () => {
               <Route path="/support">
                 <SupportTools />
               </Route>
-              <Route path="/public">
-                <PublicPages />
-              </Route>
               <Route>
-                <Wrapper>404 Not Found</Wrapper>
+                <PublicPages />
               </Route>
             </Switch>
           </Main>

--- a/client/src/components/Atoms/Wrapper.tsx
+++ b/client/src/components/Atoms/Wrapper.tsx
@@ -7,13 +7,18 @@ export const Wrapper = styled.div`
   padding-bottom: 30px;
 `
 
-export const Inner = styled.div`
+interface IInnerProps {
+  withTopPadding?: boolean
+}
+
+export const Inner = styled.div<IInnerProps>`
   display: flex;
   margin-right: auto;
   margin-left: auto;
   width: 100%;
   max-width: 1020px;
   padding: 0 30px;
+  padding-top: ${props => (props.withTopPadding ? '30px' : '0')};
 `
 
 export default Wrapper

--- a/client/src/components/AuditAdmin/__snapshots__/AuditAdminView.test.tsx.snap
+++ b/client/src/components/AuditAdmin/__snapshots__/AuditAdminView.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
       class="bp3-callout sc-hSdWYo gMDgEE"
     >
       <div
-        class="sc-kkGfuU dREAhJ"
+        class="sc-kkGfuU frdbBK"
       >
         <div
           class="text"
@@ -43,7 +43,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
       </div>
     </div>
     <div
-      class="sc-kkGfuU dREAhJ"
+      class="sc-kkGfuU frdbBK"
     >
       <div
         class="sc-cvbbAY vOHMb"

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
       class="bp3-navbar sc-ksYbfQ QHGZm"
     >
       <div
-        class="sc-bxivhb sc-frDJqD dfcocX"
+        class="sc-bxivhb sc-frDJqD fHxfRa"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -58,7 +58,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
     </div>
     <div>
       <div
-        class="sc-bxivhb hMnACT"
+        class="sc-bxivhb imUAuK"
       >
         <div
           class="sc-fMiknA dSOusv"
@@ -454,7 +454,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
       class="bp3-navbar sc-ksYbfQ QHGZm"
     >
       <div
-        class="sc-bxivhb sc-frDJqD dfcocX"
+        class="sc-bxivhb sc-frDJqD fHxfRa"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -508,7 +508,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
         class="sc-bZQynM gcSISu"
       >
         <div
-          class="sc-bxivhb sc-gzVnrw dPFfSP"
+          class="sc-bxivhb sc-gzVnrw bBxgry"
         >
           <div
             class="sc-ifAKCX Eaynb"
@@ -550,7 +550,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
         </div>
       </div>
       <div
-        class="sc-bxivhb hMnACT"
+        class="sc-bxivhb imUAuK"
       >
         <div
           class="sc-htoDjs hxAtLW"
@@ -2735,7 +2735,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
       class="bp3-navbar sc-ksYbfQ QHGZm"
     >
       <div
-        class="sc-bxivhb sc-frDJqD dfcocX"
+        class="sc-bxivhb sc-frDJqD fHxfRa"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -2789,7 +2789,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
         class="sc-bZQynM gcSISu"
       >
         <div
-          class="sc-bxivhb sc-gzVnrw dPFfSP"
+          class="sc-bxivhb sc-gzVnrw bBxgry"
         >
           <div
             class="sc-ifAKCX Eaynb"
@@ -2831,7 +2831,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
         </div>
       </div>
       <div
-        class="sc-bxivhb hMnACT"
+        class="sc-bxivhb imUAuK"
       >
         <div
           class="sc-htoDjs hxAtLW"
@@ -4638,7 +4638,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
       class="bp3-navbar sc-ksYbfQ QHGZm"
     >
       <div
-        class="sc-bxivhb sc-frDJqD dfcocX"
+        class="sc-bxivhb sc-frDJqD fHxfRa"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -4692,7 +4692,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
         class="sc-bZQynM gcSISu"
       >
         <div
-          class="sc-bxivhb sc-gzVnrw dPFfSP"
+          class="sc-bxivhb sc-gzVnrw bBxgry"
         >
           <div
             class="sc-ifAKCX Eaynb"
@@ -4734,7 +4734,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
         </div>
       </div>
       <div
-        class="sc-bxivhb hMnACT"
+        class="sc-bxivhb imUAuK"
       >
         <div
           class="sc-htoDjs hxAtLW"
@@ -4962,7 +4962,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
       class="bp3-navbar sc-ksYbfQ QHGZm"
     >
       <div
-        class="sc-bxivhb sc-frDJqD dfcocX"
+        class="sc-bxivhb sc-frDJqD fHxfRa"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -5016,7 +5016,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
         class="sc-bZQynM gcSISu"
       >
         <div
-          class="sc-bxivhb sc-gzVnrw dPFfSP"
+          class="sc-bxivhb sc-gzVnrw bBxgry"
         >
           <div
             class="sc-ifAKCX Eaynb"
@@ -5058,7 +5058,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
         </div>
       </div>
       <div
-        class="sc-bxivhb hMnACT"
+        class="sc-bxivhb imUAuK"
       >
         <div
           class="sc-htoDjs hxAtLW"

--- a/client/src/components/AuditBoard/__snapshots__/Ballot.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/Ballot.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Ballot renders correctly with an audited ballot 1`] = `
 <div>
   <div>
     <div
-      class="sc-hMqMXs clYEUh"
+      class="sc-hMqMXs hlEuTf"
     >
       <div
         class="sc-kkGfuU eOTllS"
@@ -303,7 +303,7 @@ exports[`Ballot renders correctly with an unaudited ballot 1`] = `
 <div>
   <div>
     <div
-      class="sc-hMqMXs clYEUh"
+      class="sc-hMqMXs hlEuTf"
     >
       <div
         class="sc-kkGfuU eOTllS"
@@ -599,7 +599,7 @@ exports[`Ballot selects Blank Vote 1`] = `
 <div>
   <div>
     <div
-      class="sc-hMqMXs clYEUh"
+      class="sc-hMqMXs hlEuTf"
     >
       <div
         class="sc-kkGfuU eOTllS"
@@ -893,7 +893,7 @@ exports[`Ballot selects Not on Ballot 1`] = `
 <div>
   <div>
     <div
-      class="sc-hMqMXs clYEUh"
+      class="sc-hMqMXs hlEuTf"
     >
       <div
         class="sc-kkGfuU eOTllS"
@@ -1187,7 +1187,7 @@ exports[`Ballot switches audit and review views 1`] = `
 <div>
   <div>
     <div
-      class="sc-hMqMXs clYEUh"
+      class="sc-hMqMXs hlEuTf"
     >
       <div
         class="sc-kkGfuU eOTllS"

--- a/client/src/components/AuditBoard/__snapshots__/BoardTable.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/BoardTable.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
       class="sc-bZQynM gcSISu"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw dPFfSP"
+        class="sc-bxivhb sc-gzVnrw bBxgry"
       >
         <div
           class="sc-ifAKCX Eaynb"
@@ -57,7 +57,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
       </div>
     </div>
     <div
-      class="sc-bxivhb hMnACT"
+      class="sc-bxivhb imUAuK"
     >
       <div
         class="sc-htoDjs hxAtLW"
@@ -634,7 +634,7 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
       class="sc-bZQynM gcSISu"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw dPFfSP"
+        class="sc-bxivhb sc-gzVnrw bBxgry"
       >
         <div
           class="sc-ifAKCX Eaynb"
@@ -676,7 +676,7 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
       </div>
     </div>
     <div
-      class="sc-bxivhb hMnACT"
+      class="sc-bxivhb imUAuK"
     >
       <div
         class="sc-htoDjs hxAtLW"
@@ -1019,7 +1019,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
       class="sc-bZQynM gcSISu"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw dPFfSP"
+        class="sc-bxivhb sc-gzVnrw bBxgry"
       >
         <div
           class="sc-ifAKCX Eaynb"
@@ -1061,7 +1061,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
       </div>
     </div>
     <div
-      class="sc-bxivhb hMnACT"
+      class="sc-bxivhb imUAuK"
     >
       <div
         class="sc-htoDjs hxAtLW"
@@ -1451,7 +1451,7 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
       class="sc-bZQynM gcSISu"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw dPFfSP"
+        class="sc-bxivhb sc-gzVnrw bBxgry"
       >
         <div
           class="sc-ifAKCX Eaynb"
@@ -1493,7 +1493,7 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
       </div>
     </div>
     <div
-      class="sc-bxivhb hMnACT"
+      class="sc-bxivhb imUAuK"
     >
       <div
         class="sc-htoDjs hxAtLW"
@@ -1789,7 +1789,7 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
       class="sc-bZQynM gcSISu"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw dPFfSP"
+        class="sc-bxivhb sc-gzVnrw bBxgry"
       >
         <div
           class="sc-ifAKCX Eaynb"
@@ -1831,7 +1831,7 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
       </div>
     </div>
     <div
-      class="sc-bxivhb hMnACT"
+      class="sc-bxivhb imUAuK"
     >
       <div
         class="sc-htoDjs hxAtLW"
@@ -2174,7 +2174,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
       class="sc-bZQynM gcSISu"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw dPFfSP"
+        class="sc-bxivhb sc-gzVnrw bBxgry"
       >
         <div
           class="sc-ifAKCX Eaynb"
@@ -2216,7 +2216,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
       </div>
     </div>
     <div
-      class="sc-bxivhb hMnACT"
+      class="sc-bxivhb imUAuK"
     >
       <div
         class="sc-htoDjs hxAtLW"
@@ -4022,7 +4022,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
       class="sc-bZQynM gcSISu"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw dPFfSP"
+        class="sc-bxivhb sc-gzVnrw bBxgry"
       >
         <div
           class="sc-ifAKCX Eaynb"
@@ -4064,7 +4064,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
       </div>
     </div>
     <div
-      class="sc-bxivhb hMnACT"
+      class="sc-bxivhb imUAuK"
     >
       <div
         class="sc-htoDjs hxAtLW"

--- a/client/src/components/AuditBoard/__snapshots__/SignOff.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/SignOff.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Sign Off handles inputs 1`] = `
 <div>
   <div
-    class="sc-jzJRlG sc-cSHVUG fTSAZa"
+    class="sc-jzJRlG sc-cSHVUG fCktZa"
   >
     <div>
       <h1
@@ -108,7 +108,7 @@ exports[`Sign Off handles inputs 1`] = `
 exports[`Sign Off renders correctly 1`] = `
 <div>
   <div
-    class="sc-jzJRlG sc-cSHVUG fTSAZa"
+    class="sc-jzJRlG sc-cSHVUG fCktZa"
   >
     <div>
       <h1

--- a/client/src/components/JurisdictionAdmin/__snapshots__/JurisdictionAdminView.test.tsx.snap
+++ b/client/src/components/JurisdictionAdmin/__snapshots__/JurisdictionAdminView.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`JA setup renders initial state 1`] = `
       class="bp3-callout sc-bxivhb dweKfW"
     >
       <div
-        class="sc-bwzfXH jiphYj"
+        class="sc-bwzfXH dkQuHa"
       >
         <div
           class="text"
@@ -31,7 +31,7 @@ exports[`JA setup renders initial state 1`] = `
       </div>
     </div>
     <div
-      class="sc-bwzfXH sc-brqgnP gXSrBl"
+      class="sc-bwzfXH sc-brqgnP hXccOg"
     >
       <h2
         class="bp3-heading sc-ifAKCX cmZyyF"

--- a/client/src/components/PublicPages/AuditPlanner.tsx
+++ b/client/src/components/PublicPages/AuditPlanner.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { H1 } from '@blueprintjs/core'
+
+import { Inner } from '../Atoms/Wrapper'
+
+const AuditPlanner: React.FC = () => {
+  return (
+    <Inner withTopPadding>
+      <H1>Audit Planner</H1>
+    </Inner>
+  )
+}
+
+export default AuditPlanner

--- a/client/src/components/PublicPages/NotFound.tsx
+++ b/client/src/components/PublicPages/NotFound.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import { Inner } from '../Atoms/Wrapper'
+
+const NotFound: React.FC = () => {
+  return (
+    <Inner withTopPadding>
+      <p>404 Not Found</p>
+    </Inner>
+  )
+}
+
+export default NotFound

--- a/client/src/components/PublicPages/PublicPages.tsx
+++ b/client/src/components/PublicPages/PublicPages.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Redirect, Route, Switch } from 'react-router-dom'
+
+import AuditPlanner from './AuditPlanner'
+import { Wrapper } from '../Atoms/Wrapper'
+
+const PublicPages: React.FC = () => {
+  return (
+    <Wrapper>
+      <Switch>
+        <Route exact path="/public/audit-planner">
+          <AuditPlanner />
+        </Route>
+        <Route>
+          <Redirect to="/" />
+        </Route>
+      </Switch>
+    </Wrapper>
+  )
+}
+
+export default PublicPages

--- a/client/src/components/PublicPages/PublicPages.tsx
+++ b/client/src/components/PublicPages/PublicPages.tsx
@@ -1,18 +1,19 @@
 import React from 'react'
-import { Redirect, Route, Switch } from 'react-router-dom'
+import { Route, Switch } from 'react-router-dom'
 
 import AuditPlanner from './AuditPlanner'
+import NotFound from './NotFound'
 import { Wrapper } from '../Atoms/Wrapper'
 
 const PublicPages: React.FC = () => {
   return (
     <Wrapper>
       <Switch>
-        <Route exact path="/public/audit-planner">
+        <Route exact path="/planner">
           <AuditPlanner />
         </Route>
         <Route>
-          <Redirect to="/" />
+          <NotFound />
         </Route>
       </Switch>
     </Wrapper>

--- a/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
+++ b/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Home screen redirects to audit screen if only one election exists for J
       class="bp3-navbar sc-bxivhb jwFLoW"
     >
       <div
-        class="sc-bwzfXH sc-EHOje liwrdT"
+        class="sc-bwzfXH sc-EHOje bQWeEw"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -94,7 +94,7 @@ exports[`Home screen redirects to audit screen if only one election exists for J
         class="bp3-callout sc-kEYyzF ejxvfy"
       >
         <div
-          class="sc-bwzfXH jiphYj"
+          class="sc-bwzfXH dkQuHa"
         >
           <div
             class="text"
@@ -116,7 +116,7 @@ exports[`Home screen redirects to audit screen if only one election exists for J
         </div>
       </div>
       <div
-        class="sc-bwzfXH sc-dVhcbM jDwyKc"
+        class="sc-bwzfXH sc-dVhcbM iPDjEJ"
       >
         <h2
           class="bp3-heading sc-kkGfuU cPdmuO"


### PR DESCRIPTION
A first step for https://github.com/votingworks/arlo/issues/1440 (the new public audit planner), this PR sets up scaffolding for public Arlo pages.

Once we deploy this, it will be possible to navigate to https://arlo.voting.works/planner and see the incomplete audit planner. I don't believe that this is a big deal but correct me if I'm wrong - happy to introduce some sort of gating logic for prod!

https://user-images.githubusercontent.com/12616928/188966061-892f14c0-5544-4ab3-88c2-6154faa51a8b.mov