### PR TITLE
Polish audit planner election results card

### DIFF
--- a/client/src/components/PublicPages/AuditPlanner/AuditPlanner.test.tsx
+++ b/client/src/components/PublicPages/AuditPlanner/AuditPlanner.test.tsx
@@ -58,16 +58,24 @@ async function checkThatElectionResultsCardIsInInitialState() {
   const candidate0VotesInput = screen.getByRole('spinbutton', {
     name: 'Candidate 0 Votes',
   })
+  const candidate0RemoveButton = screen.getByRole('button', {
+    name: 'Remove Candidate 0',
+  })
   const candidate1NameInput = screen.getByRole('textbox', {
     name: 'Candidate 1 Name',
   })
   const candidate1VotesInput = screen.getByRole('spinbutton', {
     name: 'Candidate 1 Votes',
   })
+  const candidate1RemoveButton = screen.getByRole('button', {
+    name: 'Remove Candidate 1',
+  })
   expect(candidate0NameInput).toHaveValue('')
   expect(candidate0VotesInput).toHaveValue(null)
+  expect(candidate0RemoveButton).toBeDisabled()
   expect(candidate1NameInput).toHaveValue('')
   expect(candidate1VotesInput).toHaveValue(null)
+  expect(candidate1RemoveButton).toBeDisabled()
   const addCandidateButton = screen.getByRole('button', {
     name: /Add Candidate/,
   })
@@ -86,8 +94,10 @@ async function checkThatElectionResultsCardIsInInitialState() {
   return {
     candidate0NameInput,
     candidate0VotesInput,
+    candidate0RemoveButton,
     candidate1NameInput,
     candidate1VotesInput,
+    candidate1RemoveButton,
     addCandidateButton,
     numberOfWinnersInput,
     totalBallotsCastInput,

--- a/client/src/components/PublicPages/AuditPlanner/ElectionResultsCard.tsx
+++ b/client/src/components/PublicPages/AuditPlanner/ElectionResultsCard.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Card,
   Classes,
+  Colors,
   FormGroup,
   H2,
   HTMLTable,
@@ -36,7 +37,6 @@ const CandidatesTable = styled(HTMLTable)`
   table-layout: fixed;
 
   &.bp3-html-table th {
-    font-size: 14px;
     padding: 8px;
   }
 
@@ -67,7 +67,7 @@ const CandidatesTable = styled(HTMLTable)`
     width: 100%;
   }
   &.bp3-html-table .bp3-input[readonly] {
-    background: transparent;
+    background: ${Colors.LIGHT_GRAY5};
     box-shadow: none;
   }
 
@@ -225,16 +225,14 @@ const ElectionResultsCard: React.FC<IProps> = ({
                         })}
                         type="number"
                       />
-                      {editable && (
-                        <Button
-                          aria-label={`Remove Candidate ${i}`}
-                          disabled={!editable || candidateFields.length === 2}
-                          icon="delete"
-                          intent="danger"
-                          minimal
-                          onClick={() => removeCandidate(i)}
-                        />
-                      )}
+                      <Button
+                        aria-label={`Remove Candidate ${i}`}
+                        disabled={!editable || candidateFields.length === 2}
+                        icon="delete"
+                        intent={editable ? 'danger' : undefined}
+                        minimal
+                        onClick={() => removeCandidate(i)}
+                      />
                     </CandidateVotesInputAndRemoveButtonContainer>
                   </FormGroup>
                 </td>

--- a/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
+++ b/client/src/components/__snapshots__/HomeScreen.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Home screen redirects to audit screen if only one election exists for J
     class="Toastify"
   />
   <div
-    class="sc-cbkKFq dlbcxN"
+    class="sc-krvtoX dgZkJF"
   >
     <div
       class="bp3-navbar sc-bxivhb jwFLoW"


### PR DESCRIPTION
## Overview

Some simple UI polish that I decided to move into its own PR since it's unrelated to the other PR I'm working on to complete the second half of the audit planner UI! Specifically decreases the size of the input labels in the election results card, moves the candidate remove buttons such that the empty space on the right of the card is no more, and tweaks the uneditable state.

Reviewing with [`?w=1`](https://github.com/votingworks/arlo/pull/1596/files?w=1) recommended

https://user-images.githubusercontent.com/12616928/190547570-2999902e-cc41-4a27-b373-49c843adc7e2.mov

Regarding the smaller input labels, I did look ahead to the "Audit Plan" card and verified that the smaller labels will look okay more generally.

## Testing

- [x] Updated automated tests
- [x] Tested manually