### PR TITLE
Tally entry accounts (backend)

### DIFF
--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -5,9 +5,11 @@ import string
 from datetime import datetime, timezone
 from typing import Optional
 from urllib.parse import urljoin, urlencode
+import uuid
 from flask import jsonify, request, session, render_template
 from authlib.integrations.flask_client import OAuth, OAuthError
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, Conflict
+from xkcdpass import xkcd_password as xp
 
 from server.util.redirect import redirect
 
@@ -16,6 +18,7 @@ from ..models import *  # pylint: disable=wildcard-import
 from ..database import db_session
 from .lib import (
     get_loggedin_user,
+    restrict_access,
     set_loggedin_user,
     clear_loggedin_user,
     set_support_user,
@@ -23,7 +26,7 @@ from .lib import (
     get_support_user,
     UserType,
 )
-from ..api.audit_boards import serialize_members
+from ..api.audit_boards import WORDS, serialize_members, validate_members
 from ..activity_log import JurisdictionAdminLogin, record_activity, ActivityBase
 from ..util.isoformat import isoformat
 from ..config import (
@@ -85,7 +88,7 @@ def auth_me():
     if user_type == UserType.AUDIT_ADMIN:
         db_user = User.query.filter_by(email=user_key).one()
         user = dict(type=user_type, email=db_user.email, id=db_user.id)
-    if user_type == UserType.JURISDICTION_ADMIN:
+    elif user_type == UserType.JURISDICTION_ADMIN:
         db_user = User.query.filter_by(email=user_key).one()
         user = dict(
             type=user_type,
@@ -114,6 +117,21 @@ def auth_me():
                 name=audit_board.name,
                 members=serialize_members(audit_board),
                 signedOffAt=isoformat(audit_board.signed_off_at),
+            )
+    elif user_type == UserType.TALLY_ENTRY:
+        tally_entry_user = TallyEntryUser.query.get(user_key)
+        jurisdiction = tally_entry_user.jurisdiction
+        if jurisdiction.election.deleted_at is None:
+            user = dict(
+                type=user_type,
+                id=tally_entry_user.id,
+                loginCode=tally_entry_user.login_code,
+                loginConfirmedAt=isoformat(tally_entry_user.login_confirmed_at),
+                jurisdictionId=jurisdiction.id,
+                jurisdictionName=jurisdiction.name,
+                electionId=jurisdiction.election.id,
+                auditName=jurisdiction.election.audit_name,
+                members=serialize_members(tally_entry_user),
             )
 
     support_user_email = get_support_user(session)
@@ -315,6 +333,143 @@ def auditboard_passphrase(passphrase: str):
     return redirect(
         f"/election/{audit_board.jurisdiction.election.id}/audit-board/{audit_board.id}"
     )
+
+
+@auth.route("/tallyentry/<passphrase>", methods=["GET"])
+def tally_entry_passphrase(passphrase: str):
+    jurisdiction = Jurisdiction.query.filter_by(
+        tally_entry_passphrase=passphrase
+    ).one_or_none()
+    if jurisdiction is None:
+        # TODO does it make sense to redirect to the main login page here?
+        # Maybe a 404 would be a better first cut?
+        return redirect(
+            "/?"
+            + urlencode(
+                {"error": "invalid_login_link", "message": "Invalid login link."}
+            )
+        )
+    return redirect(f"/jurisdiction/{jurisdiction.id}/tally-entry")
+
+
+@auth.route("/auth/tallyentry/code", methods=["POST"])
+def tally_entry_user_generate_code():
+    body = request.get_json()
+    jurisdiction = Jurisdiction.query.get(body.get("jurisdictionId"))
+    if jurisdiction is None:
+        raise BadRequest(
+            "Invalid jurisdiction. Please try visiting your login link again."
+        )
+
+    members = body.get("members", [])
+    validate_members(members)
+
+    tally_entry_user = TallyEntryUser(
+        id=str(uuid.uuid4()),
+        jurisdiction_id=jurisdiction.id,
+        member_1=members[0]["name"].strip(),
+        member_1_affiliation=members[0]["affiliation"],
+    )
+    if len(members) > 1:
+        tally_entry_user.member_2 = members[1]["name"].strip()
+        tally_entry_user.member_2_affiliation = members[1]["affiliation"]
+
+    db_session.add(tally_entry_user)
+
+    # Generate a login code and make sure its unique to the jurisdiction.
+    #
+    # Note that this doesn't protect against race conditions that might result
+    # in a duplicate code, but we have a unique index on the table that will
+    # prevent the code from being written in that very rare case.  Here we're
+    # just checking for collisions not resulting from a race.
+    while True:
+        login_code = "".join(secrets.choice(string.digits) for _ in range(3))
+        if not TallyEntryUser.query.filter_by(
+            jurisdiction_id=jurisdiction.id, login_code=login_code
+        ).one_or_none():
+            tally_entry_user.login_code = login_code
+            break
+
+    # We set the tally entry user in the session even though their code isn't
+    # confirmed yet. The restrict_access decorator ensures that they can't
+    # do anything until the code is confirmed.
+    set_loggedin_user(session, UserType.TALLY_ENTRY, tally_entry_user.id)
+
+    db_session.commit()
+
+    return jsonify(status="ok")
+
+
+@auth.route(
+    "/auth/tallyentry/election/<election_id>/jurisdiction/<jurisdiction_id>",
+    methods=["POST"],
+)
+@restrict_access([UserType.JURISDICTION_ADMIN])
+def tally_entry_jurisdiction_generate_passphrase(
+    election: Election, jurisdiction: Jurisdiction
+):
+    if election.audit_type != AuditType.BATCH_COMPARISON:
+        return Conflict(
+            "Tally entry accounts are only supported in batch comparison audits."
+        )
+
+    jurisdiction.tally_entry_passphrase = xp.generate_xkcdpassword(WORDS, numwords=4, delimiter="-")
+
+    db_session.commit()
+    return jsonify(status="ok")
+
+
+@auth.route(
+    "/auth/tallyentry/election/<election_id>/jurisdiction/<jurisdiction_id>",
+    methods=["GET"],
+)
+@restrict_access([UserType.JURISDICTION_ADMIN])
+def tally_entry_jurisdiction_status(
+    election: Election, jurisdiction: Jurisdiction  # pylint: disable=unused-argument
+):
+    tally_entry_users = (
+        TallyEntryUser.query.filter_by(jurisdiction_id=jurisdiction.id)
+        .order_by(TallyEntryUser.created_at.desc())
+        .all()
+    )
+    return jsonify(
+        passphrase=jurisdiction.tally_entry_passphrase,
+        loginRequests=[
+            dict(
+                tallyEntryUserId=tally_entry_user.id,
+                createdAt=tally_entry_user.created_at.isoformat(),
+                members=serialize_members(tally_entry_user),
+                loginConfirmedAt=isoformat(tally_entry_user.login_confirmed_at),
+            )
+            for tally_entry_user in tally_entry_users
+        ],
+    )
+
+
+@auth.route(
+    "/auth/tallyentry/election/<election_id>/jurisdiction/<jurisdiction_id>/confirm",
+    methods=["POST"],
+)
+@restrict_access([UserType.JURISDICTION_ADMIN])
+def tally_entry_jurisdiction_confirm_login_code(
+    election: Election, jurisdiction: Jurisdiction  # pylint: disable=unused-argument
+):
+    body = request.get_json()
+    tally_entry_user = TallyEntryUser.query.get(body.get("tallyEntryUserId"))
+    if not tally_entry_user:
+        raise BadRequest("Tally entry user not found.")
+
+    if tally_entry_user.jurisdiction_id != jurisdiction.id:
+        raise BadRequest("Tally entry user is not in your jurisdiction.")
+
+    if body.get("loginCode") != tally_entry_user.login_code:
+        raise BadRequest("Invalid code.")
+
+    tally_entry_user.login_confirmed_at = datetime.now(timezone.utc)
+
+    db_session.commit()
+
+    return jsonify(status="ok")
 
 
 @auth.errorhandler(OAuthError)

--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -362,7 +362,7 @@ def tally_entry_passphrase(passphrase: str):
     # their login code is confirmed by the JA.
     set_loggedin_user(session, UserType.TALLY_ENTRY, tally_entry_user.id)
 
-    return redirect("/tally-entry/login")
+    return redirect("/tally-entry")
 
 
 @auth.route("/auth/tallyentry/code", methods=["POST"])

--- a/server/migrations/versions/244744c21027_tally_entry_accounts.py
+++ b/server/migrations/versions/244744c21027_tally_entry_accounts.py
@@ -1,0 +1,61 @@
+# pylint: disable=invalid-name
+"""Tally entry accounts
+
+Revision ID: 244744c21027
+Revises: fed66f26125e
+Create Date: 2022-10-12 23:37:55.383296+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "244744c21027"
+down_revision = "fed66f26125e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "tally_entry_user",
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("id", sa.String(length=200), nullable=False),
+        sa.Column("jurisdiction_id", sa.String(length=200), nullable=False),
+        sa.Column("member_1", sa.String(length=200), nullable=True),
+        sa.Column(
+            "member_1_affiliation",
+            postgresql.ENUM(name="affiliation", create_type=False),
+            nullable=True,
+        ),
+        sa.Column("member_2", sa.String(length=200), nullable=True),
+        sa.Column(
+            "member_2_affiliation",
+            postgresql.ENUM(name="affiliation", create_type=False),
+            nullable=True,
+        ),
+        sa.Column("login_code", sa.String(length=200), nullable=True),
+        sa.Column("login_confirmed_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["jurisdiction_id"],
+            ["jurisdiction.id"],
+            name=op.f("tally_entry_user_jurisdiction_id_fkey"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("tally_entry_user_pkey")),
+        sa.UniqueConstraint(
+            "jurisdiction_id",
+            "login_code",
+            name=op.f("tally_entry_user_jurisdiction_id_login_code_key"),
+        ),
+    )
+    op.add_column(
+        "jurisdiction",
+        sa.Column("tally_entry_passphrase", sa.String(length=200), nullable=True),
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -517,6 +517,23 @@ class AuditBoard(BaseModel):
 
     __table_args__ = (UniqueConstraint("jurisdiction_id", "round_id", "name"),)
 
+class TallyEntryAccount(BaseModel):
+    id = Column(String(200), primary_key=True)
+
+    jurisdiction_id = Column(
+        String(200), ForeignKey("jurisdiction.id", ondelete="cascade"), nullable=False,
+    )
+    jurisdiction = relationship("Jurisdiction", back_populates="tally_entry_accounts")
+
+    member_1 = Column(String(200))
+    member_1_affiliation = Column(Enum(Affiliation))
+    member_2 = Column(String(200))
+    member_2_affiliation = Column(Enum(Affiliation))
+
+    login_code = Column(String(200), unique=True)
+    login_code_requested_at = Column(UTCDateTime)
+    login_code_attempts = Column(Integer)
+
 
 class SampleSizeOptions(BaseModel):
     election_id = Column(

--- a/server/models.py
+++ b/server/models.py
@@ -276,6 +276,10 @@ class Jurisdiction(BaseModel):
 
     finalized_full_hand_tally_results_at = Column(UTCDateTime)
 
+    # In batch comparison audits, JMs can generate a login link for additional
+    # tally entry users to log in.
+    tally_entry_passphrase = Column(String(200))
+
     batches = relationship(
         "Batch", back_populates="jurisdiction", uselist=True, passive_deletes=True
     )
@@ -486,6 +490,8 @@ class Affiliation(str, enum.Enum):
     OTHER = "OTH"
 
 
+# In ballot polling/comparison audits, ballots are divvied up between audit
+# boards, who can log in and enter their ballot interpretation
 class AuditBoard(BaseModel):
     id = Column(String(200), primary_key=True)
 
@@ -517,22 +523,28 @@ class AuditBoard(BaseModel):
 
     __table_args__ = (UniqueConstraint("jurisdiction_id", "round_id", "name"),)
 
-class TallyEntryAccount(BaseModel):
+
+# In batch comparison audits, jurisdiction managers can allow additional people
+# to log in and help enter tallies using a TallyEntryUser
+class TallyEntryUser(BaseModel):
     id = Column(String(200), primary_key=True)
 
     jurisdiction_id = Column(
         String(200), ForeignKey("jurisdiction.id", ondelete="cascade"), nullable=False,
     )
-    jurisdiction = relationship("Jurisdiction", back_populates="tally_entry_accounts")
+    jurisdiction = relationship("Jurisdiction")
 
+    # In some cases, the tally entry user might be an audit board and have
+    # multiple members. In others, it might just be one person.
     member_1 = Column(String(200))
     member_1_affiliation = Column(Enum(Affiliation))
     member_2 = Column(String(200))
     member_2_affiliation = Column(Enum(Affiliation))
 
-    login_code = Column(String(200), unique=True)
-    login_code_requested_at = Column(UTCDateTime)
-    login_code_attempts = Column(Integer)
+    login_code = Column(String(200))
+    login_confirmed_at = Column(UTCDateTime)
+
+    __table_args__ = (UniqueConstraint("jurisdiction_id", "login_code"),)
 
 
 class SampleSizeOptions(BaseModel):

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -327,6 +327,17 @@ def auth_decorator_test_routes():
         assert audit_board
         return jsonify([election.id, jurisdiction.id, round.id, audit_board.id])
 
+    @app.route(
+        "/api/election/<election_id>/jurisdiction/<jurisdiction_id>/tally-entry/test_auth"
+    )
+    @restrict_access([UserType.TALLY_ENTRY])
+    def fake_tally_entry_route(
+        election: Election, jurisdiction: Jurisdiction
+    ):  # pylint: disable=unused-variable
+        assert election
+        assert jurisdiction
+        return jsonify([election.id, jurisdiction.id])
+
 
 # Add special routes to test our error handlers. This fixture will run once before
 # the test session starts. We have to add the route before starting any tests

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -288,6 +288,11 @@ def assert_match_report(report_bytes: bytes, snapshot):
     snapshot.assert_match(scrub_datetime(report))
 
 
+def assert_is_string(value):
+    __tracebackhide__ = True  # pylint: disable=unused-variable
+    assert isinstance(value, str)
+
+
 def assert_is_id(value):
     __tracebackhide__ = True  # pylint: disable=unused-variable
     assert isinstance(value, str)

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -554,7 +554,7 @@ def test_tally_entry_login(
     login_link = f"/tallyentry/{tally_entry_status['passphrase']}"
     rv = tally_entry_client.get(login_link)
     assert rv.status_code == 302
-    assert urlparse(rv.location).path == "/tally-entry/login"
+    assert urlparse(rv.location).path == "/tally-entry"
 
     # Load the jurisdiction info
     rv = tally_entry_client.get("/api/me")


### PR DESCRIPTION
Task: #1531

Backend API for tally entry user login for batch comparison audits.

Includes several new endpoints:
- `GET /tallyentry/<passphrase>` - The login link that a JM shares with tally entry users. This is the login entry point.
- `POST /auth/tallyentry/code` - Endpoint to for a tally entry user to request a confirmation code, submitting member names/party affiliations.
- `GET /auth/tallyentry/election/<election_id>/jurisdiction/<jurisdiction_id>` - Endpoint for a JM to check for login requests from tally entry users
- `POST /auth/tallyentry/election/<election_id>/jurisdiction/<jurisdiction_id>/confirm` - Endpoint for a JM to submit a login confirmation code for a tally entry user to log them in

As well as an update to `/api/me` to include tally entry users (most importantly, their login confirmation code and a timestamp indicating when their login is confirmed).