### PR TITLE
Compute overall candidate vote totals using candidate totals by batch across all jurisdictions

### DIFF
--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -493,6 +493,28 @@ def list_jurisdictions(election: Election):
         serialize_jurisdiction(election, jurisdiction, round_status[jurisdiction.id])
         for jurisdiction in jurisdictions
     ]
+
+    contest_index = 0
+    candidate_vote_totals = {}
+    candidate_ids_to_names = {
+        choice.id: choice.name for choice in election.contests[contest_index].choices
+    }
+    for jurisdiction in jurisdictions:
+        batch_tallies = jurisdiction.batch_tallies
+        if batch_tallies is None:
+            continue
+        for tallies_by_contest_id in batch_tallies.values():
+            tallies = tallies_by_contest_id[election.contests[contest_index].id]
+            for candidate_id, votes in tallies.items():
+                if candidate_id == "ballots":
+                    continue
+                candidate_name = candidate_ids_to_names[candidate_id]
+                if candidate_name not in candidate_vote_totals:
+                    candidate_vote_totals[candidate_name] = votes
+                else:
+                    candidate_vote_totals[candidate_name] += votes
+    print(candidate_vote_totals)
+
     return jsonify({"jurisdictions": json_jurisdictions})
 
 


### PR DESCRIPTION
A (very hacky!) hack for PA that we ended up not needing. Would've allowed us to compute overall candidate vote totals using candidate totals by batch across all jurisdictions.

Steps:

1. Take a snapshot of the prod DB and update your local DB using that snapshot
2. Run Arlo locally with this change and open the jurisdictions page for the relevant audit
3. Refresh the page and see the candidate vote totals printed in your Arlo terminal