### PR TITLE
Make audit planner mobile friendly and add utils for responsive design

### DIFF
--- a/client/src/components/Atoms/SegmentedControl.tsx
+++ b/client/src/components/Atoms/SegmentedControl.tsx
@@ -6,6 +6,7 @@ const Option = styled(Button)`
   &.bp3-button {
     flex-basis: 0;
     flex-grow: 1;
+    text-align: center;
   }
 `
 
@@ -22,12 +23,13 @@ interface IProps<T extends string> {
   onChange: (value: T) => void
   options: IOption<T>[]
   value: T
+  vertical?: boolean
 }
 
 const SegmentedControl = <T extends string>(
   props: IProps<T>
 ): React.ReactElement => {
-  const { disabled, fill, large, onChange, options, value } = props
+  const { disabled, fill, large, onChange, options, value, vertical } = props
 
   // TODO: Use a proper radio group under the hood or add the required keyboard support for a radio
   // group (https://www.w3.org/WAI/ARIA/apg/example-index/radio/radio-rating.html#kbd_label) to
@@ -38,6 +40,7 @@ const SegmentedControl = <T extends string>(
       fill={fill}
       large={large}
       role="radiogroup"
+      vertical={vertical}
     >
       {options.map(option => (
         <Option

--- a/client/src/components/PublicPages/AuditPlanner/AuditPlanCard.tsx
+++ b/client/src/components/PublicPages/AuditPlanner/AuditPlanCard.tsx
@@ -6,7 +6,10 @@ import SampleSize from './SampleSize'
 import SegmentedControl from '../../Atoms/SegmentedControl'
 import { AuditType } from '../../useAuditSettings'
 import { IElectionResults } from './electionResults'
+import { useCssBreakpoints } from '../../../utils/responsiveness'
 import { useSampleSizes } from './sampleSizes'
+
+const HIDDEN_LABEL_CLASS_NAME = 'hidden-label'
 
 interface IContainerProps {
   disabled?: boolean
@@ -17,9 +20,10 @@ const Container = styled(Card)<IContainerProps>`
     margin: auto;
     margin-top: 24px;
     margin-bottom: 72px;
+    max-width: 640px;
     opacity: ${props => (props.disabled ? '0.5' : '1')}
     padding: 0;
-    width: 640px;
+    width: 100%;
   }
 `
 
@@ -48,6 +52,15 @@ const SubHeading = styled(H3)`
   }
 `
 
+const RiskLimitSlider = styled(Slider)`
+  &.bp3-slider .${HIDDEN_LABEL_CLASS_NAME} {
+    color: transparent;
+  }
+  &.bp3-slider .bp3-slider-handle .${HIDDEN_LABEL_CLASS_NAME} {
+    color: white;
+  }
+`
+
 const SampleSizeSection = styled.div`
   background: #f3f8ff; // A custom tint of Blueprint v4 @blue5
   border-bottom-left-radius: 3px; // Match Blueprint card
@@ -71,6 +84,7 @@ const AuditPlanCard: React.FC<IProps> = ({ disabled, electionResults }) => {
     }
   }, [])
 
+  const { isMobileWidth } = useCssBreakpoints()
   const [selectedAuditType, setSelectedAuditType] = useState<
     Exclude<AuditType, 'HYBRID'>
   >('BALLOT_POLLING')
@@ -105,23 +119,24 @@ const AuditPlanCard: React.FC<IProps> = ({ disabled, electionResults }) => {
               { label: 'Batch Comparison', value: 'BATCH_COMPARISON' },
             ]}
             value={selectedAuditType}
+            vertical={isMobileWidth}
           />
         </Section>
 
         <Section>
           <SubHeading>Risk Limit</SubHeading>
-          <Slider
+          <RiskLimitSlider
             disabled={disabled}
             labelRenderer={value => (
               <span
                 // A hack to display the listed values on both the slider axis and the slider label,
                 // and all other values on only the slider label. More recent versions of the
                 // Blueprint slider actually support this differentiation
-                style={{
-                  color: [0, 5, 10, 15, 20].includes(value)
-                    ? undefined
-                    : 'white',
-                }}
+                className={
+                  ![0, 5, 10, 15, 20].includes(value)
+                    ? HIDDEN_LABEL_CLASS_NAME
+                    : undefined
+                }
               >
                 {value}%
               </span>

--- a/client/src/components/PublicPages/AuditPlanner/AuditPlanner.test.tsx
+++ b/client/src/components/PublicPages/AuditPlanner/AuditPlanner.test.tsx
@@ -196,6 +196,19 @@ const apiMocks = {
   }),
 }
 
+jest.mock(
+  '../../../utils/responsiveness',
+  (): typeof import('../../../utils/responsiveness') => {
+    return {
+      ...jest.requireActual('../../../utils/responsiveness'),
+      useCssBreakpoints: () => ({
+        isMobileWidth: false,
+        isTabletWidth: false,
+        isDesktopWidth: true,
+      }),
+    }
+  }
+)
 let mockScrollIntoView: jest.Mock
 
 beforeEach(async () => {

--- a/client/src/components/PublicPages/AuditPlanner/ElectionResultsCard.tsx
+++ b/client/src/components/PublicPages/AuditPlanner/ElectionResultsCard.tsx
@@ -20,6 +20,7 @@ import {
   ICandidateFormState,
   IElectionResultsFormState,
 } from './electionResults'
+import { useCssBreakpoints } from '../../../utils/responsiveness'
 
 const HIDDEN_INPUT_CLASS_NAME = 'hidden-input'
 
@@ -224,7 +225,7 @@ const ElectionResultsCard: React.FC<IProps> = ({
   planAudit,
 }) => {
   const { confirm, confirmProps } = useConfirm()
-
+  const { isMobileWidth, isTabletWidth, isDesktopWidth } = useCssBreakpoints()
   const {
     control,
     formState,
@@ -382,11 +383,12 @@ const ElectionResultsCard: React.FC<IProps> = ({
             <tr>
               <td>
                 <Button
+                  aria-label={isMobileWidth ? 'Add Candidate' : undefined}
                   disabled={!editable}
                   icon="plus"
                   onClick={() => addCandidate(constructNewCandidate())}
                 >
-                  Add Candidate
+                  {(isTabletWidth || isDesktopWidth) && 'Add Candidate'}
                 </Button>
               </td>
               <td />

--- a/client/src/utils/responsiveness.ts
+++ b/client/src/utils/responsiveness.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 /**
  * Given a CSS media query, returns whether the media query is matched, e.g.
@@ -8,7 +8,7 @@ import { useState, useEffect } from 'react'
  * Listens for updates, e.g. in response to window resizing.
  */
 export function useMediaQuery(query: string): boolean {
-  const [isMatched, setIsMatched] = useState(false)
+  const [isMatched, setIsMatched] = useState(window.matchMedia(query).matches)
 
   useEffect(() => {
     const matchMedia = window.matchMedia(query)

--- a/client/src/utils/responsiveness.ts
+++ b/client/src/utils/responsiveness.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * Given a CSS media query, returns whether the media query is matched, e.g.
+ *
+ * const isDesktopWidth = useMediaQuery('(min-width: 64em)')
+ *
+ * Listens for updates, e.g. in response to window resizing.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [isMatched, setIsMatched] = useState(false)
+
+  useEffect(() => {
+    const matchMedia = window.matchMedia(query)
+    setIsMatched(matchMedia.matches)
+    const handleChange = () => {
+      setIsMatched(matchMedia.matches)
+    }
+    matchMedia.addEventListener('change', handleChange)
+    return () => {
+      matchMedia.removeEventListener('change', handleChange)
+    }
+  }, [query])
+
+  return isMatched
+}
+
+/** A breakpoint for mobile vs. tablet */
+export const BREAKPOINT_M = '40em'
+/** A breakpoint for tablet vs. desktop */
+export const BREAKPOINT_L = '64em'
+
+interface IBreakpoints {
+  isMobileWidth: boolean
+  isTabletWidth: boolean
+  isDesktopWidth: boolean
+}
+
+/**
+ * Returns information about the size of the screen. Listens for updates, e.g. in response to
+ * window resizing.
+ */
+export function useCssBreakpoints(): IBreakpoints {
+  const isDesktopWidth = useMediaQuery(`(min-width: ${BREAKPOINT_L})`)
+  const isTabletWidth =
+    useMediaQuery(`(min-width: ${BREAKPOINT_M})`) && !isDesktopWidth
+  const isMobileWidth = !isDesktopWidth && !isTabletWidth
+
+  return {
+    isMobileWidth,
+    isTabletWidth,
+    isDesktopWidth,
+  }
+}


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/arlo/issues/1614

This PR makes the audit planner mobile friendly in the most basic way possible (still leaving plenty of room for improvement but at least ensuring that the page isn't broken on mobile).

It also adds utils for responsive design that'll hopefully come in handy with upcoming work to make the audit board screens mobile friendly / responsive! I'm excited about these! [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia), which the utils use under the hood, is magic 🪄 and basically brings the power of CSS media queries to JS.

### Before and after on iPhone SE width

<img alt="before" src="https://user-images.githubusercontent.com/12616928/193356066-f4efe213-d585-4f9c-88f8-68065470a1e0.png" width=300 /> <img alt="after" src="https://user-images.githubusercontent.com/12616928/193356065-f949d479-7d94-4c35-a3c4-25222268afed.png" width=300 />

### Responsiveness in action

https://user-images.githubusercontent.com/12616928/193356028-7a6b61fd-c452-45ed-92bf-7c81ea0bef9e.mov

## Testing

- [x] Tested manually (see above)