### PR TITLE
Batch inventory: aggregate write-ins from CVRs

### DIFF
--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 import csv
 from datetime import datetime, timezone
 import io
+import re
 from typing import TypedDict, Dict, Tuple
 import uuid
 from xml.etree import ElementTree
@@ -56,6 +57,13 @@ def items_list_to_dict(items):
     }
 
 
+WRITE_IN_REGEX = re.compile(r"write[- ]?in", re.IGNORECASE)
+
+
+def is_write_in(choice_name: str) -> bool:
+    return WRITE_IN_REGEX.match(choice_name) is not None
+
+
 @background_task
 def process_batch_inventory_cvr_file(jurisdiction_id: str):
     batch_inventory_data = BatchInventoryData.query.get(jurisdiction_id)
@@ -83,12 +91,23 @@ def process_batch_inventory_cvr_file(jurisdiction_id: str):
     if len(choice_indices) == 0:
         raise UserError(f"Could not find contest in CVR file: {contest.name}.")
 
-    missing_choices = set(choice.name for choice in contest.choices) - set(
-        choice_indices.keys()
+    write_in_choice = next(
+        (choice for choice in contest.choices if is_write_in(choice.name)), None
     )
-    if len(missing_choices) > 0:
+
+    contest_choice_names = [
+        choice.name for choice in contest.choices if not is_write_in(choice.name)
+    ]
+    cvr_choice_names = [
+        choice_name
+        for choice_name in choice_indices.keys()
+        if not is_write_in(choice_name)
+    ]
+    if set(contest_choice_names) != set(cvr_choice_names):
         raise UserError(
-            f"Could not find contest choices in CVR file: {', '.join(missing_choices)}."
+            "CVR contest choice names don't match the choice names for this audit."
+            f" CVR contest choice names: {', '.join(cvr_choice_names)}."
+            f" Audit contest choice names: {', '.join(contest_choice_names)}."
         )
 
     header_indices = get_header_indices(headers_and_affiliations)
@@ -116,12 +135,12 @@ def process_batch_inventory_cvr_file(jurisdiction_id: str):
         batch_to_counting_group[batch_key] = counting_group
 
         choice_votes = {
-            choice.name: parse_vote(
+            choice_name: parse_vote(
                 column_value(
-                    row, choice.name, cvr_number, choice_indices, required=False
+                    row, choice_name, cvr_number, choice_indices, required=False
                 )
             )
-            for choice in contest.choices
+            for choice_name in choice_indices.keys()
         }
 
         # Skip overvotes
@@ -129,6 +148,10 @@ def process_batch_inventory_cvr_file(jurisdiction_id: str):
             continue
 
         for choice_name, vote in choice_votes.items():
+            # Aggregate all write-in votes for the specified write-in choice
+            # from the contest definition
+            if is_write_in(choice_name) and write_in_choice is not None:
+                choice_name = write_in_choice.name
             batch_tallies[batch_key][choice_name] += vote
 
     election_results: ElectionResults = dict(

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
@@ -42,9 +42,9 @@ Election Day,Tabulator 2 - BATCH2,6\r
 
 snapshots[
     "test_batch_inventory_happy_path 3"
-] = """Batch Name,Choice 1-1,Choice 1-2\r
-Tabulator 1 - BATCH1,1,2\r
-Tabulator 1 - BATCH2,2,1\r
-Tabulator 2 - BATCH1,2,1\r
-Tabulator 2 - BATCH2,2,0\r
+] = """Batch Name,Choice 1-1,Choice 1-2,Write-in\r
+Tabulator 1 - BATCH1,1,2,0\r
+Tabulator 1 - BATCH2,2,1,0\r
+Tabulator 2 - BATCH1,1,1,0\r
+Tabulator 2 - BATCH2,1,0,3\r
 """

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -3,25 +3,25 @@ from flask.testing import FlaskClient
 from ..helpers import *  # pylint: disable=wildcard-import
 from ...models import BatchInventoryData
 
-TEST_CVR = """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
-,,,,,,,,Contest 1 (Vote For=1),Contest 1 (Vote For=1),Contest 2 (Vote For=2),Contest 2 (Vote For=2),Contest 2 (Vote For=2)
-,,,,,,,,Choice 1-1,Choice 1-2,Choice 2-1,Choice 2-2,Choice 2-3
-CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM,LBR,IND,,
-1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1,1,1,0
-2,TABULATOR1,BATCH1,2,1-1-2,Election Day,12345,COUNTY,1,0,1,0,1
-3,TABULATOR1,BATCH1,3,1-1-3,Election Day,12345,COUNTY,0,1,1,1,0
-4,TABULATOR1,BATCH2,1,1-2-1,Election Day,12345,COUNTY,1,0,1,0,1
-5,TABULATOR1,BATCH2,2,1-2-2,Election Day,12345,COUNTY,0,1,1,1,0
-6,TABULATOR1,BATCH2,3,1-2-3,Election Day,12345,COUNTY,1,0,1,0,1
-7,TABULATOR2,BATCH1,1,2-1-1,Election Day,12345,COUNTY,0,1,1,1,0
-8,TABULATOR2,BATCH1,2,2-1-2,Mail,12345,COUNTY,1,0,1,0,1
-9,TABULATOR2,BATCH1,3,2-1-3,Mail,12345,COUNTY,1,0,1,1,0
-10,TABULATOR2,BATCH2,1,2-2-1,Election Day,12345,COUNTY,1,0,1,0,1
-11,TABULATOR2,BATCH2,2,2-2-2,Election Day,12345,COUNTY,1,1,1,1,0
-12,TABULATOR2,BATCH2,3,2-2-3,Election Day,12345,COUNTY,1,0,1,0,1
-13,TABULATOR2,BATCH2,4,2-2-4,Election Day,12345,CITY,,,1,0,1
-14,TABULATOR2,BATCH2,5,2-2-5,Election Day,12345,CITY,,,1,1,0
-15,TABULATOR2,BATCH2,6,2-2-6,Election Day,12345,CITY,,,1,0,1
+TEST_CVR = """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,,,
+,,,,,,,,Contest 1 (Vote For=1),Contest 1 (Vote For=1),Contest 1 (Vote For=1),Contest 1 (Vote For=1),Contest 2 (Vote For=2),Contest 2 (Vote For=2),Contest 2 (Vote For=2)
+,,,,,,,,Choice 1-1,Choice 1-2,Write In Alice Adams,Write-in Bob Bates,Choice 2-1,Choice 2-2,Choice 2-3
+CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM,,,LBR,IND,,
+1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1,0,0,1,1,0
+2,TABULATOR1,BATCH1,2,1-1-2,Election Day,12345,COUNTY,1,0,0,0,1,0,1
+3,TABULATOR1,BATCH1,3,1-1-3,Election Day,12345,COUNTY,0,1,0,0,1,1,0
+4,TABULATOR1,BATCH2,1,1-2-1,Election Day,12345,COUNTY,1,0,0,0,1,0,1
+5,TABULATOR1,BATCH2,2,1-2-2,Election Day,12345,COUNTY,0,1,0,0,1,1,0
+6,TABULATOR1,BATCH2,3,1-2-3,Election Day,12345,COUNTY,1,0,0,0,1,0,1
+7,TABULATOR2,BATCH1,1,2-1-1,Election Day,12345,COUNTY,0,1,0,0,1,1,0
+8,TABULATOR2,BATCH1,2,2-1-2,Mail,12345,COUNTY,1,0,0,0,1,0,1
+9,TABULATOR2,BATCH1,3,2-1-3,Mail,12345,COUNTY,1,0,1,0,1,1,0
+10,TABULATOR2,BATCH2,1,2-2-1,Election Day,12345,COUNTY,0,0,0,1,1,0,1
+11,TABULATOR2,BATCH2,2,2-2-2,Election Day,12345,COUNTY,0,0,1,0,1,1,0
+12,TABULATOR2,BATCH2,3,2-2-3,Election Day,12345,COUNTY,0,0,0,1,1,0,1
+13,TABULATOR2,BATCH2,4,2-2-4,Election Day,12345,CITY,1,0,0,0,1,0,1
+14,TABULATOR2,BATCH2,5,2-2-5,Election Day,12345,CITY,,,,,1,1,0
+15,TABULATOR2,BATCH2,6,2-2-6,Election Day,12345,CITY,,,,,1,0,1
 """
 
 TEST_TABULATOR_STATUS = """<?xml version="1.0" standalone="yes"?>
@@ -57,8 +57,9 @@ def contest_id(client: FlaskClient, election_id: str, jurisdiction_ids: List[str
         "isTargeted": True,
         "choices": [
             # Double the actual number of votes in TEST_CVR
-            {"id": str(uuid.uuid4()), "name": "Choice 1-1", "numVotes": 14},
+            {"id": str(uuid.uuid4()), "name": "Choice 1-1", "numVotes": 10},
             {"id": str(uuid.uuid4()), "name": "Choice 1-2", "numVotes": 8},
+            {"id": str(uuid.uuid4()), "name": "Write-in", "numVotes": 6},
         ],
         "numWinners": 1,
         "votesAllowed": 1,
@@ -267,7 +268,7 @@ def test_batch_inventory_invalid_file_uploads(
         ),
         (
             TEST_CVR.replace("Choice 1-1", "Choice X"),
-            "Could not find contest choices in CVR file: Choice 1-1.",
+            "CVR contest choice names don't match the choice names for this audit. CVR contest choice names: Choice X, Choice 1-2. Audit contest choice names: Choice 1-1, Choice 1-2.",
         ),
     ]
     for invalid_cvr, expected_error in invalid_cvrs:
@@ -338,12 +339,12 @@ def test_batch_inventory_invalid_file_uploads(
             "cvr": (
                 io.BytesIO(
                     TEST_CVR.replace(
-                        """1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1,1,1,0
-2,TABULATOR1,BATCH1,2,1-1-2,Election Day,12345,COUNTY,1,0,1,0,1
-3,TABULATOR1,BATCH1,3,1-1-3,Election Day,12345,COUNTY,0,1,1,1,0
-4,TABULATOR1,BATCH2,1,1-2-1,Election Day,12345,COUNTY,1,0,1,0,1
-5,TABULATOR1,BATCH2,2,1-2-2,Election Day,12345,COUNTY,0,1,1,1,0
-6,TABULATOR1,BATCH2,3,1-2-3,Election Day,12345,COUNTY,1,0,1,0,1
+                        """1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1,0,0,1,1,0
+2,TABULATOR1,BATCH1,2,1-1-2,Election Day,12345,COUNTY,1,0,0,0,1,0,1
+3,TABULATOR1,BATCH1,3,1-1-3,Election Day,12345,COUNTY,0,1,0,0,1,1,0
+4,TABULATOR1,BATCH2,1,1-2-1,Election Day,12345,COUNTY,1,0,0,0,1,0,1
+5,TABULATOR1,BATCH2,2,1-2-2,Election Day,12345,COUNTY,0,1,0,0,1,1,0
+6,TABULATOR1,BATCH2,3,1-2-3,Election Day,12345,COUNTY,1,0,0,0,1,0,1
 """,
                         "",
                     ).encode()


### PR DESCRIPTION
Write-ins might be specified in the CVR as "Write-in" or "Write-in \<candidate name\>", so we aggregate those votes into one choice (as specified by the audit admin).