### PR TITLE
Fix broken timers tests

### DIFF
--- a/client/src/components/AuditAdmin/AuditAdminView.test.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.test.tsx
@@ -220,6 +220,25 @@ describe('AA setup flow', () => {
     })
   })
 
+  it('shows a spinner while sample is being drawn', async () => {
+    const expectedCalls = [
+      aaApiCalls.getUser,
+      aaApiCalls.getRounds(roundMocks.drawSampleInProgress),
+      aaApiCalls.getJurisdictions,
+      aaApiCalls.getContests(contestMocks.filledTargeted),
+      aaApiCalls.getSettings(auditSettingsMocks.all),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render('progress')
+      await screen.findByRole('heading', {
+        name: 'Drawing a random sample of ballots...',
+      })
+      screen.getByText(
+        'For large elections, this can take a couple of minutes.'
+      )
+    })
+  })
+
   it('redirects to /progress after audit is launched', async () => {
     const expectedCalls = [
       aaApiCalls.getUser,

--- a/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
@@ -20,6 +20,7 @@ import {
   jurisdictionMocks,
   contestMocks,
   auditSettingsMocks,
+  aaApiCalls,
 } from '../../../_mocks'
 
 const apiCalls = {
@@ -1023,5 +1024,29 @@ describe('Audit Setup > Review & Launch', () => {
       ).closest('.bp3-callout') as HTMLElement
       expect(warning).toHaveClass('bp3-intent-warning')
     })
+  })
+
+  it('shows a spinner while sample sizes are computed', async () => {
+    jest.useFakeTimers()
+    const expectedCalls = [
+      apiCalls.getSettings(settingsMock.full),
+      apiCalls.getJurisdictions({
+        jurisdictions: jurisdictionMocks.allManifests,
+      }),
+      apiCalls.getJurisdictionFile,
+      apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      aaApiCalls.getSampleSizes(sampleSizeMock.calculating),
+      aaApiCalls.getSampleSizes(sampleSizeMock.ballotPolling),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderView()
+      await screen.findByRole('heading', { name: 'Sample Size' })
+      screen.getByText('Loading sample size options...')
+      jest.advanceTimersByTime(1000)
+      await screen.findByText(
+        'Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.'
+      )
+    })
+    jest.useRealTimers()
   })
 })


### PR DESCRIPTION
These stopped working during the Vite upgrade so I skipped them to unblock myself.

When trying to fix them, I realized only one test actually relied on the fake clock (which is different from relying on fake timers - the logic looks at Date.now). So I moved the two other tests back into regular test files and then fixed that one test.