### PR TITLE
Bugfix: Ignore case when looking up JA email on login

### DIFF
--- a/server/auth/auth_routes.py
+++ b/server/auth/auth_routes.py
@@ -299,7 +299,7 @@ def record_login(user: User, error: Optional[str] = None):
 def jurisdiction_admin_login():
     body = request.get_json()
     user = (
-        User.query.filter_by(email=body.get("email"))
+        User.query.filter_by(email=body.get("email").lower())
         .join(JurisdictionAdministration)
         .with_for_update()
         .one_or_none()

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -287,7 +287,9 @@ def test_jurisdiction_admin_login(mock_smtp, client: FlaskClient, ja_email: str)
     assert code in message.get_body(("html")).get_content()
 
     rv = post_json(
-        client, "/auth/jurisdictionadmin/login", dict(email=ja_email, code=code)
+        client,
+        "/auth/jurisdictionadmin/login",
+        dict(email=ja_email.upper(), code=code),  # Login should not be case sensitive
     )
     assert_ok(rv)
 


### PR DESCRIPTION
We store emails in the db as lowercase in order to avoid case-sensitivity issues. We missed this one query though.