### PR TITLE
Tally entry users - tally entry screen

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -83,12 +83,12 @@ describe('App', () => {
 
     it('redirects to tally entry flow when logged in as a tally entry user', async () => {
       const expectedCalls = [
-        tallyEntryApiCalls.getUser(tallyEntryUser.confirmed),
-        tallyEntryApiCalls.getUser(tallyEntryUser.confirmed),
+        tallyEntryApiCalls.getUser(tallyEntryUser.initial),
+        tallyEntryApiCalls.getUser(tallyEntryUser.initial),
       ]
       await withMockFetch(expectedCalls, async () => {
         const { history } = renderView('/')
-        await screen.findByRole('heading', { name: 'Enter Tallies' })
+        await screen.findByRole('heading', { name: 'Tally Entry Log In' })
         expect(history.location.pathname).toEqual('/tally-entry')
       })
     })
@@ -153,14 +153,14 @@ describe('App', () => {
 
     it('redirects to tally entry when logged in as tally entry user', async () => {
       const expectedCalls = [
-        tallyEntryApiCalls.getUser(tallyEntryUser.confirmed),
-        tallyEntryApiCalls.getUser(tallyEntryUser.confirmed),
+        tallyEntryApiCalls.getUser(tallyEntryUser.initial),
+        tallyEntryApiCalls.getUser(tallyEntryUser.initial),
       ]
       await withMockFetch(expectedCalls, async () => {
         const { history } = renderView(
           '/election/1/jurisdiction/jurisdiction-id-1'
         )
-        await screen.findByRole('heading', { name: 'Enter Tallies' })
+        await screen.findByRole('heading', { name: 'Tally Entry Log In' })
         expect(history.location.pathname).toEqual('/tally-entry')
       })
     })
@@ -203,12 +203,12 @@ describe('App', () => {
 
     it('redirects to tally entry when logged in as tally entry user', async () => {
       const expectedCalls = [
-        tallyEntryApiCalls.getUser(tallyEntryUser.confirmed),
-        tallyEntryApiCalls.getUser(tallyEntryUser.confirmed),
+        tallyEntryApiCalls.getUser(tallyEntryUser.initial),
+        tallyEntryApiCalls.getUser(tallyEntryUser.initial),
       ]
       await withMockFetch(expectedCalls, async () => {
         const { history } = renderView('/election/1/audit-board/audit-board-1')
-        await screen.findByRole('heading', { name: 'Enter Tallies' })
+        await screen.findByRole('heading', { name: 'Tally Entry Log In' })
         expect(history.location.pathname).toEqual('/tally-entry')
       })
     })
@@ -227,12 +227,12 @@ describe('App', () => {
   describe('/tally-entry', () => {
     it('renders tally entry flow when logged in as tally entry user', async () => {
       const expectedCalls = [
-        tallyEntryApiCalls.getUser(tallyEntryUser.confirmed),
-        tallyEntryApiCalls.getUser(tallyEntryUser.confirmed),
+        tallyEntryApiCalls.getUser(tallyEntryUser.initial),
+        tallyEntryApiCalls.getUser(tallyEntryUser.initial),
       ]
       await withMockFetch(expectedCalls, async () => {
         renderView('/tally-entry')
-        await screen.findByRole('heading', { name: 'Enter Tallies' })
+        await screen.findByRole('heading', { name: 'Tally Entry Log In' })
       })
     })
 

--- a/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.test.tsx
@@ -10,10 +10,7 @@ import { IBatches, IBatchResultTallySheet } from './useBatchResults'
 import { IContest } from '../../types'
 import { withMockFetch, findAndCloseToast, serverError } from '../testUtilities'
 import { queryClient } from '../../App'
-import {
-  contestMocks,
-  roundMocks,
-} from '../AuditAdmin/useSetupMenuItems/_mocks'
+import { contestMocks } from '../AuditAdmin/useSetupMenuItems/_mocks'
 
 jest.mock('copy-to-clipboard', () => jest.fn(() => true))
 

--- a/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.test.tsx
@@ -62,6 +62,7 @@ const renderComponent = () =>
         electionId="1"
         jurisdictionId="1"
         roundId="round-1"
+        showFinalizeAndCopyButtons
       />
       <ToastContainer />
     </QueryClientProvider>

--- a/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { screen, within, waitFor } from '@testing-library/react'
-import { useParams } from 'react-router-dom'
+import { render, screen, within, waitFor } from '@testing-library/react'
 import { QueryClientProvider } from 'react-query'
 import userEvent from '@testing-library/user-event'
 import copy from 'copy-to-clipboard'
@@ -9,12 +8,7 @@ import BatchRoundDataEntry from './BatchRoundDataEntry'
 import { batchesMocks } from './_mocks'
 import { IBatches, IBatchResultTallySheet } from './useBatchResults'
 import { IContest } from '../../types'
-import {
-  renderWithRouter,
-  withMockFetch,
-  findAndCloseToast,
-  serverError,
-} from '../testUtilities'
+import { withMockFetch, findAndCloseToast, serverError } from '../testUtilities'
 import { queryClient } from '../../App'
 import {
   contestMocks,
@@ -22,17 +16,6 @@ import {
 } from '../AuditAdmin/useSetupMenuItems/_mocks'
 
 jest.mock('copy-to-clipboard', () => jest.fn(() => true))
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
-  useRouteMatch: jest.fn(),
-  useParams: jest.fn(),
-}))
-const paramsMock = useParams as jest.Mock
-paramsMock.mockReturnValue({
-  electionId: '1',
-  jurisdictionId: '1',
-})
 
 const apiCalls = {
   getJAContests: (response: { contests: IContest[] }) => ({
@@ -72,15 +55,16 @@ const batchesWithResults = (resultTallySheets: IBatchResultTallySheet[]) => [
   ...batchesMocks.emptyInitial.batches.slice(1),
 ]
 
-const render = () =>
-  renderWithRouter(
+const renderComponent = () =>
+  render(
     <QueryClientProvider client={queryClient}>
-      <BatchRoundDataEntry round={roundMocks.singleIncomplete[0]} />
+      <BatchRoundDataEntry
+        electionId="1"
+        jurisdictionId="1"
+        roundId="round-1"
+      />
       <ToastContainer />
-    </QueryClientProvider>,
-    {
-      route: '/election/1/jurisdiction/1',
-    }
+    </QueryClientProvider>
   )
 
 describe('Batch comparison data entry', () => {
@@ -90,7 +74,7 @@ describe('Batch comparison data entry', () => {
       apiCalls.getBatches(batchesMocks.emptyInitial),
     ]
     await withMockFetch(expectedCalls, async () => {
-      render()
+      renderComponent()
       const batchTable = await screen.findByRole('table')
 
       const headers = within(batchTable).getAllByRole('columnheader')
@@ -156,7 +140,7 @@ describe('Batch comparison data entry', () => {
       }),
     ]
     await withMockFetch(expectedCalls, async () => {
-      render()
+      renderComponent()
       const batchTable = await screen.findByRole('table')
       let rows = within(batchTable).getAllByRole('row')
       userEvent.click(within(rows[1]).getByRole('button', { name: /Edit/ }))
@@ -221,7 +205,7 @@ describe('Batch comparison data entry', () => {
       apiCalls.getBatches(batchesMocks.emptyInitial),
     ]
     await withMockFetch(expectedCalls, async () => {
-      render()
+      renderComponent()
       const batchTable = await screen.findByRole('table')
       let rows = within(batchTable).getAllByRole('row')
       userEvent.click(within(rows[1]).getByRole('button', { name: /Edit/ }))
@@ -279,7 +263,7 @@ describe('Batch comparison data entry', () => {
       }),
     ]
     await withMockFetch(expectedCalls, async () => {
-      render()
+      renderComponent()
       const batchTable = await screen.findByRole('table')
       let rows = within(batchTable).getAllByRole('row')
       userEvent.click(within(rows[1]).getByRole('button', { name: /More/ }))
@@ -440,7 +424,7 @@ describe('Batch comparison data entry', () => {
       apiCalls.getBatches(batchesMocks.complete),
     ]
     await withMockFetch(expectedCalls, async () => {
-      render()
+      renderComponent()
       const finalizeButton = await screen.findByRole('button', {
         name: /Finalize Results/,
       })
@@ -475,7 +459,7 @@ describe('Batch comparison data entry', () => {
       }),
     ]
     await withMockFetch(expectedCalls, async () => {
-      render()
+      renderComponent()
       const finalizeButton = await screen.findByRole('button', {
         name: /Finalize Results/,
       })
@@ -505,7 +489,7 @@ describe('Batch comparison data entry', () => {
       ),
     ]
     await withMockFetch(expectedCalls, async () => {
-      render()
+      renderComponent()
       const batchTable = await screen.findByRole('table')
       let rows = within(batchTable).getAllByRole('row')
       userEvent.click(within(rows[1]).getByRole('button', { name: /Edit/ }))
@@ -538,7 +522,7 @@ describe('Batch comparison data entry', () => {
       serverError('finalizeBatchResults', apiCalls.finalizeBatchResults()),
     ]
     await withMockFetch(expectedCalls, async () => {
-      render()
+      renderComponent()
       userEvent.click(
         await screen.findByRole('button', { name: /Finalize Results/ })
       )

--- a/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.tsx
@@ -434,10 +434,9 @@ const BatchRoundDataEntry: React.FC<IBatchRoundDataEntryProps> = ({
   return (
     <div>
       <div>
-        <p>
-          When you have examined all of the ballots assigned to you, enter the
-          number of votes recorded for each candidate/choice from the audited
-          ballots in each batch.
+        <p className="bp3-text-large">
+          For each batch, enter the number of votes tallied for each
+          candidate/choice.
         </p>
         {resultsFinalizedAt && (
           <Callout

--- a/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.tsx
@@ -434,7 +434,7 @@ const BatchRoundDataEntry: React.FC<IBatchRoundDataEntryProps> = ({
   return (
     <div>
       <div>
-        <p className="bp3-text-large">
+        <p className={Classes.TEXT_LARGE}>
           For each batch, enter the number of votes tallied for each
           candidate/choice.
         </p>

--- a/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.tsx
@@ -29,7 +29,6 @@ import { sum } from '../../utils/number'
 import { IContest } from '../../types'
 import CopyToClipboard from '../Atoms/CopyToClipboard'
 import { useConfirm, Confirm } from '../Atoms/Confirm'
-import { IRound } from '../AuditAdmin/useRoundsAuditAdmin'
 
 const ResultsTable = styled(HTMLTable).attrs({
   striped: true,
@@ -359,17 +358,23 @@ const BatchTallySheetsModal = ({
   )
 }
 
-const BatchRoundDataEntry: React.FC<{ round: IRound }> = ({ round }) => {
-  const { electionId, jurisdictionId } = useParams<{
-    electionId: string
-    jurisdictionId: string
-  }>()
+interface IBatchRoundDataEntryProps {
+  electionId: string
+  jurisdictionId: string
+  roundId: string
+}
+
+const BatchRoundDataEntry: React.FC<IBatchRoundDataEntryProps> = ({
+  electionId,
+  jurisdictionId,
+  roundId,
+}) => {
   const contests = useContestsJurisdictionAdmin(electionId, jurisdictionId)
-  const batchesResp = useBatches(electionId, jurisdictionId, round.id)
+  const batchesResp = useBatches(electionId, jurisdictionId, roundId)
   const finalizeResults = useFinalizeBatchResults(
     electionId,
     jurisdictionId,
-    round.id
+    roundId
   )
   const { confirm, confirmProps } = useConfirm()
   const [editing, setEditing] = useState<{
@@ -467,7 +472,7 @@ const BatchRoundDataEntry: React.FC<{ round: IRound }> = ({ round }) => {
               <BatchResultsForm
                 electionId={electionId}
                 jurisdictionId={jurisdictionId}
-                roundId={round.id}
+                roundId={roundId}
                 contest={contest}
                 batch={batch}
                 key={batch.id}
@@ -569,7 +574,7 @@ const BatchRoundDataEntry: React.FC<{ round: IRound }> = ({ round }) => {
           batch={batches.find(batch => batch.id === editing.batchId)!}
           electionId={electionId}
           jurisdictionId={jurisdictionId}
-          roundId={round.id}
+          roundId={roundId}
           contest={contest}
           closeModal={() => setEditing(null)}
         />

--- a/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.tsx
@@ -362,12 +362,14 @@ interface IBatchRoundDataEntryProps {
   electionId: string
   jurisdictionId: string
   roundId: string
+  showFinalizeAndCopyButtons: boolean
 }
 
 const BatchRoundDataEntry: React.FC<IBatchRoundDataEntryProps> = ({
   electionId,
   jurisdictionId,
   roundId,
+  showFinalizeAndCopyButtons,
 }) => {
   const contests = useContestsJurisdictionAdmin(electionId, jurisdictionId)
   const batchesResp = useBatches(electionId, jurisdictionId, roundId)
@@ -579,25 +581,27 @@ const BatchRoundDataEntry: React.FC<IBatchRoundDataEntryProps> = ({
           closeModal={() => setEditing(null)}
         />
       )}
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          marginTop: '20px',
-        }}
-      >
-        <CopyToClipboard
-          getText={() => document.getElementById('results-table')!.outerHTML}
-        />
-        <Button
-          intent="primary"
-          onClick={onClickFinalize}
-          disabled={!!resultsFinalizedAt}
+      {showFinalizeAndCopyButtons && (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginTop: '20px',
+          }}
         >
-          Finalize Results
-        </Button>
-        <Confirm {...confirmProps} />
-      </div>
+          <CopyToClipboard
+            getText={() => document.getElementById('results-table')!.outerHTML}
+          />
+          <Button
+            intent="primary"
+            onClick={onClickFinalize}
+            disabled={!!resultsFinalizedAt}
+          >
+            Finalize Results
+          </Button>
+          <Confirm {...confirmProps} />
+        </div>
+      )}
     </div>
   )
 }

--- a/client/src/components/JurisdictionAdmin/RoundManagement.tsx
+++ b/client/src/components/JurisdictionAdmin/RoundManagement.tsx
@@ -152,6 +152,7 @@ const RoundManagement: React.FC<IRoundManagementProps> = ({
             electionId={electionId}
             jurisdictionId={jurisdictionId}
             roundId={round.id}
+            showFinalizeAndCopyButtons
           />
         ) : auditSettings.online ? (
           <RoundProgress auditBoards={auditBoards} />

--- a/client/src/components/JurisdictionAdmin/RoundManagement.tsx
+++ b/client/src/components/JurisdictionAdmin/RoundManagement.tsx
@@ -148,7 +148,11 @@ const RoundManagement: React.FC<IRoundManagementProps> = ({
       )}
       <SpacedDiv>
         {auditSettings.auditType === 'BATCH_COMPARISON' ? (
-          <BatchRoundDataEntry round={round} />
+          <BatchRoundDataEntry
+            electionId={electionId}
+            jurisdictionId={jurisdictionId}
+            roundId={round.id}
+          />
         ) : auditSettings.online ? (
           <RoundProgress auditBoards={auditBoards} />
         ) : round.isFullHandTally ? (

--- a/client/src/components/TallyEntryUser/TallyEntryLoginScreen.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryLoginScreen.tsx
@@ -182,20 +182,18 @@ const TallyEntryLoginScreen: React.FC<ITallyEntryLoginScreenProps> = ({
 }) => {
   const { jurisdictionName, auditName, loginCode } = user
   return (
-    <Wrapper>
-      <Inner flexDirection="column">
-        <LogInPanel>
-          <AuditHeading>
-            {jurisdictionName} &mdash; {auditName}
-          </AuditHeading>
-          {loginCode === null ? (
-            <LoginStartForm />
-          ) : (
-            <LoginCodeDisplay loginCode={loginCode} />
-          )}
-        </LogInPanel>
-      </Inner>
-    </Wrapper>
+    <Inner flexDirection="column">
+      <LogInPanel>
+        <AuditHeading>
+          {jurisdictionName} &mdash; {auditName}
+        </AuditHeading>
+        {loginCode === null ? (
+          <LoginStartForm />
+        ) : (
+          <LoginCodeDisplay loginCode={loginCode} />
+        )}
+      </LogInPanel>
+    </Inner>
   )
 }
 

--- a/client/src/components/TallyEntryUser/TallyEntryScreen.test.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryScreen.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { QueryClientProvider } from 'react-query'
+import { render, screen, within } from '@testing-library/react'
+import { tallyEntryApiCalls } from '../_mocks'
+import TallyEntryScreen from './TallyEntryScreen'
+import { queryClient } from '../../App'
+import { withMockFetch } from '../testUtilities'
+import { contestMocks } from '../AuditAdmin/useSetupMenuItems/_mocks'
+import { batchesMocks } from '../JurisdictionAdmin/_mocks'
+
+const renderScreen = () =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TallyEntryScreen
+        electionId="1"
+        jurisdictionId="jurisdiction-id-1"
+        roundId="round-1"
+      />
+    </QueryClientProvider>
+  )
+
+describe('TallyEntryScreen', () => {
+  it('shows batch tally results', async () => {
+    const expectedCalls = [
+      tallyEntryApiCalls.getContests(contestMocks.oneTargeted),
+      tallyEntryApiCalls.getBatches(batchesMocks.emptyInitial),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderScreen()
+      await screen.findByRole('heading', { name: 'Enter Tallies' })
+      screen.getByText(
+        'For each batch, enter the number of votes tallied for each candidate/choice.'
+      )
+      screen.getByText('Batch One')
+      // TODO fill in comprehensive tests once the tally entry interface is finalized
+    })
+  })
+})

--- a/client/src/components/TallyEntryUser/TallyEntryScreen.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { H2 } from '@blueprintjs/core'
-import { Wrapper, Inner } from '../Atoms/Wrapper'
+import { Inner } from '../Atoms/Wrapper'
 import BatchRoundDataEntry from '../JurisdictionAdmin/BatchRoundDataEntry'
 
 interface ITallyEntryScreenProps {

--- a/client/src/components/TallyEntryUser/TallyEntryScreen.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryScreen.tsx
@@ -1,11 +1,29 @@
 import React from 'react'
-import { H1 } from '@blueprintjs/core'
+import { H2 } from '@blueprintjs/core'
+import { Wrapper, Inner } from '../Atoms/Wrapper'
+import BatchRoundDataEntry from '../JurisdictionAdmin/BatchRoundDataEntry'
 
-const TallyEntryScreen: React.FC = () => {
+interface ITallyEntryScreenProps {
+  electionId: string
+  jurisdictionId: string
+  roundId: string
+}
+
+const TallyEntryScreen: React.FC<ITallyEntryScreenProps> = ({
+  electionId,
+  jurisdictionId,
+  roundId,
+}) => {
   return (
-    <div>
-      <H1>Enter Tallies</H1>
-    </div>
+    <Inner flexDirection="column" withTopPadding>
+      <H2>Enter Tallies</H2>
+      <BatchRoundDataEntry
+        electionId={electionId}
+        jurisdictionId={jurisdictionId}
+        roundId={roundId}
+        showFinalizeAndCopyButtons={false}
+      />
+    </Inner>
   )
 }
 

--- a/client/src/components/TallyEntryUser/TallyEntryUserView.test.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryUserView.test.tsx
@@ -5,6 +5,8 @@ import TallyEntryUserView from './TallyEntryUserView'
 import { queryClient } from '../../App'
 import { withMockFetch, renderWithRouter } from '../testUtilities'
 import { tallyEntryApiCalls, tallyEntryUser } from '../_mocks'
+import { contestMocks } from '../AuditAdmin/useSetupMenuItems/_mocks'
+import { batchesMocks } from '../JurisdictionAdmin/_mocks'
 
 const renderView = () =>
   renderWithRouter(
@@ -41,6 +43,8 @@ describe('TallyEntryUserView', () => {
     const expectedCalls = [
       tallyEntryApiCalls.getUser(tallyEntryUser.unconfirmed),
       tallyEntryApiCalls.getUser(tallyEntryUser.confirmed),
+      tallyEntryApiCalls.getContests(contestMocks.oneTargeted),
+      tallyEntryApiCalls.getBatches(batchesMocks.emptyInitial),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()

--- a/client/src/components/TallyEntryUser/TallyEntryUserView.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryUserView.tsx
@@ -31,7 +31,11 @@ const TallyEntryUserView: React.FC = () => {
       {user.loginConfirmedAt === null ? (
         <TallyEntryLoginScreen user={user} />
       ) : (
-        <TallyEntryScreen />
+        <TallyEntryScreen
+          electionId={user.electionId}
+          jurisdictionId={user.jurisdictionId}
+          roundId={user.roundId}
+        />
       )}
     </>
   )

--- a/client/src/components/UserContext.tsx
+++ b/client/src/components/UserContext.tsx
@@ -67,6 +67,7 @@ export interface ITallyEntryUser {
   jurisdictionId: string
   jurisdictionName: string
   electionId: string
+  roundId: string
   auditName: string
   members: IMember[]
 }

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -560,6 +560,7 @@ export const tallyEntryUser = mocksOfType<ITallyEntryUser>()({
     jurisdictionName: 'Jurisdiction One',
     electionId: '1',
     auditName: 'Test Audit',
+    roundId: 'round-1',
     loginCode: null,
     loginConfirmedAt: null,
     members: [],
@@ -571,6 +572,7 @@ export const tallyEntryUser = mocksOfType<ITallyEntryUser>()({
     jurisdictionName: 'Jurisdiction One',
     electionId: '1',
     auditName: 'Test Audit',
+    roundId: 'round-1',
     loginCode: '123',
     loginConfirmedAt: null,
     members: [
@@ -588,6 +590,7 @@ export const tallyEntryUser = mocksOfType<ITallyEntryUser>()({
     jurisdictionName: 'Jurisdiction One',
     electionId: '1',
     auditName: 'Test Audit',
+    roundId: 'round-1',
     loginCode: '123',
     loginConfirmedAt: '2022-10-17T21:12:42.600Z',
     members: [
@@ -617,6 +620,8 @@ export const tallyEntryApiCalls = {
     },
     response: { status: 'ok' },
   }),
+  getBatches: jaApiCalls.getBatches,
+  getContests: jaApiCalls.getJurisdictionContests,
 }
 
 export const fileInfoMocks = mocksOfType<IFileInfo>()({

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -89,7 +89,9 @@ def serialize_batch(batch: Batch) -> JSONDict:
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/batches",
     methods=["GET"],
 )
-@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
+@restrict_access(
+    [UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN, UserType.TALLY_ENTRY]
+)
 def list_batches_for_jurisdiction(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
@@ -198,7 +200,7 @@ def validate_batch_results(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/round/<round_id>/batches/<batch_id>/results",
     methods=["PUT"],
 )
-@restrict_access([UserType.JURISDICTION_ADMIN])
+@restrict_access([UserType.JURISDICTION_ADMIN, UserType.TALLY_ENTRY])
 def record_batch_results(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -223,7 +223,9 @@ def list_contests(election: Election):
 @api.route(
     "/election/<election_id>/jurisdiction/<jurisdiction_id>/contest", methods=["GET"]
 )
-@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
+@restrict_access(
+    [UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN, UserType.TALLY_ENTRY]
+)
 def list_jurisdictions_contests(
     election: Election, jurisdiction: Jurisdiction,  # pylint: disable=unused-argument
 ):

--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -10,6 +10,7 @@ from flask import jsonify, request, session, render_template
 from authlib.integrations.flask_client import OAuth, OAuthError
 from werkzeug.exceptions import BadRequest, Conflict
 from xkcdpass import xkcd_password as xp
+from server.api.rounds import get_current_round
 
 from server.util.redirect import redirect
 
@@ -127,6 +128,7 @@ def auth_me():
             # that we only return data that they are allowed to see during the
             # login process. Data that is only available after login
             # confirmation should be accessed via separate endpoints.
+            round = get_current_round(jurisdiction.election)
             user = dict(
                 type=user_type,
                 id=tally_entry_user.id,
@@ -136,6 +138,7 @@ def auth_me():
                 jurisdictionName=jurisdiction.name,
                 electionId=jurisdiction.election.id,
                 auditName=jurisdiction.election.audit_name,
+                roundId=round.id,
                 members=serialize_members(tally_entry_user),
             )
 

--- a/server/auth/routes.py
+++ b/server/auth/routes.py
@@ -129,6 +129,7 @@ def auth_me():
             # login process. Data that is only available after login
             # confirmation should be accessed via separate endpoints.
             round = get_current_round(jurisdiction.election)
+            assert round is not None
             user = dict(
                 type=user_type,
                 id=tally_entry_user.id,

--- a/server/tests/batch_comparison/test_batches.py
+++ b/server/tests/batch_comparison/test_batches.py
@@ -107,6 +107,7 @@ def test_record_batch_results(
     election_id: str,
     jurisdiction_ids: List[str],
     round_1_id: str,
+    tally_entry_user_id: str,
     snapshot,
 ):
     set_logged_in_user(
@@ -191,7 +192,8 @@ def test_record_batch_results(
     rounds = json.loads(rv.data)["rounds"]
     assert rounds[0]["endedAt"] is None
 
-    # Record results for the other jurisdiction
+    # Record results for the other jurisdiction using a tally entry account
+    set_logged_in_user(client, UserType.TALLY_ENTRY, tally_entry_user_id)
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/batches"
     )
@@ -226,6 +228,9 @@ def test_record_batch_results(
     assert batches[0]["resultTallySheets"] == tally_sheets
 
     # Finalize results
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
     rv = post_json(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/batches/finalize",

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -87,6 +87,11 @@ def round_id(election_id: str) -> str:
     return create_round(election_id)
 
 
+@pytest.fixture
+def batch_round_id(batch_election_id: str) -> str:
+    return create_round(batch_election_id)
+
+
 def create_audit_board(jurisdiction_id: str, round_id: str) -> str:
     audit_board_id = str(uuid.uuid4())
     audit_board = AuditBoard(
@@ -535,6 +540,7 @@ def test_tally_entry_login(
     batch_election_id: str,
     batch_jurisdiction_id: str,
     batch_ja_email: str,
+    batch_round_id: str,  # pylint: disable=unused-argument
 ):
     tally_entry_client = app.test_client()
 
@@ -589,6 +595,7 @@ def test_tally_entry_login(
                 jurisdictionName=jurisdiction.name,
                 electionId=election_id,
                 auditName=election.audit_name,
+                roundId=batch_round_id,
                 members=[],
             ),
             supportUser=None,
@@ -682,6 +689,7 @@ def test_tally_entry_generate_unique_code(
     batch_election_id: str,
     batch_jurisdiction_id: str,
     batch_ja_email: str,
+    batch_round_id: str,  # pylint: disable=unused-argument
 ):
     # To make sure that the login codes are unique within a jurisdiction, we'll
     # create tally entry users with every possible login code except one (000)
@@ -832,6 +840,7 @@ def test_tally_entry_invalid_code(
     batch_election_id: str,
     batch_jurisdiction_id: str,
     batch_ja_email: str,
+    batch_round_id: str,  # pylint: disable=unused-argument
     election_id: str,
     jurisdiction_id: str,
     ja_email: str,


### PR DESCRIPTION
_Review by commits_

- Uses the existing `BatchRoundDataEntry` component to allow tally entry users to enter tallies. Hides the ability to copy or finalize. I didn't put a ton of effort into making this nice (from both a design perspective and a code perspective) since it will be replaced for #1623.
- Also updates the permissions on the necessary API endpoints. Since a tally entry user can edit all of the batches that a JM can edit, I just reused the same endpoints. 

<img width="1312" alt="Screen Shot 2022-10-13 at 4 24 39 PM" src="https://user-images.githubusercontent.com/530106/195730019-34e3393d-a9ea-49c7-9f8f-d9fb009abdab.png">
