### PR TITLE
Use correct port for support login links in development

### DIFF
--- a/server/api/support.py
+++ b/server/api/support.py
@@ -2,7 +2,7 @@ import uuid
 import secrets
 from typing import Optional
 from urllib.parse import urlparse
-from flask import jsonify, request, session, redirect
+from flask import jsonify, request, session
 from auth0.v3.authentication import GetToken
 from auth0.v3.management import Auth0
 from auth0.v3.exceptions import Auth0Error
@@ -26,6 +26,7 @@ from ..config import (
 from ..util.jsonschema import validate
 from ..util.isoformat import isoformat
 from ..util.file import delete_file
+from ..util.redirect import redirect
 from .rounds import delete_round_and_corresponding_sampled_ballots, get_current_round
 
 AUTH0_DOMAIN = urlparse(AUDITADMIN_AUTH0_BASE_URL).hostname

--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -5,9 +5,11 @@ import string
 from datetime import datetime, timezone
 from typing import Optional
 from urllib.parse import urljoin, urlencode
-from flask import redirect as flask_redirect, jsonify, request, session, render_template
+from flask import jsonify, request, session, render_template
 from authlib.integrations.flask_client import OAuth, OAuthError
 from werkzeug.exceptions import BadRequest
+
+from server.util.redirect import redirect
 
 from . import auth
 from ..models import *  # pylint: disable=wildcard-import
@@ -25,7 +27,6 @@ from ..api.audit_boards import serialize_members
 from ..activity_log import JurisdictionAdminLogin, record_activity, ActivityBase
 from ..util.isoformat import isoformat
 from ..config import (
-    HTTP_ORIGIN,
     SMTP_HOST,
     SMTP_PASSWORD,
     SMTP_PORT,
@@ -38,13 +39,6 @@ from ..config import (
     AUDITADMIN_AUTH0_CLIENT_SECRET,
 )
 from .. import config
-
-# Use the app's configured origin for redirects since the Flask dev server
-# origin (localhost:3001) is different from the frontend dev server origin
-# (localhost:3000), which can cause CORS issues in Cypress tests.
-def redirect(path: str):
-    return flask_redirect(urljoin(HTTP_ORIGIN, path))
-
 
 SUPPORT_OAUTH_CALLBACK_URL = "/auth/support/callback"
 AUDITADMIN_OAUTH_CALLBACK_URL = "/auth/auditadmin/callback"

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -10,6 +10,7 @@ from ...api.support import (
     AUDITADMIN_AUTH0_CLIENT_SECRET,
     Auth0Error,
 )
+from ...config import HTTP_ORIGIN
 
 SUPPORT_EMAIL = "support@example.org"
 
@@ -442,6 +443,7 @@ def test_support_log_in_as_audit_admin(
     rv = client.get(f"/api/support/audit-admins/{DEFAULT_AA_EMAIL}/login")
     assert rv.status_code == 302
     assert urlparse(rv.location).path == "/"
+    assert urlparse(rv.location).port == urlparse(HTTP_ORIGIN).port
 
     with client.session_transaction() as session:  # type: ignore
         assert session["_user"]["type"] == UserType.AUDIT_ADMIN
@@ -464,6 +466,7 @@ def test_support_log_in_as_jurisdiction_admin(
     )
     assert rv.status_code == 302
     assert urlparse(rv.location).path == "/"
+    assert urlparse(rv.location).port == urlparse(HTTP_ORIGIN).port
 
     with client.session_transaction() as session:  # type: ignore
         assert session["_user"]["type"] == UserType.JURISDICTION_ADMIN
@@ -482,6 +485,7 @@ def test_support_log_in_to_audit_as_audit_admin(client: FlaskClient, election_id
     rv = client.get(f"/api/support/elections/{election_id}/login")
     assert rv.status_code == 302
     assert urlparse(rv.location).path == f"/election/{election_id}"
+    assert urlparse(rv.location).port == urlparse(HTTP_ORIGIN).port
 
     with client.session_transaction() as session:  # type: ignore
         assert session["_user"]["type"] == UserType.AUDIT_ADMIN

--- a/server/util/redirect.py
+++ b/server/util/redirect.py
@@ -1,0 +1,10 @@
+from urllib.parse import urljoin
+from flask import redirect as flask_redirect
+from ..config import HTTP_ORIGIN
+
+# Use the app's configured origin for redirects since the Flask dev server
+# origin (localhost:3001) is different from the frontend dev server origin
+# (localhost:3000). We always want to user to be redirected to the frontend dev
+# server (to avoid CORS issues in Cypress tests, among other reasons).
+def redirect(path: str):
+    return flask_redirect(urljoin(HTTP_ORIGIN, path))


### PR DESCRIPTION
To ensure that login links always redirect to the frontend dev server at port 3000 (rather than backend dev server at 3001), we use the same fix we used for auth redirects when migrating to Vite.