### PR TITLE
Batch audit full hand tally escalation fixes and improvements

### DIFF
--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -689,8 +689,8 @@ def full_hand_tally_sizes(election: Election):
     return dict(contests_query.values(Contest.id, Contest.total_ballots_cast))
 
 
-# Returns True if the sample size for any targeted contest in the given round
-# requires a full hand tally
+# Returns True if the cumulative sample size up to the specified round for any targeted contest
+# indicates that a full hand tally is needed
 def needs_full_hand_tally(round: Round, election: Election) -> bool:
     full_hand_tally_size = full_hand_tally_sizes(election)
     cumulative_sample_sizes = dict(

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -203,7 +203,7 @@ def samples_not_found_by_round(contest: Contest) -> Dict[str, int]:
 
 
 # { batch_key: { contest_id: { choice_id: votes }}}
-BatchTallies = Dict[Tuple[str, str], Dict[str, Dict[str, int]]]
+BatchTallies = Dict[sampler.BatchKey, Dict[str, Dict[str, int]]]
 
 
 def batch_tallies(election: Election) -> BatchTallies:
@@ -268,7 +268,7 @@ def sampled_batch_results(election: Election,) -> BatchTallies:
     }
 
 
-def sampled_batches_by_ticket_number(election: Election) -> Dict[str, Tuple[str, str]]:
+def sampled_batches_by_ticket_number(election: Election) -> Dict[str, sampler.BatchKey]:
     batches_by_ticket_number = (
         SampledBatchDraw.query.join(Batch)
         .join(Jurisdiction)
@@ -732,7 +732,7 @@ class SampleSize(TypedDict):
 
 class BallotDraw(NamedTuple):
     # ballot_key: ((jurisdiction name, batch name), ballot_position)
-    ballot_key: Tuple[Tuple[str, str], int]
+    ballot_key: Tuple[sampler.BatchKey, int]
     contest_id: str
     ticket_number: str
 
@@ -910,7 +910,7 @@ def sample_batches(
         for jurisdiction_name, batch_name, batch_id in batches
     }
 
-    previously_sampled_batch_keys: List[Tuple[str, str]] = list(
+    previously_sampled_batch_keys: List[sampler.BatchKey] = list(
         SampledBatchDraw.query.join(Batch)
         .join(Jurisdiction)
         .filter_by(election_id=election.id)

--- a/server/audit_math/sampler.py
+++ b/server/audit_math/sampler.py
@@ -8,6 +8,9 @@ from . import macro
 from .sampler_contest import Contest
 
 
+BatchKey = Tuple[str, str]  # (jurisdiction name, batch name)
+
+
 def draw_sample(
     seed: str,
     manifest: Dict[Any, List[int]],
@@ -65,9 +68,6 @@ def draw_sample(
             )
         )[num_sampled:],
     )
-
-
-BatchKey = Tuple[str, str]  # (jurisdiction name, batch name)
 
 
 def draw_ppeb_sample(

--- a/server/audit_math/sampler.py
+++ b/server/audit_math/sampler.py
@@ -129,17 +129,18 @@ def draw_ppeb_sample(
         for batch in batch_results
     ]
 
-    is_full_hand_tally = sample_size >= len(batch_results)
     num_previously_sampled_batches = len(previously_sampled_batch_keys)
+    cumulative_sample_size = num_previously_sampled_batches + sample_size
+    is_full_hand_tally_needed = cumulative_sample_size >= len(batch_results)
 
     sampled_batch_keys_including_previously_sampled: List[BatchKey] = (
         (
             previously_sampled_batch_keys
-            # When the sample size indicates a full hand tally, ensure that we draw all batches,
-            # minus batches already audited in previous rounds
+            # When the cumulative sample size indicates that a full hand tally is needed, ensure
+            # that we draw all batches, minus batches already audited in previous rounds
             + sorted(list(batch_results.keys() - previously_sampled_batch_keys))
         )
-        if is_full_hand_tally
+        if is_full_hand_tally_needed
         # Otherwise, sample as usual
         else cast(
             List[BatchKey],

--- a/server/audit_math/sampler.py
+++ b/server/audit_math/sampler.py
@@ -144,6 +144,8 @@ def draw_ppeb_sample(
         else cast(
             List[BatchKey],
             (
+                # For some reason, NumPy converts the tuple to a list in sampling, so we convert
+                # back to a tuple
                 tuple(sampled_batch_key)
                 for sampled_batch_key in generator.choice(
                     list(batch_results.keys()),

--- a/server/audit_math/sampler.py
+++ b/server/audit_math/sampler.py
@@ -119,6 +119,7 @@ def draw_ppeb_sample(
 
     U = macro.compute_U(batch_results, cast(Dict, {}), contest)
 
+    # Should only be possible if the specified contest isn't in any batches
     if U == 0:
         return []
 

--- a/server/tests/audit_math/snapshots/snap_test_sampler.py
+++ b/server/tests/audit_math/snapshots/snap_test_sampler.py
@@ -25,6 +25,11 @@ snapshots["test_draw_macro_full_hand_tally 3"] = [
     ("0.851346057402501613", ("Jx 1", "pct 3")),
 ]
 
+snapshots["test_draw_macro_full_hand_tally 4"] = [
+    ("0.370405751560609643", ("Jx 1", "pct 1")),
+    ("0.851346057402501613", ("Jx 1", "pct 3")),
+]
+
 snapshots["test_draw_macro_multiple_contests 1"] = [
     ("0.202823455933455274", ("Jx 1", "pct 5")),
     ("0.328034953571610594", ("Jx 1", "pct 4")),

--- a/server/tests/audit_math/snapshots/snap_test_sampler.py
+++ b/server/tests/audit_math/snapshots/snap_test_sampler.py
@@ -7,6 +7,24 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots["test_draw_macro_full_hand_tally 1"] = [
+    ("0.370405751560609643", ("Jx 1", "pct 1")),
+    ("0.847430249189970028", ("Jx 1", "pct 2")),
+    ("0.851346057402501613", ("Jx 1", "pct 3")),
+    ("0.328034953571610594", ("Jx 1", "pct 4")),
+]
+
+snapshots["test_draw_macro_full_hand_tally 2"] = [
+    ("0.847430249189970028", ("Jx 1", "pct 2")),
+    ("0.851346057402501613", ("Jx 1", "pct 3")),
+    ("0.328034953571610594", ("Jx 1", "pct 4")),
+]
+
+snapshots["test_draw_macro_full_hand_tally 3"] = [
+    ("0.370405751560609643", ("Jx 1", "pct 1")),
+    ("0.851346057402501613", ("Jx 1", "pct 3")),
+]
+
 snapshots["test_draw_macro_multiple_contests 1"] = [
     ("0.202823455933455274", ("Jx 1", "pct 5")),
     ("0.328034953571610594", ("Jx 1", "pct 4")),
@@ -97,7 +115,3 @@ snapshots["test_draw_sample 1"] = [
     ("0.135840440920085144", ("pct 3", 10), 1),
     ("0.138772253094235762", ("pct 4", 20), 1),
 ]
-
-snapshots["test_macro_recount_sample 1"] = []
-
-snapshots["test_macro_recount_sample 2"] = []

--- a/server/tests/audit_math/test_sampler.py
+++ b/server/tests/audit_math/test_sampler.py
@@ -173,6 +173,16 @@ def test_draw_macro_full_hand_tally(close_macro_batches, close_macro_contest, sn
     )
     snapshot.assert_match(sample)
 
+    sample = sampler.draw_ppeb_sample(
+        SEED,
+        close_macro_contest,
+        # The sample size is less than all batches, but the cumulative sample size is all batches
+        len(close_macro_batches) - 2,
+        previously_sampled_batch_keys=[("Jx 1", "pct 2"), ("Jx 1", "pct 4")],
+        batch_results=close_macro_batches,
+    )
+    snapshot.assert_match(sample)
+
 
 def test_draw_macro_multiple_contests(macro_batches, snapshot):
     info_dict = {


### PR DESCRIPTION
# Overview

Issue link: https://github.com/votingworks/arlo/issues/1525, https://github.com/votingworks/arlo/issues/1679

One of many pieces of https://github.com/votingworks/arlo/issues/1525 (improved full hand tally escalation) and https://github.com/votingworks/arlo/issues/1679 (round 2+ stuck jurisdictions), this PR cleans up the escalation pathway for batch audits (in many ways the easiest kind of audit to escalate to a full hand tally since a full hand tally is now just a batch audit with all batches).

The PR specifically makes it such that, when escalating a batch audit to a full hand tally, all batches _minus those already audited in previous rounds_ are selected (as opposed to all batches without any exclusion - what we do today).

Note that, when batches _are_ reselected across rounds, the UI does indicate that they've already been audited and doesn't require that they be audited again. But the UI can end up in a stuck state for some jurisdictions (https://github.com/votingworks/arlo/issues/1679). We should still tackle that issue. But this PR at least eliminates that issue for the most high stakes multiple-round situation and also the situation where that issue is most likely to come up.

The PR also fixes a bug documented in https://github.com/votingworks/arlo/issues/1679 (see https://github.com/votingworks/arlo/pull/1703#discussion_r1023140574), arguably the most important part of this PR.

# Testing

- [x] Added automated tests
- [x] Manually tested full hand tally escalation