### PR TITLE
Button to reject tally entry login request

### DIFF
--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
@@ -282,7 +282,7 @@ describe('BatchRoundSteps', () => {
     })
   })
 
-  it('on Step 2, polls for login requests and can confirm a request', async () => {
+  it('on Step 2, polls for login requests and can confirm/reject a request', async () => {
     jest.useFakeTimers()
     const expectedCalls = [
       jaApiCalls.getBatches(batchesMocks.emptyInitial),
@@ -311,6 +311,17 @@ describe('BatchRoundSteps', () => {
       jaApiCalls.getTallyEntryAccountStatus(
         tallyEntryAccountStatusMocks.loginRequestsOneConfirmed
       ),
+      jaApiCalls.getTallyEntryAccountStatus(
+        tallyEntryAccountStatusMocks.loginRequestsOneConfirmed
+      ),
+      jaApiCalls.postRejectTallyEntryLoginRequest,
+      jaApiCalls.getTallyEntryAccountStatus({
+        ...tallyEntryAccountStatusMocks.loginRequestsOneConfirmed,
+        loginRequests: [
+          tallyEntryAccountStatusMocks.loginRequestsOneConfirmed
+            .loginRequests[0],
+        ],
+      }),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderComponent('/tally-entry-accounts')
@@ -399,6 +410,15 @@ describe('BatchRoundSteps', () => {
         expect(
           screen.queryByText('Confirm Login: Kevin Jones')
         ).not.toBeInTheDocument()
+      })
+
+      // Reject the request
+      const rejectButton = screen.getByRole('button', {
+        name: 'Reject login request',
+      })
+      userEvent.click(rejectButton)
+      await waitFor(() => {
+        expect(loginRequest2).not.toBeInTheDocument()
       })
 
       jest.useRealTimers()

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -295,6 +295,17 @@ export const jaApiCalls = {
     },
     response: { status: 'ok' },
   },
+  postRejectTallyEntryLoginRequest: {
+    url: `/auth/tallyentry/election/1/jurisdiction/jurisdiction-id-1/reject`,
+    options: {
+      method: 'POST',
+      body: JSON.stringify({
+        tallyEntryUserId: 'tally-entry-user-id-2',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    },
+    response: { status: 'ok' },
+  },
 }
 
 export const mockOrganizations = {


### PR DESCRIPTION
It can get a little annoying to have no way to clean up unused login requests. Maybe this won't be an issue in real audits, but I figured it's always nice to have a way to say no.


https://user-images.githubusercontent.com/530106/198161974-5d14ca35-18f1-4bb2-afff-32cd2373f7cb.mov

