### PR TITLE
Hart CVR parsing: Mitigate "Too many open files" errors

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -1033,6 +1033,7 @@ def parse_hart_cvrs(
 
     def parse_cvr_ballots() -> Iterable[CvrBallot]:
         for (cvr_zip_file_name, cvr_file_name), cvr_file_path in cvr_file_paths.items():
+            cvr_zip_file_name_without_extension = cvr_zip_file_name[:-4]
             cvr_file = open(cvr_file_path, "rb")
             cvr_xml = ET.parse(cvr_file)
             cvr_file.close()
@@ -1041,7 +1042,7 @@ def parse_hart_cvrs(
             batch_sequence = find(cvr_xml, "BatchSequence").text
 
             db_batch = batches_by_key.get(
-                (cvr_zip_file_name.strip(".zip"), batch_number)
+                (cvr_zip_file_name_without_extension, batch_number)
                 if use_cvr_zip_file_names_as_tabulator_names
                 else batch_number
             )
@@ -1067,7 +1068,8 @@ def parse_hart_cvrs(
                     raise UserError(
                         f"Error in file: {cvr_file_name} from {cvr_zip_file_name}. "
                         "Couldn't find a matching batch for "
-                        f"Tabulator: {cvr_zip_file_name.strip('.zip')}, BatchNumber: {batch_number}. "
+                        f"Tabulator: {cvr_zip_file_name_without_extension}, "
+                        f"BatchNumber: {batch_number}. "
                         "The BatchNumber field in the CVR file must match the Batch Name field in "
                         "the ballot manifest, and the ZIP file name must match the Tabulator "
                         "field in the ballot manifest. " + general_guidance

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -840,7 +840,7 @@ def parse_hart_cvrs(
     flag_temporary_directory_for_removal(wrapper_zip_file_extract_dir)
     wrapper_zip_file.close()
 
-    cvr_zip_files: Dict[str, BinaryIO] = {}
+    cvr_zip_files: Dict[str, BinaryIO] = {}  # { file_name: file }
     scanned_ballot_information_file: Union[BinaryIO, None] = None
     for file_name in file_names:
         if file_name.lower().endswith(".zip"):
@@ -911,13 +911,17 @@ def parse_hart_cvrs(
         else {}
     )
 
-    cvr_file_paths: Dict[Tuple[str, str], str] = {}
+    cvr_file_paths: Dict[
+        Tuple[str, str], str
+    ] = {}  # { (zip_file_name, file_name): file_path }
     for cvr_zip_file_name, cvr_zip_file in cvr_zip_files.items():
         cvr_zip_file_extract_dir, cvr_file_names = unzip_files(cvr_zip_file)
         flag_temporary_directory_for_removal(cvr_zip_file_extract_dir)
         for cvr_file_name in cvr_file_names:
             # Ignore extraneous files, like the WriteIn directory
             if cvr_file_name.lower().endswith(".xml"):
+                # Don't open the files here and just prepare the paths so that they can be opened
+                # and closed one at a time later to avoid hitting "Too many open files" errors
                 cvr_file_paths[(cvr_zip_file_name, cvr_file_name)] = os.path.join(
                     cvr_zip_file_extract_dir, cvr_file_name
                 )

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -3,7 +3,7 @@ import shutil
 import io
 import os
 import tempfile
-from typing import IO, BinaryIO, Dict, Optional
+from typing import BinaryIO, Dict, IO, List, Optional, Tuple
 from urllib.parse import urlparse
 from zipfile import ZipFile
 import boto3
@@ -92,11 +92,10 @@ def zip_files(files: Dict[str, BinaryIO]) -> IO[bytes]:
     return zip_file
 
 
-def unzip_files(zip_file: BinaryIO) -> Dict[str, BinaryIO]:
-    extract_dir = tempfile.TemporaryDirectory()
+# Returns 1) the path of the temporary directory to which files were extracted and 2) the names of
+# the extracted files. Consumers are responsible for deleting the temporary directory.
+def unzip_files(zip_file: BinaryIO,) -> Tuple[str, List[str]]:
+    extract_dir = tempfile.mkdtemp()
     with ZipFile(zip_file, "r") as zip_archive:
-        zip_archive.extractall(extract_dir.name)
-        return {
-            file_name: open(os.path.join(extract_dir.name, file_name), "rb")
-            for file_name in zip_archive.namelist()
-        }
+        zip_archive.extractall(extract_dir)
+        return extract_dir, zip_archive.namelist()

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -3,7 +3,7 @@ import shutil
 import io
 import os
 import tempfile
-from typing import BinaryIO, Dict, IO, List, Optional, Tuple
+from typing import BinaryIO, Dict, IO, List, Optional
 from urllib.parse import urlparse
 from zipfile import ZipFile
 import boto3
@@ -92,10 +92,9 @@ def zip_files(files: Dict[str, BinaryIO]) -> IO[bytes]:
     return zip_file
 
 
-# Returns 1) the path of the temporary directory to which files were extracted and 2) the names of
-# the extracted files. Consumers are responsible for deleting the temporary directory.
-def unzip_files(zip_file: BinaryIO,) -> Tuple[str, List[str]]:
-    extract_dir = tempfile.mkdtemp()
+# Extracts the contents of the provided zip file to the specified directory and returns the list of
+# extracted file names
+def unzip_files(zip_file: BinaryIO, directory_to_extract_to: str) -> List[str]:
     with ZipFile(zip_file, "r") as zip_archive:
-        zip_archive.extractall(extract_dir)
-        return extract_dir, zip_archive.namelist()
+        zip_archive.extractall(directory_to_extract_to)
+        return zip_archive.namelist()


### PR DESCRIPTION
# Overview

In testing with Orange County's close-to-ready CVR files, I found myself hitting "Too many open files" errors locally. My local ulimit matches the ulimit on our prod servers (`ulimit -n` --> 1,024 * 1,024 = 1,048,576). Rather than finding a way to bump the ulimit even higher, which may not even be possible in prod (unless a higher tier of Heroku Dyno comes with a higher limit), I've modified the Hart CVR parsing code to open CVR files one at a time instead of all at once.

I also uncovered and fixed a fun bug involving a misuse of `.strip` in the process!

# Testing

- [x] Verified that existing tests still pass
- [x] Successfully uploaded OC's close-to-ready CVR files locally*

*By running this code in conjunction with https://github.com/votingworks/arlo/pull/1712 and making some manual tweaks to account for some CVRs not having a `BatchNumber` (which won't be the case in OC's final files)