### PR TITLE
Limit size of numbers provided to audit planner

### DIFF
--- a/client/src/components/PublicPages/AuditPlanner/AuditPlanner.test.tsx
+++ b/client/src/components/PublicPages/AuditPlanner/AuditPlanner.test.tsx
@@ -254,10 +254,16 @@ test('Entering election results - validation and submit', async () => {
       notDisplayed: ['At least 1 candidate must have greater than 0 votes'],
     })
     userEvent.clear(candidate0VotesInput)
+    userEvent.type(candidate0VotesInput, '10000000000000000')
+    await areExpectedErrorMessagesDisplayed({
+      displayed: ['Too large'],
+      notDisplayed: ['Cannot be less than 0'],
+    })
+    userEvent.clear(candidate0VotesInput)
     userEvent.type(candidate0VotesInput, '1000.2')
     await areExpectedErrorMessagesDisplayed({
       displayed: ['Can only contain numeric characters'],
-      notDisplayed: ['Cannot be less than 0'],
+      notDisplayed: ['Too large'],
     })
     userEvent.clear(candidate0VotesInput)
     userEvent.type(candidate0VotesInput, '1000')
@@ -269,15 +275,20 @@ test('Entering election results - validation and submit', async () => {
     userEvent.type(candidate1VotesInput, '900')
     userEvent.clear(totalBallotsCastInput)
     userEvent.type(totalBallotsCastInput, '0')
-    userEvent.click(planAuditButton)
     await areExpectedErrorMessagesDisplayed({
       displayed: ['Cannot be less than 1'],
+    })
+    userEvent.clear(totalBallotsCastInput)
+    userEvent.type(totalBallotsCastInput, '10000000000000000')
+    await areExpectedErrorMessagesDisplayed({
+      displayed: ['Too large'],
+      notDisplayed: ['Cannot be less than 1'],
     })
     userEvent.clear(totalBallotsCastInput)
     userEvent.type(totalBallotsCastInput, '2000.2')
     await areExpectedErrorMessagesDisplayed({
       displayed: ['Can only contain numeric characters'],
-      notDisplayed: ['Cannot be less than 1'],
+      notDisplayed: ['Too large'],
     })
     userEvent.clear(totalBallotsCastInput)
     userEvent.type(totalBallotsCastInput, '2000')
@@ -289,10 +300,16 @@ test('Entering election results - validation and submit', async () => {
     await areExpectedErrorMessagesDisplayed({
       displayed: ['Required'],
     })
+    userEvent.type(numberOfWinnersInput, '0')
+    await areExpectedErrorMessagesDisplayed({
+      displayed: ['Cannot be less than 1'],
+      notDisplayed: ['Required'],
+    })
+    userEvent.clear(numberOfWinnersInput)
     userEvent.type(numberOfWinnersInput, '2')
     await areExpectedErrorMessagesDisplayed({
       displayed: ['Must be less than number of candidates'],
-      notDisplayed: ['Required'],
+      notDisplayed: ['Cannot be less than 1'],
     })
     userEvent.clear(numberOfWinnersInput)
     userEvent.type(numberOfWinnersInput, '1.2')

--- a/client/src/components/PublicPages/AuditPlanner/ElectionResultsCard.tsx
+++ b/client/src/components/PublicPages/AuditPlanner/ElectionResultsCard.tsx
@@ -20,7 +20,6 @@ import {
   ICandidateFormState,
   IElectionResultsFormState,
 } from './electionResults'
-import { sum } from '../../../utils/number'
 
 const HIDDEN_INPUT_CLASS_NAME = 'hidden-input'
 
@@ -107,6 +106,23 @@ const CardActionsRow = styled.div`
   }
 `
 
+const minValueRule = (minValue: number) => ({
+  message: `Cannot be less than ${minValue}`,
+  value: minValue,
+})
+
+/**
+ * Leave enough buffer to support an election of galactic scale while making it hard for users to
+ * crash the sample size math by holding down the 0 key :D
+ * Keep this in sync with the server-side limit in server/api/public.py
+ */
+const MAX_NUMERICAL_VALUE = 1e15
+
+const maxValueRule = {
+  message: 'Too large',
+  value: MAX_NUMERICAL_VALUE,
+}
+
 const numericValidationRule = {
   message: 'Can only contain numeric characters',
   value: /^[0-9]+$/,
@@ -137,8 +153,8 @@ const NumericInput = forwardRef<HTMLInputElement, INumericInputProps>(
       value,
     } = props
 
-    // Renders two inputs under the hood, one managed by react-hook-form via the passed in ref
-    // and the other for read-only display
+    // Render two inputs under the hood, one managed by react-hook-form via the passed in ref and
+    // the other for read-only display
     return (
       <>
         <input
@@ -330,10 +346,8 @@ const ElectionResultsCard: React.FC<IProps> = ({
                         placeholder="0"
                         readOnly={!editable}
                         ref={register({
-                          min: {
-                            message: 'Cannot be less than 0',
-                            value: 0,
-                          },
+                          min: minValueRule(0),
+                          max: maxValueRule,
                           pattern: numericValidationRule,
                           required: 'Required',
                           validate: () => {
@@ -394,10 +408,8 @@ const ElectionResultsCard: React.FC<IProps> = ({
                   placeholder="0"
                   readOnly={!editable}
                   ref={register({
-                    min: {
-                      message: 'Cannot be less than 1',
-                      value: 1,
-                    },
+                    min: minValueRule(1),
+                    max: maxValueRule,
                     pattern: numericValidationRule,
                     required: 'Required',
                     validate: value => {
@@ -427,10 +439,8 @@ const ElectionResultsCard: React.FC<IProps> = ({
                   placeholder="0"
                   readOnly={!editable}
                   ref={register({
-                    min: {
-                      message: 'Cannot be less than 1',
-                      value: 1,
-                    },
+                    min: minValueRule(1),
+                    max: maxValueRule,
                     pattern: numericValidationRule,
                     required: 'Required',
                     valueAsNumber: true,

--- a/server/api/public.py
+++ b/server/api/public.py
@@ -10,11 +10,16 @@ from ..util.jsonschema import validate
 from ..models import *  # pylint: disable=wildcard-import
 
 
+# Leave enough buffer to support an election of galactic scale while making it hard for users to
+# crash the sample size math by holding down the 0 key :D
+# Keep this in sync with the client-side limit in client/src/components/PublicPages/AuditPlanner/
+MAX_NUMERICAL_VALUE = 1e15
+
 ELECTION_RESULTS_CANDIDATE_SCHEMA = {
     "type": "object",
     "properties": {
         "name": {"type": "string"},
-        "votes": {"type": "integer", "minimum": 0},
+        "votes": {"type": "integer", "minimum": 0, "maximum": MAX_NUMERICAL_VALUE},
     },
     "additionalProperties": False,
     "required": ["name", "votes"],
@@ -28,8 +33,16 @@ ELECTION_RESULTS_SCHEMA = {
             "items": ELECTION_RESULTS_CANDIDATE_SCHEMA,
             "minItems": 2,
         },
-        "numWinners": {"type": "integer", "minimum": 1},
-        "totalBallotsCast": {"type": "integer", "minimum": 1},
+        "numWinners": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": MAX_NUMERICAL_VALUE,
+        },
+        "totalBallotsCast": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": MAX_NUMERICAL_VALUE,
+        },
     },
     "additionalProperties": False,
     "required": ["candidates", "numWinners", "totalBallotsCast"],

--- a/server/tests/api/test_public.py
+++ b/server/tests/api/test_public.py
@@ -119,6 +119,20 @@ def test_public_compute_sample_sizes_input_validation(client: FlaskClient):
                 "electionResults": {
                     **valid_input["electionResults"],
                     "candidates": [
+                        {"name": "Helga Hippo", "votes": 1e16},
+                        {"name": "Bobby Bear", "votes": 900},
+                    ],
+                },
+            },
+            "expected_status_code": 400,
+            "expected_error_message": "1e+16 is greater than the maximum of 1000000000000000.0",
+        },
+        {
+            "body": {
+                **valid_input,
+                "electionResults": {
+                    **valid_input["electionResults"],
+                    "candidates": [
                         {"name": "Helga Hippo", "votes": 1.2},
                         {"name": "Bobby Bear", "votes": 900},
                     ],
@@ -134,6 +148,17 @@ def test_public_compute_sample_sizes_input_validation(client: FlaskClient):
             },
             "expected_status_code": 400,
             "expected_error_message": "0 is less than the minimum of 1",
+        },
+        {
+            "body": {
+                **valid_input,
+                "electionResults": {
+                    **valid_input["electionResults"],
+                    "numWinners": 1e16,
+                },
+            },
+            "expected_status_code": 400,
+            "expected_error_message": "1e+16 is greater than the maximum of 1000000000000000.0",
         },
         {
             "body": {
@@ -156,6 +181,17 @@ def test_public_compute_sample_sizes_input_validation(client: FlaskClient):
             },
             "expected_status_code": 400,
             "expected_error_message": "0 is less than the minimum of 1",
+        },
+        {
+            "body": {
+                **valid_input,
+                "electionResults": {
+                    **valid_input["electionResults"],
+                    "totalBallotsCast": 1e16,
+                },
+            },
+            "expected_status_code": 400,
+            "expected_error_message": "1e+16 is greater than the maximum of 1000000000000000.0",
         },
         {
             "body": {


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/arlo/issues/1605

There's a natural human impulse when provided a calculation tool to enter the largest numbers possible 😆

<img width="250" alt="lol" src="https://user-images.githubusercontent.com/12616928/193315671-659d3fc0-0d36-46a1-b518-70a700f83b49.png">

As much as I feel this impulse too, these super large numbers can crash our underlying sample size math. Rather than playing whack-a-mole with all the places that large numbers can break our sample size math, this PR limits the size of numbers provided to the audit planner. I've settled on a limit of `1e15` (1 quadrillion), which should, as noted in the code:

> Leave enough buffer to support an election of galactic scale while making it hard for users to crash the sample size math by holding down the 0 key :D

<img width="450" alt="limit" src="https://user-images.githubusercontent.com/12616928/193316937-249fed85-d4a5-4465-aaea-c9e43f30f714.png">

## Testing

- [x] Added tests for client-side logic
- [x] Added tests for server-side logic