### PR TITLE
Update Hart CVR parsing to support multiple CVR ZIP files

### DIFF
--- a/client/src/components/Atoms/CSVForm.tsx
+++ b/client/src/components/Atoms/CSVForm.tsx
@@ -93,11 +93,6 @@ const CSVFile: React.FC<IProps> = ({
               {title && <H4>{title}</H4>}
               <FormSectionDescription>
                 {description}
-                {values.cvrFileType === CvrFileType.HART &&
-                  ' ' +
-                    'For Hart, you can provide one ZIP file or multiple, one for each tabulator. ' +
-                    'You can also provide an optional scanned ballot information CSV. ' +
-                    'If provided, the unique identifiers in the CSV will be used as imprinted IDs.'}
                 {sampleFileLink && (
                   <>
                     <br />

--- a/client/src/components/Atoms/CSVForm.tsx
+++ b/client/src/components/Atoms/CSVForm.tsx
@@ -95,7 +95,8 @@ const CSVFile: React.FC<IProps> = ({
                 {description}
                 {values.cvrFileType === CvrFileType.HART &&
                   ' ' +
-                    'For Hart, you can also provide an optional scanned ballot information CSV. ' +
+                    'For Hart, you can provide one ZIP file or multiple, one for each tabulator. ' +
+                    'You can also provide an optional scanned ballot information CSV. ' +
                     'If provided, the unique identifiers in the CSV will be used as imprinted IDs.'}
                 {sampleFileLink && (
                   <>

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
@@ -428,9 +428,6 @@ describe('JA setup', () => {
         screen.getByLabelText(/CVR File Type:/),
         screen.getByRole('option', { name: 'Hart' })
       )
-      await screen.findByText(
-        /For Hart, you can provide one ZIP file or multiple, one for each tabulator. You can also provide an optional scanned ballot information CSV. If provided, the unique identifiers in the CSV will be used as imprinted IDs./
-      )
 
       const fileSelect = screen.getByLabelText('Select files...')
       userEvent.upload(fileSelect, [cvrsZip, scannedBallotInformationCsv])

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
@@ -429,7 +429,7 @@ describe('JA setup', () => {
         screen.getByRole('option', { name: 'Hart' })
       )
       await screen.findByText(
-        /For Hart, you can also provide an optional scanned ballot information CSV. If provided, the unique identifiers in the CSV will be used as imprinted IDs./
+        /For Hart, you can provide one ZIP file or multiple, one for each tabulator. You can also provide an optional scanned ballot information CSV. If provided, the unique identifiers in the CSV will be used as imprinted IDs./
       )
 
       const fileSelect = screen.getByLabelText('Select files...')

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -1050,11 +1050,11 @@ def parse_hart_cvrs(
                 )
                 if use_cvr_zip_file_names_as_tabulator_names:
                     raise UserError(
-                        f"Error in file: {file_name}. "
+                        f"Error in file: {file_name} from {cvr_zip_file_name}. "
                         "Couldn't find a matching batch for "
                         f"Tabulator: {cvr_zip_file_name.strip('.zip')}, BatchNumber: {batch_number}. "
                         "The BatchNumber field in the CVR file must match the Batch Name field in "
-                        "the ballot manifest, and the ZIP file names must match the Tabulator "
+                        "the ballot manifest, and the ZIP file name must match the Tabulator "
                         "field in the ballot manifest. " + general_guidance
                     )
                 else:

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -1001,9 +1001,11 @@ def parse_hart_cvrs(
             "column to the ballot manifest and upload a separate CVR export for each tabulator."
         )
     batches_by_key = {
-        (batch.tabulator, batch.name)
-        if use_cvr_zip_file_names_as_tabulator_names
-        else batch.name: batch
+        (
+            (batch.tabulator, batch.name)
+            if use_cvr_zip_file_names_as_tabulator_names
+            else batch.name
+        ): batch
         for batch in jurisdiction.batches
     }
 

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -996,7 +996,7 @@ def parse_hart_cvrs(
     if not use_cvr_zip_file_names_as_tabulator_names and duplicate_batch_name:
         raise UserError(
             "Batch names in ballot manifest must be unique. "
-            f"Found duplicate batch name: {duplicate_batch_name}."
+            f"Found duplicate batch name: {duplicate_batch_name}. "
             "If you have multiple tabulators that use the same batch names, add a Tabulator "
             "column to the ballot manifest and upload a separate CVR export for each tabulator."
         )

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -995,8 +995,10 @@ def parse_hart_cvrs(
     )
     if not use_cvr_zip_file_names_as_tabulator_names and duplicate_batch_name:
         raise UserError(
-            "Batch names in ballot manifest must be unique, unless providing multiple ZIP files exported by tabulator. "
+            "Batch names in ballot manifest must be unique. "
             f"Found duplicate batch name: {duplicate_batch_name}."
+            "If you have multiple tabulators that use the same batch names, add a Tabulator "
+            "column to the ballot manifest and upload a separate CVR export for each tabulator."
         )
     batches_by_key = {
         (batch.tabulator, batch.name)
@@ -1049,10 +1051,9 @@ def parse_hart_cvrs(
                         f"Error in file: {file_name}. "
                         "Couldn't find a matching batch for "
                         f"Tabulator: {cvr_zip_file_name.strip('.zip')}, BatchNumber: {batch_number}. "
-                        "The BatchNumber field in the CVR file must match the Batch Name field in the ballot manifest, "
-                        "and if providing multiple ZIP files exported by tabulator, "
-                        "the ZIP file names must match the Tabulator field in the ballot manifest. "
-                        + general_guidance
+                        "The BatchNumber field in the CVR file must match the Batch Name field in "
+                        "the ballot manifest, and the ZIP file names must match the Tabulator "
+                        "field in the ballot manifest. " + general_guidance
                     )
                 else:
                     close_matches = difflib.get_close_matches(

--- a/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
@@ -997,6 +997,128 @@ snapshots["test_hart_cvr_upload 2"] = {
     },
 }
 
+snapshots["test_hart_cvr_upload_with_multiple_cvr_zip_files 1"] = [
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH1",
+        "imprinted_id": "1-1-1",
+        "interpretations": "0,1,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH1",
+        "imprinted_id": "1-1-2",
+        "interpretations": "1,0,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH1",
+        "imprinted_id": "1-1-3",
+        "interpretations": "0,1,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-2-1",
+        "interpretations": "1,0,1,0,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-2-2",
+        "interpretations": "0,1,0,1,0,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-2-3",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR1",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH1",
+        "imprinted_id": "1-3-1",
+        "interpretations": "1,0,0,1,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH1",
+        "imprinted_id": "1-3-2",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH1",
+        "imprinted_id": "1-3-3",
+        "interpretations": "1,0,0,1,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-4-1",
+        "interpretations": "1,0,0,0,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-4-2",
+        "interpretations": "1,1,1,1,1,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-4-4",
+        "interpretations": ",,1,0,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 4,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-4-5",
+        "interpretations": ",,1,0,0,0",
+        "tabulator": "TABULATOR2",
+    },
+    {
+        "ballot_position": 5,
+        "batch_name": "BATCH2",
+        "imprinted_id": "1-4-6",
+        "interpretations": ",,0,0,0,1",
+        "tabulator": "TABULATOR2",
+    },
+]
+
+snapshots["test_hart_cvr_upload_with_multiple_cvr_zip_files 2"] = {
+    "Contest 1": {
+        "choices": {
+            "Choice 1-1": {"column": 0, "num_votes": 7},
+            "Choice 1-2": {"column": 1, "num_votes": 3},
+        },
+        "total_ballots_cast": 11,
+        "votes_allowed": 1,
+    },
+    "Contest 2": {
+        "choices": {
+            "Choice 2-1": {"column": 2, "num_votes": 6},
+            "Choice 2-2": {"column": 3, "num_votes": 3},
+            "Choice 2-3": {"column": 4, "num_votes": 3},
+            "Write-In": {"column": 5, "num_votes": 1},
+        },
+        "total_ballots_cast": 14,
+        "votes_allowed": 1,
+    },
+}
+
 snapshots["test_hart_cvr_upload_with_scanned_ballot_information 1"] = [
     {
         "ballot_position": 1,

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -2168,7 +2168,7 @@ def test_hart_cvr_upload_with_multiple_cvr_zip_files_and_invalid_cvrs(
                     "TABULATOR2.zip",
                 ),
             ],
-            "Error in file: cvr-0.xml. Couldn't find a matching batch for Tabulator: TABULATOR2, BatchNumber: invalid-batch. The BatchNumber field in the CVR file must match the Batch Name field in the ballot manifest, and the ZIP file names must match the Tabulator field in the ballot manifest. Please check your CVR files and ballot manifest thoroughly to make sure these values match - there may be a similar inconsistency in other files in the CVR export.",
+            "Error in file: cvr-0.xml from TABULATOR2.zip. Couldn't find a matching batch for Tabulator: TABULATOR2, BatchNumber: invalid-batch. The BatchNumber field in the CVR file must match the Batch Name field in the ballot manifest, and the ZIP file name must match the Tabulator field in the ballot manifest. Please check your CVR files and ballot manifest thoroughly to make sure these values match - there may be a similar inconsistency in other files in the CVR export.",
         ),
         (
             [
@@ -2181,7 +2181,7 @@ def test_hart_cvr_upload_with_multiple_cvr_zip_files_and_invalid_cvrs(
                     "forgot-to-rename-this-to-match-tabulator-in-ballot-manifest.zip",
                 ),
             ],
-            "Error in file: cvr-0.xml. Couldn't find a matching batch for Tabulator: forgot-to-rename-this-to-match-tabulator-in-ballot-manifest, BatchNumber: BATCH1. The BatchNumber field in the CVR file must match the Batch Name field in the ballot manifest, and the ZIP file names must match the Tabulator field in the ballot manifest. Please check your CVR files and ballot manifest thoroughly to make sure these values match - there may be a similar inconsistency in other files in the CVR export.",
+            "Error in file: cvr-0.xml from forgot-to-rename-this-to-match-tabulator-in-ballot-manifest.zip. Couldn't find a matching batch for Tabulator: forgot-to-rename-this-to-match-tabulator-in-ballot-manifest, BatchNumber: BATCH1. The BatchNumber field in the CVR file must match the Batch Name field in the ballot manifest, and the ZIP file name must match the Tabulator field in the ballot manifest. Please check your CVR files and ballot manifest thoroughly to make sure these values match - there may be a similar inconsistency in other files in the CVR export.",
         ),
     ]
 

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -2168,7 +2168,7 @@ def test_hart_cvr_upload_with_multiple_cvr_zip_files_and_invalid_cvrs(
                     "TABULATOR2.zip",
                 ),
             ],
-            "Error in file: cvr-0.xml. Couldn't find a matching batch for Tabulator: TABULATOR2, BatchNumber: invalid-batch. The BatchNumber field in the CVR file must match the Batch Name field in the ballot manifest, and if providing multiple ZIP files exported by tabulator, the ZIP file names must match the Tabulator field in the ballot manifest. Please check your CVR files and ballot manifest thoroughly to make sure these values match - there may be a similar inconsistency in other files in the CVR export.",
+            "Error in file: cvr-0.xml. Couldn't find a matching batch for Tabulator: TABULATOR2, BatchNumber: invalid-batch. The BatchNumber field in the CVR file must match the Batch Name field in the ballot manifest, and the ZIP file names must match the Tabulator field in the ballot manifest. Please check your CVR files and ballot manifest thoroughly to make sure these values match - there may be a similar inconsistency in other files in the CVR export.",
         ),
         (
             [
@@ -2181,7 +2181,7 @@ def test_hart_cvr_upload_with_multiple_cvr_zip_files_and_invalid_cvrs(
                     "forgot-to-rename-this-to-match-tabulator-in-ballot-manifest.zip",
                 ),
             ],
-            "Error in file: cvr-0.xml. Couldn't find a matching batch for Tabulator: forgot-to-rename-this-to-match-tabulator-in-ballot-manifest, BatchNumber: BATCH1. The BatchNumber field in the CVR file must match the Batch Name field in the ballot manifest, and if providing multiple ZIP files exported by tabulator, the ZIP file names must match the Tabulator field in the ballot manifest. Please check your CVR files and ballot manifest thoroughly to make sure these values match - there may be a similar inconsistency in other files in the CVR export.",
+            "Error in file: cvr-0.xml. Couldn't find a matching batch for Tabulator: forgot-to-rename-this-to-match-tabulator-in-ballot-manifest, BatchNumber: BATCH1. The BatchNumber field in the CVR file must match the Batch Name field in the ballot manifest, and the ZIP file names must match the Tabulator field in the ballot manifest. Please check your CVR files and ballot manifest thoroughly to make sure these values match - there may be a similar inconsistency in other files in the CVR export.",
         ),
     ]
 
@@ -2254,7 +2254,7 @@ def test_hart_cvr_upload_with_duplicate_batches_in_manifest(
                 "status": ProcessingStatus.ERRORED,
                 "startedAt": assert_is_date,
                 "completedAt": assert_is_date,
-                "error": "Batch names in ballot manifest must be unique, unless providing multiple ZIP files exported by tabulator. Found duplicate batch name: BATCH1.",
+                "error": "Batch names in ballot manifest must be unique. Found duplicate batch name: BATCH1.If you have multiple tabulators that use the same batch names, add a Tabulator column to the ballot manifest and upload a separate CVR export for each tabulator.",
                 "workProgress": 0,
                 "workTotal": manifest_num_ballots,
             },

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -2254,7 +2254,7 @@ def test_hart_cvr_upload_with_duplicate_batches_in_manifest(
                 "status": ProcessingStatus.ERRORED,
                 "startedAt": assert_is_date,
                 "completedAt": assert_is_date,
-                "error": "Batch names in ballot manifest must be unique. Found duplicate batch name: BATCH1.If you have multiple tabulators that use the same batch names, add a Tabulator column to the ballot manifest and upload a separate CVR export for each tabulator.",
+                "error": "Batch names in ballot manifest must be unique. Found duplicate batch name: BATCH1. If you have multiple tabulators that use the same batch names, add a Tabulator column to the ballot manifest and upload a separate CVR export for each tabulator.",
                 "workProgress": 0,
                 "workTotal": manifest_num_ballots,
             },


### PR DESCRIPTION
# Overview

Issue link: https://github.com/votingworks/arlo/issues/1446

This PR updates Hart CVR parsing to support multiple CVR ZIP files, one for each tabulator, for Orange County but also others down the road who:

- Don't have unique batch names across tabulators
- Don't have tabulator info in their XML files
- Can easily export CVRs by tabulator

As noted in a code comment:

> When multiple files are provided, we use zip file names (with ".zip" removed) as tabulator names. (These tabulator names need to match the ballot manifest, of course.)

# Testing

- [x] Updated automated tests
- [x] Tested manually