### PR TITLE
Remove all state logic from Steps component

### DIFF
--- a/client/src/components/Atoms/Steps.test.tsx
+++ b/client/src/components/Atoms/Steps.test.tsx
@@ -1,16 +1,29 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { Button, Colors } from '@blueprintjs/core'
-import { Steps, StepList, StepListItem, StepPanel, StepActions } from './Steps'
+import {
+  Steps,
+  StepList,
+  StepListItem,
+  StepPanel,
+  StepActions,
+  stepState,
+} from './Steps'
 
 describe('Steps', () => {
   it('renders a step list, panel, and actions', () => {
     render(
       <Steps>
         <StepList>
-          <StepListItem>Log In</StepListItem>
-          <StepListItem current>Prepare</StepListItem>
-          <StepListItem>Audit Ballots</StepListItem>
+          <StepListItem stepNumber={1} state="complete">
+            Log In
+          </StepListItem>
+          <StepListItem stepNumber={2} state="current">
+            Prepare
+          </StepListItem>
+          <StepListItem stepNumber={3} state="incomplete">
+            Audit Ballots
+          </StepListItem>
         </StepList>
         <StepPanel>Prepare your ballots</StepPanel>
         <StepActions
@@ -52,5 +65,12 @@ describe('Steps', () => {
 
     screen.getByRole('button', { name: 'Back' })
     screen.getByRole('button', { name: 'Next' })
+  })
+
+  it('has a stepState helper to determine step state in the common case', () => {
+    const currentStepNumber = 2
+    expect(stepState(1, currentStepNumber)).toBe('complete')
+    expect(stepState(2, currentStepNumber)).toBe('current')
+    expect(stepState(3, currentStepNumber)).toBe('incomplete')
   })
 })

--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -26,8 +26,9 @@ import {
   StepPanel,
   StepActions,
   Steps,
-  StepListItem,
   StepList,
+  StepListItem,
+  stepState,
 } from '../Atoms/Steps'
 
 const STEPS = [
@@ -326,6 +327,7 @@ const BatchInventorySteps: React.FC<{
   const [currentStep, setCurrentStep] = useState<typeof STEPS[number]>(
     initialStep
   )
+  const currentStepNumber = STEPS.indexOf(currentStep) + 1
 
   return (
     <Wrapper>
@@ -342,8 +344,12 @@ const BatchInventorySteps: React.FC<{
         </HeadingRow>
         <Steps>
           <StepList>
-            {STEPS.map(step => (
-              <StepListItem key={step} current={step === currentStep}>
+            {STEPS.map((step, index) => (
+              <StepListItem
+                key={step}
+                stepNumber={index + 1}
+                state={stepState(index + 1, currentStepNumber)}
+              >
                 {step}
               </StepListItem>
             ))}


### PR DESCRIPTION
I realized that the approach of marking one `StepListItem` with a `current` prop was brittle - if the `StepListItem` wasn't a direct child of `StepList`, there was no way to access the `current` prop in `StepList`.

Also, upon using the components more, I think they will be easier to reason about if they are purely graphical and completely controlled.