### PR TITLE
Tally entry polish

### DIFF
--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-bYSBpT dUdHWJ"
+        class="bp3-card bp3-elevation-2 sc-elJkPf iwLbDp"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -120,18 +120,18 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-feJyhm krYXpQ"
+            class="sc-iELTvK bfpsxz"
           >
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -146,12 +146,12 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -167,15 +167,15 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -190,12 +190,12 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -211,7 +211,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <p
-              class="sc-btzYZH imeNGU"
+              class="sc-lhVmIH ijDAgt"
             >
               Add a new candidate/choice
             </p>
@@ -287,7 +287,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
         </div>
       </div>
       <div
-        class="sc-ktHwxA dgqBlL"
+        class="sc-cIShpX hnSaSy"
       >
         <button
           class="bp3-button sc-dnqmqq iQfLYL"
@@ -305,7 +305,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
       </div>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -346,7 +346,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-bYSBpT dUdHWJ"
+        class="bp3-card bp3-elevation-2 sc-elJkPf iwLbDp"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -452,18 +452,18 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-feJyhm krYXpQ"
+            class="sc-iELTvK bfpsxz"
           >
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -478,12 +478,12 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -499,15 +499,15 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -522,12 +522,12 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -543,7 +543,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-btzYZH imeNGU"
+              class="sc-lhVmIH ijDAgt"
             >
               Add a new candidate/choice
             </p>
@@ -619,7 +619,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
         </div>
       </div>
       <div
-        class="sc-ktHwxA dgqBlL"
+        class="sc-cIShpX hnSaSy"
       >
         <button
           class="bp3-button sc-dnqmqq iQfLYL"
@@ -637,7 +637,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -678,7 +678,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-bYSBpT dUdHWJ"
+        class="bp3-card bp3-elevation-2 sc-elJkPf iwLbDp"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -784,18 +784,18 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-feJyhm krYXpQ"
+            class="sc-iELTvK bfpsxz"
           >
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -810,12 +810,12 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -831,15 +831,15 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -854,12 +854,12 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -875,7 +875,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <p
-              class="sc-btzYZH imeNGU"
+              class="sc-lhVmIH ijDAgt"
             >
               Add a new candidate/choice
             </p>
@@ -951,7 +951,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
         </div>
       </div>
       <div
-        class="sc-ktHwxA dgqBlL"
+        class="sc-cIShpX hnSaSy"
       >
         <button
           class="bp3-button sc-dnqmqq iQfLYL"
@@ -969,7 +969,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
       </div>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -1010,7 +1010,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-bYSBpT dUdHWJ"
+        class="bp3-card bp3-elevation-2 sc-elJkPf iwLbDp"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -1116,18 +1116,18 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-feJyhm krYXpQ"
+            class="sc-iELTvK bfpsxz"
           >
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1142,12 +1142,12 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1163,15 +1163,15 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1186,12 +1186,12 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1207,7 +1207,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-btzYZH imeNGU"
+              class="sc-lhVmIH ijDAgt"
             >
               Add a new candidate/choice
             </p>
@@ -1283,7 +1283,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
         </div>
       </div>
       <div
-        class="sc-ktHwxA dgqBlL"
+        class="sc-cIShpX hnSaSy"
       >
         <button
           class="bp3-button sc-dnqmqq iQfLYL"
@@ -1301,7 +1301,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-bYSBpT dUdHWJ"
+        class="bp3-card bp3-elevation-2 sc-elJkPf iwLbDp"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -40,7 +40,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                Name
               <br />
               <div
-                class="bp3-html-select sc-elJkPf hrgGIk"
+                class="bp3-html-select sc-jtRfpW gAuylS"
               >
                 <select
                   field="[object Object]"
@@ -156,18 +156,18 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-feJyhm krYXpQ"
+            class="sc-iELTvK bfpsxz"
           >
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -182,12 +182,12 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -203,15 +203,15 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -226,12 +226,12 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -247,7 +247,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <p
-              class="sc-btzYZH imeNGU"
+              class="sc-lhVmIH ijDAgt"
             >
               Add a new candidate/choice
             </p>
@@ -255,7 +255,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
         </div>
       </div>
       <div
-        class="sc-ktHwxA dgqBlL"
+        class="sc-cIShpX hnSaSy"
       >
         <button
           class="bp3-button sc-dnqmqq iQfLYL"
@@ -273,7 +273,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
       </div>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"

--- a/client/src/components/AuditAdmin/Setup/__snapshots__/Setup.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/__snapshots__/Setup.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select sc-jtRfpW erLKZH"
+              class="bp3-html-select sc-kTUwUJ iPieaP"
             >
               <select
                 field="[object Object]"
@@ -463,7 +463,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select sc-jtRfpW erLKZH"
+              class="bp3-html-select sc-kTUwUJ iPieaP"
             >
               <select
                 data-testid="risk-limit"
@@ -631,7 +631,7 @@ exports[`Setup renders Audit Settings stage 1`] = `
       </div>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -687,7 +687,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select bp3-disabled sc-jtRfpW erLKZH"
+              class="bp3-html-select bp3-disabled sc-kTUwUJ iPieaP"
             >
               <select
                 disabled=""
@@ -1125,7 +1125,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select bp3-disabled sc-jtRfpW erLKZH"
+              class="bp3-html-select bp3-disabled sc-kTUwUJ iPieaP"
             >
               <select
                 data-testid="risk-limit"
@@ -1295,7 +1295,7 @@ exports[`Setup renders Audit Settings stage with locked next stage 1`] = `
       </div>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -1353,7 +1353,7 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select sc-jtRfpW erLKZH"
+              class="bp3-html-select sc-kTUwUJ iPieaP"
             >
               <select
                 field="[object Object]"
@@ -1787,7 +1787,7 @@ exports[`Setup renders Audit Settings stage with processing next stage 1`] = `
           </p>
           <div>
             <div
-              class="bp3-html-select sc-jtRfpW erLKZH"
+              class="bp3-html-select sc-kTUwUJ iPieaP"
             >
               <select
                 data-testid="risk-limit"
@@ -1998,7 +1998,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-bYSBpT dUdHWJ"
+        class="bp3-card bp3-elevation-2 sc-elJkPf iwLbDp"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -2104,18 +2104,18 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-feJyhm krYXpQ"
+            class="sc-iELTvK bfpsxz"
           >
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -2130,12 +2130,12 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -2151,15 +2151,15 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -2174,12 +2174,12 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -2195,7 +2195,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
               </label>
             </div>
             <p
-              class="sc-btzYZH imeNGU"
+              class="sc-lhVmIH ijDAgt"
             >
               Add a new candidate/choice
             </p>
@@ -2271,7 +2271,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
         </div>
       </div>
       <div
-        class="sc-ktHwxA dgqBlL"
+        class="sc-cIShpX hnSaSy"
       >
         <button
           class="bp3-button sc-dnqmqq iQfLYL"
@@ -2289,7 +2289,7 @@ exports[`Setup renders Opportunistic Contests stage 1`] = `
       </div>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -2330,7 +2330,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-bYSBpT dUdHWJ"
+        class="bp3-card bp3-elevation-2 sc-elJkPf iwLbDp"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -2439,18 +2439,18 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-feJyhm krYXpQ"
+            class="sc-iELTvK bfpsxz"
           >
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
@@ -2466,12 +2466,12 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
@@ -2488,15 +2488,15 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
               </label>
             </div>
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
@@ -2512,12 +2512,12 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
@@ -2606,7 +2606,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
         </div>
       </div>
       <div
-        class="sc-ktHwxA dgqBlL"
+        class="sc-cIShpX hnSaSy"
       >
         <button
           class="bp3-button sc-dnqmqq iQfLYL"
@@ -2624,7 +2624,7 @@ exports[`Setup renders Opportunistic Contests stage with locked next stage 1`] =
       </div>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -2667,7 +2667,7 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-bYSBpT dUdHWJ"
+        class="bp3-card bp3-elevation-2 sc-elJkPf iwLbDp"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -2773,18 +2773,18 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-feJyhm krYXpQ"
+            class="sc-iELTvK bfpsxz"
           >
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -2799,12 +2799,12 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -2820,15 +2820,15 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
               </label>
             </div>
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -2843,12 +2843,12 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -2864,7 +2864,7 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
               </label>
             </div>
             <p
-              class="sc-btzYZH imeNGU"
+              class="sc-lhVmIH ijDAgt"
             >
               Add a new candidate/choice
             </p>
@@ -2940,7 +2940,7 @@ exports[`Setup renders Opportunistic Contests stage with processing next stage 1
         </div>
       </div>
       <div
-        class="sc-ktHwxA dgqBlL"
+        class="sc-cIShpX hnSaSy"
       >
         <button
           class="bp3-button sc-dnqmqq iQfLYL"
@@ -3049,7 +3049,7 @@ exports[`Setup renders Participants stage 1`] = `
       </div>
     </form>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
@@ -3128,7 +3128,7 @@ exports[`Setup renders Participants stage with locked next stage 1`] = `
       </div>
     </form>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button bp3-disabled bp3-intent-primary sc-dnqmqq iQfLYL"
@@ -3209,7 +3209,7 @@ exports[`Setup renders Participants stage with processing next stage 1`] = `
       </div>
     </form>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button bp3-intent-primary sc-dnqmqq iQfLYL"
@@ -3268,7 +3268,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
       class="bp3-card bp3-elevation-0"
     >
       <table
-        class="sc-kTUwUJ lbibZk"
+        class="sc-dqBHgY kqHugB"
       >
         <tbody>
           <tr>
@@ -3482,7 +3482,7 @@ exports[`Setup renders Review & Launch stage 1`] = `
       </span>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -3553,7 +3553,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
       class="bp3-card bp3-elevation-0"
     >
       <table
-        class="sc-kTUwUJ lbibZk"
+        class="sc-dqBHgY kqHugB"
       >
         <tbody>
           <tr>
@@ -3767,7 +3767,7 @@ exports[`Setup renders Review & Launch stage with locked next stage 1`] = `
       </span>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -3838,7 +3838,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
       class="bp3-card bp3-elevation-0"
     >
       <table
-        class="sc-kTUwUJ lbibZk"
+        class="sc-dqBHgY kqHugB"
       >
         <tbody>
           <tr>
@@ -4052,7 +4052,7 @@ exports[`Setup renders Review & Launch stage with processing next stage 1`] = `
       </span>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -4095,7 +4095,7 @@ exports[`Setup renders Target Contests stage 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-bYSBpT dUdHWJ"
+        class="bp3-card bp3-elevation-2 sc-elJkPf iwLbDp"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -4201,18 +4201,18 @@ exports[`Setup renders Target Contests stage 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-feJyhm krYXpQ"
+            class="sc-iELTvK bfpsxz"
           >
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -4227,12 +4227,12 @@ exports[`Setup renders Target Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -4248,15 +4248,15 @@ exports[`Setup renders Target Contests stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -4271,12 +4271,12 @@ exports[`Setup renders Target Contests stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -4292,7 +4292,7 @@ exports[`Setup renders Target Contests stage 1`] = `
               </label>
             </div>
             <p
-              class="sc-btzYZH imeNGU"
+              class="sc-lhVmIH ijDAgt"
             >
               Add a new candidate/choice
             </p>
@@ -4368,7 +4368,7 @@ exports[`Setup renders Target Contests stage 1`] = `
         </div>
       </div>
       <div
-        class="sc-ktHwxA dgqBlL"
+        class="sc-cIShpX hnSaSy"
       >
         <button
           class="bp3-button sc-dnqmqq iQfLYL"
@@ -4386,7 +4386,7 @@ exports[`Setup renders Target Contests stage 1`] = `
       </div>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -4427,7 +4427,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-bYSBpT dUdHWJ"
+        class="bp3-card bp3-elevation-2 sc-elJkPf iwLbDp"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -4536,18 +4536,18 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-feJyhm krYXpQ"
+            class="sc-iELTvK bfpsxz"
           >
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
@@ -4563,12 +4563,12 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
@@ -4585,15 +4585,15 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
@@ -4609,12 +4609,12 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group bp3-disabled sc-VigVT hfLuvB"
@@ -4703,7 +4703,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
         </div>
       </div>
       <div
-        class="sc-ktHwxA dgqBlL"
+        class="sc-cIShpX hnSaSy"
       >
         <button
           class="bp3-button sc-dnqmqq iQfLYL"
@@ -4721,7 +4721,7 @@ exports[`Setup renders Target Contests stage with locked next stage 1`] = `
       </div>
     </div>
     <div
-      class="sc-ktHwxA dgqBlL"
+      class="sc-cIShpX hnSaSy"
     >
       <button
         class="bp3-button sc-dnqmqq iQfLYL"
@@ -4764,7 +4764,7 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-2 sc-bYSBpT dUdHWJ"
+        class="bp3-card bp3-elevation-2 sc-elJkPf iwLbDp"
       >
         <div
           class="sc-bZQynM bGsEQi"
@@ -4870,18 +4870,18 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-feJyhm krYXpQ"
+            class="sc-iELTvK bfpsxz"
           >
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -4896,12 +4896,12 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -4917,15 +4917,15 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
               </label>
             </div>
             <div
-              class="sc-iELTvK eQBeVz"
+              class="sc-cmTdod kSjajG"
             >
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -4940,12 +4940,12 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jwKygS bTurBK"
+                class="bp3-label sc-btzYZH ilSSKh"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-cmTdod kZUjmP sc-gqjmRU egaEhI"
+                  class="sc-jwKygS ivhutu sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -4961,7 +4961,7 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
               </label>
             </div>
             <p
-              class="sc-btzYZH imeNGU"
+              class="sc-lhVmIH ijDAgt"
             >
               Add a new candidate/choice
             </p>
@@ -5037,7 +5037,7 @@ exports[`Setup renders Target Contests stage with processing next stage 1`] = `
         </div>
       </div>
       <div
-        class="sc-ktHwxA dgqBlL"
+        class="sc-cIShpX hnSaSy"
       >
         <button
           class="bp3-button sc-dnqmqq iQfLYL"

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -61,19 +61,19 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-dymIpo bCZGGM"
+          class="sc-bnXvFD hPDGgo"
         >
           <div
-            class="sc-bnXvFD chMRXM"
+            class="sc-gFaPwZ gitDhs"
           >
             <div
-              class="sc-gFaPwZ exogZK"
+              class="sc-fhYwyz cZrpRe"
             >
               <div
-                class="sc-gJWqzi kQKNdw"
+                class="sc-rBLzX cSMbsl"
               >
                 <button
-                  class="bp3-button bp3-minimal sc-jzgbtB dyEboN"
+                  class="bp3-button bp3-minimal sc-gJWqzi jsleDq"
                   href="/election/1/audit-board/audit-board-1"
                   type="button"
                 >
@@ -103,56 +103,56 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                   </span>
                 </button>
                 <h3
-                  class="bp3-heading sc-cpmLhU fRwInG"
+                  class="bp3-heading sc-dymIpo LUbrk"
                 >
                   Audit Ballot Selections
                 </h3>
               </div>
               <div
-                class="bp3-divider sc-iujRgT jCEjpC"
+                class="bp3-divider sc-GMQeP iQpIrV"
               />
               <div
-                class="sc-fOKMvo gDDLHl"
+                class="sc-dUjcNx jKrREz"
               >
                 <div>
                   <h5
-                    class="bp3-heading sc-krvtoX kNVSLK"
+                    class="bp3-heading sc-fYiAbW hrVJLl"
                   >
                     Tabulator
                   </h5>
                   <h4
-                    class="bp3-heading sc-dUjcNx kMaxPn"
+                    class="bp3-heading sc-gHboQg ZRMoo"
                   >
                     11
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-krvtoX kNVSLK"
+                    class="bp3-heading sc-fYiAbW hrVJLl"
                   >
                     Batch
                   </h5>
                   <h4
-                    class="bp3-heading sc-dUjcNx kMaxPn"
+                    class="bp3-heading sc-gHboQg ZRMoo"
                   >
                     0003-04-Precinct 19 (Jonesboro Fire Department)
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-krvtoX kNVSLK"
+                    class="bp3-heading sc-fYiAbW hrVJLl"
                   >
                     Ballot Number
                   </h5>
                   <h4
-                    class="bp3-heading sc-dUjcNx kMaxPn"
+                    class="bp3-heading sc-gHboQg ZRMoo"
                   >
                     2112
                   </h4>
                 </div>
                 <div>
                   <button
-                    class="bp3-button bp3-large bp3-intent-danger sc-gHboQg cAeqPr"
+                    class="bp3-button bp3-large bp3-intent-danger sc-eilVRo bDOAlf"
                     type="button"
                   >
                     <span
@@ -164,36 +164,36 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 </div>
               </div>
               <div
-                class="bp3-divider sc-iujRgT jCEjpC"
+                class="bp3-divider sc-GMQeP iQpIrV"
               />
               <div
-                class="sc-GMQeP jStzdB"
+                class="sc-exAgwC fjYUSS"
               >
                 <div
                   class="ballot-main"
                 >
                   <h5
-                    class="bp3-heading sc-krvtoX kNVSLK"
+                    class="bp3-heading sc-fYiAbW hrVJLl"
                   >
                     Ballot Contests
                   </h5>
                   <form>
                     <div
-                      class="sc-exAgwC kDVnMR"
+                      class="sc-cQFLBn fJDCQF"
                     >
                       <div
-                        class="sc-lkqHmb kBWYRq"
+                        class="sc-eLExRp zQklM"
                       >
                         <div
-                          class="sc-eLExRp fnmqTt"
+                          class="sc-cbkKFq ivQXOC"
                         >
                           <h3
-                            class="bp3-heading sc-eerKOB eLHEpn"
+                            class="bp3-heading sc-emmjRN brqvJy"
                           >
                             Contest 1
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-fYiAbW cTwHRq"
+                            class="bp3-control bp3-checkbox sc-fOKMvo ewFyBh"
                           >
                             <input
                               type="checkbox"
@@ -209,7 +209,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-fYiAbW cTwHRq"
+                            class="bp3-control bp3-checkbox sc-fOKMvo ewFyBh"
                           >
                             <input
                               type="checkbox"
@@ -226,10 +226,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-cbkKFq cAAESy"
+                          class="sc-krvtoX ePzNJw"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-fYiAbW cTwHRq"
+                            class="bp3-control bp3-checkbox sc-fOKMvo ewFyBh"
                           >
                             <input
                               type="checkbox"
@@ -245,7 +245,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-fYiAbW cTwHRq"
+                            class="bp3-control bp3-checkbox sc-fOKMvo ewFyBh"
                           >
                             <input
                               type="checkbox"
@@ -261,7 +261,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-fYiAbW cTwHRq"
+                            class="bp3-control bp3-checkbox sc-fOKMvo ewFyBh"
                           >
                             <input
                               type="checkbox"
@@ -277,7 +277,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-eilVRo jiwLPR"
+                            class="bp3-input sc-eerKOB gaScCM"
                             name="comment-Contest 1"
                             placeholder="Add Note"
                           />
@@ -285,21 +285,21 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-exAgwC kDVnMR"
+                      class="sc-cQFLBn fJDCQF"
                     >
                       <div
-                        class="sc-lkqHmb kBWYRq"
+                        class="sc-eLExRp zQklM"
                       >
                         <div
-                          class="sc-eLExRp fnmqTt"
+                          class="sc-cbkKFq ivQXOC"
                         >
                           <h3
-                            class="bp3-heading sc-eerKOB eLHEpn"
+                            class="bp3-heading sc-emmjRN brqvJy"
                           >
                             Contest 2
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-fYiAbW cTwHRq"
+                            class="bp3-control bp3-checkbox sc-fOKMvo ewFyBh"
                           >
                             <input
                               type="checkbox"
@@ -315,7 +315,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-fYiAbW cTwHRq"
+                            class="bp3-control bp3-checkbox sc-fOKMvo ewFyBh"
                           >
                             <input
                               type="checkbox"
@@ -332,10 +332,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-cbkKFq cAAESy"
+                          class="sc-krvtoX ePzNJw"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-fYiAbW cTwHRq"
+                            class="bp3-control bp3-checkbox sc-fOKMvo ewFyBh"
                           >
                             <input
                               type="checkbox"
@@ -351,7 +351,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-fYiAbW cTwHRq"
+                            class="bp3-control bp3-checkbox sc-fOKMvo ewFyBh"
                           >
                             <input
                               type="checkbox"
@@ -367,7 +367,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-fYiAbW cTwHRq"
+                            class="bp3-control bp3-checkbox sc-fOKMvo ewFyBh"
                           >
                             <input
                               type="checkbox"
@@ -383,7 +383,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-eilVRo jiwLPR"
+                            class="bp3-input sc-eerKOB gaScCM"
                             name="comment-Contest 2"
                             placeholder="Add Note"
                           />
@@ -391,10 +391,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-gojNiO hBzvZd"
+                      class="sc-daURTG RvzMT"
                     >
                       <button
-                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-emmjRN rhekj sc-dnqmqq iQfLYL"
+                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-cpmLhU kJKVeE sc-dnqmqq iQfLYL"
                         disabled=""
                         tabindex="-1"
                         type="submit"
@@ -421,7 +421,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
               </div>
             </div>
             <div
-              class="sc-fhYwyz gcjafP"
+              class="sc-jzgbtB bsKESq"
             >
               <h4
                 class="bp3-heading"
@@ -429,7 +429,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 Instructions
               </h4>
               <ol
-                class="bp3-list sc-rBLzX iksspZ"
+                class="bp3-list sc-bMvGRv eBpnBq"
               >
                 <li>
                   Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -534,13 +534,13 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
       class="board-table-container"
     >
       <div
-        class="sc-epnACN eTmQRZ"
+        class="sc-iQNlJl dMDGey"
       >
         <div
-          class="sc-bwzfXH sc-iQNlJl laBoKw"
+          class="sc-bwzfXH sc-bsbRJL cNJRhm"
         >
           <div
-            class="sc-gwVKww fTBFfA"
+            class="sc-hXRMBi fSFhHH"
           >
             <p>
               18
@@ -549,23 +549,23 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-hMFtBS hMQNuR"
+              class="summary-label sc-cLQEGU fOwvLx"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-cLQEGU bOEQxn"
+              class="summary-label sc-gqPbQI eFtLSi"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-hXRMBi gwQLAb"
+            class="sc-epnACN etwReV"
           >
             <button
-              class="bp3-button bp3-intent-success sc-hORach hhCkDg"
+              class="bp3-button bp3-intent-success sc-bMVAic fdbZSH"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -582,10 +582,10 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-bsbRJL gAbEEU"
+          class="sc-hZSUBg dpZUjx"
         >
           <div
-            class="sc-hZSUBg ifMNaM"
+            class="sc-cMhqgX bGUGOE"
           >
             <h3
               class="bp3-heading"
@@ -594,7 +594,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Audit Board #1
             </h3>
             <div
-              class="sc-cMhqgX kcBDat"
+              class="sc-iuJeZd gnppoj"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -799,7 +799,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -809,7 +809,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -819,7 +819,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -829,7 +829,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -858,7 +858,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -877,7 +877,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -886,7 +886,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -895,7 +895,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -904,7 +904,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -913,7 +913,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -934,7 +934,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -944,7 +944,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -954,7 +954,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -964,7 +964,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -993,7 +993,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -1012,7 +1012,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1022,7 +1022,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1032,7 +1032,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1042,7 +1042,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1071,7 +1071,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -1090,7 +1090,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -1099,7 +1099,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1108,7 +1108,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -1117,7 +1117,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -1126,7 +1126,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -1147,7 +1147,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1157,7 +1157,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1167,7 +1167,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1177,7 +1177,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1206,7 +1206,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -1225,7 +1225,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1235,7 +1235,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1245,7 +1245,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1255,7 +1255,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1284,7 +1284,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -1303,7 +1303,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -1312,7 +1312,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1321,7 +1321,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -1330,7 +1330,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -1339,7 +1339,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -1360,7 +1360,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1370,7 +1370,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1380,7 +1380,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1390,7 +1390,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1419,7 +1419,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -1438,7 +1438,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1448,7 +1448,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1458,7 +1458,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1468,7 +1468,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1497,7 +1497,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -1516,7 +1516,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -1525,7 +1525,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1534,7 +1534,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -1543,7 +1543,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -1552,7 +1552,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -1573,7 +1573,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1583,7 +1583,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1593,7 +1593,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1603,7 +1603,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1632,7 +1632,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -1651,7 +1651,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1661,7 +1661,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1671,7 +1671,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1681,7 +1681,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1710,7 +1710,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -1729,7 +1729,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -1738,7 +1738,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1747,7 +1747,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -1756,7 +1756,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -1765,7 +1765,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -1786,7 +1786,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1796,7 +1796,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1806,7 +1806,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1816,7 +1816,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1845,7 +1845,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -1864,7 +1864,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1874,7 +1874,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1884,7 +1884,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1894,7 +1894,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1923,7 +1923,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -1942,7 +1942,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -1951,7 +1951,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1960,7 +1960,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -1969,7 +1969,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -1978,7 +1978,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -1999,7 +1999,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2009,7 +2009,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2019,7 +2019,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2029,7 +2029,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2058,7 +2058,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -2077,7 +2077,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2087,7 +2087,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2097,7 +2097,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2107,7 +2107,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2136,7 +2136,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -2155,7 +2155,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -2164,7 +2164,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2173,7 +2173,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -2182,7 +2182,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -2191,7 +2191,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -2212,7 +2212,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2222,7 +2222,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2232,7 +2232,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2242,7 +2242,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2271,7 +2271,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -2290,7 +2290,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2300,7 +2300,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2310,7 +2310,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2320,7 +2320,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2349,7 +2349,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -2368,7 +2368,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -2377,7 +2377,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2386,7 +2386,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -2395,7 +2395,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -2404,7 +2404,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -2425,7 +2425,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2435,7 +2435,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2445,7 +2445,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2455,7 +2455,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2484,7 +2484,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -2503,7 +2503,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2513,7 +2513,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2523,7 +2523,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2533,7 +2533,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2562,7 +2562,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -2581,7 +2581,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -2590,7 +2590,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2599,7 +2599,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -2608,7 +2608,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -2617,7 +2617,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -2638,7 +2638,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2648,7 +2648,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2658,7 +2658,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2668,7 +2668,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2697,7 +2697,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -2713,7 +2713,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-bMVAic iKphmS"
+              class="bp3-button bp3-disabled bp3-large sc-bAeIUo bMNvpu"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -2727,7 +2727,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
             </button>
           </div>
           <div
-            class="sc-iuJeZd dpgEAl"
+            class="sc-esOvli dOZOEr"
           >
             <h4
               class="bp3-heading"
@@ -2735,7 +2735,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-gqPbQI fopDxs"
+              class="bp3-list sc-hORach otqOU"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -2815,13 +2815,13 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
       class="board-table-container"
     >
       <div
-        class="sc-epnACN eTmQRZ"
+        class="sc-iQNlJl dMDGey"
       >
         <div
-          class="sc-bwzfXH sc-iQNlJl laBoKw"
+          class="sc-bwzfXH sc-bsbRJL cNJRhm"
         >
           <div
-            class="sc-gwVKww fTBFfA"
+            class="sc-hXRMBi fSFhHH"
           >
             <p>
               0
@@ -2830,23 +2830,23 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-hMFtBS hMQNuR"
+              class="summary-label sc-cLQEGU fOwvLx"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-cLQEGU bOEQxn"
+              class="summary-label sc-gqPbQI eFtLSi"
             >
               Not Audited: 
               27
             </span>
           </div>
           <div
-            class="sc-hXRMBi gwQLAb"
+            class="sc-epnACN etwReV"
           >
             <button
-              class="bp3-button bp3-intent-success sc-hORach hhCkDg"
+              class="bp3-button bp3-intent-success sc-bMVAic fdbZSH"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
               type="button"
             >
@@ -2863,10 +2863,10 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-bsbRJL gAbEEU"
+          class="sc-hZSUBg dpZUjx"
         >
           <div
-            class="sc-hZSUBg ifMNaM"
+            class="sc-cMhqgX bGUGOE"
           >
             <h3
               class="bp3-heading"
@@ -2875,7 +2875,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Audit Board #1
             </h3>
             <div
-              class="sc-cMhqgX kcBDat"
+              class="sc-iuJeZd gnppoj"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -3080,7 +3080,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3089,7 +3089,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3098,7 +3098,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         313
                       </p>
@@ -3107,7 +3107,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3116,7 +3116,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -3137,7 +3137,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3146,7 +3146,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3155,7 +3155,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -3164,7 +3164,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3173,7 +3173,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -3194,7 +3194,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3203,7 +3203,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3212,7 +3212,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         1789
                       </p>
@@ -3221,7 +3221,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3230,7 +3230,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -3251,7 +3251,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3260,7 +3260,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3269,7 +3269,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         313
                       </p>
@@ -3278,7 +3278,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3287,7 +3287,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -3308,7 +3308,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3317,7 +3317,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3326,7 +3326,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -3335,7 +3335,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3344,7 +3344,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -3365,7 +3365,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3374,7 +3374,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3383,7 +3383,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         1789
                       </p>
@@ -3392,7 +3392,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3401,7 +3401,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -3422,7 +3422,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3431,7 +3431,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3440,7 +3440,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         313
                       </p>
@@ -3449,7 +3449,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3458,7 +3458,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -3479,7 +3479,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3488,7 +3488,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3497,7 +3497,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -3506,7 +3506,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3515,7 +3515,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -3536,7 +3536,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3545,7 +3545,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3554,7 +3554,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         1789
                       </p>
@@ -3563,7 +3563,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3572,7 +3572,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -3593,7 +3593,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3602,7 +3602,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3611,7 +3611,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         313
                       </p>
@@ -3620,7 +3620,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3629,7 +3629,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -3650,7 +3650,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3659,7 +3659,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3668,7 +3668,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -3677,7 +3677,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3686,7 +3686,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -3707,7 +3707,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3716,7 +3716,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3725,7 +3725,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         1789
                       </p>
@@ -3734,7 +3734,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3743,7 +3743,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -3764,7 +3764,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3773,7 +3773,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3782,7 +3782,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         313
                       </p>
@@ -3791,7 +3791,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3800,7 +3800,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -3821,7 +3821,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3830,7 +3830,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3839,7 +3839,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -3848,7 +3848,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3857,7 +3857,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -3878,7 +3878,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3887,7 +3887,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3896,7 +3896,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         1789
                       </p>
@@ -3905,7 +3905,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3914,7 +3914,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -3935,7 +3935,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -3944,7 +3944,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3953,7 +3953,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         313
                       </p>
@@ -3962,7 +3962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -3971,7 +3971,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -3992,7 +3992,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -4001,7 +4001,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4010,7 +4010,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -4019,7 +4019,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -4028,7 +4028,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -4049,7 +4049,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -4058,7 +4058,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4067,7 +4067,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         1789
                       </p>
@@ -4076,7 +4076,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -4085,7 +4085,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -4106,7 +4106,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -4115,7 +4115,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4124,7 +4124,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         313
                       </p>
@@ -4133,7 +4133,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -4142,7 +4142,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -4163,7 +4163,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -4172,7 +4172,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4181,7 +4181,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -4190,7 +4190,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -4199,7 +4199,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -4220,7 +4220,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -4229,7 +4229,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4238,7 +4238,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         1789
                       </p>
@@ -4247,7 +4247,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -4256,7 +4256,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -4277,7 +4277,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -4286,7 +4286,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4295,7 +4295,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         313
                       </p>
@@ -4304,7 +4304,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -4313,7 +4313,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -4334,7 +4334,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -4343,7 +4343,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4352,7 +4352,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -4361,7 +4361,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -4370,7 +4370,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -4391,7 +4391,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -4400,7 +4400,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4409,7 +4409,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         1789
                       </p>
@@ -4418,7 +4418,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -4427,7 +4427,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -4448,7 +4448,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -4457,7 +4457,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4466,7 +4466,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         313
                       </p>
@@ -4475,7 +4475,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -4484,7 +4484,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -4505,7 +4505,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -4514,7 +4514,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4523,7 +4523,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -4532,7 +4532,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -4541,7 +4541,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -4562,7 +4562,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -4571,7 +4571,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4580,7 +4580,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         1789
                       </p>
@@ -4589,7 +4589,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -4598,7 +4598,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -4616,7 +4616,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-bMVAic iKphmS"
+              class="bp3-button bp3-disabled bp3-large sc-bAeIUo bMNvpu"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -4630,7 +4630,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
             </button>
           </div>
           <div
-            class="sc-iuJeZd dpgEAl"
+            class="sc-esOvli dOZOEr"
           >
             <h4
               class="bp3-heading"
@@ -4638,7 +4638,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-gqPbQI fopDxs"
+              class="bp3-list sc-hORach otqOU"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -4718,13 +4718,13 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
       class="board-table-container"
     >
       <div
-        class="sc-epnACN eTmQRZ"
+        class="sc-iQNlJl dMDGey"
       >
         <div
-          class="sc-bwzfXH sc-iQNlJl laBoKw"
+          class="sc-bwzfXH sc-bsbRJL cNJRhm"
         >
           <div
-            class="sc-gwVKww fTBFfA"
+            class="sc-hXRMBi fSFhHH"
           >
             <p>
               0
@@ -4733,23 +4733,23 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-hMFtBS hMQNuR"
+              class="summary-label sc-cLQEGU fOwvLx"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-cLQEGU bOEQxn"
+              class="summary-label sc-gqPbQI eFtLSi"
             >
               Not Audited: 
               0
             </span>
           </div>
           <div
-            class="sc-hXRMBi gwQLAb"
+            class="sc-epnACN etwReV"
           >
             <button
-              class="bp3-button bp3-intent-success sc-hORach hhCkDg"
+              class="bp3-button bp3-intent-success sc-bMVAic fdbZSH"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4766,10 +4766,10 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-bsbRJL gAbEEU"
+          class="sc-hZSUBg dpZUjx"
         >
           <div
-            class="sc-hZSUBg ifMNaM"
+            class="sc-cMhqgX bGUGOE"
           >
             <h3
               class="bp3-heading"
@@ -4778,7 +4778,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Audit Board #1
             </h3>
             <div
-              class="sc-cMhqgX kcBDat"
+              class="sc-iuJeZd gnppoj"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -4942,7 +4942,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               </table>
             </div>
             <button
-              class="bp3-button bp3-large bp3-intent-success sc-bMVAic iKphmS"
+              class="bp3-button bp3-large bp3-intent-success sc-bAeIUo bMNvpu"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4954,7 +4954,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
             </button>
           </div>
           <div
-            class="sc-iuJeZd dpgEAl"
+            class="sc-esOvli dOZOEr"
           >
             <h4
               class="bp3-heading"
@@ -4962,7 +4962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-gqPbQI fopDxs"
+              class="bp3-list sc-hORach otqOU"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -5042,13 +5042,13 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
       class="board-table-container"
     >
       <div
-        class="sc-epnACN eTmQRZ"
+        class="sc-iQNlJl dMDGey"
       >
         <div
-          class="sc-bwzfXH sc-iQNlJl laBoKw"
+          class="sc-bwzfXH sc-bsbRJL cNJRhm"
         >
           <div
-            class="sc-gwVKww fTBFfA"
+            class="sc-hXRMBi fSFhHH"
           >
             <p>
               18
@@ -5057,23 +5057,23 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-hMFtBS hMQNuR"
+              class="summary-label sc-cLQEGU fOwvLx"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-cLQEGU bOEQxn"
+              class="summary-label sc-gqPbQI eFtLSi"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-hXRMBi gwQLAb"
+            class="sc-epnACN etwReV"
           >
             <button
-              class="bp3-button bp3-intent-success sc-hORach hhCkDg"
+              class="bp3-button bp3-intent-success sc-bMVAic fdbZSH"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -5090,10 +5090,10 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-bsbRJL gAbEEU"
+          class="sc-hZSUBg dpZUjx"
         >
           <div
-            class="sc-hZSUBg ifMNaM"
+            class="sc-cMhqgX bGUGOE"
           >
             <h3
               class="bp3-heading"
@@ -5102,7 +5102,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Audit Board #1
             </h3>
             <div
-              class="sc-cMhqgX kcBDat"
+              class="sc-iuJeZd gnppoj"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -5307,7 +5307,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5317,7 +5317,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5327,7 +5327,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5337,7 +5337,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5366,7 +5366,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -5385,7 +5385,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -5394,7 +5394,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5403,7 +5403,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -5412,7 +5412,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -5421,7 +5421,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -5442,7 +5442,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5452,7 +5452,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5462,7 +5462,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5472,7 +5472,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5501,7 +5501,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -5520,7 +5520,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5530,7 +5530,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5540,7 +5540,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5550,7 +5550,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5579,7 +5579,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -5598,7 +5598,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -5607,7 +5607,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5616,7 +5616,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -5625,7 +5625,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -5634,7 +5634,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -5655,7 +5655,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5665,7 +5665,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5675,7 +5675,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5685,7 +5685,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5714,7 +5714,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -5733,7 +5733,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5743,7 +5743,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5753,7 +5753,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5763,7 +5763,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5792,7 +5792,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -5811,7 +5811,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -5820,7 +5820,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5829,7 +5829,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -5838,7 +5838,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -5847,7 +5847,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -5868,7 +5868,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5878,7 +5878,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5888,7 +5888,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5898,7 +5898,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5927,7 +5927,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -5946,7 +5946,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5956,7 +5956,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5966,7 +5966,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5976,7 +5976,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6005,7 +6005,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -6024,7 +6024,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -6033,7 +6033,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6042,7 +6042,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -6051,7 +6051,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -6060,7 +6060,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -6081,7 +6081,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6091,7 +6091,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6101,7 +6101,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6111,7 +6111,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6140,7 +6140,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -6159,7 +6159,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6169,7 +6169,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6179,7 +6179,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6189,7 +6189,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6218,7 +6218,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -6237,7 +6237,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -6246,7 +6246,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6255,7 +6255,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -6264,7 +6264,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -6273,7 +6273,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -6294,7 +6294,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6304,7 +6304,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6314,7 +6314,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6324,7 +6324,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6353,7 +6353,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -6372,7 +6372,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6382,7 +6382,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6392,7 +6392,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6402,7 +6402,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6431,7 +6431,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -6450,7 +6450,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -6459,7 +6459,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6468,7 +6468,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -6477,7 +6477,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -6486,7 +6486,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -6507,7 +6507,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6517,7 +6517,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6527,7 +6527,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6537,7 +6537,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6566,7 +6566,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -6585,7 +6585,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6595,7 +6595,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6605,7 +6605,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6615,7 +6615,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6644,7 +6644,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -6663,7 +6663,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -6672,7 +6672,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6681,7 +6681,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -6690,7 +6690,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -6699,7 +6699,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -6720,7 +6720,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6730,7 +6730,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6740,7 +6740,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6750,7 +6750,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6779,7 +6779,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -6798,7 +6798,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6808,7 +6808,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6818,7 +6818,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6828,7 +6828,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6857,7 +6857,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -6876,7 +6876,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -6885,7 +6885,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6894,7 +6894,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -6903,7 +6903,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -6912,7 +6912,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -6933,7 +6933,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6943,7 +6943,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6953,7 +6953,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6963,7 +6963,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6992,7 +6992,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -7011,7 +7011,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7021,7 +7021,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -7031,7 +7031,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -7041,7 +7041,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7070,7 +7070,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -7089,7 +7089,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         11
                       </p>
@@ -7098,7 +7098,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -7107,7 +7107,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                       >
                         2112
                       </p>
@@ -7116,7 +7116,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-cLQEGU bOEQxn"
+                        class="sc-gqPbQI eFtLSi"
                       >
                         Not Audited
                       </span>
@@ -7125,7 +7125,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -7146,7 +7146,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7156,7 +7156,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -7166,7 +7166,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -7176,7 +7176,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bAeIUo fltotD"
+                        class="sc-iujRgT euDuiH"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7205,7 +7205,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-esOvli cgHuro"
+                        class="bp3-button bp3-fill bp3-minimal sc-cmthru dfNwDT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -7221,7 +7221,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-bMVAic iKphmS"
+              class="bp3-button bp3-disabled bp3-large sc-bAeIUo bMNvpu"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -7235,7 +7235,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
             </button>
           </div>
           <div
-            class="sc-iuJeZd dpgEAl"
+            class="sc-esOvli dOZOEr"
           >
             <h4
               class="bp3-heading"
@@ -7243,7 +7243,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-gqPbQI fopDxs"
+              class="bp3-list sc-hORach otqOU"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
@@ -438,15 +438,7 @@ describe('BatchRoundSteps', () => {
       })
 
       expect(screen.getAllByText('Batch One')).toHaveLength(2)
-      // TODO fill in comprehensive tests once the tally entry interface is finalized
-
-      const finalizeButton = screen.getByRole('button', {
-        name: /Finalize Tallies/,
-      })
-      userEvent.click(finalizeButton)
-      await findAndCloseToast(
-        'Please enter tallies for all batches before finalizing.'
-      )
+      // Comprehensive tests are in BatchRoundTallyEntry.test.tsx
     })
   })
 
@@ -468,6 +460,7 @@ describe('BatchRoundSteps', () => {
       })
       await screen.findByRole('table')
 
+      screen.getByText('All batches audited')
       const finalizeButton = screen.getByRole('button', {
         name: /Finalize Tallies/,
       })
@@ -481,7 +474,7 @@ describe('BatchRoundSteps', () => {
       userEvent.click(within(dialog).getByRole('button', { name: 'Confirm' }))
 
       await screen.findByText('Tallies finalized')
-      expect(finalizeButton).toBeDisabled()
+      expect(finalizeButton).not.toBeInTheDocument()
     })
   })
 

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundTallyEntry/BatchDetail.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundTallyEntry/BatchDetail.tsx
@@ -572,6 +572,7 @@ const BatchResultTallySheet: React.FC<IBatchResultTallySheetProps> = ({
             return (
               <ButtonGroup>
                 <Button
+                  intent="primary"
                   disabled={areResultsFinalized || isRemovingSheet}
                   icon="edit"
                   onClick={enableEditing}
@@ -609,6 +610,7 @@ const BatchResultTallySheet: React.FC<IBatchResultTallySheetProps> = ({
                   position="bottom"
                 >
                   <Button
+                    intent="primary"
                     aria-label="Additional Actions"
                     disabled={areResultsFinalized || isRemovingSheet}
                     icon="caret-down"

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundTallyEntry/BatchRoundTallyEntry.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundTallyEntry/BatchRoundTallyEntry.tsx
@@ -135,9 +135,6 @@ const BatchRoundTallyEntryContent: React.FC<IBatchRoundTallyEntryContentProps> =
 
   return (
     <Container>
-      {areResultsFinalized && (
-        <Callout intent="success">Tallies finalized</Callout>
-      )}
       <ListAndDetail>
         <List
           search={{

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundTallyEntry/BatchRoundTallyEntry.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundTallyEntry/BatchRoundTallyEntry.tsx
@@ -24,7 +24,6 @@ import { useDebounce } from '../../../../utils/debounce'
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  max-height: 500px;
   width: 100%;
 
   .${Classes.CALLOUT} {

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/EnterTalliesStep.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/EnterTalliesStep.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { toast } from 'react-toastify'
 import { Button, Callout, Classes } from '@blueprintjs/core'
 import styled from 'styled-components'
 import { IJurisdiction } from '../../UserContext'
@@ -51,19 +50,15 @@ const EnterTalliesStep: React.FC<IEnterTalliesStepProps> = ({
   )
 
   const onClickFinalize = () => {
-    if (!areAllBatchesAudited) {
-      toast.error('Please enter tallies for all batches before finalizing.')
-    } else {
-      confirm({
-        title: 'Are you sure you want to finalize your tallies?',
-        description:
-          'Before finalizing your tallies, check the tallies you have entered into Arlo against your tally sheets.',
-        yesButtonLabel: 'Confirm',
-        onYesClick: async () => {
-          await finalizeResults.mutateAsync()
-        },
-      })
-    }
+    confirm({
+      title: 'Are you sure you want to finalize your tallies?',
+      description:
+        'Before finalizing your tallies, check the tallies you have entered into Arlo against your tally sheets.',
+      yesButtonLabel: 'Confirm',
+      onYesClick: async () => {
+        await finalizeResults.mutateAsync()
+      },
+    })
   }
 
   return (

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/EnterTalliesStep.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/EnterTalliesStep.tsx
@@ -86,6 +86,15 @@ const EnterTalliesStep: React.FC<IEnterTalliesStepProps> = ({
               </Row>
             </Callout>
           )}
+          {resultsFinalizedAt && (
+            <Callout intent="success">
+              <strong>Tallies finalized</strong>
+              <div>
+                Once all jurisdictions have finalized their tallies, check back
+                here for the results of the audit.
+              </div>
+            </Callout>
+          )}
           <BatchRoundTallyEntry
             electionId={jurisdiction.election.id}
             jurisdictionId={jurisdiction.id}

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/EnterTalliesStep.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/EnterTalliesStep.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { toast } from 'react-toastify'
 import { Button } from '@blueprintjs/core'
+import styled from 'styled-components'
 import { IJurisdiction } from '../../UserContext'
 import { IRound } from '../../AuditAdmin/useRoundsAuditAdmin'
 import BatchRoundTallyEntry from './BatchRoundTallyEntry'
@@ -8,6 +9,11 @@ import { useBatches, useFinalizeBatchResults } from '../useBatchResults'
 import { useConfirm, Confirm } from '../../Atoms/Confirm'
 import { StepPanel, StepActions } from '../../Atoms/Steps'
 import LinkButton from '../../Atoms/LinkButton'
+
+const Panel = styled(StepPanel)`
+  padding: 0;
+  height: auto;
+`
 
 interface IEnterTalliesStepProps {
   previousStepUrl: string
@@ -54,13 +60,13 @@ const EnterTalliesStep: React.FC<IEnterTalliesStepProps> = ({
 
   return (
     <>
-      <StepPanel noPadding>
+      <Panel>
         <BatchRoundTallyEntry
           electionId={jurisdiction.election.id}
           jurisdictionId={jurisdiction.id}
           roundId={round.id}
         />
-      </StepPanel>
+      </Panel>
       <StepActions
         left={
           <LinkButton to={previousStepUrl} icon="chevron-left">

--- a/client/src/components/TallyEntryUser/TallyEntryScreen.tsx
+++ b/client/src/components/TallyEntryUser/TallyEntryScreen.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Card, H2 } from '@blueprintjs/core'
+import { Card, H2, Callout } from '@blueprintjs/core'
 import { Inner } from '../Atoms/Wrapper'
 import BatchRoundTallyEntry from '../JurisdictionAdmin/BatchRoundSteps/BatchRoundTallyEntry'
+import { useBatches } from '../JurisdictionAdmin/useBatchResults'
 
 const Heading = styled(H2)`
   margin-bottom: 16px;
 `
 
 const BatchRoundTallyEntryContainer = styled(Card)`
+  margin-top: 10px;
   padding: 0;
 `
 
@@ -23,9 +25,22 @@ const TallyEntryScreen: React.FC<ITallyEntryScreenProps> = ({
   jurisdictionId,
   roundId,
 }) => {
+  const batchesQuery = useBatches(electionId, jurisdictionId, roundId)
+
+  if (!batchesQuery.isSuccess) {
+    return null
+  }
+
+  const { resultsFinalizedAt } = batchesQuery.data
+
   return (
     <Inner flexDirection="column" withTopPadding>
       <Heading>Enter Tallies</Heading>
+      {resultsFinalizedAt && (
+        <Callout intent="success">
+          <strong>Tallies finalized</strong>
+        </Callout>
+      )}
       <BatchRoundTallyEntryContainer>
         <BatchRoundTallyEntry
           electionId={electionId}


### PR DESCRIPTION
Fixes #1677 

_Review by commits_

A bunch of UI polish for batch tally entry. More details in the commits.

## Overview video

https://user-images.githubusercontent.com/530106/200915577-46fe0f89-242d-4d55-9c60-f65bccbd8d6a.mov



## JM tally entry
<img width="1312" alt="Screen Shot 2022-11-09 at 10 13 27 AM" src="https://user-images.githubusercontent.com/530106/200915207-625d1776-c183-4652-b085-712fb3b9caaa.png">
<img width="1312" alt="Screen Shot 2022-11-09 at 10 09 38 AM" src="https://user-images.githubusercontent.com/530106/200915255-e818a741-10f7-4594-84ee-75bb1fa3d4dd.png">
<img width="1312" alt="Screen Shot 2022-11-09 at 10 09 31 AM" src="https://user-images.githubusercontent.com/530106/200915316-c546aaa5-a497-4de7-a643-f15feacdc357.png">

## Tally entry user

<img width="1312" alt="Screen Shot 2022-11-09 at 11 03 18 AM" src="https://user-images.githubusercontent.com/530106/200918388-3af6302c-bf2b-47f6-bb6e-83aaef40fa45.png">

