### PR TITLE
Batch inventory: reload sign off status when files change

### DIFF
--- a/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
@@ -121,8 +121,11 @@ describe('BatchInventory', () => {
       apiCalls.putCvr,
       apiCalls.getCvr(cvrProcessed),
       apiCalls.getTabulatorStatus(fileInfoMocks.empty),
+      apiCalls.getSignOff(null),
+      apiCalls.getSignOff(null),
       apiCalls.putTabulatorStatus,
       apiCalls.getTabulatorStatus(tabulatorStatusProcessed),
+      apiCalls.getSignOff(null),
     ]
     await withMockFetch(expectedCalls, async () => {
       render()

--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -54,13 +54,20 @@ const useBatchInventoryCVR = (
   const queryClient = useQueryClient()
   return {
     uploadedFile: useUploadedFile(key, url, {
-      onFileChange: () =>
+      onFileChange: () => {
         // Tabulator status file is reprocessed when CVR is uploaded
         queryClient.invalidateQueries([
           'batchInventory',
           jurisdictionId,
           'tabulatorStatus',
-        ]),
+        ])
+        // Sign off is reset if CVR is changed
+        queryClient.invalidateQueries([
+          'batchInventory',
+          jurisdictionId,
+          'signOff',
+        ])
+      },
     }),
     uploadFiles: files => {
       const formData = new FormData()
@@ -81,8 +88,18 @@ const useBatchInventoryTabulatorStatus = (
   const url = `/api/election/${electionId}/jurisdiction/${jurisdictionId}/batch-inventory/tabulator-status`
   const uploadFiles = useUploadFiles(key, url)
   const deleteFile = useDeleteFile(key, url)
+  const queryClient = useQueryClient()
   return {
-    uploadedFile: useUploadedFile(key, url),
+    uploadedFile: useUploadedFile(key, url, {
+      onFileChange: () => {
+        // Sign off is reset if tabulator status is changed
+        queryClient.invalidateQueries([
+          'batchInventory',
+          jurisdictionId,
+          'signOff',
+        ])
+      },
+    }),
     uploadFiles: files => {
       const formData = new FormData()
       formData.append('tabulatorStatus', files[0], files[0].name)

--- a/fixtures/tabulator-status.xml
+++ b/fixtures/tabulator-status.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="Small Election" Report="Tabulator Status" Create="2022-08-11 13:38:55" unofficial="Unofficial">
+      <Information Description="Election Project Name">Small Election</Information>
+      <Information Description="Report Name">Tabulator Status</Information>
+      <Information Description="Creation Date">2022-08-11 13:38:55</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <tabulators>
+      <tb id="1" tid="Tabulator A" name="Tabulator A" />
+      <tb id="2" tid="Tabulator B" name="Tabulator B" />
+      <tb id="3" tid="Tabulator C" name="Tabulator C" />
+   </tabulators>
+</ExportName>


### PR DESCRIPTION
Fixes #1668 

If a user clears and reuploads a file after signing off, we undo the sign off on the backend, since they will need to re-inventory their batches. The frontend didn't reload the sign off status when this happened, so the frontend ended up in an inconsistent state. Easy enough to fix by invalidating the query cache for sign off status.

Also added a test tabulator status file to fixtures.