### PR TITLE
Restore original Blueprint heading color

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -48,7 +48,6 @@ body,
 /* stylelint-disable-next-line no-duplicate-selectors */
 html {
   background: #ffffff;
-  color: #263238;
   font-size: 24px; /* Magic number, must synced with JavaScript global defaults */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -58,7 +57,6 @@ body {
   margin: 0;
   line-height: 1.28581;
   letter-spacing: 0;
-  color: #182026;
   font-family: 'Helvetica Neue', 'Helvetica', 'Arial', 'Lucida Grande',
     sans-serif;
   font-size: 14px;
@@ -169,10 +167,6 @@ body {
 code {
   font-family: 'source-code-pro', 'Menlo', 'Monaco', 'Consolas', 'Courier New',
     monospace;
-}
-
-.bp3-heading {
-  color: #394b59;
 }
 
 hr {

--- a/client/src/components/Atoms/Steps.test.tsx
+++ b/client/src/components/Atoms/Steps.test.tsx
@@ -34,7 +34,7 @@ describe('Steps', () => {
       name: 'Prepare',
       current: 'step',
     })
-    expect(prepareHeader).toHaveStyle({ color: Colors.DARK_GRAY5 })
+    expect(prepareHeader).toHaveStyle({ color: Colors.DARK_GRAY1 })
     const prepareCircle = prepareHeader.previousElementSibling!
     expect(prepareCircle).toHaveTextContent('2')
     expect(prepareCircle).toHaveStyle({ backgroundColor: Colors.BLUE3 })

--- a/client/src/components/Atoms/Steps.tsx
+++ b/client/src/components/Atoms/Steps.tsx
@@ -70,7 +70,7 @@ const StepListItemCircle = styled.div<{
 export const StepListItem = styled(({ current, ...props }) => (
   <H5 {...props} />
 ))<{ current: boolean }>`
-  color: ${props => (props.current ? Colors.DARK_GRAY5 : Colors.GRAY3)};
+  color: ${props => (props.current ? Colors.DARK_GRAY1 : Colors.GRAY3)};
   margin: 0;
 `
 

--- a/client/src/components/PublicPages/AuditPlanner/AuditPlanner.tsx
+++ b/client/src/components/PublicPages/AuditPlanner/AuditPlanner.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
-import { Colors, H1 } from '@blueprintjs/core'
+import { H1 } from '@blueprintjs/core'
 
 import AuditPlanCard from './AuditPlanCard'
 import ElectionResultsCard from './ElectionResultsCard'
@@ -10,13 +10,6 @@ import {
   IElectionResultsFormState,
 } from './electionResults'
 import { Inner } from '../../Atoms/Wrapper'
-
-const Container = styled(Inner)`
-  // Undo the override in App.css and restore to Blueprint's original heading color
-  .bp3-heading {
-    color: ${Colors.DARK_GRAY1};
-  }
-`
 
 const PageHeading = styled(H1)`
   margin-bottom: 24px;
@@ -47,7 +40,7 @@ const AuditPlanner: React.FC = () => {
   }
 
   return (
-    <Container flexDirection="column" withTopPadding>
+    <Inner flexDirection="column" withTopPadding>
       <PageHeading>Audit Planner</PageHeading>
       <ElectionResultsCard
         clearElectionResults={clearElectionResults}
@@ -61,7 +54,7 @@ const AuditPlanner: React.FC = () => {
           electionResults={savedElectionResults}
         />
       )}
-    </Container>
+    </Inner>
   )
 }
 


### PR DESCRIPTION
There's no reason to override it, and the original (darker) color looks better, as we learned when building the audit planner.

Tested by poking around the app and all looks well!