### PR TITLE
Only run lint-staged at top level in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged && yarn --cwd client lint-staged
+yarn lint-staged


### PR DESCRIPTION
I noticed that the top level lint-staged command seems to run on files nested in `client` and uses the correct config from `client/package.json`, so there's no reason to also run the lint-staged command again within `client`. This might have been a result of upgrading lint-staged.