### PR TITLE
Format counts correctly in server user errors

### DIFF
--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -28,6 +28,7 @@ from ..util.csv_parse import (
     CSVColumnType,
     validate_csv_mimetype,
 )
+from ..util.string import format_count
 from ..activity_log.activity_log import UploadFile, activity_base, record_activity
 
 BATCH_NAME = "Batch Name"
@@ -88,10 +89,10 @@ def process_batch_tallies_file(
             total_tallies = sum(int(row[choice.name]) for choice in contest.choices)
             if total_tallies > allowed_tallies:
                 raise UserError(
-                    f'The total votes for batch "{row[BATCH_NAME]}" ({total_tallies} votes)'
+                    f"The total votes for batch \"{row[BATCH_NAME]}\" ({format_count(total_tallies, 'vote', 'votes')})"
                     + f" cannot exceed {allowed_tallies} - the number of ballots from the manifest"
-                    + f" ({num_ballots_by_batch[row[BATCH_NAME]]} ballots) multipled by the number"
-                    + f" of votes allowed for the contest ({contest.votes_allowed} votes per ballot)."
+                    + f" ({format_count(num_ballots_by_batch[row[BATCH_NAME]], 'ballot', 'ballots')}) multipled by the number"
+                    + f" of votes allowed for the contest ({format_count(contest.votes_allowed, 'vote', 'votes')} per ballot)."
                 )
 
         # Save the tallies as a JSON blob in the format needed by the

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -26,6 +26,7 @@ from ..worker.tasks import (
     UserError,
 )
 from .. import activity_log
+from ..util.string import format_count
 
 
 def validate_all_manifests_uploaded(contest: Contest):
@@ -49,8 +50,9 @@ def validate_batch_tallies(contest):
         if total_votes_by_choice[choice.id] > choice.num_votes:
             raise UserError(
                 f"Total votes in batch tallies files for contest choice {choice.name}"
-                f" ({total_votes_by_choice[choice.id]}) is greater than the"
-                f" reported number of votes for that choice ({choice.num_votes})."
+                f" ({format_count(total_votes_by_choice[choice.id], 'vote', 'votes')})"
+                " is greater than the reported number of votes for that choice"
+                f" ({format_count(choice.num_votes, 'vote', 'votes')})."
             )
 
 
@@ -62,9 +64,10 @@ def validate_hybrid_manifests_and_cvrs(contest: Contest):
     assert contest.votes_allowed is not None
     if total_votes > total_manifest_ballots * contest.votes_allowed:
         raise UserError(
-            f"Contest {contest.name} vote counts add up to {total_votes},"
-            f" which is more than the total number of ballots across all jurisdiction manifests ({total_manifest_ballots})"
-            f" times the number of votes allowed ({contest.votes_allowed})"
+            f"Contest {contest.name} vote counts add up to {format_count(total_votes, 'vote', 'votes')},"
+            f" which is more than the total number of ballots across all"
+            f" jurisdiction manifests ({format_count(total_manifest_ballots, 'ballot', 'ballots')})"
+            f" times the number of votes allowed ({format_count(contest.votes_allowed, 'vote', 'votes')})"
         )
 
     manifest_ballots = hybrid_contest_total_ballots(contest)
@@ -77,7 +80,7 @@ def validate_hybrid_manifests_and_cvrs(contest: Contest):
     )
     if manifest_ballots.cvr < cvr_ballots:
         raise UserError(
-            f"For contest {contest.name}, found {cvr_ballots} ballots in the CVRs,"
+            f"For contest {contest.name}, found {format_count(cvr_ballots, 'ballot', 'ballots')} in the CVRs,"
             f" which is more than the total number of CVR ballots across all jurisdiction manifests ({manifest_ballots.cvr})"
             " for jurisdictions in this contest's universe"
         )
@@ -87,10 +90,12 @@ def validate_hybrid_manifests_and_cvrs(contest: Contest):
     non_cvr_votes = sum(count.non_cvr for count in vote_counts.values())
     if manifest_ballots.non_cvr * contest.votes_allowed < non_cvr_votes:
         raise UserError(
-            f"For contest {contest.name}, choice votes for non-CVR ballots add up to {non_cvr_votes},"
-            f" which is more than the total number of non-CVR ballots across all jurisdiction manifests ({manifest_ballots.non_cvr})"
-            " for jurisdictions in this contest's universe"
-            f" times the number of votes allowed ({contest.votes_allowed})"
+            f"For contest {contest.name}, choice votes for non-CVR ballots add up to"
+            f" {format_count(non_cvr_votes, 'vote', 'votes')},"
+            f" which is more than the total number of non-CVR ballots across all jurisdiction manifests"
+            f" ({format_count(manifest_ballots.non_cvr, 'ballot', 'ballots')})"
+            " for jurisdictions in this contest's universe times the number of votes allowed"
+            f" ({format_count(contest.votes_allowed, 'vote', 'votes')})"
         )
 
     choices_by_id = {choice.id: choice for choice in contest.choices}
@@ -105,8 +110,10 @@ def validate_hybrid_manifests_and_cvrs(contest: Contest):
     if invalid_count:
         choice, count = invalid_count
         raise UserError(
-            f"For contest {contest.name}, the CVRs contain more votes for choice {choice.name} ({count.cvr})"
-            f" than were entered in the contest settings ({choice.num_votes})."
+            f"For contest {contest.name}, the CVRs contain more votes for choice {choice.name}"
+            f" ({format_count(count.cvr, 'vote', 'votes')})"
+            f" than were entered in the contest settings"
+            f" ({format_count(choice.num_votes, 'vote', 'votes')})."
         )
 
 

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -129,7 +129,7 @@ def test_batch_comparison_too_many_votes(
                 "status": "ERRORED",
                 "startedAt": assert_is_date,
                 "completedAt": assert_is_date,
-                "error": "Total votes in batch tallies files for contest choice candidate 1 (5200) is greater than the reported number of votes for that choice (5000).",
+                "error": "Total votes in batch tallies files for contest choice candidate 1 (5,200 votes) is greater than the reported number of votes for that choice (5,000 votes).",
             },
         },
     )

--- a/server/tests/hybrid/test_hybrid.py
+++ b/server/tests/hybrid/test_hybrid.py
@@ -568,7 +568,7 @@ def test_hybrid_manifest_validation_too_many_votes(
                 "status": "ERRORED",
                 "startedAt": assert_is_date,
                 "completedAt": assert_is_date,
-                "error": "Contest Contest 1 vote counts add up to 130, which is more than the total number of ballots across all jurisdiction manifests (50) times the number of votes allowed (2)",
+                "error": "Contest Contest 1 vote counts add up to 130 votes, which is more than the total number of ballots across all jurisdiction manifests (50 ballots) times the number of votes allowed (2 votes)",
             },
         },
     )
@@ -714,7 +714,7 @@ def test_hybrid_manifest_validation_few_non_cvr_ballots(
                 "status": "ERRORED",
                 "startedAt": assert_is_date,
                 "completedAt": assert_is_date,
-                "error": "For contest Contest 1, choice votes for non-CVR ballots add up to 80, which is more than the total number of non-CVR ballots across all jurisdiction manifests (20) for jurisdictions in this contest's universe times the number of votes allowed (2)",
+                "error": "For contest Contest 1, choice votes for non-CVR ballots add up to 80 votes, which is more than the total number of non-CVR ballots across all jurisdiction manifests (20 ballots) for jurisdictions in this contest's universe times the number of votes allowed (2 votes)",
             },
         },
     )
@@ -757,7 +757,7 @@ def test_hybrid_manifest_validation_too_many_cvr_votes(
                 "status": "ERRORED",
                 "startedAt": assert_is_date,
                 "completedAt": assert_is_date,
-                "error": "For contest Contest 1, the CVRs contain more votes for choice Choice 1-1 (14) than were entered in the contest settings (13).",
+                "error": "For contest Contest 1, the CVRs contain more votes for choice Choice 1-1 (14 votes) than were entered in the contest settings (13 votes).",
             },
         },
     )

--- a/server/tests/util/test_strings.py
+++ b/server/tests/util/test_strings.py
@@ -1,0 +1,13 @@
+from ...util.string import format_count
+
+
+def test_format_count():
+    assert format_count(0, "item", "items") == "0 items"
+    assert format_count(1, "item", "items") == "1 item"
+    assert format_count(2, "item", "items") == "2 items"
+    assert format_count(3, "item", "items") == "3 items"
+    assert format_count(100, "item", "items") == "100 items"
+    assert format_count(1_000, "item", "items") == "1,000 items"
+    assert format_count(10_000, "item", "items") == "10,000 items"
+    assert format_count(1_000_000, "item", "items") == "1,000,000 items"
+    assert format_count(10_000_000, "item", "items") == "10,000,000 items"

--- a/server/util/string.py
+++ b/server/util/string.py
@@ -1,0 +1,3 @@
+# Formats a number using the appropriate singular or plural form of a noun.
+def format_count(count: int, singular: str, plural: str) -> str:
+    return f"{count:,} {singular if count == 1 else plural}"


### PR DESCRIPTION
I noticed an incorrect pluralization in an error message on a file upload, so decided to fix that and look through all UserErrors and fix any other potential issues.

To do so, I added a `format_count` helper function.