### PR TITLE
BRAVO: Fix division-by-zero error

### DIFF
--- a/server/audit_math/bravo.py
+++ b/server/audit_math/bravo.py
@@ -7,6 +7,7 @@ Note that this library works for one contest at a time, as if each contest being
 targeted is being audited completely independently.
 """
 import math
+import decimal
 from decimal import Decimal
 from collections import defaultdict
 import logging
@@ -15,6 +16,9 @@ from scipy import stats
 
 from .sampler_contest import Contest
 from .ballot_polling_types import SampleSizeOption
+
+# Treat n/0 as Infinity instead of raising an error
+decimal.getcontext().traps[decimal.DivisionByZero] = False
 
 
 def get_expected_sample_size(

--- a/server/audit_math/bravo.py
+++ b/server/audit_math/bravo.py
@@ -7,7 +7,6 @@ Note that this library works for one contest at a time, as if each contest being
 targeted is being audited completely independently.
 """
 import math
-import decimal
 from decimal import Decimal
 from collections import defaultdict
 import logging
@@ -16,9 +15,6 @@ from scipy import stats
 
 from .sampler_contest import Contest
 from .ballot_polling_types import SampleSizeOption
-
-# Treat n/0 as Infinity instead of raising an error
-decimal.getcontext().traps[decimal.DivisionByZero] = False
 
 
 def get_expected_sample_size(
@@ -527,7 +523,7 @@ def compute_risk(
 
     finished = True
     for pair in T:
-        raw = 1 / T[pair]
+        raw = 1 / T[pair] if T[pair] > 0 else Decimal(1)
         measurements[pair] = min(float(raw), 1.0)
 
         if raw > alpha:

--- a/server/tests/audit_math/test_bravo.py
+++ b/server/tests/audit_math/test_bravo.py
@@ -506,6 +506,28 @@ def test_compute_risk_empty(contests):
         )
 
 
+def test_compute_risk_zero_test_statistic():
+    # This case caused a divide by zero error because the test statistic for
+    # cand1/cand4 was 0.
+    contest_data = {
+        "cand1": 700,
+        "cand2": 200,
+        "cand3": 1,
+        "cand4": 0,
+        "cand5": 10,
+        "ballots": 1000,
+        "numWinners": 1,
+        "votesAllowed": 1,
+    }
+    contest = Contest("Contest", contest_data)
+    sample_results = {
+        "Contest": {"cand1": 7, "cand2": 0, "cand3": 0, "cand4": 12, "cand5": 3}
+    }
+    computed_p, res = bravo.compute_risk(5, contest, sample_results)
+    assert computed_p[("cand1", "cand4")] == 1.0
+    assert res is False
+
+
 def test_tied_contest():
     contest_data = {
         "cand1": 500,


### PR DESCRIPTION
Fixes #1678 

Here's the line that had the divide-by-zero error: https://github.com/votingworks/arlo/blob/015c7fba37457933de77894e74628f2cd8d4314d/server/audit_math/bravo.py#L530

