### PR TITLE
Make total row detection more rigorous (Clay County fix)

### DIFF
--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -361,12 +361,14 @@ def reject_final_total_row(csv: CSVDictIterator, columns: List[CSVColumnType]):
                 column_values[column.name].append(value)
         yield row
 
-    for values in column_values.values():
-        if sum(values[:-1]) == values[-1] and values[-1] != 0:
-            raise CSVParseError(
-                "It looks like the last row in the CSV might be a total row."
-                " Please remove this row from the CSV."
-            )
+    if len(column_values.values()) > 0 and all(
+        sum(values[:-1]) == values[-1] and values[-1] != 0
+        for values in column_values.values()
+    ):
+        raise CSVParseError(
+            "It looks like the last row in the CSV might be a total row."
+            " Please remove this row from the CSV."
+        )
 
 
 def convert_rows_to_dicts(csv: CSVIterator) -> CSVDictIterator:

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -352,18 +352,18 @@ def reject_total_rows(csv: CSVDictIterator) -> CSVDictIterator:
 
 
 def reject_final_total_row(csv: CSVDictIterator, columns: List[CSVColumnType]):
-    column_values = defaultdict(list)
+    numeric_column_values = defaultdict(list)
 
     for row in csv:
         for column in columns:
             value = row.get(column.name)
             if column.value_type == CSVValueType.NUMBER and value is not None:
-                column_values[column.name].append(value)
+                numeric_column_values[column.name].append(value)
         yield row
 
-    if len(column_values.values()) > 0 and all(
+    if len(numeric_column_values.values()) > 0 and all(
         sum(values[:-1]) == values[-1] and values[-1] != 0
-        for values in column_values.values()
+        for values in numeric_column_values.values()
     ):
         raise CSVParseError(
             "It looks like the last row in the CSV might be a total row."

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -361,7 +361,7 @@ def reject_final_total_row(csv: CSVDictIterator, columns: List[CSVColumnType]):
                 numeric_column_values[column.name].append(value)
         yield row
 
-    if len(numeric_column_values.values()) > 0 and all(
+    if len(numeric_column_values) > 0 and all(
         sum(values[:-1]) == values[-1] and values[-1] != 0
         for values in numeric_column_values.values()
     ):


### PR DESCRIPTION
# Overview

Our total row detection logic is flagging a false positive in Clay County. We currently raise an error if any numeric column's last value looks like a total. After this PR, we'll only raise an error if _all_ numeric columns' last value looks like a total. Other forms of total row detection, like checking for the word "total", are still in place and unaffected by this PR.

# Testing

- [x] Updated unit tests
- [x] Manually verified that Clay County's file will now be accepted