### PR TITLE
Improve minerva landslide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,16 @@
 PATH := $(PATH):$(HOME)/.local/bin
 
 deps:
-	sudo apt install python3.8 python3.8-venv libpython3.8-dev libpq-dev graphicsmagick
+	sudo apt update
+	sudo apt install -y python3.8 python3.8-venv libpython3.8-dev libpq-dev graphicsmagick
 	# Install node: https://github.com/nodesource/distributions/blob/master/README.md#deb		
 	curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 	sudo apt-get install -y nodejs
 	# Install poetry: https://python-poetry.org/docs/master/#osx--linux--bashonwindows-install-instructions 
 	curl -sSL https://install.python-poetry.org | python3.8 -	
 	sudo npm install -g yarn
-	sudo apt install postgresql
+	sudo apt install -y postgresql
+	sudo service postgresql start
 
 # this should only be used for development
 initdevdb:

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ format-server:
 lint-server:
 	poetry run pylint server scripts fixtures
 
+preflight: typecheck-server format-server lint-server
+
 test-client:
 	yarn --cwd client lint
 	yarn --cwd client test

--- a/client/run-cypress-tests.sh
+++ b/client/run-cypress-tests.sh
@@ -4,7 +4,10 @@ export ARLO_SMTP_HOST=localhost
 export ARLO_SMTP_PORT=1025
 export ARLO_SMTP_USERNAME=cypress-smtp-username
 export ARLO_SMTP_PASSWORD=cypress-smtp-password
-export ARLO_FILE_UPLOAD_STORAGE_PATH=s3://arlo-file-uploads-dev
+if [[ -n $AWS_ACCESS_KEY_ID ]] && [[ -n $AWS_SECRET_ACCESS_KEY ]]
+then
+    export ARLO_FILE_UPLOAD_STORAGE_PATH=s3://arlo-file-uploads-dev
+fi
 
 trap 'kill 0' SIGINT SIGHUP EXIT
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/server/audit_math/minerva.py
+++ b/server/audit_math/minerva.py
@@ -19,7 +19,7 @@ from .sampler_contest import Contest
 from ..config import MINERVA_MULTIPLE
 
 
-def make_arlo_contest(tally, num_winners=1, votes_allowed=1):
+def make_arlo_contest(tally, num_winners=1, votes_allowed=1) -> Contest:
     """Return an Arlo Contest with the given tally (a dictionary of candidate_name:vote_counts)
     Treat "_undervote_" candidate as undervotes
     For testing purposes.
@@ -52,7 +52,7 @@ def make_sample_results(
 
     return sample_results
 
-def fix_landslide_arlo_contest(contest: Contest, alpha: int) -> Contest:
+def fix_landslide_arlo_contest(contest: Contest, alpha: float) -> Contest:
     """Add one vote to all candidates who received zero votes
 
     Athena's wald_k_min throws a ValueError if it finds a margin between candidates of 0 or 1.

--- a/server/audit_math/minerva.py
+++ b/server/audit_math/minerva.py
@@ -52,6 +52,7 @@ def make_sample_results(
 
     return sample_results
 
+
 def fix_landslide_arlo_contest(contest: Contest, alpha: float) -> Contest:
     """Add one vote to all candidates who received zero votes
 
@@ -71,13 +72,18 @@ def fix_landslide_arlo_contest(contest: Contest, alpha: float) -> Contest:
     # The relationship seems to be: when the risk factor is cut in half, minimum votes required goes up by 5
     risky_amount = math.ceil((3 + math.log(20, 2) - math.log(alpha, 2)) * 5)
     if num_votes <= risky_amount:
-        logging.warning("Landslide contests with few total votes may produce larger first round sizes than expected")
+        logging.warning(
+            "Landslide contests with few total votes may produce larger first round sizes than expected"
+        )
         logging.warning(f"Landslide contest with {num_votes} total votes is being run.")
     for key, val in contest.margins["losers"].items():
-        if val['s_l'] == 0:
-            logging.debug(f"landslide margin detected, fixing candidate {key} from 0 to 1")
+        if val["s_l"] == 0:
+            logging.debug(
+                f"landslide margin detected, fixing candidate {key} from 0 to 1"
+            )
             new_candidate_dict[key] += 1
     return make_arlo_contest(new_candidate_dict)
+
 
 def make_athena_audit(arlo_contest, alpha):
     """Make an Athena audit object, with associated contest and election, from an Arlo contest
@@ -169,7 +175,7 @@ def get_sample_size(
     else:
         try:
             # Check for a landslide condition.
-            if max(val['s_l'] for val in contest.margins["losers"].values()) == 0:
+            if max(val["s_l"] for val in contest.margins["losers"].values()) == 0:
                 contest = fix_landslide_arlo_contest(contest, alpha)
             audit = make_athena_audit(contest, alpha)
             round_size_options = audit.find_next_round_size(quants)[

--- a/server/tests/audit_math/test_minerva.py
+++ b/server/tests/audit_math/test_minerva.py
@@ -1,4 +1,5 @@
 # pylint: disable=invalid-name
+import logging
 import pytest
 
 from pytest import approx
@@ -87,6 +88,82 @@ def test_get_sample_size_landslide():
         "0.9": {"type": None, "size": 4, "prob": 0.9},
     }
 
+
+def test_get_sample_size_landslide_other_risks():
+    d2 = minerva.make_arlo_contest({"a": 100, "b": 0})
+    res = minerva.get_sample_size(10, d2, None, [])
+    assert res == {
+        "0.7": {"type": None, "size": 4, "prob": 0.7},
+        "0.8": {"type": None, "size": 4, "prob": 0.8},
+        "0.9": {"type": None, "size": 4, "prob": 0.9},
+    }
+
+    assert d2.margins == {
+        'winners': {
+            'a': {'p_w': 1, 's_w': 1, 'swl': {'b': 1}}
+        },
+        'losers': {
+            'b': {'p_l': 0, 's_l': 0}
+        }
+    }
+
+    d2 = minerva.make_arlo_contest({"a": 100, "b": 0, "c": 0})
+    res = minerva.get_sample_size(10, d2, None, [])
+    assert res == {
+        "0.7": {"type": None, "size": 5, "prob": 0.7},
+        "0.8": {"type": None, "size": 5, "prob": 0.8},
+        "0.9": {"type": None, "size": 5, "prob": 0.9},
+    }
+
+    assert d2.margins == {
+        'winners': {
+            'a': {'p_w': 1, 's_w': 1, 'swl': {'b': 1, 'c': 1}}
+        },
+        'losers': {
+            'b': {'p_l': 0, 's_l': 0},
+            'c': {'p_l': 0, 's_l': 0}
+        }
+    }
+
+    d2 = minerva.make_arlo_contest({"a": 100, "b": 0})
+    res = minerva.get_sample_size(5, d2, None, [])
+    assert res == {
+        "0.7": {"type": None, "size": 5, "prob": 0.7},
+        "0.8": {"type": None, "size": 5, "prob": 0.8},
+        "0.9": {"type": None, "size": 5, "prob": 0.9},
+    }
+
+    assert d2.margins == {
+        'winners': {
+            'a': {'p_w': 1, 's_w': 1, 'swl': {'b': 1}}
+        },
+        'losers': {
+            'b': {'p_l': 0, 's_l': 0}
+        }
+    }
+
+    d2 = minerva.make_arlo_contest({"a": 1000, "b": 0})
+    res = minerva.get_sample_size(1, d2, None, [])
+    assert res == {
+        "0.7": {"type": None, "size": 7, "prob": 0.7},
+        "0.8": {"type": None, "size": 7, "prob": 0.8},
+        "0.9": {"type": None, "size": 7, "prob": 0.9},
+    }
+    assert d2.margins == {
+        'winners': {
+            'a': {'p_w': 1, 's_w': 1, 'swl': {'b': 1}}
+        },
+        'losers': {
+            'b': {'p_l': 0, 's_l': 0}
+        }
+    }
+
+
+def test_get_sample_size_landslide_low_votes(caplog):
+    caplog.set_level(logging.WARN)
+    d2 = minerva.make_arlo_contest({"a": 10, "b": 0})
+    res = minerva.get_sample_size(1, d2, None, [])
+    assert [record.levelname for record in caplog.records].count("WARNING") > 0
 
 def test_get_sample_size_big():
     # Binary search result, just over approximation threshold of 1.5% margin

--- a/server/tests/audit_math/test_minerva.py
+++ b/server/tests/audit_math/test_minerva.py
@@ -99,12 +99,8 @@ def test_get_sample_size_landslide_other_risks():
     }
 
     assert d2.margins == {
-        'winners': {
-            'a': {'p_w': 1, 's_w': 1, 'swl': {'b': 1}}
-        },
-        'losers': {
-            'b': {'p_l': 0, 's_l': 0}
-        }
+        "winners": {"a": {"p_w": 1, "s_w": 1, "swl": {"b": 1}}},
+        "losers": {"b": {"p_l": 0, "s_l": 0}},
     }
 
     d2 = minerva.make_arlo_contest({"a": 100, "b": 0, "c": 0})
@@ -116,13 +112,8 @@ def test_get_sample_size_landslide_other_risks():
     }
 
     assert d2.margins == {
-        'winners': {
-            'a': {'p_w': 1, 's_w': 1, 'swl': {'b': 1, 'c': 1}}
-        },
-        'losers': {
-            'b': {'p_l': 0, 's_l': 0},
-            'c': {'p_l': 0, 's_l': 0}
-        }
+        "winners": {"a": {"p_w": 1, "s_w": 1, "swl": {"b": 1, "c": 1}}},
+        "losers": {"b": {"p_l": 0, "s_l": 0}, "c": {"p_l": 0, "s_l": 0}},
     }
 
     d2 = minerva.make_arlo_contest({"a": 100, "b": 0})
@@ -134,12 +125,8 @@ def test_get_sample_size_landslide_other_risks():
     }
 
     assert d2.margins == {
-        'winners': {
-            'a': {'p_w': 1, 's_w': 1, 'swl': {'b': 1}}
-        },
-        'losers': {
-            'b': {'p_l': 0, 's_l': 0}
-        }
+        "winners": {"a": {"p_w": 1, "s_w": 1, "swl": {"b": 1}}},
+        "losers": {"b": {"p_l": 0, "s_l": 0}},
     }
 
     d2 = minerva.make_arlo_contest({"a": 1000, "b": 0})
@@ -150,20 +137,17 @@ def test_get_sample_size_landslide_other_risks():
         "0.9": {"type": None, "size": 7, "prob": 0.9},
     }
     assert d2.margins == {
-        'winners': {
-            'a': {'p_w': 1, 's_w': 1, 'swl': {'b': 1}}
-        },
-        'losers': {
-            'b': {'p_l': 0, 's_l': 0}
-        }
+        "winners": {"a": {"p_w": 1, "s_w": 1, "swl": {"b": 1}}},
+        "losers": {"b": {"p_l": 0, "s_l": 0}},
     }
 
 
 def test_get_sample_size_landslide_low_votes(caplog):
     caplog.set_level(logging.WARN)
     d2 = minerva.make_arlo_contest({"a": 10, "b": 0})
-    res = minerva.get_sample_size(1, d2, None, [])
+    minerva.get_sample_size(1, d2, None, [])
     assert [record.levelname for record in caplog.records].count("WARNING") > 0
+
 
 def test_get_sample_size_big():
     # Binary search result, just over approximation threshold of 1.5% margin


### PR DESCRIPTION
Looking at possible improvements to make to the minerva module when I found a TODO to handle landslide elections better. I tried temporarily changing the losing candidates' votes from 0 -> 1 while the athena module does its math thing, to avoid a margin of 1 which would throw a `ValueError`.

This PR is essentially replacing a heuristic (previously, just suggest pulling 4 ballots in a landslide) with a better heuristic (handles alpha values other than 10 properly, lower alpha results in more ballots being pulled). Previously if you submitted a landslide with a risk < 10, the algorithm would not return the right number of ballots to pull and the risk limiting property would technically be violated.

This PR contains:
- Improvements to install/test files, I have a PR open for that already.
- Landslide detection (if any candidates have 0 votes) and a fix by temporarily adding 1 vote to losing candidates.
- Warning generation if contest is so small that changing votes from 0 -> 1 might affect the size of the audit
  - This doesn't seem too concerning to me? Generally the size of the contest would have to be in the small dozens, in which case the difference of pulling 5 vs 8 vs 11 ballots doesn't seem too taxing (from my perspective).
- More tests for minerva to run.
  - Test landslides with different risk alphas
  - Test that contests submitted to the landslide function are not modified by the landslide function once it returns