### PR TITLE
Support Tools: Hide jurisdiction audit boards in batch comparison audits

### DIFF
--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -837,6 +837,24 @@ describe('Support Tools', () => {
     })
   })
 
+  it("jurisdiction screen doesn't shows a list of audit boards for batch comparison audits", async () => {
+    const expectedCalls = [
+      supportApiCalls.getUser,
+      apiCalls.getJurisdiction({
+        ...mockJurisdiction,
+        election: { ...mockElection, auditType: 'BATCH_COMPARISON' },
+      }),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderRoute('/support/jurisdictions/jurisdiction-id-1')
+
+      await screen.findByRole('heading', { name: 'Jurisdiction 1' })
+      expect(
+        screen.queryByRole('heading', { name: 'Current Round Audit Boards' })
+      ).not.toBeInTheDocument()
+    })
+  })
+
   it('jurisdiction screen handles error', async () => {
     const expectedCalls = [
       supportApiCalls.getUser,

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -484,19 +484,23 @@ const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
       <H2>{name}</H2>
       <div style={{ display: 'flex', width: '100%' }}>
         <Column>
-          <H3>Current Round Audit Boards</H3>
-          {auditBoards.length === 0 ? (
-            <p>The jurisdiction hasn&apos;t created audit boards yet.</p>
-          ) : (
+          {election.auditType !== 'BATCH_COMPARISON' && (
             <>
-              <Button
-                intent="danger"
-                onClick={onClickClearAuditBoards}
-                style={{ marginBottom: '10px' }}
-              >
-                Clear audit boards
-              </Button>
-              <AuditBoardsTable auditBoards={auditBoards} />
+              <H3>Current Round Audit Boards</H3>
+              {auditBoards.length === 0 ? (
+                <p>The jurisdiction hasn&apos;t created audit boards yet.</p>
+              ) : (
+                <>
+                  <Button
+                    intent="danger"
+                    onClick={onClickClearAuditBoards}
+                    style={{ marginBottom: '10px' }}
+                  >
+                    Clear audit boards
+                  </Button>
+                  <AuditBoardsTable auditBoards={auditBoards} />
+                </>
+              )}
             </>
           )}
           {election.auditType === 'BALLOT_POLLING' && !election.online && (


### PR DESCRIPTION
Missed this in #1625 