### PR TITLE
Tally entry login error screen

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -236,12 +236,11 @@ describe('App', () => {
       })
     })
 
-    it('redirects to login screen when unauthenticated', async () => {
+    it('shows an error message when unauthenticated', async () => {
       const expectedCalls = [apiMocks.failedAuth, apiMocks.failedAuth]
       await withMockFetch(expectedCalls, async () => {
-        const { history } = renderView('/tally-entry')
-        await screen.findByRole('button', { name: 'Log in to your audit' })
-        expect(history.location.pathname).toEqual('/')
+        renderView('/tally-entry')
+        await screen.findByRole('heading', { name: 'You’re logged out' })
       })
     })
 

--- a/client/src/components/TallyEntryUser/TallyEntryUserView.test.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryUserView.test.tsx
@@ -21,7 +21,7 @@ describe('TallyEntryUserView', () => {
     const expectedCalls = [apiCalls.unauthenticatedUser]
     await withMockFetch(expectedCalls, async () => {
       renderView()
-      await screen.findByRole('heading', { name: "You're logged out" })
+      await screen.findByRole('heading', { name: 'You’re logged out' })
       screen.getByText('To log in, enter your login link in the URL bar.')
     })
   })
@@ -31,7 +31,7 @@ describe('TallyEntryUserView', () => {
     await withMockFetch(expectedCalls, async () => {
       renderView({ route: '/tally-entry?error=login_link_not_found' })
       await screen.findByRole('heading', {
-        name: "We couldn't find the login link you entered",
+        name: 'We couldn’t find the login link you entered',
       })
       screen.getByText(
         'Did you make a typo? Please try entering your login link again.'

--- a/client/src/components/TallyEntryUser/TallyEntryUserView.test.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryUserView.test.tsx
@@ -4,19 +4,41 @@ import { QueryClientProvider } from 'react-query'
 import TallyEntryUserView from './TallyEntryUserView'
 import { queryClient } from '../../App'
 import { withMockFetch, renderWithRouter } from '../testUtilities'
-import { tallyEntryApiCalls, tallyEntryUser } from '../_mocks'
+import { tallyEntryApiCalls, tallyEntryUser, apiCalls } from '../_mocks'
 import { contestMocks } from '../AuditAdmin/useSetupMenuItems/_mocks'
 import { batchesMocks } from '../JurisdictionAdmin/_mocks'
 
-const renderView = () =>
+const renderView = ({ route = '/tally-entry' }: { route?: string } = {}) =>
   renderWithRouter(
     <QueryClientProvider client={queryClient}>
       <TallyEntryUserView />
     </QueryClientProvider>,
-    { route: '/tally-entry' }
+    { route }
   )
 
 describe('TallyEntryUserView', () => {
+  it('shows an error screen when the user is not logged in', async () => {
+    const expectedCalls = [apiCalls.unauthenticatedUser]
+    await withMockFetch(expectedCalls, async () => {
+      renderView()
+      await screen.findByRole('heading', { name: "You're logged out" })
+      screen.getByText('To log in, enter your login link in the URL bar.')
+    })
+  })
+
+  it('shows an error screen when the user types the wrong login link', async () => {
+    const expectedCalls = [apiCalls.unauthenticatedUser]
+    await withMockFetch(expectedCalls, async () => {
+      renderView({ route: '/tally-entry?error=login_link_not_found' })
+      await screen.findByRole('heading', {
+        name: "We couldn't find the login link you entered",
+      })
+      screen.getByText(
+        'Did you make a typo? Please try entering your login link again.'
+      )
+    })
+  })
+
   it('shows the login start screen when the user has not started logging in', async () => {
     const expectedCalls = [tallyEntryApiCalls.getUser(tallyEntryUser.initial)]
     await withMockFetch(expectedCalls, async () => {

--- a/client/src/components/TallyEntryUser/TallyEntryUserView.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryUserView.tsx
@@ -16,13 +16,13 @@ const TallyEntryNotLoggedInScreen: React.FC = () => {
   const { headline, details } = (() => {
     if (query.get('error') === 'login_link_not_found') {
       return {
-        headline: "We couldn't find the login link you entered",
+        headline: 'We couldn’t find the login link you entered',
         details:
           'Did you make a typo? Please try entering your login link again.',
       }
     }
     return {
-      headline: "You're logged out",
+      headline: 'You’re logged out',
       details: 'To log in, enter your login link in the URL bar.',
     }
   })()

--- a/client/src/components/TallyEntryUser/TallyEntryUserView.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryUserView.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { H1, Icon, Classes } from '@blueprintjs/core'
-import { useLocation } from 'react-router-dom'
+import { useLocation, Redirect } from 'react-router-dom'
 import useCurrentUser from './useCurrentUser'
 import TallyEntryLoginScreen from './TallyEntryLoginScreen'
 import TallyEntryScreen from './TallyEntryScreen'
@@ -56,8 +56,11 @@ const TallyEntryUserView: React.FC = () => {
   if (!userQuery.isSuccess) return null // Still loading
 
   const user = userQuery.data
-  if (user?.type !== 'tally_entry') {
+  if (!user) {
     return <TallyEntryNotLoggedInScreen />
+  }
+  if (user.type !== 'tally_entry') {
+    return <Redirect to="/" />
   }
 
   return (

--- a/client/src/components/TallyEntryUser/TallyEntryUserView.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryUserView.tsx
@@ -1,10 +1,46 @@
 import React from 'react'
-import { Redirect } from 'react-router-dom'
+import { H1, Icon, Classes } from '@blueprintjs/core'
+import { useLocation } from 'react-router-dom'
 import useCurrentUser from './useCurrentUser'
 import TallyEntryLoginScreen from './TallyEntryLoginScreen'
 import TallyEntryScreen from './TallyEntryScreen'
 import { IUser } from '../UserContext'
 import { HeaderTallyEntry } from '../Header'
+import { Inner } from '../Atoms/Wrapper'
+import { Column } from '../Atoms/Layout'
+
+const TallyEntryNotLoggedInScreen: React.FC = () => {
+  // Support an 'error' query parameter.
+  // We use this to communicate authentication errors to the user.
+  const query = new URLSearchParams(useLocation().search)
+  const { headline, details } = (() => {
+    if (query.get('error') === 'login_link_not_found') {
+      return {
+        headline: "We couldn't find the login link you entered",
+        details:
+          'Did you make a typo? Please try entering your login link again.',
+      }
+    }
+    return {
+      headline: "You're logged out",
+      details: 'To log in, enter your login link in the URL bar.',
+    }
+  })()
+
+  return (
+    <>
+      <Inner flexDirection="column">
+        <Column alignItems="center" gap="30px" style={{ marginTop: '100px' }}>
+          <Icon icon="warning-sign" intent="warning" iconSize={100} />
+          <Column alignItems="center" gap="10px">
+            <H1>{headline}</H1>
+            <p className={Classes.TEXT_LARGE}>{details}</p>
+          </Column>
+        </Column>
+      </Inner>
+    </>
+  )
+}
 
 const TallyEntryUserView: React.FC = () => {
   const userQuery = useCurrentUser({
@@ -21,8 +57,7 @@ const TallyEntryUserView: React.FC = () => {
 
   const user = userQuery.data
   if (user?.type !== 'tally_entry') {
-    // TODO figure out when this would happen and handle this case better
-    return <Redirect to="/" />
+    return <TallyEntryNotLoggedInScreen />
   }
 
   return (

--- a/server/auth/auth_routes.py
+++ b/server/auth/auth_routes.py
@@ -12,8 +12,6 @@ from werkzeug.exceptions import BadRequest, Conflict
 from xkcdpass import xkcd_password as xp
 from server.api.rounds import get_current_round
 
-from server.util.redirect import redirect
-
 from . import auth
 from ..models import *  # pylint: disable=wildcard-import
 from ..database import db_session
@@ -30,6 +28,7 @@ from .auth_helpers import (
 from ..api.audit_boards import WORDS, serialize_members, validate_members
 from ..activity_log import JurisdictionAdminLogin, record_activity, ActivityBase
 from ..util.isoformat import isoformat
+from ..util.redirect import redirect
 from ..config import (
     SMTP_HOST,
     SMTP_PASSWORD,
@@ -349,9 +348,13 @@ def tally_entry_passphrase(passphrase: str):
     jurisdiction = Jurisdiction.query.filter_by(
         tally_entry_passphrase=passphrase
     ).one_or_none()
-    # TODO redirect to a nice error screen that explains they probably made a typo
     if jurisdiction is None:
-        raise NotFound()
+        return redirect(
+            "/tally-entry?"
+            + urlencode(
+                {"error": "login_link_not_found", "message": "Login link not found."}
+            )
+        )
 
     tally_entry_user = TallyEntryUser(
         id=str(uuid.uuid4()), jurisdiction_id=jurisdiction.id,

--- a/server/auth/auth_routes.py
+++ b/server/auth/auth_routes.py
@@ -349,12 +349,7 @@ def tally_entry_passphrase(passphrase: str):
         tally_entry_passphrase=passphrase
     ).one_or_none()
     if jurisdiction is None:
-        return redirect(
-            "/tally-entry?"
-            + urlencode(
-                {"error": "login_link_not_found", "message": "Login link not found."}
-            )
-        )
+        return redirect("/tally-entry?" + urlencode({"error": "login_link_not_found"}))
 
     tally_entry_user = TallyEntryUser(
         id=str(uuid.uuid4()), jurisdiction_id=jurisdiction.id,

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -772,7 +772,7 @@ def test_tally_entry_invalid_passphrase(
     assert rv.status_code == 302
     location = urlparse(rv.location)
     assert location.path == "/tally-entry"
-    assert location.query == "error=login_link_not_found&message=Login+link+not+found."
+    assert location.query == "error=login_link_not_found"
 
 
 def test_tally_entry_invalid_members(

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -769,7 +769,10 @@ def test_tally_entry_invalid_passphrase(
     # As an un-logged-in user, visit an incorrect login link
     login_link = "/tallyentry/invalid-passphrase"
     rv = tally_entry_client.get(login_link)
-    assert rv.status_code == 404
+    assert rv.status_code == 302
+    location = urlparse(rv.location)
+    assert location.path == "/tally-entry"
+    assert location.query == "error=login_link_not_found&message=Login+link+not+found."
 
 
 def test_tally_entry_invalid_members(


### PR DESCRIPTION
Adds an error screen for two cases:
1. The user types in their login link incorrectly
<img width="1312" alt="Screen Shot 2022-10-20 at 2 30 30 PM" src="https://user-images.githubusercontent.com/530106/197065500-084fb801-dc9f-4d11-95a2-95a404260f8c.png">

2. Someone tries to go to /tally-entry without being logged in
<img width="1312" alt="Screen Shot 2022-10-20 at 2 30 38 PM" src="https://user-images.githubusercontent.com/530106/197065525-f2a0e078-162e-41ae-8ac8-818021bb69b7.png">
