### PR TITLE
Fix non-deterministic test

### DIFF
--- a/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
@@ -11,7 +11,7 @@ snapshots[
     "test_sample_extra_batches_by_counting_group 1"
 ] = """######## ELECTION INFO ########\r
 Organization,Election Name,State\r
-Test Org test_sample_extra_batches_by_counting_group,Test Election,CA\r
+Test Org Sample Extra Batches,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
 Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r

--- a/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
@@ -13,7 +13,7 @@ def org_id(client: FlaskClient, request) -> str:  # pylint: disable=unused-argum
     # id=str(uuid.uuid4()),
     org = Organization.query.get(org_id)
     if not org:
-        org = Organization(id=org_id, name=f"Test Org {request.node.name}",)
+        org = Organization(id=org_id, name="Test Org Sample Extra Batches",)
         db_session.add(org)
         add_admin_to_org(org_id, DEFAULT_AA_EMAIL)
         db_session.commit()


### PR DESCRIPTION
Depending on which test case ran first, the org name in the db would be different (since it was based on the test case name). This org name shows up in the audit report snapshot, which was causing flakiness.