### PR TITLE
Fix outstanding lint warnings

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "vite build",
-    "lint": "eslint --ext ts --ext tsx src",
+    "lint": "eslint --cache --ext ts --ext tsx src",
     "lint:fix": "yarn lint --fix",
     "start": "vite",
     "test": "is-ci \"test:ci\" \"test:watch\"",

--- a/client/src/components/Atoms/FileUpload.test.tsx
+++ b/client/src/components/Atoms/FileUpload.test.tsx
@@ -10,14 +10,8 @@ import {
   IFileUpload,
 } from '../useFileUpload'
 import FileUpload, { IFileUploadProps } from './FileUpload'
-import {
-  withMockFetch,
-  mocksOfType,
-  serverError,
-  findAndCloseToast,
-} from '../testUtilities'
+import { withMockFetch, serverError, findAndCloseToast } from '../testUtilities'
 import { queryClient } from '../../App'
-import { IFileInfo, FileProcessingStatus } from '../useCSV'
 import { fileInfoMocks } from '../_mocks'
 
 jest.mock('axios')

--- a/client/src/components/Atoms/StatusTag.tsx
+++ b/client/src/components/Atoms/StatusTag.tsx
@@ -35,7 +35,7 @@ interface IStatusTagProps extends Omit<ITagProps, 'minimal'> {
   progress?: number
 }
 
-export const StatusTag: React.FC<IStatusTagProps> = ({
+const StatusTag: React.FC<IStatusTagProps> = ({
   progress,
   children,
   ...props

--- a/client/src/components/Atoms/Steps.tsx
+++ b/client/src/components/Atoms/Steps.tsx
@@ -66,8 +66,7 @@ const StepListItemCircle = styled.div<{
   font-weight: 500;
 `
 
-// eslint-disable-next-line no-unused-vars
-export const StepListItem = styled(({ current, ...props }) => (
+export const StepListItem = styled(({ current: _, ...props }) => (
   <H5 {...props} />
 ))<{ current: boolean }>`
   color: ${props => (props.current ? Colors.DARK_GRAY1 : Colors.GRAY3)};

--- a/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/no-autofocus */
 import React, { useState } from 'react'
-import { useParams } from 'react-router-dom'
 import {
   HTMLTable,
   Colors,

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
@@ -3,10 +3,7 @@ import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ToastContainer } from 'react-toastify'
 import { useParams } from 'react-router-dom'
-import AuthDataProvider, {
-  useAuthDataContext,
-  IJurisdictionAdmin,
-} from '../UserContext'
+import AuthDataProvider, { useAuthDataContext } from '../UserContext'
 import JurisdictionAdminView from './JurisdictionAdminView'
 import { renderWithRouter, withMockFetch, serverError } from '../testUtilities'
 import {

--- a/client/src/components/TallyEntryUser/TallyEntryLoginScreen.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryLoginScreen.tsx
@@ -12,7 +12,7 @@ import {
 } from '@blueprintjs/core'
 import { useForm } from 'react-hook-form'
 import { useMutation, useQueryClient } from 'react-query'
-import { Inner, Wrapper } from '../Atoms/Wrapper'
+import { Inner } from '../Atoms/Wrapper'
 import { ITallyEntryUser, IMember } from '../UserContext'
 import { fetchApi } from '../../utils/api'
 

--- a/client/src/components/TallyEntryUser/TallyEntryScreen.test.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { QueryClientProvider } from 'react-query'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { tallyEntryApiCalls } from '../_mocks'
 import TallyEntryScreen from './TallyEntryScreen'
 import { queryClient } from '../../App'


### PR DESCRIPTION
Mostly just unused variables and a few other small things. Also added `--cache` to the eslint command to make it faster.