### PR TITLE
Steps atom component

### DIFF
--- a/client/src/components/Atoms/Steps.test.tsx
+++ b/client/src/components/Atoms/Steps.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Button, Colors } from '@blueprintjs/core'
+import { Steps, StepList, StepListItem, StepPanel, StepActions } from './Steps'
+
+describe('Steps', () => {
+  it('renders a step list, panel, and actions', () => {
+    render(
+      <Steps>
+        <StepList currentStepId="prepare">
+          <StepListItem id="logIn">Log In</StepListItem>
+          <StepListItem id="prepare">Prepare</StepListItem>
+          <StepListItem id="audit">Audit Ballots</StepListItem>
+        </StepList>
+        <StepPanel>Prepare your ballots</StepPanel>
+        <StepActions
+          left={<Button>Back</Button>}
+          right={<Button>Next</Button>}
+        />
+      </Steps>
+    )
+
+    const logInHeader = screen.getByRole('heading', {
+      name: 'Log In',
+      current: undefined,
+    })
+    expect(logInHeader).toHaveStyle({ color: Colors.GRAY3 })
+    const logInCircle = logInHeader.previousElementSibling!
+    expect(logInCircle.querySelector("[data-icon='tick']")).toBeInTheDocument()
+    expect(logInCircle).toHaveStyle({ backgroundColor: Colors.BLUE3 })
+    expect(logInCircle).toHaveStyle({ opacity: 0.7 })
+
+    const prepareHeader = screen.getByRole('heading', {
+      name: 'Prepare',
+      current: 'step',
+    })
+    expect(prepareHeader).toHaveStyle({ color: Colors.DARK_GRAY5 })
+    const prepareCircle = prepareHeader.previousElementSibling!
+    expect(prepareCircle).toHaveTextContent('2')
+    expect(prepareCircle).toHaveStyle({ backgroundColor: Colors.BLUE3 })
+
+    const auditHeader = screen.getByRole('heading', {
+      name: 'Audit Ballots',
+      current: undefined,
+    })
+    expect(auditHeader).toHaveStyle({ color: Colors.GRAY3 })
+    const auditCircle = auditHeader.previousElementSibling!
+    expect(auditCircle).toHaveTextContent('3')
+    expect(auditCircle).toHaveStyle({ backgroundColor: Colors.GRAY4 })
+
+    screen.getByText('Prepare your ballots')
+
+    screen.getByRole('button', { name: 'Back' })
+    screen.getByRole('button', { name: 'Next' })
+  })
+})

--- a/client/src/components/Atoms/Steps.test.tsx
+++ b/client/src/components/Atoms/Steps.test.tsx
@@ -7,10 +7,10 @@ describe('Steps', () => {
   it('renders a step list, panel, and actions', () => {
     render(
       <Steps>
-        <StepList currentStepId="prepare">
-          <StepListItem id="logIn">Log In</StepListItem>
-          <StepListItem id="prepare">Prepare</StepListItem>
-          <StepListItem id="audit">Audit Ballots</StepListItem>
+        <StepList>
+          <StepListItem>Log In</StepListItem>
+          <StepListItem current>Prepare</StepListItem>
+          <StepListItem>Audit Ballots</StepListItem>
         </StepList>
         <StepPanel>Prepare your ballots</StepPanel>
         <StepActions

--- a/client/src/components/Atoms/Steps.tsx
+++ b/client/src/components/Atoms/Steps.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Card, Colors, Icon } from '@blueprintjs/core'
+
+/**
+ * A set of components to display a multi-step process. Consists of a card
+ * containing:
+ *  - a step progress list (top)
+ *  - a step content panel (middle)
+ *  - a step actions bar (bottom)
+ *
+ * These components are purely graphical - the parent must manage all state
+ * (current step, disabling, etc.)
+ *
+ * Example usage:
+ *
+ *  <Steps>
+ *    <StepProgress steps=["Log In", "Prepare", "Audit"] currentStep="Prepare" />
+ *    <StepPanel>Prepare your ballots</StepPanel>
+ *    <StepActions
+ *      left={<Button>Back</Button>}
+ *      right={<Button>Next</Button>}
+ *    />
+ *  </Steps>
+ */
+
+export const Steps = styled(Card).attrs({ elevation: 1 })`
+  padding: 0;
+`
+
+const StepProgressRow = styled.ol`
+  background-color: ${Colors.LIGHT_GRAY5};
+  display: flex;
+  align-items: center;
+  padding: 25px;
+  margin: 0;
+  border-radius: 3px 3px 0 0;
+`
+
+const StepProgressStep = styled.li`
+  display: flex;
+  align-items: center;
+`
+
+const StepProgressCircle = styled.div<{ incomplete: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 30px;
+  width: 30px;
+  border-radius: 50%;
+  background-color: ${props =>
+    props.incomplete ? Colors.GRAY4 : Colors.BLUE3};
+  margin-right: 10px;
+  color: ${Colors.WHITE};
+  font-weight: 500;
+`
+
+const StepProgressLabel = styled.div<{ incomplete: boolean }>`
+  color: ${props => (props.incomplete ? Colors.GRAY3 : 'inherit')};
+  font-weight: 700;
+`
+
+const StepProgressLine = styled.div`
+  flex-grow: 1;
+  height: 1px;
+  background: ${Colors.GRAY5};
+  margin: 0 10px;
+`
+
+export const StepProgress: React.FC<{
+  steps: readonly string[]
+  currentStep: string
+}> = ({ steps, currentStep }) => {
+  const currentStepIndex = steps.indexOf(currentStep)
+  return (
+    <StepProgressRow>
+      {steps.map((step, i) => (
+        <React.Fragment key={step}>
+          <StepProgressStep
+            aria-label={step}
+            aria-current={i === currentStepIndex ? 'step' : undefined}
+          >
+            <StepProgressCircle incomplete={i > currentStepIndex}>
+              {i < currentStepIndex ? <Icon icon="tick" /> : i + 1}
+            </StepProgressCircle>
+            <StepProgressLabel incomplete={i > currentStepIndex}>
+              {step}
+            </StepProgressLabel>
+          </StepProgressStep>
+          {i < steps.length - 1 && <StepProgressLine />}
+        </React.Fragment>
+      ))}
+    </StepProgressRow>
+  )
+}
+
+export const StepPanel = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 70px;
+  min-height: 300px;
+  padding: 50px 70px;
+  > * {
+    flex: 1;
+  }
+`
+
+const StepActionsRow = styled.div`
+  display: flex;
+  padding: 20px;
+  background-color: ${Colors.LIGHT_GRAY5};
+  justify-content: space-between;
+  border-radius: 0 0 3px 3px;
+`
+
+export const StepActions: React.FC<{
+  left?: React.ReactElement
+  right?: React.ReactElement
+}> = ({ left, right }) => (
+  <StepActionsRow>
+    {left || <div />}
+    {right || <div />}
+  </StepActionsRow>
+)

--- a/client/src/components/Atoms/Steps.tsx
+++ b/client/src/components/Atoms/Steps.tsx
@@ -16,10 +16,10 @@ import { assert } from '../utilities'
  * Example usage:
  *
  *  <Steps>
- *    <StepList currentStepId="prepare">
- *      <StepListItem id="logIn">Log In</StepListItem>
- *      <StepListItem id="prepare">Prepare</StepListItem>
- *      <StepListItem id="audit">Audit Ballots</StepListItem>
+ *    <StepList>
+ *      <StepListItem>Log In</StepListItem>
+ *      <StepListItem current>Prepare</StepListItem>
+ *      <StepListItem>Audit Ballots</StepListItem>
  *    </StepList>
  *    <StepPanel>Prepare your ballots</StepPanel>
  *    <StepActions
@@ -66,11 +66,11 @@ const StepListItemCircle = styled.div<{
   font-weight: 500;
 `
 
-const StepListItemLabel = styled(H5)<{
-  state: StepState
-}>`
-  color: ${props =>
-    props.state === 'current' ? Colors.DARK_GRAY5 : Colors.GRAY3};
+// eslint-disable-next-line no-unused-vars
+export const StepListItem = styled(({ current, ...props }) => (
+  <H5 {...props} />
+))<{ current: boolean }>`
+  color: ${props => (props.current ? Colors.DARK_GRAY5 : Colors.GRAY3)};
   margin: 0;
 `
 
@@ -81,21 +81,15 @@ const StepListItemLine = styled.div`
   margin: 0 10px;
 `
 
-export const StepList: React.FC<{ currentStepId: string }> = ({
-  currentStepId,
-  children,
-}) => {
-  const steps = React.Children.toArray(children)
-  const currentStepIndex = steps
-    .map(step => {
-      assert(React.isValidElement(step))
-      return step.props.id
-    })
-    .indexOf(currentStepId)
+export const StepList: React.FC = ({ children }) => {
+  const stepItems = React.Children.toArray(children)
+  const currentStepIndex = stepItems.findIndex(
+    stepItem => React.isValidElement(stepItem) && stepItem.props.current
+  )
   return (
     <StepListContainer>
-      {steps.map((step, index) => {
-        assert(React.isValidElement(step))
+      {stepItems.map((stepItem, index) => {
+        assert(React.isValidElement(stepItem))
         const state =
           index < currentStepIndex
             ? 'complete'
@@ -103,30 +97,22 @@ export const StepList: React.FC<{ currentStepId: string }> = ({
             ? 'current'
             : 'incomplete'
         return (
-          <React.Fragment key={step.props.id}>
+          <React.Fragment key={stepItem.key || index}>
             <StepListItemContainer>
               <StepListItemCircle state={state}>
                 {state === 'complete' ? <Icon icon="tick" /> : index + 1}
               </StepListItemCircle>
-              <StepListItemLabel
-                state={state}
-                aria-current={state === 'current' ? 'step' : undefined}
-              >
-                {step}
-              </StepListItemLabel>
+              {React.cloneElement(stepItem, {
+                'aria-current': state === 'current' ? 'step' : undefined,
+              })}
             </StepListItemContainer>
-            {index < steps.length - 1 && <StepListItemLine />}
+            {index < stepItems.length - 1 && <StepListItemLine />}
           </React.Fragment>
         )
       })}
     </StepListContainer>
   )
 }
-
-// eslint-disable-next-line react/no-unused-prop-types
-export const StepListItem: React.FC<{ id: string }> = ({ children }) => (
-  <React.Fragment>{children}</React.Fragment>
-)
 
 export const StepPanel = styled.div`
   display: flex;

--- a/client/src/components/Atoms/Steps.tsx
+++ b/client/src/components/Atoms/Steps.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Card, Colors, Icon } from '@blueprintjs/core'
+import { Card, Colors, H5, Icon } from '@blueprintjs/core'
 import { assert } from '../utilities'
 
 /**
@@ -47,23 +47,31 @@ const StepListItemContainer = styled.li`
   align-items: center;
 `
 
-const StepListItemCircle = styled.div<{ isIncomplete: boolean }>`
+type StepState = 'incomplete' | 'current' | 'complete'
+
+const StepListItemCircle = styled.div<{
+  state: StepState
+}>`
   display: flex;
   align-items: center;
   justify-content: center;
   height: 30px;
   width: 30px;
   border-radius: 50%;
+  opacity: ${props => (props.state === 'complete' ? 0.7 : 1)};
   background-color: ${props =>
-    props.isIncomplete ? Colors.GRAY4 : Colors.BLUE3};
+    props.state === 'incomplete' ? Colors.GRAY4 : Colors.BLUE3};
   margin-right: 10px;
   color: ${Colors.WHITE};
   font-weight: 500;
 `
 
-const StepListItemLabel = styled.div<{ isIncomplete: boolean }>`
-  color: ${props => (props.isIncomplete ? Colors.GRAY3 : 'inherit')};
-  font-weight: 700;
+const StepListItemLabel = styled(H5)<{
+  state: StepState
+}>`
+  color: ${props =>
+    props.state === 'current' ? Colors.DARK_GRAY5 : Colors.GRAY3};
+  margin: 0;
 `
 
 const StepListItemLine = styled.div`
@@ -88,16 +96,22 @@ export const StepList: React.FC<{ currentStepId: string }> = ({
     <StepListContainer>
       {steps.map((step, index) => {
         assert(React.isValidElement(step))
-        const isCurrent = index === currentStepIndex
-        const isComplete = index < currentStepIndex
-        const isIncomplete = index > currentStepIndex
+        const state =
+          index < currentStepIndex
+            ? 'complete'
+            : index === currentStepIndex
+            ? 'current'
+            : 'incomplete'
         return (
           <React.Fragment key={step.props.id}>
-            <StepListItemContainer aria-current={isCurrent}>
-              <StepListItemCircle isIncomplete={isIncomplete}>
-                {isComplete ? <Icon icon="tick" /> : index + 1}
+            <StepListItemContainer>
+              <StepListItemCircle state={state}>
+                {state === 'complete' ? <Icon icon="tick" /> : index + 1}
               </StepListItemCircle>
-              <StepListItemLabel isIncomplete={isIncomplete}>
+              <StepListItemLabel
+                state={state}
+                aria-current={state === 'current' ? 'step' : undefined}
+              >
                 {step}
               </StepListItemLabel>
             </StepListItemContainer>

--- a/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
@@ -100,7 +100,7 @@ const render = () =>
   )
 
 const expectToBeOnStep = async (name: string) => {
-  await screen.findByRole('listitem', {
+  await screen.findByRole('heading', {
     name,
     current: 'step',
   })

--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -22,7 +22,13 @@ import {
 } from '../useFileUpload'
 import { apiDownload } from '../utilities'
 import LinkButton from '../Atoms/LinkButton'
-import { StepPanel, StepActions, StepProgress, Steps } from '../Atoms/Steps'
+import {
+  StepPanel,
+  StepActions,
+  Steps,
+  StepListItem,
+  StepList,
+} from '../Atoms/Steps'
 
 const STEPS = [
   'Upload Election Results',
@@ -317,7 +323,9 @@ const BatchInventorySteps: React.FC<{
     ? 'Inventory Batches'
     : 'Download Audit Files'
 
-  const [step, setStep] = useState<typeof STEPS[number]>(initialStep)
+  const [currentStep, setCurrentStep] = useState<typeof STEPS[number]>(
+    initialStep
+  )
 
   return (
     <Wrapper>
@@ -333,15 +341,21 @@ const BatchInventorySteps: React.FC<{
           </LinkButton>
         </HeadingRow>
         <Steps>
-          <StepProgress steps={STEPS} currentStep={step} />
+          <StepList currentStepId={currentStep}>
+            {STEPS.map(step => (
+              <StepListItem key={step} id={step}>
+                {step}
+              </StepListItem>
+            ))}
+          </StepList>
           {(() => {
-            switch (step) {
+            switch (currentStep) {
               case 'Upload Election Results':
                 return (
                   <UploadElectionResultsStep
                     cvrUpload={cvrUpload}
                     tabulatorStatusUpload={tabulatorStatusUpload}
-                    nextStep={() => setStep('Inventory Batches')}
+                    nextStep={() => setCurrentStep('Inventory Batches')}
                   />
                 )
               case 'Inventory Batches':
@@ -349,8 +363,8 @@ const BatchInventorySteps: React.FC<{
                   <InventoryBatchesStep
                     worksheetUrl={`/election/${electionId}/jurisdiction/${jurisdictionId}/batch-inventory/worksheet`}
                     signOffQueries={signOffQueries}
-                    prevStep={() => setStep('Upload Election Results')}
-                    nextStep={() => setStep('Download Audit Files')}
+                    prevStep={() => setCurrentStep('Upload Election Results')}
+                    nextStep={() => setCurrentStep('Download Audit Files')}
                   />
                 )
               case 'Download Audit Files':
@@ -358,7 +372,7 @@ const BatchInventorySteps: React.FC<{
                   <DownloadAuditFilesStep
                     ballotManifestUrl={`/election/${electionId}/jurisdiction/${jurisdictionId}/batch-inventory/ballot-manifest`}
                     batchTalliesUrl={`/election/${electionId}/jurisdiction/${jurisdictionId}/batch-inventory/batch-tallies`}
-                    prevStep={() => setStep('Inventory Batches')}
+                    prevStep={() => setCurrentStep('Inventory Batches')}
                   />
                 )
               default:

--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { H2, Button, H4, Colors, Icon, Checkbox, Card } from '@blueprintjs/core'
+import { H2, Button, H4, Checkbox } from '@blueprintjs/core'
 import {
   useQueryClient,
   useMutation,
@@ -22,6 +22,7 @@ import {
 } from '../useFileUpload'
 import { apiDownload } from '../utilities'
 import LinkButton from '../Atoms/LinkButton'
+import { StepPanel, StepActions, StepProgress, Steps } from '../Atoms/Steps'
 
 const STEPS = [
   'Upload Election Results',
@@ -112,107 +113,6 @@ const useBatchInventorySignOff = (
     undoSignOff,
   }
 }
-
-const StepContainer = styled(Card).attrs({ elevation: 1 })`
-  padding: 0;
-`
-
-const StepProgressRow = styled.ol`
-  background-color: ${Colors.LIGHT_GRAY5};
-  display: flex;
-  align-items: center;
-  padding: 25px;
-  margin: 0;
-  border-radius: 3px 3px 0 0;
-`
-
-const StepProgressStep = styled.li`
-  display: flex;
-  align-items: center;
-`
-
-const StepProgressCircle = styled.div<{ incomplete: boolean }>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 30px;
-  width: 30px;
-  border-radius: 50%;
-  background-color: ${props =>
-    props.incomplete ? Colors.GRAY4 : Colors.BLUE3};
-  margin-right: 10px;
-  color: ${Colors.WHITE};
-  font-weight: 500;
-`
-
-const StepProgressLabel = styled.div<{ incomplete: boolean }>`
-  color: ${props => (props.incomplete ? Colors.GRAY3 : 'inherit')};
-  font-weight: 700;
-`
-
-const StepProgressLine = styled.div`
-  flex-grow: 1;
-  height: 1px;
-  background: ${Colors.GRAY5};
-  margin: 0 10px;
-`
-
-const StepProgress: React.FC<{
-  steps: readonly string[]
-  currentStep: string
-}> = ({ steps, currentStep }) => {
-  const currentStepIndex = steps.indexOf(currentStep)
-  return (
-    <StepProgressRow>
-      {steps.map((step, i) => (
-        <React.Fragment key={step}>
-          <StepProgressStep
-            aria-label={step}
-            aria-current={i === currentStepIndex ? 'step' : undefined}
-          >
-            <StepProgressCircle incomplete={i > currentStepIndex}>
-              {i < currentStepIndex ? <Icon icon="tick" /> : i + 1}
-            </StepProgressCircle>
-            <StepProgressLabel incomplete={i > currentStepIndex}>
-              {step}
-            </StepProgressLabel>
-          </StepProgressStep>
-          {i < steps.length - 1 && <StepProgressLine />}
-        </React.Fragment>
-      ))}
-    </StepProgressRow>
-  )
-}
-
-const StepPanel = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 70px;
-  min-height: 300px;
-  padding: 50px 70px;
-  > * {
-    flex: 1;
-  }
-`
-
-const StepActionsRow = styled.div`
-  display: flex;
-  padding: 20px;
-  background-color: ${Colors.LIGHT_GRAY5};
-  justify-content: space-between;
-  border-radius: 0 0 3px 3px;
-`
-
-const StepActions: React.FC<{
-  left?: React.ReactElement
-  right?: React.ReactElement
-}> = ({ left, right }) => (
-  <StepActionsRow>
-    {left || <div />}
-    {right || <div />}
-  </StepActionsRow>
-)
 
 const UploadElectionResultsStep: React.FC<{
   nextStep: () => void
@@ -432,7 +332,7 @@ const BatchInventorySteps: React.FC<{
             Back to Audit Source Data
           </LinkButton>
         </HeadingRow>
-        <StepContainer>
+        <Steps>
           <StepProgress steps={STEPS} currentStep={step} />
           {(() => {
             switch (step) {
@@ -465,7 +365,7 @@ const BatchInventorySteps: React.FC<{
                 throw new Error('Unknown step')
             }
           })()}
-        </StepContainer>
+        </Steps>
       </Inner>
     </Wrapper>
   )

--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -341,9 +341,9 @@ const BatchInventorySteps: React.FC<{
           </LinkButton>
         </HeadingRow>
         <Steps>
-          <StepList currentStepId={currentStep}>
+          <StepList>
             {STEPS.map(step => (
-              <StepListItem key={step} id={step}>
+              <StepListItem key={step} current={step === currentStep}>
                 {step}
               </StepListItem>
             ))}


### PR DESCRIPTION
_Review by commits_

Extract a new Steps component from the batch inventory flow. This will be useful in some upcoming auditing flows.

I also made a few tweaks to the component structure and styling to prepare for more general usage (including thinking about making it possible to add links in the step list at the top).

Tweaked styles:
<img width="1001" alt="Screen Shot 2022-10-04 at 4 16 46 PM" src="https://user-images.githubusercontent.com/530106/193948017-2517df2a-a619-4bc1-a5dd-612f4659b165.png">
