### PR TITLE
QueryClient test helper

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,28 +22,27 @@ import PublicPages from './components/PublicPages/PublicPages'
 import BatchInventory from './components/JurisdictionAdmin/BatchInventory'
 import TallyEntryUserView from './components/TallyEntryUser/TallyEntryUserView'
 
+export const queryClientDefaultOptions: DefaultOptions<ApiError> = {
+  queries: {
+    retry: (failureCount: number, error: ApiError): boolean =>
+      error.statusCode >= 500 && failureCount < 3, // Only retry server errors
+    onError: (error: ApiError): void => {
+      toast.error(error.message)
+    },
+    // When a file input dialog closes, it triggers a window focus event,
+    // which causes a refetch by default, so we turn that off to avoid confusion.
+    // https://github.com/tannerlinsley/react-query/issues/2960
+    refetchOnWindowFocus: false,
+  },
+  mutations: {
+    onError: (error: ApiError): void => {
+      toast.error(error.message)
+    },
+  },
+}
+
 export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: (failureCount, error: ApiError) =>
-        // Turn off query retries in test so we can mock effectively
-        process.env.NODE_ENV !== 'test' &&
-        error.statusCode >= 500 && // Only retry server errors
-        failureCount < 3,
-      onError: (error: ApiError) => {
-        toast.error(error.message)
-      },
-      // When a file input dialog closes, it triggers a window focus event,
-      // which causes a refetch by default, so we turn that off to avoid confusion.
-      // https://github.com/tannerlinsley/react-query/issues/2960
-      refetchOnWindowFocus: false,
-    },
-    mutations: {
-      onError: (error: ApiError) => {
-        toast.error(error.message)
-      },
-    },
-  } as DefaultOptions,
+  defaultOptions: queryClientDefaultOptions as DefaultOptions<unknown>,
 })
 
 const Main = styled.div`

--- a/client/src/components/Atoms/FileUpload.test.tsx
+++ b/client/src/components/Atoms/FileUpload.test.tsx
@@ -10,8 +10,12 @@ import {
   IFileUpload,
 } from '../useFileUpload'
 import FileUpload, { IFileUploadProps } from './FileUpload'
-import { withMockFetch, serverError, findAndCloseToast } from '../testUtilities'
-import { queryClient } from '../../App'
+import {
+  withMockFetch,
+  serverError,
+  findAndCloseToast,
+  createQueryClient,
+} from '../testUtilities'
 import { fileInfoMocks } from '../_mocks'
 
 jest.mock('axios')
@@ -54,7 +58,9 @@ const TestFileUpload = ({
 
 const render = (element: React.ReactElement) =>
   testingLibraryRender(
-    <QueryClientProvider client={queryClient}>{element}</QueryClientProvider>
+    <QueryClientProvider client={createQueryClient()}>
+      {element}
+    </QueryClientProvider>
   )
 
 const testFile = new File(['test content'], 'test-file.csv', {

--- a/client/src/components/AuditAdmin/AuditAdminView.test.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.test.tsx
@@ -13,7 +13,11 @@ import {
   manifestMocks,
   jurisdictionMocks,
 } from './useSetupMenuItems/_mocks'
-import { withMockFetch, renderWithRouter } from '../testUtilities'
+import {
+  withMockFetch,
+  renderWithRouter,
+  createQueryClient,
+} from '../testUtilities'
 import AuthDataProvider, { useAuthDataContext } from '../UserContext'
 import getJurisdictionFileStatus from './useSetupMenuItems/getJurisdictionFileStatus'
 import getRoundStatus from './useSetupMenuItems/getRoundStatus'
@@ -23,7 +27,6 @@ import {
   jurisdictionErrorFile,
   standardizedContestsFile,
 } from './Setup/Participants/_mocks'
-import { queryClient } from '../../App'
 
 const getJurisdictionFileStatusMock = getJurisdictionFileStatus as jest.Mock
 const getRoundStatusMock = getRoundStatus as jest.Mock
@@ -44,7 +47,7 @@ const AuditAdminViewWithAuth = (props: RouteProps) => {
 
 const render = (view = 'setup') =>
   renderWithRouter(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <AuthDataProvider>
         <Route
           path="/election/:electionId/:view?"

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
@@ -24,8 +24,7 @@ import {
   contestMocks,
 } from '../useSetupMenuItems/_mocks'
 import { aaApiCalls, jaApiCalls } from '../../_mocks'
-import { withMockFetch } from '../../testUtilities'
-import { queryClient } from '../../../App'
+import { withMockFetch, createQueryClient } from '../../testUtilities'
 import { dummyBallots } from '../../AuditBoard/_mocks'
 import { batchesMocks } from '../../JurisdictionAdmin/_mocks'
 
@@ -53,7 +52,7 @@ Object.defineProperty(window, 'location', {
 
 const render = (props: Partial<IJurisdictionDetailProps>) =>
   testingLibraryRender(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <JurisdictionDetail
         handleClose={jest.fn()}
         jurisdiction={jurisdictionMocks.noManifests[0]}

--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -11,12 +11,15 @@ import {
   auditBoardMocks,
   manifestMocks,
 } from '../useSetupMenuItems/_mocks'
-import { withMockFetch, renderWithRouter } from '../../testUtilities'
+import {
+  withMockFetch,
+  renderWithRouter,
+  createQueryClient,
+} from '../../testUtilities'
 import { aaApiCalls, jaApiCalls } from '../../_mocks'
 import Progress, { IProgressProps } from './Progress'
 import { dummyBallots } from '../../AuditBoard/_mocks'
 import * as utilities from '../../utilities'
-import { queryClient } from '../../../App'
 
 // Borrowed from generateSheets.test.tsx
 const mockSavePDF = jest.fn()
@@ -44,7 +47,7 @@ const expectStatusTag = (cell: HTMLElement, status: string, intent: Intent) => {
 
 const render = (props: Partial<IProgressProps> = {}) =>
   renderWithRouter(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <Route
         path="/election/:electionId/progress"
         render={routeProps => (

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
@@ -6,18 +6,18 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH jFbAHP"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-bdVaJa ibVpPq"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
+        class="bp3-card bp3-elevation-2 sc-cIShpX jsCPbJ"
       >
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -27,7 +27,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
           <br />
           <div>
             <div
-              class="sc-bxivhb fbVQhV"
+              class="sc-gzVnrw kvvweo"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -39,10 +39,10 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               
                Name
               <div
-                class="sc-bZQynM iEAxBy"
+                class="sc-gqjmRU egaEhI"
               >
                 <div
-                  class="bp3-input-group sc-gzVnrw htprzv"
+                  class="bp3-input-group sc-VigVT hfLuvB"
                 >
                   <input
                     class="bp3-input"
@@ -56,7 +56,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             </label>
           </div>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the number of winners for the contest.
           </div>
@@ -65,10 +65,10 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
           >
             Winners
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -81,7 +81,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             </div>
           </label>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -90,10 +90,10 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
           >
             Votes Allowed
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -107,7 +107,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
           </label>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -115,26 +115,26 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             Candidates/Choices & Vote Totals
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-gZMcBi knllut"
+            class="sc-gGBfsJ flKOcj"
           >
             <div
-              class="sc-gqjmRU gOWiEX"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -146,15 +146,15 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -167,18 +167,18 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <div
-              class="sc-gqjmRU gOWiEX"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -190,15 +190,15 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -211,14 +211,14 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <p
-              class="sc-fjdhpX digwQU"
+              class="sc-hEsumM kbocok"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -226,7 +226,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             Total Ballot Cards Cast
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -237,10 +237,10 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
              
             
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -254,7 +254,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
           </label>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -262,7 +262,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             Contest Universe
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -273,7 +273,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-chPdSV cAXnIg"
+                class="bp3-button sc-dnqmqq iQfLYL"
                 type="button"
               >
                 <span
@@ -287,10 +287,10 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
         </div>
       </div>
       <div
-        class="sc-jzJRlG kmWpbo"
+        class="sc-jqCOkK AxCAP"
       >
         <button
-          class="bp3-button sc-chPdSV cAXnIg"
+          class="bp3-button sc-dnqmqq iQfLYL"
           type="button"
         >
           <span
@@ -305,10 +305,10 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
       </div>
     </div>
     <div
-      class="sc-jzJRlG kmWpbo"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-chPdSV cAXnIg"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -318,7 +318,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
         </span>
       </button>
       <button
-        class="bp3-button bp3-intent-primary sc-chPdSV cAXnIg"
+        class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
         type="submit"
       >
         <span
@@ -338,18 +338,18 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH jFbAHP"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-bdVaJa ibVpPq"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
+        class="bp3-card bp3-elevation-2 sc-cIShpX jsCPbJ"
       >
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -359,7 +359,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           <br />
           <div>
             <div
-              class="sc-bxivhb fbVQhV"
+              class="sc-gzVnrw kvvweo"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -371,10 +371,10 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               
                Name
               <div
-                class="sc-bZQynM iEAxBy"
+                class="sc-gqjmRU egaEhI"
               >
                 <div
-                  class="bp3-input-group sc-gzVnrw htprzv"
+                  class="bp3-input-group sc-VigVT hfLuvB"
                 >
                   <input
                     class="bp3-input"
@@ -388,7 +388,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             </label>
           </div>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the number of winners for the contest.
           </div>
@@ -397,10 +397,10 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           >
             Winners
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -413,7 +413,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             </div>
           </label>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -422,10 +422,10 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -439,7 +439,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           </label>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -447,26 +447,26 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             Candidates/Choices & Vote Totals
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-gZMcBi knllut"
+            class="sc-gGBfsJ flKOcj"
           >
             <div
-              class="sc-gqjmRU gOWiEX"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -478,15 +478,15 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -499,18 +499,18 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-gqjmRU gOWiEX"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -522,15 +522,15 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -543,14 +543,14 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-fjdhpX digwQU"
+              class="sc-hEsumM kbocok"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -558,7 +558,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             Total Ballot Cards Cast
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -569,10 +569,10 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
              
             
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -586,7 +586,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           </label>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -594,7 +594,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             Contest Universe
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -605,7 +605,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-chPdSV cAXnIg"
+                class="bp3-button sc-dnqmqq iQfLYL"
                 type="button"
               >
                 <span
@@ -619,10 +619,10 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
         </div>
       </div>
       <div
-        class="sc-jzJRlG kmWpbo"
+        class="sc-jqCOkK AxCAP"
       >
         <button
-          class="bp3-button sc-chPdSV cAXnIg"
+          class="bp3-button sc-dnqmqq iQfLYL"
           type="button"
         >
           <span
@@ -637,10 +637,10 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-jzJRlG kmWpbo"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-chPdSV cAXnIg"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -650,7 +650,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-intent-primary sc-chPdSV cAXnIg"
+        class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
         type="submit"
       >
         <span
@@ -670,18 +670,18 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH jFbAHP"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-bdVaJa ibVpPq"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
+        class="bp3-card bp3-elevation-2 sc-cIShpX jsCPbJ"
       >
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -691,7 +691,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           <br />
           <div>
             <div
-              class="sc-bxivhb fbVQhV"
+              class="sc-gzVnrw kvvweo"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -703,10 +703,10 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               
                Name
               <div
-                class="sc-bZQynM iEAxBy"
+                class="sc-gqjmRU egaEhI"
               >
                 <div
-                  class="bp3-input-group sc-gzVnrw htprzv"
+                  class="bp3-input-group sc-VigVT hfLuvB"
                 >
                   <input
                     class="bp3-input"
@@ -720,7 +720,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             </label>
           </div>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the number of winners for the contest.
           </div>
@@ -729,10 +729,10 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           >
             Winners
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -745,7 +745,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             </div>
           </label>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -754,10 +754,10 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           >
             Votes Allowed
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -771,7 +771,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           </label>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -779,26 +779,26 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             Candidates/Choices & Vote Totals
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-gZMcBi knllut"
+            class="sc-gGBfsJ flKOcj"
           >
             <div
-              class="sc-gqjmRU gOWiEX"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -810,15 +810,15 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -831,18 +831,18 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <div
-              class="sc-gqjmRU gOWiEX"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -854,15 +854,15 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -875,14 +875,14 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <p
-              class="sc-fjdhpX digwQU"
+              class="sc-hEsumM kbocok"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -890,7 +890,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             Total Ballot Cards Cast
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -901,10 +901,10 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
              
             
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -918,7 +918,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           </label>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -926,7 +926,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             Contest Universe
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -937,7 +937,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-chPdSV cAXnIg"
+                class="bp3-button sc-dnqmqq iQfLYL"
                 type="button"
               >
                 <span
@@ -951,10 +951,10 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
         </div>
       </div>
       <div
-        class="sc-jzJRlG kmWpbo"
+        class="sc-jqCOkK AxCAP"
       >
         <button
-          class="bp3-button sc-chPdSV cAXnIg"
+          class="bp3-button sc-dnqmqq iQfLYL"
           type="button"
         >
           <span
@@ -969,10 +969,10 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
       </div>
     </div>
     <div
-      class="sc-jzJRlG kmWpbo"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-chPdSV cAXnIg"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -982,7 +982,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
         </span>
       </button>
       <button
-        class="bp3-button bp3-intent-primary sc-chPdSV cAXnIg"
+        class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
         type="submit"
       >
         <span
@@ -1002,18 +1002,18 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-bwzfXH jFbAHP"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-bdVaJa ibVpPq"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kGXeez drpedP"
+        class="bp3-card bp3-elevation-2 sc-cIShpX jsCPbJ"
       >
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -1023,7 +1023,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
           <br />
           <div>
             <div
-              class="sc-bxivhb fbVQhV"
+              class="sc-gzVnrw kvvweo"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -1035,10 +1035,10 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               
                Name
               <div
-                class="sc-bZQynM iEAxBy"
+                class="sc-gqjmRU egaEhI"
               >
                 <div
-                  class="bp3-input-group sc-gzVnrw htprzv"
+                  class="bp3-input-group sc-VigVT hfLuvB"
                 >
                   <input
                     class="bp3-input"
@@ -1052,7 +1052,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             </label>
           </div>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the number of winners for the contest.
           </div>
@@ -1061,10 +1061,10 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
           >
             Winners
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -1077,7 +1077,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             </div>
           </label>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -1086,10 +1086,10 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -1103,7 +1103,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
           </label>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -1111,26 +1111,26 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             Candidates/Choices & Vote Totals
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-gZMcBi knllut"
+            class="sc-gGBfsJ flKOcj"
           >
             <div
-              class="sc-gqjmRU gOWiEX"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -1142,15 +1142,15 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -1163,18 +1163,18 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-gqjmRU gOWiEX"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -1186,15 +1186,15 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jTzLTM hdHzOo"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-VigVT kbonos sc-bZQynM iEAxBy"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gzVnrw htprzv"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -1207,14 +1207,14 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-fjdhpX digwQU"
+              class="sc-hEsumM kbocok"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -1222,7 +1222,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             Total Ballot Cards Cast
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -1233,10 +1233,10 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
              
             
             <div
-              class="sc-bZQynM iEAxBy"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gzVnrw htprzv"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -1250,7 +1250,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
           </label>
         </div>
         <div
-          class="sc-htpNat hKxttc"
+          class="sc-bZQynM bGsEQi"
         >
           <h5
             class="bp3-heading"
@@ -1258,7 +1258,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             Contest Universe
           </h5>
           <div
-            class="sc-bxivhb fbVQhV"
+            class="sc-gzVnrw kvvweo"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -1269,7 +1269,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-chPdSV cAXnIg"
+                class="bp3-button sc-dnqmqq iQfLYL"
                 type="button"
               >
                 <span
@@ -1283,10 +1283,10 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
         </div>
       </div>
       <div
-        class="sc-jzJRlG kmWpbo"
+        class="sc-jqCOkK AxCAP"
       >
         <button
-          class="bp3-button sc-chPdSV cAXnIg"
+          class="bp3-button sc-dnqmqq iQfLYL"
           type="button"
         >
           <span
@@ -1301,10 +1301,10 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-jzJRlG kmWpbo"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-chPdSV cAXnIg"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -1314,7 +1314,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-intent-primary sc-chPdSV cAXnIg"
+        class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
         type="submit"
       >
         <span

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
@@ -6,15 +6,15 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-EHOje bjGJmd"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-ifAKCX cmZyyF"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-cIShpX jsCPbJ"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -40,7 +40,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                Name
               <br />
               <div
-                class="bp3-html-select sc-dxgOiQ fvmDat"
+                class="bp3-html-select sc-kafWEX kgSbTw"
               >
                 <select
                   field="[object Object]"
@@ -101,10 +101,10 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
           >
             Winners
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -126,10 +126,10 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -156,21 +156,21 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-gGBfsJ flKOcj"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -182,15 +182,15 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -203,18 +203,18 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -226,15 +226,15 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -247,7 +247,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <p
-              class="sc-kgoBCf jCkIWs"
+              class="sc-hEsumM kbocok"
             >
               Add a new candidate/choice
             </p>
@@ -255,10 +255,10 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
         </div>
       </div>
       <div
-        class="sc-bdVaJa kcYonD"
+        class="sc-jqCOkK AxCAP"
       >
         <button
-          class="bp3-button sc-bxivhb WkpPV"
+          class="bp3-button sc-dnqmqq iQfLYL"
           type="button"
         >
           <span
@@ -273,10 +273,10 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
       </div>
     </div>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-bxivhb WkpPV"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -286,7 +286,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
         type="submit"
       >
         <span

--- a/client/src/components/AuditAdmin/Setup/__snapshots__/Setup.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/__snapshots__/Setup.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`Setup renders Audit Settings stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-EHOje bjGJmd"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-ifAKCX cmZyyF"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Audit Settings
       </h2>
@@ -29,7 +29,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select sc-eNQAEJ izJEOO"
+              class="bp3-html-select sc-feJyhm bdjRUt"
             >
               <select
                 field="[object Object]"
@@ -385,10 +385,10 @@ exports[`Setup renders Audit Settings stage 1`] = `
             Enter the name of the election you are auditing.
           </p>
           <div
-            class="sc-gZMcBi ggdJUe"
+            class="sc-gqjmRU egaEhI"
           >
             <div
-              class="bp3-input-group sc-gqjmRU kmAUGh"
+              class="bp3-input-group sc-VigVT hfLuvB"
             >
               <input
                 aria-labelledby="election-name-label"
@@ -463,7 +463,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select sc-eNQAEJ izJEOO"
+              class="bp3-html-select sc-feJyhm bdjRUt"
             >
               <select
                 data-testid="risk-limit"
@@ -611,10 +611,10 @@ exports[`Setup renders Audit Settings stage 1`] = `
             Enter the random characters to seed the pseudo-random number generator.
           </p>
           <div
-            class="sc-gZMcBi ggdJUe"
+            class="sc-gqjmRU egaEhI"
           >
             <div
-              class="bp3-input-group sc-gqjmRU kmAUGh"
+              class="bp3-input-group sc-VigVT hfLuvB"
             >
               <input
                 aria-labelledby="random-seed-label"
@@ -631,10 +631,10 @@ exports[`Setup renders Audit Settings stage 1`] = `
       </div>
     </div>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-bxivhb WkpPV"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -644,7 +644,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -664,10 +664,10 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-EHOje bjGJmd"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-ifAKCX cmZyyF"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Audit Settings
       </h2>
@@ -687,7 +687,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select bp3-disabled sc-eNQAEJ izJEOO"
+              class="bp3-html-select bp3-disabled sc-feJyhm bdjRUt"
             >
               <select
                 disabled=""
@@ -1044,10 +1044,10 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
             Enter the name of the election you are auditing.
           </p>
           <div
-            class="sc-gZMcBi ggdJUe"
+            class="sc-gqjmRU egaEhI"
           >
             <div
-              class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+              class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
             >
               <input
                 aria-labelledby="election-name-label"
@@ -1125,7 +1125,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select bp3-disabled sc-eNQAEJ izJEOO"
+              class="bp3-html-select bp3-disabled sc-feJyhm bdjRUt"
             >
               <select
                 data-testid="risk-limit"
@@ -1274,10 +1274,10 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
             Enter the random characters to seed the pseudo-random number generator.
           </p>
           <div
-            class="sc-gZMcBi ggdJUe"
+            class="sc-gqjmRU egaEhI"
           >
             <div
-              class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+              class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
             >
               <input
                 aria-labelledby="random-seed-label"
@@ -1295,10 +1295,10 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
       </div>
     </div>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-bxivhb WkpPV"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -1308,7 +1308,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-disabled bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq iQfLYL"
         disabled=""
         tabindex="-1"
         type="button"
@@ -1330,10 +1330,10 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-EHOje bjGJmd"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-ifAKCX cmZyyF"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Audit Settings
       </h2>
@@ -1353,7 +1353,7 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select sc-eNQAEJ izJEOO"
+              class="bp3-html-select sc-feJyhm bdjRUt"
             >
               <select
                 field="[object Object]"
@@ -1709,10 +1709,10 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
             Enter the name of the election you are auditing.
           </p>
           <div
-            class="sc-gZMcBi ggdJUe"
+            class="sc-gqjmRU egaEhI"
           >
             <div
-              class="bp3-input-group sc-gqjmRU kmAUGh"
+              class="bp3-input-group sc-VigVT hfLuvB"
             >
               <input
                 aria-labelledby="election-name-label"
@@ -1787,7 +1787,7 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select sc-eNQAEJ izJEOO"
+              class="bp3-html-select sc-feJyhm bdjRUt"
             >
               <select
                 data-testid="risk-limit"
@@ -1935,10 +1935,10 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
             Enter the random characters to seed the pseudo-random number generator.
           </p>
           <div
-            class="sc-gZMcBi ggdJUe"
+            class="sc-gqjmRU egaEhI"
           >
             <div
-              class="bp3-input-group sc-gqjmRU kmAUGh"
+              class="bp3-input-group sc-VigVT hfLuvB"
             >
               <input
                 aria-labelledby="random-seed-label"
@@ -1990,15 +1990,15 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-EHOje bjGJmd"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-ifAKCX cmZyyF"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-cIShpX jsCPbJ"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -2023,10 +2023,10 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
               
                Name
               <div
-                class="sc-gZMcBi ggdJUe"
+                class="sc-gqjmRU egaEhI"
               >
                 <div
-                  class="bp3-input-group sc-gqjmRU kmAUGh"
+                  class="bp3-input-group sc-VigVT hfLuvB"
                 >
                   <input
                     class="bp3-input"
@@ -2049,10 +2049,10 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
           >
             Winners
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -2074,10 +2074,10 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -2104,21 +2104,21 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-gGBfsJ flKOcj"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2130,15 +2130,15 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2151,18 +2151,18 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2174,15 +2174,15 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2195,7 +2195,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
               </label>
             </div>
             <p
-              class="sc-kgoBCf jCkIWs"
+              class="sc-hEsumM kbocok"
             >
               Add a new candidate/choice
             </p>
@@ -2221,10 +2221,10 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
              
             
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -2257,7 +2257,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-bxivhb WkpPV"
+                class="bp3-button sc-dnqmqq iQfLYL"
                 type="button"
               >
                 <span
@@ -2271,10 +2271,10 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
         </div>
       </div>
       <div
-        class="sc-bdVaJa kcYonD"
+        class="sc-jqCOkK AxCAP"
       >
         <button
-          class="bp3-button sc-bxivhb WkpPV"
+          class="bp3-button sc-dnqmqq iQfLYL"
           type="button"
         >
           <span
@@ -2289,10 +2289,10 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
       </div>
     </div>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-bxivhb WkpPV"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -2302,7 +2302,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
         type="submit"
       >
         <span
@@ -2322,15 +2322,15 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
     data-testid="form-one"
   >
     <div
-      class="sc-EHOje bjGJmd"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-ifAKCX cmZyyF"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-cIShpX jsCPbJ"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -2355,10 +2355,10 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
               
                Name
               <div
-                class="sc-gZMcBi ggdJUe"
+                class="sc-gqjmRU egaEhI"
               >
                 <div
-                  class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                  class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
                 >
                   <input
                     class="bp3-input"
@@ -2382,10 +2382,10 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
           >
             Winners
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -2408,10 +2408,10 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
           >
             Votes Allowed
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -2439,21 +2439,21 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-gGBfsJ flKOcj"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                    class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2466,15 +2466,15 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                    class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2488,18 +2488,18 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                    class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2512,15 +2512,15 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                    class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2555,10 +2555,10 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
              
             
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -2592,7 +2592,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-bxivhb WkpPV"
+                class="bp3-button sc-dnqmqq iQfLYL"
                 type="button"
               >
                 <span
@@ -2606,10 +2606,10 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
         </div>
       </div>
       <div
-        class="sc-bdVaJa kcYonD"
+        class="sc-jqCOkK AxCAP"
       >
         <button
-          class="bp3-button sc-bxivhb WkpPV"
+          class="bp3-button sc-dnqmqq iQfLYL"
           type="button"
         >
           <span
@@ -2624,10 +2624,10 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
       </div>
     </div>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-bxivhb WkpPV"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -2637,7 +2637,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
         </span>
       </button>
       <button
-        class="bp3-button bp3-disabled bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq iQfLYL"
         disabled=""
         tabindex="-1"
         type="submit"
@@ -2659,15 +2659,15 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
     data-testid="form-one"
   >
     <div
-      class="sc-EHOje bjGJmd"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-ifAKCX cmZyyF"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-cIShpX jsCPbJ"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -2692,10 +2692,10 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
               
                Name
               <div
-                class="sc-gZMcBi ggdJUe"
+                class="sc-gqjmRU egaEhI"
               >
                 <div
-                  class="bp3-input-group sc-gqjmRU kmAUGh"
+                  class="bp3-input-group sc-VigVT hfLuvB"
                 >
                   <input
                     class="bp3-input"
@@ -2718,10 +2718,10 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
           >
             Winners
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -2743,10 +2743,10 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
           >
             Votes Allowed
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -2773,21 +2773,21 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-gGBfsJ flKOcj"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2799,15 +2799,15 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2820,18 +2820,18 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2843,15 +2843,15 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -2864,7 +2864,7 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
               </label>
             </div>
             <p
-              class="sc-kgoBCf jCkIWs"
+              class="sc-hEsumM kbocok"
             >
               Add a new candidate/choice
             </p>
@@ -2890,10 +2890,10 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
              
             
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -2926,7 +2926,7 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-bxivhb WkpPV"
+                class="bp3-button sc-dnqmqq iQfLYL"
                 type="button"
               >
                 <span
@@ -2940,10 +2940,10 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
         </div>
       </div>
       <div
-        class="sc-bdVaJa kcYonD"
+        class="sc-jqCOkK AxCAP"
       >
         <button
-          class="bp3-button sc-bxivhb WkpPV"
+          class="bp3-button sc-dnqmqq iQfLYL"
           type="button"
         >
           <span
@@ -2990,19 +2990,19 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
 exports[`Setup renders Participants stage 1`] = `
 <div>
   <div
-    class="sc-EHOje bjGJmd"
+    class="sc-hSdWYo hzbdZY"
   >
     <h2
-      class="bp3-heading sc-ifAKCX cmZyyF"
+      class="bp3-heading sc-iAyFgw cHZdIf"
     >
       Participants
     </h2>
     <form>
       <div
-        class="sc-EHOje bjGJmd"
+        class="sc-hSdWYo hzbdZY"
       >
         <h2
-          class="bp3-heading sc-ifAKCX cmZyyF"
+          class="bp3-heading sc-iAyFgw cHZdIf"
         />
         <div
           class="sc-bZQynM bGsEQi"
@@ -3043,7 +3043,7 @@ exports[`Setup renders Participants stage 1`] = `
             style="display: flex; margin-top: 15px; margin-bottom: 10px; align-items: center; width: 300px;"
           />
           <button
-            class="bp3-button bp3-intent-primary sc-bxivhb WkpPV"
+            class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
             type="submit"
           >
             <span
@@ -3056,10 +3056,10 @@ exports[`Setup renders Participants stage 1`] = `
       </div>
     </form>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
         type="submit"
       >
         <span
@@ -3076,19 +3076,19 @@ exports[`Setup renders Participants stage 1`] = `
 exports[`Setup renders Participants stage with locked next stage 1`] = `
 <div>
   <div
-    class="sc-EHOje bjGJmd"
+    class="sc-hSdWYo hzbdZY"
   >
     <h2
-      class="bp3-heading sc-ifAKCX cmZyyF"
+      class="bp3-heading sc-iAyFgw cHZdIf"
     >
       Participants
     </h2>
     <form>
       <div
-        class="sc-EHOje bjGJmd"
+        class="sc-hSdWYo hzbdZY"
       >
         <h2
-          class="bp3-heading sc-ifAKCX cmZyyF"
+          class="bp3-heading sc-iAyFgw cHZdIf"
         />
         <div
           class="sc-bZQynM bGsEQi"
@@ -3129,7 +3129,7 @@ exports[`Setup renders Participants stage with locked next stage 1`] = `
             style="display: flex; margin-top: 15px; margin-bottom: 10px; align-items: center; width: 300px;"
           />
           <button
-            class="bp3-button bp3-intent-primary sc-bxivhb WkpPV"
+            class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
             type="submit"
           >
             <span
@@ -3142,10 +3142,10 @@ exports[`Setup renders Participants stage with locked next stage 1`] = `
       </div>
     </form>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button bp3-disabled bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq iQfLYL"
         disabled=""
         tabindex="-1"
         type="submit"
@@ -3164,19 +3164,19 @@ exports[`Setup renders Participants stage with locked next stage 1`] = `
 exports[`Setup renders Participants stage with processing next stage 1`] = `
 <div>
   <div
-    class="sc-EHOje bjGJmd"
+    class="sc-hSdWYo hzbdZY"
   >
     <h2
-      class="bp3-heading sc-ifAKCX cmZyyF"
+      class="bp3-heading sc-iAyFgw cHZdIf"
     >
       Participants
     </h2>
     <form>
       <div
-        class="sc-EHOje bjGJmd"
+        class="sc-hSdWYo hzbdZY"
       >
         <h2
-          class="bp3-heading sc-ifAKCX cmZyyF"
+          class="bp3-heading sc-iAyFgw cHZdIf"
         />
         <div
           class="sc-bZQynM bGsEQi"
@@ -3217,7 +3217,7 @@ exports[`Setup renders Participants stage with processing next stage 1`] = `
             style="display: flex; margin-top: 15px; margin-bottom: 10px; align-items: center; width: 300px;"
           />
           <button
-            class="bp3-button bp3-intent-primary sc-bxivhb WkpPV"
+            class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
             type="submit"
           >
             <span
@@ -3230,10 +3230,10 @@ exports[`Setup renders Participants stage with processing next stage 1`] = `
       </div>
     </form>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
         type="submit"
       >
         <span
@@ -3251,7 +3251,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
 <div>
   <div>
     <h2
-      class="bp3-heading sc-ifAKCX cmZyyF"
+      class="bp3-heading sc-iAyFgw cHZdIf"
     >
       Review & Launch
     </h2>
@@ -3289,7 +3289,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
       class="bp3-card bp3-elevation-0"
     >
       <table
-        class="sc-hMqMXs kgAdZo"
+        class="sc-iELTvK gqejRJ"
       >
         <tbody>
           <tr>
@@ -3394,7 +3394,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
       >
         <div>
           <table
-            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-jKJlTe hDGQko"
+            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-kpOJdX glKwqV"
             style="width: 280px; margin-right: 20px;"
           >
             <thead>
@@ -3431,7 +3431,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
           style="width: 100%; position: relative; min-height: 140px;"
         >
           <table
-            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-jKJlTe uqzjr"
+            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-kpOJdX jGhzRA"
             style="position: absolute; height: 100%;"
           >
             <thead>
@@ -3503,10 +3503,10 @@ exports[`Setup renders Review & Launch stage 1`] = `
       </span>
     </div>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-bxivhb WkpPV"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -3516,7 +3516,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-disabled bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq iQfLYL"
         disabled=""
         tabindex="-1"
         type="button"
@@ -3536,7 +3536,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
 <div>
   <div>
     <h2
-      class="bp3-heading sc-ifAKCX cmZyyF"
+      class="bp3-heading sc-iAyFgw cHZdIf"
     >
       Review & Launch
     </h2>
@@ -3574,7 +3574,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
       class="bp3-card bp3-elevation-0"
     >
       <table
-        class="sc-hMqMXs kgAdZo"
+        class="sc-iELTvK gqejRJ"
       >
         <tbody>
           <tr>
@@ -3679,7 +3679,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
       >
         <div>
           <table
-            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-jKJlTe hDGQko"
+            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-kpOJdX glKwqV"
             style="width: 280px; margin-right: 20px;"
           >
             <thead>
@@ -3716,7 +3716,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
           style="width: 100%; position: relative; min-height: 140px;"
         >
           <table
-            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-jKJlTe uqzjr"
+            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-kpOJdX jGhzRA"
             style="position: absolute; height: 100%;"
           >
             <thead>
@@ -3788,10 +3788,10 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
       </span>
     </div>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-bxivhb WkpPV"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -3801,7 +3801,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-disabled bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq iQfLYL"
         disabled=""
         tabindex="-1"
         type="button"
@@ -3821,7 +3821,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
 <div>
   <div>
     <h2
-      class="bp3-heading sc-ifAKCX cmZyyF"
+      class="bp3-heading sc-iAyFgw cHZdIf"
     >
       Review & Launch
     </h2>
@@ -3859,7 +3859,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
       class="bp3-card bp3-elevation-0"
     >
       <table
-        class="sc-hMqMXs kgAdZo"
+        class="sc-iELTvK gqejRJ"
       >
         <tbody>
           <tr>
@@ -3964,7 +3964,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
       >
         <div>
           <table
-            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-jKJlTe hDGQko"
+            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-kpOJdX glKwqV"
             style="width: 280px; margin-right: 20px;"
           >
             <thead>
@@ -4001,7 +4001,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
           style="width: 100%; position: relative; min-height: 140px;"
         >
           <table
-            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-jKJlTe uqzjr"
+            class="bp3-html-table bp3-html-table-condensed bp3-html-table-striped sc-kpOJdX jGhzRA"
             style="position: absolute; height: 100%;"
           >
             <thead>
@@ -4073,10 +4073,10 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
       </span>
     </div>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-bxivhb WkpPV"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -4086,7 +4086,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-disabled bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq iQfLYL"
         disabled=""
         tabindex="-1"
         type="button"
@@ -4108,15 +4108,15 @@ exports[`Setup renders Target Contests stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-EHOje bjGJmd"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-ifAKCX cmZyyF"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-cIShpX jsCPbJ"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -4141,10 +4141,10 @@ exports[`Setup renders Target Contests stage 1`] = `
               
                Name
               <div
-                class="sc-gZMcBi ggdJUe"
+                class="sc-gqjmRU egaEhI"
               >
                 <div
-                  class="bp3-input-group sc-gqjmRU kmAUGh"
+                  class="bp3-input-group sc-VigVT hfLuvB"
                 >
                   <input
                     class="bp3-input"
@@ -4167,10 +4167,10 @@ exports[`Setup renders Target Contests stage 1`] = `
           >
             Winners
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -4192,10 +4192,10 @@ exports[`Setup renders Target Contests stage 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -4222,21 +4222,21 @@ exports[`Setup renders Target Contests stage 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-gGBfsJ flKOcj"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4248,15 +4248,15 @@ exports[`Setup renders Target Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4269,18 +4269,18 @@ exports[`Setup renders Target Contests stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4292,15 +4292,15 @@ exports[`Setup renders Target Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4313,7 +4313,7 @@ exports[`Setup renders Target Contests stage 1`] = `
               </label>
             </div>
             <p
-              class="sc-kgoBCf jCkIWs"
+              class="sc-hEsumM kbocok"
             >
               Add a new candidate/choice
             </p>
@@ -4339,10 +4339,10 @@ exports[`Setup renders Target Contests stage 1`] = `
              
             
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -4375,7 +4375,7 @@ exports[`Setup renders Target Contests stage 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-bxivhb WkpPV"
+                class="bp3-button sc-dnqmqq iQfLYL"
                 type="button"
               >
                 <span
@@ -4389,10 +4389,10 @@ exports[`Setup renders Target Contests stage 1`] = `
         </div>
       </div>
       <div
-        class="sc-bdVaJa kcYonD"
+        class="sc-jqCOkK AxCAP"
       >
         <button
-          class="bp3-button sc-bxivhb WkpPV"
+          class="bp3-button sc-dnqmqq iQfLYL"
           type="button"
         >
           <span
@@ -4407,10 +4407,10 @@ exports[`Setup renders Target Contests stage 1`] = `
       </div>
     </div>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-bxivhb WkpPV"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -4420,7 +4420,7 @@ exports[`Setup renders Target Contests stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
         type="submit"
       >
         <span
@@ -4440,15 +4440,15 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-EHOje bjGJmd"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-ifAKCX cmZyyF"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-cIShpX jsCPbJ"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -4473,10 +4473,10 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
               
                Name
               <div
-                class="sc-gZMcBi ggdJUe"
+                class="sc-gqjmRU egaEhI"
               >
                 <div
-                  class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                  class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
                 >
                   <input
                     class="bp3-input"
@@ -4500,10 +4500,10 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
           >
             Winners
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -4526,10 +4526,10 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -4557,21 +4557,21 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-gGBfsJ flKOcj"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                    class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4584,15 +4584,15 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                    class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4606,18 +4606,18 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                    class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4630,15 +4630,15 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                    class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4673,10 +4673,10 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
              
             
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group bp3-disabled sc-gqjmRU kmAUGh"
+                class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -4710,7 +4710,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-bxivhb WkpPV"
+                class="bp3-button sc-dnqmqq iQfLYL"
                 type="button"
               >
                 <span
@@ -4724,10 +4724,10 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
         </div>
       </div>
       <div
-        class="sc-bdVaJa kcYonD"
+        class="sc-jqCOkK AxCAP"
       >
         <button
-          class="bp3-button sc-bxivhb WkpPV"
+          class="bp3-button sc-dnqmqq iQfLYL"
           type="button"
         >
           <span
@@ -4742,10 +4742,10 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
       </div>
     </div>
     <div
-      class="sc-bdVaJa kcYonD"
+      class="sc-jqCOkK AxCAP"
     >
       <button
-        class="bp3-button sc-bxivhb WkpPV"
+        class="bp3-button sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -4755,7 +4755,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
         </span>
       </button>
       <button
-        class="bp3-button bp3-disabled bp3-intent-primary sc-bxivhb WkpPV"
+        class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq iQfLYL"
         disabled=""
         tabindex="-1"
         type="submit"
@@ -4777,15 +4777,15 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
     data-testid="form-one"
   >
     <div
-      class="sc-EHOje bjGJmd"
+      class="sc-hSdWYo hzbdZY"
     >
       <h2
-        class="bp3-heading sc-ifAKCX cmZyyF"
+        class="bp3-heading sc-iAyFgw cHZdIf"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-kpOJdX cxMGpA"
+        class="bp3-card bp3-elevation-2 sc-cIShpX jsCPbJ"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -4810,10 +4810,10 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
               
                Name
               <div
-                class="sc-gZMcBi ggdJUe"
+                class="sc-gqjmRU egaEhI"
               >
                 <div
-                  class="bp3-input-group sc-gqjmRU kmAUGh"
+                  class="bp3-input-group sc-VigVT hfLuvB"
                 >
                   <input
                     class="bp3-input"
@@ -4836,10 +4836,10 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
           >
             Winners
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -4861,10 +4861,10 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -4891,21 +4891,21 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jzJRlG hqJpHa"
+            class="sc-gGBfsJ flKOcj"
           >
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4917,15 +4917,15 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4938,18 +4938,18 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-cSHVUG jUKlPT"
+              class="sc-jnlKLf kLpYhO"
             >
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4961,15 +4961,15 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-chPdSV ewyFtw"
+                class="bp3-label sc-tilXH fnEhEh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kAzzGY ekBBqo sc-gZMcBi ggdJUe"
+                  class="sc-fYxtnH leTVyo sc-gqjmRU egaEhI"
                 >
                   <div
-                    class="bp3-input-group sc-gqjmRU kmAUGh"
+                    class="bp3-input-group sc-VigVT hfLuvB"
                   >
                     <input
                       class="bp3-input"
@@ -4982,7 +4982,7 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
               </label>
             </div>
             <p
-              class="sc-kgoBCf jCkIWs"
+              class="sc-hEsumM kbocok"
             >
               Add a new candidate/choice
             </p>
@@ -5008,10 +5008,10 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
              
             
             <div
-              class="sc-gZMcBi ggdJUe"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-gqjmRU kmAUGh"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -5044,7 +5044,7 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-bxivhb WkpPV"
+                class="bp3-button sc-dnqmqq iQfLYL"
                 type="button"
               >
                 <span
@@ -5058,10 +5058,10 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
         </div>
       </div>
       <div
-        class="sc-bdVaJa kcYonD"
+        class="sc-jqCOkK AxCAP"
       >
         <button
-          class="bp3-button sc-bxivhb WkpPV"
+          class="bp3-button sc-dnqmqq iQfLYL"
           type="button"
         >
           <span

--- a/client/src/components/AuditAdmin/__snapshots__/ActivityLog.test.tsx.snap
+++ b/client/src/components/AuditAdmin/__snapshots__/ActivityLog.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Activity Log shows a table of activity for the org 1`] = `
 <table
-  class="sc-htpNat cJosdG"
+  class="sc-kGXeez fVIhxz"
   id="activityLog"
   style="table-layout: auto;"
 >

--- a/client/src/components/AuditAdmin/timers.test.tsx
+++ b/client/src/components/AuditAdmin/timers.test.tsx
@@ -12,11 +12,14 @@ import getJurisdictionFileStatus from './useSetupMenuItems/getJurisdictionFileSt
 import getRoundStatus from './useSetupMenuItems/getRoundStatus'
 import AuthDataProvider, { useAuthDataContext } from '../UserContext'
 import AuditAdminView from './AuditAdminView'
-import { renderWithRouter, withMockFetch } from '../testUtilities'
+import {
+  renderWithRouter,
+  withMockFetch,
+  createQueryClient,
+} from '../testUtilities'
 import { aaApiCalls } from '../_mocks'
 import { auditSettings, roundMocks } from './useSetupMenuItems/_mocks'
 import { sampleSizeMock } from './Setup/Review/_mocks'
-import { queryClient } from '../../App'
 
 const getJurisdictionFileStatusMock = getJurisdictionFileStatus as jest.Mock
 const getRoundStatusMock = getRoundStatus as jest.Mock
@@ -35,7 +38,7 @@ const AuditAdminViewWithAuth: React.FC = () => {
 
 const renderWithRoute = (route: string, component: ReactElement) =>
   renderWithRouter(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <Route path="/election/:electionId/:view">
         <AuthDataProvider>{component}</AuthDataProvider>
       </Route>

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
 <div>
   <div
-    class="sc-htpNat cBZqYS"
+    class="sc-bdVaJa bKocXA"
   >
     <div
-      class="bp3-navbar sc-gisBJw dpeRNj"
+      class="bp3-navbar sc-bxivhb jwFLoW"
     >
       <div
-        class="sc-bxivhb sc-cHGsZl iPCsle"
+        class="sc-bwzfXH sc-EHOje eysEZT"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -58,22 +58,22 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
     </div>
     <div>
       <div
-        class="sc-bxivhb kYcBbd"
+        class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-csuQGl cKHbnJ"
+          class="sc-cbkKFq fxbNsw"
         >
           <div
-            class="sc-Rmtcm evvFKW"
+            class="sc-krvtoX icRbSZ"
           >
             <div
-              class="sc-bRBYWo eNFGUv"
+              class="sc-fYiAbW lqcPQ"
             >
               <div
-                class="sc-fBuWsC iwWyFr"
+                class="sc-gHboQg imMLsK"
               >
                 <button
-                  class="bp3-button bp3-minimal sc-jhAzac coxLCj"
+                  class="bp3-button bp3-minimal sc-dUjcNx eMyggx"
                   href="/election/1/audit-board/audit-board-1"
                   type="button"
                 >
@@ -103,56 +103,56 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                   </span>
                 </button>
                 <h3
-                  class="bp3-heading sc-gipzik eQUCeP"
+                  class="bp3-heading sc-eLExRp nHHTK"
                 >
                   Audit Ballot Selections
                 </h3>
               </div>
               <div
-                class="bp3-divider sc-ckVGcZ dgQdnS"
+                class="bp3-divider sc-cMhqgX fRdIfa"
               />
               <div
-                class="sc-cMljjf ijrbIJ"
+                class="sc-exAgwC goZCOj"
               >
                 <div>
                   <h5
-                    class="bp3-heading sc-jWBwVP bDsnAc"
+                    class="bp3-heading sc-iujRgT kMRTAR"
                   >
                     Tabulator
                   </h5>
                   <h4
-                    class="bp3-heading sc-jAaTju bJLMVU"
+                    class="bp3-heading sc-cQFLBn kIgTSX"
                   >
                     11
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-jWBwVP bDsnAc"
+                    class="bp3-heading sc-iujRgT kMRTAR"
                   >
                     Batch
                   </h5>
                   <h4
-                    class="bp3-heading sc-jAaTju bJLMVU"
+                    class="bp3-heading sc-cQFLBn kIgTSX"
                   >
                     0003-04-Precinct 19 (Jonesboro Fire Department)
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-jWBwVP bDsnAc"
+                    class="bp3-heading sc-iujRgT kMRTAR"
                   >
                     Ballot Number
                   </h5>
                   <h4
-                    class="bp3-heading sc-jAaTju bJLMVU"
+                    class="bp3-heading sc-cQFLBn kIgTSX"
                   >
                     2112
                   </h4>
                 </div>
                 <div>
                   <button
-                    class="bp3-button bp3-large bp3-intent-danger sc-jDwBTQ zUGYg"
+                    class="bp3-button bp3-large bp3-intent-danger sc-gojNiO EFNDE"
                     type="button"
                   >
                     <span
@@ -164,36 +164,36 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 </div>
               </div>
               <div
-                class="bp3-divider sc-ckVGcZ dgQdnS"
+                class="bp3-divider sc-cMhqgX fRdIfa"
               />
               <div
-                class="sc-jKJlTe brEhRC"
+                class="sc-iuJeZd enFSa"
               >
                 <div
                   class="ballot-main"
                 >
                   <h5
-                    class="bp3-heading sc-jWBwVP bDsnAc"
+                    class="bp3-heading sc-iujRgT kMRTAR"
                   >
                     Ballot Contests
                   </h5>
                   <form>
                     <div
-                      class="sc-eNQAEJ iFCaEp"
+                      class="sc-esOvli cNsbzE"
                     >
                       <div
-                        class="sc-hSdWYo chGHYH"
+                        class="sc-hORach gXWAmX"
                       >
                         <div
-                          class="sc-eHgmQL kYkRfs"
+                          class="sc-bMVAic jdZHzu"
                         >
                           <h3
-                            class="bp3-heading sc-iRbamj gePPsN"
+                            class="bp3-heading sc-bXGyLb hkGtwY"
                           >
                             Contest 1
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-brqgnP iQRexL"
+                            class="bp3-control bp3-checkbox sc-GMQeP fXkAKJ"
                           >
                             <input
                               type="checkbox"
@@ -209,7 +209,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-brqgnP iQRexL"
+                            class="bp3-control bp3-checkbox sc-GMQeP fXkAKJ"
                           >
                             <input
                               type="checkbox"
@@ -226,10 +226,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-cvbbAY ixevJx"
+                          class="sc-bAeIUo gJfspE"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-brqgnP iQRexL"
+                            class="bp3-control bp3-checkbox sc-GMQeP fXkAKJ"
                           >
                             <input
                               type="checkbox"
@@ -245,7 +245,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-brqgnP iQRexL"
+                            class="bp3-control bp3-checkbox sc-GMQeP fXkAKJ"
                           >
                             <input
                               type="checkbox"
@@ -261,7 +261,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-brqgnP iQRexL"
+                            class="bp3-control bp3-checkbox sc-GMQeP fXkAKJ"
                           >
                             <input
                               type="checkbox"
@@ -277,7 +277,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-gPEVay kBKLHX"
+                            class="bp3-input sc-daURTG gkyGTV"
                             name="comment-Contest 1"
                             placeholder="Add Note"
                           />
@@ -285,21 +285,21 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-eNQAEJ iFCaEp"
+                      class="sc-esOvli cNsbzE"
                     >
                       <div
-                        class="sc-hSdWYo chGHYH"
+                        class="sc-hORach gXWAmX"
                       >
                         <div
-                          class="sc-eHgmQL kYkRfs"
+                          class="sc-bMVAic jdZHzu"
                         >
                           <h3
-                            class="bp3-heading sc-iRbamj gePPsN"
+                            class="bp3-heading sc-bXGyLb hkGtwY"
                           >
                             Contest 2
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-brqgnP iQRexL"
+                            class="bp3-control bp3-checkbox sc-GMQeP fXkAKJ"
                           >
                             <input
                               type="checkbox"
@@ -315,7 +315,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-brqgnP iQRexL"
+                            class="bp3-control bp3-checkbox sc-GMQeP fXkAKJ"
                           >
                             <input
                               type="checkbox"
@@ -332,10 +332,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-cvbbAY ixevJx"
+                          class="sc-bAeIUo gJfspE"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-brqgnP iQRexL"
+                            class="bp3-control bp3-checkbox sc-GMQeP fXkAKJ"
                           >
                             <input
                               type="checkbox"
@@ -351,7 +351,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-brqgnP iQRexL"
+                            class="bp3-control bp3-checkbox sc-GMQeP fXkAKJ"
                           >
                             <input
                               type="checkbox"
@@ -367,7 +367,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-brqgnP iQRexL"
+                            class="bp3-control bp3-checkbox sc-GMQeP fXkAKJ"
                           >
                             <input
                               type="checkbox"
@@ -383,7 +383,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-gPEVay kBKLHX"
+                            class="bp3-input sc-daURTG gkyGTV"
                             name="comment-Contest 2"
                             placeholder="Add Note"
                           />
@@ -391,10 +391,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-kEYyzF hgMwhC"
+                      class="sc-hMFtBS yJghD"
                     >
                       <button
-                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-jlyJG ezzNhI sc-dxgOiQ iagcVQ"
+                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-lkqHmb lhzgYA sc-dnqmqq iQfLYL"
                         disabled=""
                         tabindex="-1"
                         type="submit"
@@ -421,7 +421,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
               </div>
             </div>
             <div
-              class="sc-hzDkRC kAgOIS"
+              class="sc-fOKMvo cJdnFg"
             >
               <h4
                 class="bp3-heading"
@@ -429,7 +429,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 Instructions
               </h4>
               <ol
-                class="bp3-list sc-fMiknA limQSO"
+                class="bp3-list sc-eilVRo jusmwY"
               >
                 <li>
                   Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -477,13 +477,13 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
 exports[`AuditBoardView ballot interaction renders board table with ballots 1`] = `
 <div>
   <div
-    class="sc-htpNat cBZqYS"
+    class="sc-bdVaJa bKocXA"
   >
     <div
-      class="bp3-navbar sc-gisBJw dpeRNj"
+      class="bp3-navbar sc-bxivhb jwFLoW"
     >
       <div
-        class="sc-bxivhb sc-cHGsZl iPCsle"
+        class="sc-bwzfXH sc-EHOje eysEZT"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -534,13 +534,13 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
       class="board-table-container"
     >
       <div
-        class="sc-bZQynM gcSISu"
+        class="sc-kIPQKe nGuVW"
       >
         <div
-          class="sc-bxivhb sc-gzVnrw cXrPFV"
+          class="sc-bwzfXH sc-eXEjpC erJefL"
         >
           <div
-            class="sc-ifAKCX Eaynb"
+            class="sc-kfGgVZ hhCIYU"
           >
             <p>
               18
@@ -549,23 +549,23 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-jTzLTM gLFziH"
+              class="summary-label sc-gwVKww bzMont"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-fjdhpX cExqPy"
+              class="summary-label sc-hXRMBi jCWpx"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-EHOje iSYCcM"
+            class="sc-esjQYD eSbAFP"
           >
             <button
-              class="bp3-button bp3-intent-success sc-cSHVUG cVsyeo"
+              class="bp3-button bp3-intent-success sc-iQNlJl jQIpgT"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -579,13 +579,13 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
         </div>
       </div>
       <div
-        class="sc-bxivhb kYcBbd"
+        class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-htoDjs hxAtLW"
+          class="sc-ibxdXY VlfBk"
         >
           <div
-            class="sc-dnqmqq iEAKuG"
+            class="sc-RefOD iOENTb"
           >
             <h3
               class="bp3-heading"
@@ -594,10 +594,10 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Audit Board #1
             </h3>
             <div
-              class="sc-iwsKbI cgDfoK"
+              class="sc-iQKALj TzEYR"
             >
               <table
-                class="sc-bdVaJa djjOKa"
+                class="sc-kGXeez fVIhxz"
                 role="table"
               >
                 <thead>
@@ -799,7 +799,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -809,7 +809,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -819,7 +819,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -829,7 +829,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -858,7 +858,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -877,7 +877,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -886,7 +886,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -895,7 +895,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -904,7 +904,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -913,7 +913,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -934,7 +934,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -944,7 +944,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -954,7 +954,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -964,7 +964,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -993,7 +993,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -1012,7 +1012,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1022,7 +1022,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1032,7 +1032,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1042,7 +1042,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1071,7 +1071,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -1090,7 +1090,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -1099,7 +1099,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1108,7 +1108,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -1117,7 +1117,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -1126,7 +1126,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -1147,7 +1147,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1157,7 +1157,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1167,7 +1167,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1177,7 +1177,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1206,7 +1206,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -1225,7 +1225,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1235,7 +1235,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1245,7 +1245,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1255,7 +1255,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1284,7 +1284,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -1303,7 +1303,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -1312,7 +1312,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1321,7 +1321,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -1330,7 +1330,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -1339,7 +1339,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -1360,7 +1360,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1370,7 +1370,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1380,7 +1380,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1390,7 +1390,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1419,7 +1419,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -1438,7 +1438,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1448,7 +1448,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1458,7 +1458,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1468,7 +1468,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1497,7 +1497,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -1516,7 +1516,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -1525,7 +1525,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1534,7 +1534,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -1543,7 +1543,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -1552,7 +1552,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -1573,7 +1573,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1583,7 +1583,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1593,7 +1593,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1603,7 +1603,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1632,7 +1632,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -1651,7 +1651,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1661,7 +1661,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1671,7 +1671,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1681,7 +1681,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1710,7 +1710,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -1729,7 +1729,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -1738,7 +1738,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1747,7 +1747,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -1756,7 +1756,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -1765,7 +1765,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -1786,7 +1786,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1796,7 +1796,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1806,7 +1806,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1816,7 +1816,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1845,7 +1845,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -1864,7 +1864,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1874,7 +1874,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1884,7 +1884,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1894,7 +1894,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1923,7 +1923,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -1942,7 +1942,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -1951,7 +1951,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1960,7 +1960,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -1969,7 +1969,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -1978,7 +1978,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -1999,7 +1999,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2009,7 +2009,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2019,7 +2019,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2029,7 +2029,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2058,7 +2058,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -2077,7 +2077,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2087,7 +2087,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2097,7 +2097,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2107,7 +2107,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2136,7 +2136,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -2155,7 +2155,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -2164,7 +2164,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2173,7 +2173,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -2182,7 +2182,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -2191,7 +2191,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -2212,7 +2212,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2222,7 +2222,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2232,7 +2232,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2242,7 +2242,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2271,7 +2271,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -2290,7 +2290,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2300,7 +2300,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2310,7 +2310,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2320,7 +2320,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2349,7 +2349,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -2368,7 +2368,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -2377,7 +2377,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2386,7 +2386,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -2395,7 +2395,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -2404,7 +2404,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -2425,7 +2425,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2435,7 +2435,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2445,7 +2445,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2455,7 +2455,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2484,7 +2484,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -2503,7 +2503,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2513,7 +2513,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2523,7 +2523,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2533,7 +2533,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2562,7 +2562,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -2581,7 +2581,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -2590,7 +2590,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2599,7 +2599,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -2608,7 +2608,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -2617,7 +2617,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -2638,7 +2638,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2648,7 +2648,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2658,7 +2658,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2668,7 +2668,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2697,7 +2697,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -2713,7 +2713,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-kAzzGY gZMjPs"
+              class="bp3-button bp3-disabled bp3-large sc-bsbRJL kyaRao"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -2727,7 +2727,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
             </button>
           </div>
           <div
-            class="sc-gZMcBi jxSIXn"
+            class="sc-bwCtUz heljAB"
           >
             <h4
               class="bp3-heading"
@@ -2735,7 +2735,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-jzJRlG bxayEV"
+              class="bp3-list sc-epnACN kVcBhQ"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -2758,13 +2758,13 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
 exports[`AuditBoardView ballot interaction renders board table with no audited ballots 1`] = `
 <div>
   <div
-    class="sc-htpNat cBZqYS"
+    class="sc-bdVaJa bKocXA"
   >
     <div
-      class="bp3-navbar sc-gisBJw dpeRNj"
+      class="bp3-navbar sc-bxivhb jwFLoW"
     >
       <div
-        class="sc-bxivhb sc-cHGsZl iPCsle"
+        class="sc-bwzfXH sc-EHOje eysEZT"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -2815,13 +2815,13 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
       class="board-table-container"
     >
       <div
-        class="sc-bZQynM gcSISu"
+        class="sc-kIPQKe nGuVW"
       >
         <div
-          class="sc-bxivhb sc-gzVnrw cXrPFV"
+          class="sc-bwzfXH sc-eXEjpC erJefL"
         >
           <div
-            class="sc-ifAKCX Eaynb"
+            class="sc-kfGgVZ hhCIYU"
           >
             <p>
               0
@@ -2830,23 +2830,23 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-jTzLTM gLFziH"
+              class="summary-label sc-gwVKww bzMont"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-fjdhpX cExqPy"
+              class="summary-label sc-hXRMBi jCWpx"
             >
               Not Audited: 
               27
             </span>
           </div>
           <div
-            class="sc-EHOje iSYCcM"
+            class="sc-esjQYD eSbAFP"
           >
             <button
-              class="bp3-button bp3-intent-success sc-cSHVUG cVsyeo"
+              class="bp3-button bp3-intent-success sc-iQNlJl jQIpgT"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
               type="button"
             >
@@ -2860,13 +2860,13 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
         </div>
       </div>
       <div
-        class="sc-bxivhb kYcBbd"
+        class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-htoDjs hxAtLW"
+          class="sc-ibxdXY VlfBk"
         >
           <div
-            class="sc-dnqmqq iEAKuG"
+            class="sc-RefOD iOENTb"
           >
             <h3
               class="bp3-heading"
@@ -2875,10 +2875,10 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Audit Board #1
             </h3>
             <div
-              class="sc-iwsKbI cgDfoK"
+              class="sc-iQKALj TzEYR"
             >
               <table
-                class="sc-bdVaJa djjOKa"
+                class="sc-kGXeez fVIhxz"
                 role="table"
               >
                 <thead>
@@ -3080,7 +3080,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3089,7 +3089,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3098,7 +3098,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         313
                       </p>
@@ -3107,7 +3107,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3116,7 +3116,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -3137,7 +3137,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3146,7 +3146,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3155,7 +3155,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -3164,7 +3164,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3173,7 +3173,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -3194,7 +3194,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3203,7 +3203,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3212,7 +3212,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         1789
                       </p>
@@ -3221,7 +3221,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3230,7 +3230,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -3251,7 +3251,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3260,7 +3260,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3269,7 +3269,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         313
                       </p>
@@ -3278,7 +3278,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3287,7 +3287,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -3308,7 +3308,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3317,7 +3317,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3326,7 +3326,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -3335,7 +3335,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3344,7 +3344,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -3365,7 +3365,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3374,7 +3374,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3383,7 +3383,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         1789
                       </p>
@@ -3392,7 +3392,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3401,7 +3401,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -3422,7 +3422,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3431,7 +3431,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3440,7 +3440,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         313
                       </p>
@@ -3449,7 +3449,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3458,7 +3458,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -3479,7 +3479,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3488,7 +3488,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3497,7 +3497,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -3506,7 +3506,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3515,7 +3515,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -3536,7 +3536,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3545,7 +3545,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3554,7 +3554,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         1789
                       </p>
@@ -3563,7 +3563,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3572,7 +3572,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -3593,7 +3593,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3602,7 +3602,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3611,7 +3611,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         313
                       </p>
@@ -3620,7 +3620,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3629,7 +3629,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -3650,7 +3650,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3659,7 +3659,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3668,7 +3668,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -3677,7 +3677,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3686,7 +3686,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -3707,7 +3707,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3716,7 +3716,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3725,7 +3725,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         1789
                       </p>
@@ -3734,7 +3734,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3743,7 +3743,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -3764,7 +3764,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3773,7 +3773,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3782,7 +3782,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         313
                       </p>
@@ -3791,7 +3791,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3800,7 +3800,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -3821,7 +3821,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3830,7 +3830,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3839,7 +3839,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -3848,7 +3848,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3857,7 +3857,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -3878,7 +3878,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3887,7 +3887,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3896,7 +3896,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         1789
                       </p>
@@ -3905,7 +3905,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3914,7 +3914,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -3935,7 +3935,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -3944,7 +3944,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3953,7 +3953,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         313
                       </p>
@@ -3962,7 +3962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -3971,7 +3971,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -3992,7 +3992,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -4001,7 +4001,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4010,7 +4010,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -4019,7 +4019,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -4028,7 +4028,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -4049,7 +4049,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -4058,7 +4058,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4067,7 +4067,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         1789
                       </p>
@@ -4076,7 +4076,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -4085,7 +4085,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -4106,7 +4106,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -4115,7 +4115,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4124,7 +4124,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         313
                       </p>
@@ -4133,7 +4133,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -4142,7 +4142,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -4163,7 +4163,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -4172,7 +4172,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4181,7 +4181,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -4190,7 +4190,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -4199,7 +4199,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -4220,7 +4220,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -4229,7 +4229,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4238,7 +4238,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         1789
                       </p>
@@ -4247,7 +4247,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -4256,7 +4256,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -4277,7 +4277,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -4286,7 +4286,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4295,7 +4295,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         313
                       </p>
@@ -4304,7 +4304,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -4313,7 +4313,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -4334,7 +4334,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -4343,7 +4343,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4352,7 +4352,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -4361,7 +4361,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -4370,7 +4370,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -4391,7 +4391,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -4400,7 +4400,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4409,7 +4409,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         1789
                       </p>
@@ -4418,7 +4418,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -4427,7 +4427,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -4448,7 +4448,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -4457,7 +4457,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4466,7 +4466,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         313
                       </p>
@@ -4475,7 +4475,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -4484,7 +4484,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -4505,7 +4505,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -4514,7 +4514,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4523,7 +4523,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -4532,7 +4532,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -4541,7 +4541,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -4562,7 +4562,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -4571,7 +4571,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4580,7 +4580,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         1789
                       </p>
@@ -4589,7 +4589,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -4598,7 +4598,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -4616,7 +4616,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-kAzzGY gZMjPs"
+              class="bp3-button bp3-disabled bp3-large sc-bsbRJL kyaRao"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -4630,7 +4630,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
             </button>
           </div>
           <div
-            class="sc-gZMcBi jxSIXn"
+            class="sc-bwCtUz heljAB"
           >
             <h4
               class="bp3-heading"
@@ -4638,7 +4638,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-jzJRlG bxayEV"
+              class="bp3-list sc-epnACN kVcBhQ"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -4661,13 +4661,13 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
 exports[`AuditBoardView ballot interaction renders board table with no ballots 1`] = `
 <div>
   <div
-    class="sc-htpNat cBZqYS"
+    class="sc-bdVaJa bKocXA"
   >
     <div
-      class="bp3-navbar sc-gisBJw dpeRNj"
+      class="bp3-navbar sc-bxivhb jwFLoW"
     >
       <div
-        class="sc-bxivhb sc-cHGsZl iPCsle"
+        class="sc-bwzfXH sc-EHOje eysEZT"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -4718,13 +4718,13 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
       class="board-table-container"
     >
       <div
-        class="sc-bZQynM gcSISu"
+        class="sc-kIPQKe nGuVW"
       >
         <div
-          class="sc-bxivhb sc-gzVnrw cXrPFV"
+          class="sc-bwzfXH sc-eXEjpC erJefL"
         >
           <div
-            class="sc-ifAKCX Eaynb"
+            class="sc-kfGgVZ hhCIYU"
           >
             <p>
               0
@@ -4733,23 +4733,23 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-jTzLTM gLFziH"
+              class="summary-label sc-gwVKww bzMont"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-fjdhpX cExqPy"
+              class="summary-label sc-hXRMBi jCWpx"
             >
               Not Audited: 
               0
             </span>
           </div>
           <div
-            class="sc-EHOje iSYCcM"
+            class="sc-esjQYD eSbAFP"
           >
             <button
-              class="bp3-button bp3-intent-success sc-cSHVUG cVsyeo"
+              class="bp3-button bp3-intent-success sc-iQNlJl jQIpgT"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4763,13 +4763,13 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
         </div>
       </div>
       <div
-        class="sc-bxivhb kYcBbd"
+        class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-htoDjs hxAtLW"
+          class="sc-ibxdXY VlfBk"
         >
           <div
-            class="sc-dnqmqq iEAKuG"
+            class="sc-RefOD iOENTb"
           >
             <h3
               class="bp3-heading"
@@ -4778,10 +4778,10 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Audit Board #1
             </h3>
             <div
-              class="sc-iwsKbI cgDfoK"
+              class="sc-iQKALj TzEYR"
             >
               <table
-                class="sc-bdVaJa djjOKa"
+                class="sc-kGXeez fVIhxz"
                 role="table"
               >
                 <thead>
@@ -4942,7 +4942,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               </table>
             </div>
             <button
-              class="bp3-button bp3-large bp3-intent-success sc-kAzzGY gZMjPs"
+              class="bp3-button bp3-large bp3-intent-success sc-bsbRJL kyaRao"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4954,7 +4954,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
             </button>
           </div>
           <div
-            class="sc-gZMcBi jxSIXn"
+            class="sc-bwCtUz heljAB"
           >
             <h4
               class="bp3-heading"
@@ -4962,7 +4962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-jzJRlG bxayEV"
+              class="bp3-list sc-epnACN kVcBhQ"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -4985,13 +4985,13 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
 exports[`AuditBoardView member form submits, goes to ballot table, and header shows member names 1`] = `
 <div>
   <div
-    class="sc-htpNat cBZqYS"
+    class="sc-bdVaJa bKocXA"
   >
     <div
-      class="bp3-navbar sc-gisBJw dpeRNj"
+      class="bp3-navbar sc-bxivhb jwFLoW"
     >
       <div
-        class="sc-bxivhb sc-cHGsZl iPCsle"
+        class="sc-bwzfXH sc-EHOje eysEZT"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -5042,13 +5042,13 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
       class="board-table-container"
     >
       <div
-        class="sc-bZQynM gcSISu"
+        class="sc-kIPQKe nGuVW"
       >
         <div
-          class="sc-bxivhb sc-gzVnrw cXrPFV"
+          class="sc-bwzfXH sc-eXEjpC erJefL"
         >
           <div
-            class="sc-ifAKCX Eaynb"
+            class="sc-kfGgVZ hhCIYU"
           >
             <p>
               18
@@ -5057,23 +5057,23 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-jTzLTM gLFziH"
+              class="summary-label sc-gwVKww bzMont"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-fjdhpX cExqPy"
+              class="summary-label sc-hXRMBi jCWpx"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-EHOje iSYCcM"
+            class="sc-esjQYD eSbAFP"
           >
             <button
-              class="bp3-button bp3-intent-success sc-cSHVUG cVsyeo"
+              class="bp3-button bp3-intent-success sc-iQNlJl jQIpgT"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -5087,13 +5087,13 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
         </div>
       </div>
       <div
-        class="sc-bxivhb kYcBbd"
+        class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-htoDjs hxAtLW"
+          class="sc-ibxdXY VlfBk"
         >
           <div
-            class="sc-dnqmqq iEAKuG"
+            class="sc-RefOD iOENTb"
           >
             <h3
               class="bp3-heading"
@@ -5102,10 +5102,10 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Audit Board #1
             </h3>
             <div
-              class="sc-iwsKbI cgDfoK"
+              class="sc-iQKALj TzEYR"
             >
               <table
-                class="sc-bdVaJa djjOKa"
+                class="sc-kGXeez fVIhxz"
                 role="table"
               >
                 <thead>
@@ -5307,7 +5307,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5317,7 +5317,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5327,7 +5327,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5337,7 +5337,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5366,7 +5366,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -5385,7 +5385,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -5394,7 +5394,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5403,7 +5403,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -5412,7 +5412,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -5421,7 +5421,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -5442,7 +5442,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5452,7 +5452,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5462,7 +5462,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5472,7 +5472,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5501,7 +5501,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -5520,7 +5520,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5530,7 +5530,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5540,7 +5540,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5550,7 +5550,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5579,7 +5579,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -5598,7 +5598,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -5607,7 +5607,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5616,7 +5616,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -5625,7 +5625,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -5634,7 +5634,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -5655,7 +5655,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5665,7 +5665,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5675,7 +5675,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5685,7 +5685,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5714,7 +5714,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -5733,7 +5733,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5743,7 +5743,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5753,7 +5753,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5763,7 +5763,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5792,7 +5792,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -5811,7 +5811,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -5820,7 +5820,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5829,7 +5829,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -5838,7 +5838,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -5847,7 +5847,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -5868,7 +5868,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5878,7 +5878,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5888,7 +5888,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5898,7 +5898,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5927,7 +5927,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -5946,7 +5946,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5956,7 +5956,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5966,7 +5966,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5976,7 +5976,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6005,7 +6005,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -6024,7 +6024,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -6033,7 +6033,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6042,7 +6042,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -6051,7 +6051,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -6060,7 +6060,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -6081,7 +6081,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6091,7 +6091,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6101,7 +6101,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6111,7 +6111,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6140,7 +6140,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -6159,7 +6159,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6169,7 +6169,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6179,7 +6179,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6189,7 +6189,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6218,7 +6218,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -6237,7 +6237,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -6246,7 +6246,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6255,7 +6255,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -6264,7 +6264,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -6273,7 +6273,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -6294,7 +6294,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6304,7 +6304,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6314,7 +6314,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6324,7 +6324,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6353,7 +6353,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -6372,7 +6372,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6382,7 +6382,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6392,7 +6392,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6402,7 +6402,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6431,7 +6431,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -6450,7 +6450,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -6459,7 +6459,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6468,7 +6468,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -6477,7 +6477,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -6486,7 +6486,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -6507,7 +6507,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6517,7 +6517,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6527,7 +6527,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6537,7 +6537,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6566,7 +6566,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -6585,7 +6585,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6595,7 +6595,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6605,7 +6605,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6615,7 +6615,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6644,7 +6644,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -6663,7 +6663,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -6672,7 +6672,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6681,7 +6681,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -6690,7 +6690,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -6699,7 +6699,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -6720,7 +6720,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6730,7 +6730,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6740,7 +6740,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6750,7 +6750,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6779,7 +6779,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -6798,7 +6798,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6808,7 +6808,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6818,7 +6818,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6828,7 +6828,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6857,7 +6857,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -6876,7 +6876,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -6885,7 +6885,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6894,7 +6894,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -6903,7 +6903,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -6912,7 +6912,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -6933,7 +6933,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6943,7 +6943,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6953,7 +6953,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6963,7 +6963,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6992,7 +6992,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -7011,7 +7011,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7021,7 +7021,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -7031,7 +7031,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -7041,7 +7041,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7070,7 +7070,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -7089,7 +7089,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         11
                       </p>
@@ -7098,7 +7098,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -7107,7 +7107,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                       >
                         2112
                       </p>
@@ -7116,7 +7116,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-fjdhpX cExqPy"
+                        class="sc-hXRMBi jCWpx"
                       >
                         Not Audited
                       </span>
@@ -7125,7 +7125,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -7146,7 +7146,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7156,7 +7156,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -7166,7 +7166,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -7176,7 +7176,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-chPdSV gcANmR"
+                        class="sc-hZSUBg eiCpSQ"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7205,7 +7205,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                        class="bp3-button bp3-fill bp3-minimal sc-hrWEMg faWZJh"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -7221,7 +7221,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-kAzzGY gZMjPs"
+              class="bp3-button bp3-disabled bp3-large sc-bsbRJL kyaRao"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -7235,7 +7235,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
             </button>
           </div>
           <div
-            class="sc-gZMcBi jxSIXn"
+            class="sc-bwCtUz heljAB"
           >
             <h4
               class="bp3-heading"
@@ -7243,7 +7243,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-jzJRlG bxayEV"
+              class="bp3-list sc-epnACN kVcBhQ"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.

--- a/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
@@ -4,10 +4,13 @@ import { QueryClientProvider } from 'react-query'
 import { Route } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 import BatchInventory from './BatchInventory'
-import { withMockFetch, renderWithRouter } from '../testUtilities'
+import {
+  withMockFetch,
+  renderWithRouter,
+  createQueryClient,
+} from '../testUtilities'
 import { IFileInfo } from '../useCSV'
 import { fileInfoMocks } from '../_mocks'
-import { queryClient } from '../../App'
 
 jest.mock('axios')
 
@@ -91,7 +94,7 @@ const apiCalls = {
 
 const render = () =>
   renderWithRouter(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <Route path="/election/:electionId/jurisdiction/:jurisdictionId/batch-inventory">
         <BatchInventory />
       </Route>

--- a/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundDataEntry.test.tsx
@@ -7,8 +7,12 @@ import BatchRoundDataEntry from './BatchRoundDataEntry'
 import { batchesMocks } from './_mocks'
 import { IBatches, IBatchResultTallySheet } from './useBatchResults'
 import { IContest } from '../../types'
-import { withMockFetch, findAndCloseToast, serverError } from '../testUtilities'
-import { queryClient } from '../../App'
+import {
+  withMockFetch,
+  findAndCloseToast,
+  serverError,
+  createQueryClient,
+} from '../testUtilities'
 import { contestMocks } from '../AuditAdmin/useSetupMenuItems/_mocks'
 
 const apiCalls = {
@@ -51,7 +55,7 @@ const batchesWithResults = (resultTallySheets: IBatchResultTallySheet[]) => [
 
 const renderComponent = () =>
   render(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <BatchRoundDataEntry
         electionId="1"
         jurisdictionId="1"

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
@@ -12,8 +12,8 @@ import {
   withMockFetch,
   findAndCloseToast,
   serverError,
+  createQueryClient,
 } from '../../testUtilities'
-import { queryClient } from '../../../App'
 import BatchRoundSteps from './BatchRoundSteps'
 import { jaApiCalls } from '../../_mocks'
 import {
@@ -44,7 +44,7 @@ jest.mock('@sentry/react', () => ({
 
 const renderComponent = (stepPath = '') => {
   renderWithRouter(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <Route path="/election/:electionId/jurisdiction/:jurisdictionId/round/:roundId">
         <BatchRoundSteps
           jurisdiction={jaApiCalls.getUser.response.user.jurisdictions[0]}

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
@@ -397,6 +397,7 @@ describe('BatchRoundSteps', () => {
 
   it('shows Step 3: Enter Tallies', async () => {
     const expectedCalls = [
+      jaApiCalls.getBatches(batchesMocks.emptyInitial),
       jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
       jaApiCalls.getBatches(batchesMocks.emptyInitial),
     ]
@@ -425,6 +426,10 @@ describe('BatchRoundSteps', () => {
 
   it('on Step 3, confirms finalizing tallies', async () => {
     const expectedCalls = [
+      jaApiCalls.getBatches({
+        ...batchesMocks.complete,
+        resultsFinalizedAt: null,
+      }),
       jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
       jaApiCalls.getBatches({
         ...batchesMocks.complete,
@@ -439,6 +444,7 @@ describe('BatchRoundSteps', () => {
         name: 'Enter Tallies',
         current: 'step',
       })
+      await screen.findByRole('table')
 
       const finalizeButton = screen.getByRole('button', {
         name: /Finalize Tallies/,
@@ -459,6 +465,10 @@ describe('BatchRoundSteps', () => {
 
   it('handles errors on finalize', async () => {
     const expectedCalls = [
+      jaApiCalls.getBatches({
+        ...batchesMocks.complete,
+        resultsFinalizedAt: null,
+      }),
       jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
       jaApiCalls.getBatches({
         ...batchesMocks.complete,

--- a/client/src/components/JurisdictionAdmin/FullHandTallyDataEntry.test.tsx
+++ b/client/src/components/JurisdictionAdmin/FullHandTallyDataEntry.test.tsx
@@ -15,9 +15,12 @@ import {
 } from './useFullHandTallyResults'
 import FullHandTallyDataEntry from './FullHandTallyDataEntry'
 import { contestMocks } from '../AuditAdmin/useSetupMenuItems/_mocks'
-import { withMockFetch, renderWithRouter } from '../testUtilities'
+import {
+  withMockFetch,
+  renderWithRouter,
+  createQueryClient,
+} from '../testUtilities'
 import { IContest } from '../../types'
-import { queryClient } from '../../App'
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
@@ -87,7 +90,7 @@ const apiCalls = {
 
 const renderComponent = () =>
   renderWithRouter(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <FullHandTallyDataEntry round={roundMocks.fullHandTallyIncomplete} />
     </QueryClientProvider>,
     {

--- a/client/src/components/JurisdictionAdmin/RoundDataEntry.test.tsx
+++ b/client/src/components/JurisdictionAdmin/RoundDataEntry.test.tsx
@@ -10,8 +10,11 @@ import {
   roundMocks,
 } from '../AuditAdmin/useSetupMenuItems/_mocks'
 import { resultsMocks, INullResultValues } from './_mocks'
-import { withMockFetch, renderWithRouter } from '../testUtilities'
-import { queryClient } from '../../App'
+import {
+  withMockFetch,
+  renderWithRouter,
+  createQueryClient,
+} from '../testUtilities'
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'), // use actual for all non-hook parts
@@ -48,7 +51,7 @@ const apiCalls = {
 
 const renderComponent = () =>
   renderWithRouter(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <RoundDataEntry round={roundMocks.singleIncomplete[0]} />
     </QueryClientProvider>,
     {

--- a/client/src/components/JurisdictionAdmin/RoundManagement.test.tsx
+++ b/client/src/components/JurisdictionAdmin/RoundManagement.test.tsx
@@ -14,8 +14,11 @@ import { jaApiCalls } from '../_mocks'
 import { IAuditSettings } from '../useAuditSettings'
 import { IFullHandTallyBatchResults } from './useFullHandTallyResults'
 import RoundManagement, { IRoundManagementProps } from './RoundManagement'
-import { renderWithRouter, withMockFetch } from '../testUtilities'
-import { queryClient } from '../../App'
+import {
+  renderWithRouter,
+  withMockFetch,
+  createQueryClient,
+} from '../testUtilities'
 import AuthDataProvider from '../UserContext'
 import { dummyBallots } from '../AuditBoard/_mocks'
 import { IContest } from '../../types'
@@ -43,7 +46,7 @@ const renderView = (props: IRoundManagementProps) =>
     <Route
       path="/election/:electionId/jurisdiction/:jurisdictionId"
       render={routeProps => (
-        <QueryClientProvider client={queryClient}>
+        <QueryClientProvider client={createQueryClient()}>
           <AuthDataProvider>
             <RoundManagement {...routeProps} {...props} />
           </AuthDataProvider>

--- a/client/src/components/JurisdictionAdmin/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
+++ b/client/src/components/JurisdictionAdmin/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`full hand tally data entry deletes full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-bdVaJa hazmWT"
+    class="sc-jlyJG hHBFug"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -159,7 +159,7 @@ exports[`full hand tally data entry deletes full hand tally batch result 1`] = `
 exports[`full hand tally data entry edits full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-bdVaJa hazmWT"
+    class="sc-jlyJG hHBFug"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -360,7 +360,7 @@ exports[`full hand tally data entry edits full hand tally batch result 1`] = `
 exports[`full hand tally data entry finalizes full hand tally results 1`] = `
 <div>
   <form
-    class="sc-bdVaJa hazmWT"
+    class="sc-jlyJG hHBFug"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -593,7 +593,7 @@ exports[`full hand tally data entry finalizes full hand tally results 1`] = `
 exports[`full hand tally data entry renders 1`] = `
 <div>
   <form
-    class="sc-bdVaJa hazmWT"
+    class="sc-jlyJG hHBFug"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -749,7 +749,7 @@ exports[`full hand tally data entry renders 1`] = `
 exports[`full hand tally data entry renders with full hand tally results 1`] = `
 <div>
   <form
-    class="sc-bdVaJa hazmWT"
+    class="sc-jlyJG hHBFug"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -950,7 +950,7 @@ exports[`full hand tally data entry renders with full hand tally results 1`] = `
 exports[`full hand tally data entry renders with proper totals 1`] = `
 <div>
   <form
-    class="sc-bdVaJa hazmWT"
+    class="sc-jlyJG hHBFug"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -1203,7 +1203,7 @@ exports[`full hand tally data entry renders with proper totals 1`] = `
 exports[`full hand tally data entry submits full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-bdVaJa hazmWT"
+    class="sc-jlyJG hHBFug"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -1404,7 +1404,7 @@ exports[`full hand tally data entry submits full hand tally batch result 1`] = `
 exports[`full hand tally data entry validation error for blank submission 1`] = `
 <div>
   <form
-    class="sc-bdVaJa hazmWT"
+    class="sc-jlyJG hHBFug"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"

--- a/client/src/components/JurisdictionAdmin/__snapshots__/RoundManagement.test.tsx.snap
+++ b/client/src/components/JurisdictionAdmin/__snapshots__/RoundManagement.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`RoundManagement renders audit setup with ballot audit 1`] = `
 <div>
   <div
-    class="sc-bdVaJa sc-gipzik iuWObY"
+    class="sc-bdVaJa sc-kvZOFW buxZzP"
   >
     <h3
       class="bp3-heading"
@@ -13,13 +13,13 @@ exports[`RoundManagement renders audit setup with ballot audit 1`] = `
        Audit Board Setup
     </h3>
     <p
-      class="sc-Rmtcm oXfno"
+      class="sc-jbKcbu ezTDBH"
     >
       Ballots to audit: 
       27
     </p>
     <div
-      class="sc-dnqmqq jnbCEU"
+      class="sc-jWBwVP fgskbB"
     >
       <h4
         class="bp3-heading"
@@ -30,10 +30,10 @@ exports[`RoundManagement renders audit setup with ballot audit 1`] = `
         Select the appropriate number of audit boards based upon the personnel available and the number of ballots assigned to your jurisdiction for this round of the audit. You will have the opportunity to adjust the number of audit boards before the next round of the audit, if another round is required.
       </p>
       <div
-        class="sc-gzVnrw iZqYnV"
+        class="sc-bZQynM bGsEQi"
       >
         <div
-          class="bp3-html-select sc-iwsKbI iSMuWx sc-bZQynM dFcXvN"
+          class="bp3-html-select sc-brqgnP iEmaVB sc-cvbbAY jAgsBm"
         >
           <select
             data-testid="numAuditBoards"
@@ -664,7 +664,7 @@ exports[`RoundManagement renders audit setup with ballot audit 1`] = `
         </div>
       </div>
       <button
-        class="bp3-button bp3-intent-primary sc-EHOje gmpgQN"
+        class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
         type="button"
       >
         <span
@@ -681,7 +681,7 @@ exports[`RoundManagement renders audit setup with ballot audit 1`] = `
 exports[`RoundManagement renders complete view 1`] = `
 <div>
   <div
-    class="sc-bdVaJa sc-gipzik iuWObY"
+    class="sc-bdVaJa sc-kvZOFW buxZzP"
   >
     <h2
       class="bp3-heading"
@@ -695,7 +695,7 @@ exports[`RoundManagement renders complete view 1`] = `
 exports[`RoundManagement renders links & data entry with offline ballot audit 1`] = `
 <div>
   <div
-    class="sc-bdVaJa sc-gipzik iuWObY"
+    class="sc-bdVaJa sc-kvZOFW buxZzP"
   >
     <h3
       class="bp3-heading"
@@ -705,10 +705,10 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
        Data Entry
     </h3>
     <div
-      class="sc-csuQGl hRric"
+      class="sc-hqyNC bkcVXz"
     >
       <p
-        class="sc-Rmtcm oXfno"
+        class="sc-jbKcbu ezTDBH"
       >
         Ballots to audit: 
         27
@@ -806,7 +806,7 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
       </div>
     </div>
     <div
-      class="sc-csuQGl hRric"
+      class="sc-hqyNC bkcVXz"
     >
       <form>
         <p>
@@ -821,17 +821,17 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
             Contest 1
           </h5>
           <label
-            class="sc-chPdSV izZSzF"
+            class="sc-iRbamj kQWgHU"
             for="results[contest-id-1][choice-id-1]"
           >
             Votes for 
             Choice One
             :
             <div
-              class="sc-jTzLTM gTHUJn"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-fjdhpX dmEgAR"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -844,17 +844,17 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
             </div>
           </label>
           <label
-            class="sc-chPdSV izZSzF"
+            class="sc-iRbamj kQWgHU"
             for="results[contest-id-1][choice-id-2]"
           >
             Votes for 
             Choice Two
             :
             <div
-              class="sc-jTzLTM gTHUJn"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-fjdhpX dmEgAR"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -876,17 +876,17 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
             Contest 2
           </h5>
           <label
-            class="sc-chPdSV izZSzF"
+            class="sc-iRbamj kQWgHU"
             for="results[contest-id-2][choice-id-3]"
           >
             Votes for 
             Choice Three
             :
             <div
-              class="sc-jTzLTM gTHUJn"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-fjdhpX dmEgAR"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -899,17 +899,17 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
             </div>
           </label>
           <label
-            class="sc-chPdSV izZSzF"
+            class="sc-iRbamj kQWgHU"
             for="results[contest-id-2][choice-id-4]"
           >
             Votes for 
             Choice Four
             :
             <div
-              class="sc-jTzLTM gTHUJn"
+              class="sc-gqjmRU egaEhI"
             >
               <div
-                class="bp3-input-group sc-fjdhpX dmEgAR"
+                class="bp3-input-group sc-VigVT hfLuvB"
               >
                 <input
                   class="bp3-input"
@@ -923,7 +923,7 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
           </label>
         </div>
         <button
-          class="bp3-button bp3-intent-primary sc-kAzzGY cxWquR sc-EHOje gmpgQN"
+          class="bp3-button bp3-intent-primary sc-gPEVay eGxjmR sc-dnqmqq iQfLYL"
           type="submit"
         >
           <span
@@ -941,7 +941,7 @@ exports[`RoundManagement renders links & data entry with offline ballot audit 1`
 exports[`RoundManagement renders links & progress with online ballot audit 1`] = `
 <div>
   <div
-    class="sc-bdVaJa sc-gipzik iuWObY"
+    class="sc-bdVaJa sc-kvZOFW buxZzP"
   >
     <h3
       class="bp3-heading"
@@ -951,10 +951,10 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
        Data Entry
     </h3>
     <div
-      class="sc-csuQGl hRric"
+      class="sc-hqyNC bkcVXz"
     >
       <p
-        class="sc-Rmtcm oXfno"
+        class="sc-jbKcbu ezTDBH"
       >
         Ballots to audit: 
         27
@@ -1079,7 +1079,7 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
           </span>
         </button>
         <div
-          class="sc-VigVT iyEYjY"
+          class="sc-jDwBTQ idqqoL"
           id="qr-root"
         >
           <span
@@ -1095,10 +1095,10 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
       </div>
     </div>
     <div
-      class="sc-csuQGl hRric"
+      class="sc-hqyNC bkcVXz"
     >
       <div
-        class="sc-gZMcBi cPjbpf"
+        class="sc-cMljjf hhbGWd"
       >
         <h4
           class="bp3-heading"
@@ -1122,7 +1122,7 @@ exports[`RoundManagement renders links & progress with online ballot audit 1`] =
         </div>
       </div>
       <div
-        class="sc-gqjmRU cknesl"
+        class="sc-jAaTju cAxehW"
       >
         <div>
           <span>

--- a/client/src/components/PublicPages/AuditPlanner/AuditPlanner.test.tsx
+++ b/client/src/components/PublicPages/AuditPlanner/AuditPlanner.test.tsx
@@ -5,16 +5,16 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { ToastContainer } from 'react-toastify'
 
 import AuditPlanner from './AuditPlanner'
-import { queryClient } from '../../../App'
 import {
   renderWithRouter,
   serverError,
   withMockFetch,
+  createQueryClient,
 } from '../../testUtilities'
 
 function renderAuditPlanner() {
   renderWithRouter(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <AuditPlanner />
       <ToastContainer />
     </QueryClientProvider>,
@@ -214,7 +214,6 @@ let mockScrollIntoView: jest.Mock
 beforeEach(async () => {
   mockScrollIntoView = jest.fn()
   window.HTMLElement.prototype.scrollIntoView = mockScrollIntoView
-  await queryClient.invalidateQueries()
 })
 
 test('Entering election results - validation and submit', async () => {

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -8,6 +8,7 @@ import {
   renderWithRouter,
   serverError,
   findAndCloseToast,
+  createQueryClient,
 } from '../testUtilities'
 import SupportTools from './SupportTools'
 import AuthDataProvider from '../UserContext'
@@ -21,7 +22,6 @@ import {
   IJurisdiction,
   IRound,
 } from './support-api'
-import { queryClient } from '../../App'
 
 const mockOrganizationBase: IOrganizationBase = {
   id: 'organization-id-1',
@@ -184,7 +184,7 @@ const apiCalls = {
 
 const renderRoute = (route: string) =>
   renderWithRouter(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <AuthDataProvider>
         <SupportTools />
         <ToastContainer />

--- a/client/src/components/TallyEntryUser/TallyEntryLoginScreen.test.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryLoginScreen.test.tsx
@@ -6,12 +6,11 @@ import TallyEntryLoginScreen, {
   ITallyEntryLoginScreenProps,
 } from './TallyEntryLoginScreen'
 import { tallyEntryUser, tallyEntryApiCalls } from '../_mocks'
-import { queryClient } from '../../App'
-import { withMockFetch } from '../testUtilities'
+import { withMockFetch, createQueryClient } from '../testUtilities'
 
 const renderScreen = (props: ITallyEntryLoginScreenProps) =>
   render(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <TallyEntryLoginScreen {...props} />
     </QueryClientProvider>
   )

--- a/client/src/components/TallyEntryUser/TallyEntryScreen.test.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryScreen.test.tsx
@@ -3,14 +3,13 @@ import { QueryClientProvider } from 'react-query'
 import { render, screen } from '@testing-library/react'
 import { tallyEntryApiCalls } from '../_mocks'
 import TallyEntryScreen from './TallyEntryScreen'
-import { queryClient } from '../../App'
-import { withMockFetch } from '../testUtilities'
+import { withMockFetch, createQueryClient } from '../testUtilities'
 import { contestMocks } from '../AuditAdmin/useSetupMenuItems/_mocks'
 import { batchesMocks } from '../JurisdictionAdmin/_mocks'
 
 const renderScreen = () =>
   render(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <TallyEntryScreen
         electionId="1"
         jurisdictionId="jurisdiction-id-1"

--- a/client/src/components/TallyEntryUser/TallyEntryUserView.test.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryUserView.test.tsx
@@ -2,15 +2,18 @@ import React from 'react'
 import { screen } from '@testing-library/react'
 import { QueryClientProvider } from 'react-query'
 import TallyEntryUserView from './TallyEntryUserView'
-import { queryClient } from '../../App'
-import { withMockFetch, renderWithRouter } from '../testUtilities'
+import {
+  withMockFetch,
+  renderWithRouter,
+  createQueryClient,
+} from '../testUtilities'
 import { tallyEntryApiCalls, tallyEntryUser, apiCalls } from '../_mocks'
 import { contestMocks } from '../AuditAdmin/useSetupMenuItems/_mocks'
 import { batchesMocks } from '../JurisdictionAdmin/_mocks'
 
 const renderView = ({ route = '/tally-entry' }: { route?: string } = {}) =>
   renderWithRouter(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={createQueryClient()}>
       <TallyEntryUserView />
     </QueryClientProvider>,
     { route }

--- a/client/src/components/testUtilities.tsx
+++ b/client/src/components/testUtilities.tsx
@@ -12,6 +12,8 @@ import {
   Queries,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { QueryClient, DefaultOptions } from 'react-query'
+import { queryClientDefaultOptions } from '../App'
 
 type MatchParameter<Params> = { [K in keyof Params]?: string }
 
@@ -230,3 +232,13 @@ export const findAndCloseToast = async (
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const mocksOfType = <T,>() => <Mock,>(mock: { [K in keyof Mock]: T }) =>
   mock
+
+// Create a react-query query client with the same defaults as the app, except
+// turn off query retries since those make it hard to test query error handling
+export const createQueryClient = (): QueryClient =>
+  new QueryClient({
+    defaultOptions: {
+      ...queryClientDefaultOptions,
+      queries: { ...queryClientDefaultOptions.queries, retry: false },
+    } as DefaultOptions<unknown>,
+  })


### PR DESCRIPTION
We have been using the same queryClient instance from App.tsx in all tests. This has been mostly fine, but sometimes there can be weird interactions between tests since they are using the same query cache. I started to run into problems with this (honestly surprised it didn't become an issue sooner), so decided to change to creating a new QueryClient per test case.