### PR TITLE
Improve AA jurisdiction progress detail for batch comparison

### DIFF
--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
@@ -21,6 +21,7 @@ import {
   manifestFile,
   cvrsFile,
   talliesFile,
+  contestMocks,
 } from '../useSetupMenuItems/_mocks'
 import { aaApiCalls, jaApiCalls } from '../../_mocks'
 import { withMockFetch } from '../../testUtilities'
@@ -467,7 +468,7 @@ describe('JurisdictionDetail', () => {
         round: roundMocks.singleIncomplete[0],
       })
 
-      await screen.findByRole('heading', { name: 'Round 1 Data Entry' })
+      await screen.findByRole('heading', { name: 'Current Audit Round' })
 
       userEvent.click(
         screen.getByRole('button', {
@@ -540,7 +541,7 @@ describe('JurisdictionDetail', () => {
         round: roundMocks.singleIncomplete[0],
       })
 
-      await screen.findByRole('heading', { name: 'Round 1 Data Entry' })
+      await screen.findByRole('heading', { name: 'Current Audit Round' })
       screen.getByRole('button', {
         name: /Download Ballot Retrieval List/,
       })
@@ -566,6 +567,8 @@ describe('JurisdictionDetail', () => {
       jaApiCalls.getBatchTalliesFile(talliesMocks.processed),
       jaApiCalls.getAuditBoards(auditBoardMocks.unfinished),
       jaApiCalls.getBatches(batchesMocks.emptyInitial),
+      jaApiCalls.getBatches(batchesMocks.emptyInitial),
+      jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
     ]
     await withMockFetch(expectedCalls, async () => {
       render({
@@ -586,8 +589,28 @@ describe('JurisdictionDetail', () => {
         within(talliesCard).getByRole('button', { name: /Delete/ })
       ).toBeDisabled()
 
-      await screen.findByRole('heading', { name: 'Round 1 Data Entry' })
-      screen.getByText('Auditing in progress')
+      await screen.findByRole('heading', { name: 'Current Audit Round' })
+      userEvent.click(
+        screen.getByRole('button', {
+          name: /Download Batch Retrieval List/,
+        })
+      )
+      expect(window.open).toHaveBeenCalledWith(
+        '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/batches/retrieval-list'
+      )
+
+      userEvent.click(
+        screen.getByRole('button', { name: /Download Batch Tally Sheets/ })
+      )
+      await waitFor(() =>
+        expect(
+          mockSavePDF
+        ).toHaveBeenCalledWith(
+          'Batch Tally Sheets - Jurisdiction 1 - Test Audit.pdf',
+          { returnPromise: true }
+        )
+      )
+      mockSavePDF.mockClear()
     })
   })
 
@@ -669,10 +692,10 @@ describe('JurisdictionDetail', () => {
         round: roundMocks.singleIncomplete[0],
       })
 
-      await screen.findByText('Results finalized')
+      await screen.findByText('Tallies finalized')
 
       userEvent.click(
-        screen.getByRole('button', { name: 'Unfinalize Results' })
+        screen.getByRole('button', { name: 'Unfinalize Tallies' })
       )
       await waitFor(() => {
         expect(window.location.reload).toHaveBeenCalled()

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
@@ -7,6 +7,7 @@ import {
   Card,
   Button,
   HTMLSelect,
+  ButtonGroup,
 } from '@blueprintjs/core'
 import styled from 'styled-components'
 import { Formik, FormikProps } from 'formik'
@@ -27,6 +28,8 @@ import {
   ICvrsFileUpload,
 } from '../../useFileUpload'
 import AuditBoardsTable from './AuditBoardsTable'
+import DownloadBatchRetrievalListButton from '../../JurisdictionAdmin/BatchRoundSteps/DownloadBatchRetrievalListButton'
+import DownloadBatchTallySheetsButton from '../../JurisdictionAdmin/BatchRoundSteps/DownloadBatchTallySheetsButton'
 
 const StatusCard = styled(Card)`
   &:not(:last-child) {
@@ -337,7 +340,7 @@ const RoundStatusSection = ({
       if (auditSettings.auditType === 'BATCH_COMPARISON') {
         return (
           <div>
-            <p>Results finalized</p>
+            <p>Tallies finalized</p>
             <AsyncButton
               onClick={() =>
                 unfinalizeBatchResults({
@@ -348,7 +351,7 @@ const RoundStatusSection = ({
               }
               intent="danger"
             >
-              Unfinalize Results
+              Unfinalize Tallies
             </AsyncButton>
           </div>
         )
@@ -362,7 +365,22 @@ const RoundStatusSection = ({
     }
 
     if (auditSettings.auditType === 'BATCH_COMPARISON') {
-      return <p>Auditing in progress</p>
+      return (
+        <ButtonGroup vertical alignText="left">
+          <DownloadBatchRetrievalListButton
+            electionId={electionId}
+            jurisdictionId={jurisdiction.id}
+            roundId={round.id}
+          />
+          <DownloadBatchTallySheetsButton
+            electionId={electionId}
+            auditName={auditSettings.auditName}
+            jurisdictionId={jurisdiction.id}
+            jurisdictionName={jurisdiction.name}
+            roundId={round.id}
+          />
+        </ButtonGroup>
+      )
     }
 
     if (auditBoards.length === 0) {
@@ -388,7 +406,7 @@ const RoundStatusSection = ({
 
   return (
     <Section>
-      <H5>Round {round.roundNum} Data Entry</H5>
+      <H5>Current Audit Round</H5>
       {status}
     </Section>
   )

--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -606,7 +606,7 @@ describe('Progress screen', () => {
         .getByRole('heading', { name: 'Jurisdiction 1' })
         .closest('div.bp3-dialog')! as HTMLElement
       await within(modal).findByRole('heading', {
-        name: 'Round 1 Data Entry',
+        name: 'Current Audit Round',
       })
 
       // Tested further in JurisdictionDetail.test.tsx

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
@@ -186,9 +186,12 @@ describe('BatchRoundSteps', () => {
       userEvent.click(batchTallySheetButton)
       expect(batchTallySheetButton).toBeDisabled()
       await waitFor(() =>
-        expect(mockSavePDF).toHaveBeenCalledWith('Batch Tally Sheets.pdf', {
-          returnPromise: true,
-        })
+        expect(mockSavePDF).toHaveBeenCalledWith(
+          'Batch Tally Sheets - Jurisdiction One - audit one.pdf',
+          {
+            returnPromise: true,
+          }
+        )
       )
       expect(batchTallySheetButton).toBeEnabled()
     })

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/DownloadBatchRetrievalListButton.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/DownloadBatchRetrievalListButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { IButtonProps } from '@blueprintjs/core'
+import AsyncButton from '../../Atoms/AsyncButton'
+import { apiDownload } from '../../utilities'
+
+interface IDownloadBatchRetrievalListButtonProps extends IButtonProps {
+  electionId: string
+  jurisdictionId: string
+  roundId: string
+}
+
+const DownloadBatchRetrievalListButton: React.FC<IDownloadBatchRetrievalListButtonProps> = ({
+  electionId,
+  jurisdictionId,
+  roundId,
+  ...buttonProps
+}) => (
+  <AsyncButton
+    icon="download"
+    {...buttonProps}
+    onClick={() =>
+      apiDownload(
+        `/election/${electionId}/jurisdiction/${jurisdictionId}/round/${roundId}/batches/retrieval-list`
+      )
+    }
+  >
+    Download Batch Retrieval List
+  </AsyncButton>
+)
+
+export default DownloadBatchRetrievalListButton

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/DownloadBatchTallySheetsButton.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/DownloadBatchTallySheetsButton.tsx
@@ -2,14 +2,16 @@ import React from 'react'
 import { toast } from 'react-toastify'
 import * as Sentry from '@sentry/react'
 
-import AsyncButton from '../Atoms/AsyncButton'
-import useContestsJurisdictionAdmin from './useContestsJurisdictionAdmin'
-import { downloadBatchTallySheets } from './generateSheets'
-import { useBatches } from './useBatchResults'
-import { sleep } from '../../utils/sleep'
+import { IButtonProps } from '@blueprintjs/core'
+import AsyncButton from '../../Atoms/AsyncButton'
+import useContestsJurisdictionAdmin from '../useContestsJurisdictionAdmin'
+import { downloadBatchTallySheets } from '../generateSheets'
+import { useBatches } from '../useBatchResults'
+import { sleep } from '../../../utils/sleep'
 
-interface IProps {
+interface IDownloadBatchTallySheetsButtonProps extends IButtonProps {
   electionId: string
+  auditName: string
   jurisdictionId: string
   jurisdictionName: string
   roundId: string
@@ -17,10 +19,12 @@ interface IProps {
 
 const DownloadBatchTallySheetsButton = ({
   electionId,
+  auditName,
   jurisdictionId,
   jurisdictionName,
   roundId,
-}: IProps): JSX.Element | null => {
+  ...buttonProps
+}: IDownloadBatchTallySheetsButtonProps): JSX.Element | null => {
   const batchesQuery = useBatches(electionId, jurisdictionId, roundId)
   const contestsQuery = useContestsJurisdictionAdmin(electionId, jurisdictionId)
 
@@ -37,7 +41,12 @@ const DownloadBatchTallySheetsButton = ({
     const [contest] = contestsQuery.data
 
     try {
-      await downloadBatchTallySheets(batches, contest.choices, jurisdictionName)
+      await downloadBatchTallySheets(
+        batches,
+        contest.choices,
+        jurisdictionName,
+        auditName
+      )
     } catch (err) {
       toast.error('Error preparing batch tally sheets for download')
       Sentry.captureException(err)
@@ -45,7 +54,7 @@ const DownloadBatchTallySheetsButton = ({
   }
 
   return (
-    <AsyncButton icon="download" intent="primary" onClick={onClick}>
+    <AsyncButton icon="download" {...buttonProps} onClick={onClick}>
       Download Batch Tally Sheets
     </AsyncButton>
   )

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/PrepareBatchesStep.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/PrepareBatchesStep.tsx
@@ -3,10 +3,9 @@ import { H5, UL } from '@blueprintjs/core'
 import { IJurisdiction } from '../../UserContext'
 import { IRound } from '../../AuditAdmin/useRoundsAuditAdmin'
 import { StepPanel, StepPanelColumn, StepActions } from '../../Atoms/Steps'
-import { apiDownload } from '../../utilities'
-import DownloadBatchTallySheetsButton from '../DownloadBatchTallySheetsButton'
+import DownloadBatchTallySheetsButton from './DownloadBatchTallySheetsButton'
 import LinkButton from '../../Atoms/LinkButton'
-import AsyncButton from '../../Atoms/AsyncButton'
+import DownloadBatchRetrievalListButton from './DownloadBatchRetrievalListButton'
 
 interface IPrepareBatchesStepProps {
   nextStepUrl: string
@@ -24,17 +23,12 @@ const PrepareBatchesStep: React.FC<IPrepareBatchesStepProps> = ({
       <StepPanelColumn>
         <H5>Retrieve Batches from Storage</H5>
         <p>
-          <AsyncButton
-            icon="download"
+          <DownloadBatchRetrievalListButton
+            electionId={jurisdiction.election.id}
+            jurisdictionId={jurisdiction.id}
+            roundId={round.id}
             intent="primary"
-            onClick={() =>
-              apiDownload(
-                `/election/${jurisdiction.election.id}/jurisdiction/${jurisdiction.id}/round/${round.id}/batches/retrieval-list`
-              )
-            }
-          >
-            Download Batch Retrieval List
-          </AsyncButton>
+          />
         </p>
         <span>For each batch in the retrieval list:</span>
         <UL>
@@ -48,9 +42,11 @@ const PrepareBatchesStep: React.FC<IPrepareBatchesStepProps> = ({
         <p>
           <DownloadBatchTallySheetsButton
             electionId={jurisdiction.election.id}
+            auditName={jurisdiction.election.auditName}
             jurisdictionId={jurisdiction.id}
             jurisdictionName={jurisdiction.name}
             roundId={round.id}
+            intent="primary"
           />
         </p>
         <p>

--- a/client/src/components/JurisdictionAdmin/generateSheets.test.tsx
+++ b/client/src/components/JurisdictionAdmin/generateSheets.test.tsx
@@ -327,28 +327,36 @@ describe('generateSheets', () => {
       const pdf = await downloadBatchTallySheets(
         mockBatches,
         constructContestChoices(2),
-        mockJurisdiction.name
+        mockJurisdiction.name,
+        mockJurisdiction.election.auditName
       )
       await expect(Buffer.from(pdf)).toMatchPdfSnapshot({
         tolerance: diffTolerance,
       })
-      expect(mockSavePDF).toHaveBeenCalledWith('Batch Tally Sheets.pdf', {
-        returnPromise: true,
-      })
+      expect(mockSavePDF).toHaveBeenCalledWith(
+        'Batch Tally Sheets - Jurisdiction One - audit one.pdf',
+        {
+          returnPromise: true,
+        }
+      )
     })
 
     it('Handles single-batch case', async () => {
       const pdf = await downloadBatchTallySheets(
         [mockBatches[0]],
         constructContestChoices(2),
-        mockJurisdiction.name
+        mockJurisdiction.name,
+        mockJurisdiction.election.auditName
       )
       await expect(Buffer.from(pdf)).toMatchPdfSnapshot({
         tolerance: diffTolerance,
       })
-      expect(mockSavePDF).toHaveBeenCalledWith('Batch Tally Sheets.pdf', {
-        returnPromise: true,
-      })
+      expect(mockSavePDF).toHaveBeenCalledWith(
+        'Batch Tally Sheets - Jurisdiction One - audit one.pdf',
+        {
+          returnPromise: true,
+        }
+      )
     })
 
     it('Handles long content', async () => {
@@ -380,14 +388,18 @@ describe('generateSheets', () => {
       const pdf = await downloadBatchTallySheets(
         batches,
         contestChoices,
-        jurisdictionName
+        jurisdictionName,
+        'Test Audit'
       )
       await expect(Buffer.from(pdf)).toMatchPdfSnapshot({
         tolerance: diffTolerance,
       })
-      expect(mockSavePDF).toHaveBeenCalledWith('Batch Tally Sheets.pdf', {
-        returnPromise: true,
-      })
+      expect(mockSavePDF).toHaveBeenCalledWith(
+        `Batch Tally Sheets - ${jurisdictionName} - Test Audit.pdf`,
+        {
+          returnPromise: true,
+        }
+      )
     })
 
     it('Handles long content with no spaces', async () => {
@@ -415,14 +427,18 @@ describe('generateSheets', () => {
       const pdf = await downloadBatchTallySheets(
         batches,
         contestChoices,
-        jurisdictionName
+        jurisdictionName,
+        'Test Audit'
       )
       await expect(Buffer.from(pdf)).toMatchPdfSnapshot({
         tolerance: diffTolerance,
       })
-      expect(mockSavePDF).toHaveBeenCalledWith('Batch Tally Sheets.pdf', {
-        returnPromise: true,
-      })
+      expect(mockSavePDF).toHaveBeenCalledWith(
+        `Batch Tally Sheets - ${jurisdictionName} - Test Audit.pdf`,
+        {
+          returnPromise: true,
+        }
+      )
     })
 
     // Cover all possible after-table page breaks
@@ -431,7 +447,8 @@ describe('generateSheets', () => {
         const pdf = await downloadBatchTallySheets(
           mockBatches,
           constructContestChoices(6 + i),
-          mockJurisdiction.name
+          mockJurisdiction.name,
+          mockJurisdiction.election.auditName
         )
         await expect(Buffer.from(pdf)).toMatchPdfSnapshot({
           tolerance: diffTolerance,

--- a/client/src/components/JurisdictionAdmin/generateSheets.ts
+++ b/client/src/components/JurisdictionAdmin/generateSheets.ts
@@ -353,7 +353,8 @@ export const downloadAuditBoardCredentials = async (
 export const downloadBatchTallySheets = async (
   batches: IBatch[],
   contestChoices: ICandidate[],
-  jurisdictionName: string
+  jurisdictionName: string,
+  auditName: string
 ): Promise<string> => {
   const doc = new jsPDF({ format: 'letter', unit: 'pt' })
 
@@ -621,7 +622,10 @@ export const downloadBatchTallySheets = async (
     }
   }
 
-  await doc.save('Batch Tally Sheets.pdf', { returnPromise: true })
+  await doc.save(
+    `Batch Tally Sheets - ${jurisdictionName} - ${auditName}.pdf`,
+    { returnPromise: true }
+  )
   return doc.output() // Returned for snapshot tests
 }
 


### PR DESCRIPTION
- Add back the batch retrieval list/tally sheet buttons
- Rename the section "Current Audit Round"
- Change "Results finalized" -> "Tallies finalized"
- Add the jurisdiction name and audit name to the tally sheet file name to match the naming convention of other file downloads
<img width="539" alt="Screen Shot 2022-10-20 at 3 46 08 PM" src="https://user-images.githubusercontent.com/530106/197076880-45b0c33e-9aec-4b95-ad3a-82860b39a9c0.png">
<img width="561" alt="Screen Shot 2022-10-20 at 3 48 13 PM" src="https://user-images.githubusercontent.com/530106/197076884-8cfdd292-17d4-4fe1-83af-1592a6c15bd2.png">

