### PR TITLE
Improve data fetching/redirect on audit launch

### DIFF
--- a/client/src/components/Atoms/StatusBox.test.tsx
+++ b/client/src/components/Atoms/StatusBox.test.tsx
@@ -266,8 +266,9 @@ describe('StatusBox', () => {
         ).toBeDisabled()
         await waitFor(() => expect(startNextRoundMock).toHaveBeenCalledTimes(1))
         expect(startNextRoundMock).toHaveBeenCalledWith({
-          'contest-id':
-            sampleSizeMock.ballotComparison.sampleSizes['contest-id'][0],
+          'contest-id': sampleSizeMock.ballotComparison.sampleSizes![
+            'contest-id'
+          ][0],
         })
       })
     })

--- a/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
@@ -35,20 +35,6 @@ const apiCalls = {
     url: '/api/election/1/round',
     response: { rounds: [] },
   },
-  postRound: (sampleSizes: { [contestId: string]: number }) => ({
-    url: '/api/election/1/round',
-    response: { status: 'ok' },
-    options: {
-      body: JSON.stringify({
-        roundNum: 1,
-        sampleSizes,
-      }),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      method: 'POST',
-    },
-  }),
   getJurisdictions: (response: { jurisdictions: IJurisdiction[] }) => ({
     url: '/api/election/1/jurisdiction',
     response,
@@ -917,8 +903,9 @@ describe('Audit Setup > Review & Launch', () => {
         ...sampleSizeMock.ballotPolling,
         sampleSizes: {
           ...sampleSizeMock.ballotPolling.sampleSizes,
-          'contest-id-2':
-            sampleSizeMock.ballotPolling.sampleSizes['contest-id'],
+          'contest-id-2': sampleSizeMock.ballotPolling.sampleSizes![
+            'contest-id'
+          ],
         },
       }),
     ]

--- a/client/src/components/AuditAdmin/Setup/Review/Review.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useHistory, Link } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import {
   H4,
   Callout,
@@ -82,7 +82,6 @@ const Review: React.FC<IProps> = ({
     { enabled: isStandardizedContestsFileEnabled }
   )
   const contestsQuery = useContests(electionId)
-  const history = useHistory()
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false)
 
   const [
@@ -448,11 +447,7 @@ const Review: React.FC<IProps> = ({
         }: {
           sampleSizes: IFormOptions
         }) => {
-          if (await startNextRound(sampleSizes)) {
-            history.push(`/election/${electionId}/progress`)
-          } else {
-            // TEST TODO when withMockFetch works with error handling
-          }
+          await startNextRound(sampleSizes)
         }
 
         const targetedContests = contests.filter(contest => contest.isTargeted)

--- a/client/src/components/AuditAdmin/Setup/Review/_mocks.ts
+++ b/client/src/components/AuditAdmin/Setup/Review/_mocks.ts
@@ -1,5 +1,7 @@
 import { IAuditSettings } from '../../../useAuditSettings'
 import { FileProcessingStatus } from '../../../useCSV'
+import { mocksOfType } from '../../../testUtilities'
+import { ISampleSizesResponse } from './useSampleSizes'
 
 export const settingsMock: {
   [key in 'empty' | 'full' | 'offline' | 'batch']: IAuditSettings
@@ -46,6 +48,13 @@ export const settingsMock: {
   },
 }
 
+const taskInProgressMock = {
+  status: FileProcessingStatus.PROCESSING,
+  startedAt: '2019-07-18T16:34:07.000+00:00',
+  completedAt: null,
+  error: null,
+}
+
 const taskCompleteMock = {
   status: FileProcessingStatus.PROCESSED,
   startedAt: '2019-07-18T16:34:07.000+00:00',
@@ -53,7 +62,12 @@ const taskCompleteMock = {
   error: null,
 }
 
-export const sampleSizeMock = {
+export const sampleSizeMock = mocksOfType<ISampleSizesResponse>()({
+  calculating: {
+    sampleSizes: null,
+    selected: null,
+    task: taskInProgressMock,
+  },
   batchComparison: {
     sampleSizes: {
       'contest-id': [{ prob: null, size: 4, key: 'macro' }],
@@ -80,6 +94,6 @@ export const sampleSizeMock = {
     selected: null,
     task: taskCompleteMock,
   },
-}
+})
 
 export default settingsMock

--- a/client/src/components/AuditAdmin/Setup/Setup.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Setup.test.tsx
@@ -16,6 +16,7 @@ import {
   contestMocks,
 } from '../../_mocks'
 import Setup, { ISetupProps } from './Setup'
+import { sampleSizeMock } from './Review/_mocks'
 
 const renderSetup = (props: Partial<ISetupProps> = {}) =>
   renderWithRouter(
@@ -256,7 +257,7 @@ describe('Setup', () => {
       aaApiCalls.getSettings(auditSettingsMocks.all),
       aaApiCalls.getJurisdictions,
       aaApiCalls.getContests(contestMocks.filledTargeted),
-      aaApiCalls.getSampleSizes,
+      aaApiCalls.getSampleSizes(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderSetup({ isAuditStarted: true })

--- a/client/src/components/AuditAdmin/timers.test.tsx
+++ b/client/src/components/AuditAdmin/timers.test.tsx
@@ -121,8 +121,8 @@ describe.skip('timers', () => {
       aaApiCalls.getJurisdictions,
       aaApiCalls.getJurisdictionFile,
       aaApiCalls.getContests(contestMocks.filledTargeted),
-      aaApiCalls.getSampleSizes,
-      { ...aaApiCalls.getSampleSizes, response: sampleSizeMock.ballotPolling },
+      aaApiCalls.getSampleSizes(sampleSizeMock.calculating),
+      aaApiCalls.getSampleSizes(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderWithRoute('/election/1/setup', <AuditAdminViewWithAuth />)

--- a/client/src/components/AuditAdmin/useRoundsAuditAdmin.ts
+++ b/client/src/components/AuditAdmin/useRoundsAuditAdmin.ts
@@ -35,6 +35,7 @@ export const isDrawingSample = (rounds: IRound[]): boolean =>
   rounds[rounds.length - 1].drawSampleTask.completedAt === null
 
 export const isDrawSampleComplete = (rounds: IRound[]): boolean =>
+  rounds.length > 0 &&
   rounds[rounds.length - 1].drawSampleTask.completedAt !== null
 
 export const drawSampleError = (rounds: IRound[]): string | null =>

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -6,7 +6,7 @@ import {
   jurisdictionFile,
   standardizedContestsFile,
 } from './AuditAdmin/Setup/Participants/_mocks'
-import { IRound } from './AuditAdmin/useRoundsAuditAdmin'
+import { IRound, ISampleSizes } from './AuditAdmin/useRoundsAuditAdmin'
 import { IBallot } from './JurisdictionAdmin/useBallots'
 import { IBatches } from './JurisdictionAdmin/useBatchResults'
 import { IOrganization, ITallyEntryUser, IMember } from './UserContext'
@@ -23,6 +23,7 @@ import {
   IJurisdiction,
 } from './useJurisdictions'
 import { IStandardizedContest } from './useStandardizedContests'
+import { ISampleSizesResponse } from './AuditAdmin/Setup/Review/useSampleSizes'
 
 export const manifestFile = new File(
   ['fake manifest - contents dont matter'],
@@ -1695,6 +1696,20 @@ export const aaApiCalls = {
     url: '/api/election/1/round',
     response: { rounds },
   }),
+  postRound: (sampleSizes: ISampleSizes) => ({
+    url: '/api/election/1/round',
+    response: { status: 'ok' },
+    options: {
+      body: JSON.stringify({
+        roundNum: 1,
+        sampleSizes,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    },
+  }),
   getJurisdictions: {
     url: '/api/election/1/jurisdiction',
     response: {
@@ -1808,19 +1823,10 @@ export const aaApiCalls = {
     url: '/api/election/1/standardized-contests',
     response: standardizedContests,
   }),
-  getSampleSizes: {
+  getSampleSizes: (response: ISampleSizesResponse) => ({
     url: '/api/election/1/sample-sizes/1',
-    response: {
-      sampleSizes: null,
-      selected: null,
-      task: {
-        status: 'READY_TO_PROCESS',
-        startedAt: null,
-        completedAt: null,
-        error: null,
-      },
-    },
-  },
+    response,
+  }),
   putJurisdictionFile: {
     url: '/api/election/1/jurisdiction/file',
     options: {


### PR DESCRIPTION
There were two issues going on:
1. After launching the audit, the review screen would immediately redirect to the progress screen. This redirect could occur before the rounds query updated, which would lead to a flash of the rounds screen before showing the drawing sample message.
2. When drawing the sample completed, the jurisdictions query didn't reload, meaning the progress screen wouldn't show the sampled ballots for each jurisdiction until the user refreshed.

We fix both of those issues by moving the logic for redirecting/reloading into the onSuccess callback of the rounds query.