### PR TITLE
Fix dc audit

### DIFF
--- a/client/src/components/AuditAdmin/Setup/Settings/states.ts
+++ b/client/src/components/AuditAdmin/Setup/Settings/states.ts
@@ -7,7 +7,7 @@ export const states: { [abbreviation: string]: string } = {
   CO: 'Colorado',
   CT: 'Connecticut',
   DE: 'Delaware',
-  DC: 'District Of Columbia',
+  DC: 'District of Columbia',
   FL: 'Florida',
   GA: 'Georgia',
   HI: 'Hawaii',


### PR DESCRIPTION
Related to: https://github.com/votingworks/arlo/issues/1568

This should fix a bug that was originating in `/workspaces/arlo/client/src/components/AuditAdmin/Progress/ProgressMap.tsx`. Basically, there's a string comparison looking for a matching state name and DC should be `District of Columbia`, not `District Of Columbia` with a capitalized "of".

Another option to fix this would be to change the string comparison to be case insensitive. But given that "District of Columbia" is the correct way, I figured this made more sense.