### PR TITLE
Hart CVR parsing: Remove sheet number check

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -1016,14 +1016,7 @@ def parse_hart_cvrs(
             cvr_guid = find(cvr_xml, "CvrGuid").text
             batch_number = find(cvr_xml, "BatchNumber").text
             batch_sequence = find(cvr_xml, "BatchSequence").text
-            sheet_number = find(cvr_xml, "SheetNumber").text
             file.close()
-            if sheet_number != "1":
-                raise UserError(
-                    f"Error in file: {file_name}."
-                    " Arlo currently only supports Hart CVRs with SheetNumber 1."
-                    f" Got SheetNumber: {sheet_number}."
-                )
 
             db_batch = batches_by_key.get(
                 (cvr_zip_file_name.strip(".zip"), batch_number)

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -2095,15 +2095,6 @@ def test_hart_cvr_upload_with_invalid_cvrs(
             [build_hart_cvr("bad batch", "1", "1-1-1", "0,1,1,0,0")],
             "Error in file: cvr-0.xml. Couldn't find a matching batch for BatchNumber: bad batch. The BatchNumber field in the CVR must match the Batch Name field in the ballot manifest. Please check your CVR files and ballot manifest thoroughly to make sure these values match - there may be a similar inconsistency in other files in the CVR export.",
         ),
-        (
-            [
-                build_hart_cvr("BATCH1", "2", "1-1-2", "0,1,1,0,0"),
-                build_hart_cvr("BATCH1", "1", "1-1-1", "0,1,1,0,0").replace(
-                    "<SheetNumber>1</SheetNumber>", "<SheetNumber>2</SheetNumber>"
-                ),
-            ],
-            "Error in file: cvr-1.xml. Arlo currently only supports Hart CVRs with SheetNumber 1. Got SheetNumber: 2.",
-        ),
     ]
 
     set_logged_in_user(


### PR DESCRIPTION
# Overview

The check that this PR removes seems to be unnecessary and will in fact interfere with Orange County's upcoming CVR upload, which will contain CVRs for ballots that span multiple sheets. Our current process for OC involves converting their Hart CVRs to Dominion CVRs, ignoring sheet number. The end result is a separate CVR record in the DB per sheet. The math handles this fine, recognizing that many CVR records will be not contain the targeted contests. With this change, we'll allow for the same when parsing Hart CVRs.

# Testing

- [x] Successfully uploaded OC's close-to-ready CVR files locally*

*By running this code in conjunction with https://github.com/votingworks/arlo/pull/1726 and making some manual tweaks to account for some CVRs not having a `BatchNumber` (which won't be the case in OC's final files)