### PR TITLE
Ensure consistent batch tally sheet ordering

### DIFF
--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -4,7 +4,7 @@ from typing import List
 import uuid
 from flask import jsonify, request
 from werkzeug.exceptions import BadRequest, Conflict
-from sqlalchemy.orm import Query, contains_eager
+from sqlalchemy.orm import Query, joinedload
 from sqlalchemy import func
 
 from . import api
@@ -102,11 +102,9 @@ def list_batches_for_jurisdiction(
         .join(SampledBatchDraw)
         .filter_by(round_id=round.id)
         .filter(Batch.id.notin_(already_audited_batches(jurisdiction, round)))
-        .outerjoin(BatchResultTallySheet)
-        .outerjoin(BatchResult)
         .order_by(func.human_sort(Batch.name))
         .options(
-            contains_eager(Batch.result_tally_sheets).contains_eager(
+            joinedload(Batch.result_tally_sheets).joinedload(
                 BatchResultTallySheet.results
             )
         )

--- a/server/models.py
+++ b/server/models.py
@@ -401,6 +401,7 @@ class Batch(BaseModel):
         uselist=True,
         cascade="all, delete-orphan",
         passive_deletes=True,
+        order_by="BatchResultTallySheet.created_at",
     )
 
     __table_args__ = (UniqueConstraint("jurisdiction_id", "tabulator", "name"),)


### PR DESCRIPTION
Two root causes here:
- There was no ordering defined on the `Batch.results_tally_sheet` relationship
- We were using SQLAlchemy's `contains_eager` loading helper, which uses the ordering defined in the query's existing join expression. We needed to switch to using `joinedload`, which uses the relationship definition for ordering