### PR TITLE
Revert "Use react-query for useSampleSizes"

### DIFF
--- a/client/src/components/Atoms/StatusBox.test.tsx
+++ b/client/src/components/Atoms/StatusBox.test.tsx
@@ -2,10 +2,9 @@ import React from 'react'
 import { BrowserRouter as Router, useParams } from 'react-router-dom'
 import { render, fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { QueryClientProvider } from 'react-query'
 import { AuditAdminStatusBox } from './StatusBox'
 import { IAuditSettings } from '../useAuditSettings'
-import { withMockFetch, createQueryClient } from '../testUtilities'
+import { withMockFetch } from '../testUtilities'
 import {
   aaApiCalls,
   auditSettingsMocks,
@@ -240,18 +239,16 @@ describe('StatusBox', () => {
       await withMockFetch(expectedCalls, async () => {
         const startNextRoundMock = jest.fn()
         render(
-          <QueryClientProvider client={createQueryClient()}>
-            <Router>
-              <AuditAdminStatusBox
-                rounds={roundMocks.needAnother}
-                startNextRound={startNextRoundMock}
-                undoRoundStart={jest.fn()}
-                jurisdictions={jurisdictionMocks.allComplete}
-                contests={contestMocks.filledTargeted}
-                auditSettings={auditSettingsMocks.ballotComparisonAll}
-              />
-            </Router>
-          </QueryClientProvider>
+          <Router>
+            <AuditAdminStatusBox
+              rounds={roundMocks.needAnother}
+              startNextRound={startNextRoundMock}
+              undoRoundStart={jest.fn()}
+              jurisdictions={jurisdictionMocks.allComplete}
+              contests={contestMocks.filledTargeted}
+              auditSettings={auditSettingsMocks.ballotComparisonAll}
+            />
+          </Router>
         )
         screen.getByText(
           'Round 1 of the audit is complete - another round is needed'
@@ -287,18 +284,16 @@ describe('StatusBox', () => {
       await withMockFetch(expectedCalls, async () => {
         const startNextRoundMock = jest.fn()
         render(
-          <QueryClientProvider client={createQueryClient()}>
-            <Router>
-              <AuditAdminStatusBox
-                rounds={roundMocks.needAnother}
-                startNextRound={startNextRoundMock}
-                undoRoundStart={jest.fn()}
-                jurisdictions={jurisdictionMocks.allComplete}
-                contests={contestMocks.filledTargeted}
-                auditSettings={auditSettingsMocks.batchComparisonAll}
-              />
-            </Router>
-          </QueryClientProvider>
+          <Router>
+            <AuditAdminStatusBox
+              rounds={roundMocks.needAnother}
+              startNextRound={startNextRoundMock}
+              undoRoundStart={jest.fn()}
+              jurisdictions={jurisdictionMocks.allComplete}
+              contests={contestMocks.filledTargeted}
+              auditSettings={auditSettingsMocks.batchComparisonAll}
+            />
+          </Router>
         )
         screen.getByText(
           'Round 1 of the audit is complete - another round is needed'
@@ -327,18 +322,16 @@ describe('StatusBox', () => {
       ]
       await withMockFetch(expectedCalls, async () => {
         render(
-          <QueryClientProvider client={createQueryClient()}>
-            <Router>
-              <AuditAdminStatusBox
-                rounds={roundMocks.needAnother}
-                startNextRound={jest.fn()}
-                undoRoundStart={jest.fn()}
-                jurisdictions={jurisdictionMocks.allComplete}
-                contests={contestMocks.filledTargeted}
-                auditSettings={auditSettingsMocks.ballotComparisonAll}
-              />
-            </Router>
-          </QueryClientProvider>
+          <Router>
+            <AuditAdminStatusBox
+              rounds={roundMocks.needAnother}
+              startNextRound={jest.fn()}
+              undoRoundStart={jest.fn()}
+              jurisdictions={jurisdictionMocks.allComplete}
+              contests={contestMocks.filledTargeted}
+              auditSettings={auditSettingsMocks.ballotComparisonAll}
+            />
+          </Router>
         )
         await screen.findByText(
           'Error computing sample sizes: something went wrong'

--- a/client/src/components/Atoms/StatusBox.tsx
+++ b/client/src/components/Atoms/StatusBox.tsx
@@ -299,12 +299,13 @@ const AuditAdminAnotherRoundStatusBox = ({
   startNextRound,
   children,
 }: IAuditAdminAnotherRoundStatusBoxProps) => {
-  const sampleSizesQuery = useSampleSizes(electionId, roundNum + 1)
+  const sampleSizesResponse = useSampleSizes(electionId, roundNum + 1, true)
   // The server should autoselect one option per contest, so we pick the first
   // item in the options array for each contest
   const sampleSizes =
-    sampleSizesQuery.data?.sampleSizes &&
-    mapValues(sampleSizesQuery.data.sampleSizes, options => options[0])
+    sampleSizesResponse &&
+    sampleSizesResponse.sampleSizes &&
+    mapValues(sampleSizesResponse.sampleSizes, options => options[0])
   const ballotsOrBatches =
     auditSettings.auditType === 'BATCH_COMPARISON' ? 'batches' : 'ballots'
 
@@ -312,11 +313,14 @@ const AuditAdminAnotherRoundStatusBox = ({
     <StatusBox
       headline={`Round ${roundNum} of the audit is complete - another round is needed`}
       details={(() => {
-        if (!sampleSizesQuery.data?.task.completedAt)
+        if (
+          sampleSizesResponse === null ||
+          sampleSizesResponse.task.completedAt === null
+        )
           return ['Loading sample sizes...']
-        if (sampleSizesQuery.data.task.error !== null)
+        if (sampleSizesResponse.task.error !== null)
           return [
-            `Error computing sample sizes: ${sampleSizesQuery.data.task.error}`,
+            `Error computing sample sizes: ${sampleSizesResponse.task.error}`,
           ]
         return [
           `Round ${roundNum + 1} Sample Sizes`,

--- a/client/src/components/utilities.test.ts
+++ b/client/src/components/utilities.test.ts
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react'
 import { toast } from 'react-toastify'
-import { api, testNumber, downloadFile } from './utilities'
+import { api, testNumber, poll, downloadFile } from './utilities'
 
 const response = () =>
   new Response(new Blob([JSON.stringify({ success: true })]))
@@ -119,6 +119,80 @@ describe('utilities.ts', () => {
   describe('testNumber', () => {
     it('uses default message', () => {
       expect(testNumber(50)(100)).resolves.toBe('Must be smaller than 50')
+    })
+  })
+
+  describe('poll', () => {
+    it('iterates', async () => {
+      const j = (function* idMaker() {
+        let index = 0
+        while (true) yield (index += 1)
+      })()
+      let result = ''
+      const condition = async () => j.next().value > 2
+      const callback = () => {
+        result = 'callback completed'
+      }
+      const error = () => {
+        result = 'an error'
+      }
+      poll(condition, callback, error, undefined, 1)
+      await waitFor(() => {
+        expect(result).toBe('callback completed')
+      })
+    })
+
+    it('times out', async () => {
+      let result = ''
+      const condition = async () => false
+      const callback = () => {
+        result = 'callback completed'
+      }
+      const error = () => {
+        result = 'an error'
+      }
+      poll(condition, callback, error, 50, 10)
+      await waitFor(() => {
+        expect(result).toBe('an error')
+      })
+    })
+
+    it('times out with spies', async () => {
+      const startDate: number = Date.now()
+      const lateDate: number = startDate + 130000
+      const dateSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(startDate)
+        .mockReturnValueOnce(lateDate)
+      let result = ''
+      const condition = async () => false
+      const callback = () => {
+        result = 'callback completed'
+      }
+      const error = () => {
+        result = 'an error'
+      }
+      poll(condition, callback, error)
+      await waitFor(() => {
+        expect(result).toBe('an error')
+        expect(dateSpy).toBeCalledTimes(2)
+      })
+      dateSpy.mockRestore()
+    })
+
+    it('handles errors in condition()', async () => {
+      let result: Error
+      const condition = async () => {
+        throw new Error('error')
+      }
+      const callback = jest.fn()
+      const error = (err: Error) => {
+        result = err
+      }
+      poll(condition, callback, error, 50, 10)
+      await waitFor(() => {
+        expect(result.message).toBe('error')
+      })
     })
   })
 

--- a/client/src/components/utilities.ts
+++ b/client/src/components/utilities.ts
@@ -75,6 +75,32 @@ export const downloadFile = (fileBlob: Blob, fileName?: string): void => {
   document.body.removeChild(a)
 }
 
+// Deprecated - use react-query's refetch interval
+export const poll = (
+  condition: () => Promise<boolean>,
+  callback: () => void,
+  errback: (arg0: Error) => void,
+  timeout = 120000,
+  interval = 1000
+): void => {
+  const endTime = Date.now() + timeout
+  ;(async function p() {
+    const time = Date.now()
+    try {
+      const done = await condition()
+      if (done) {
+        callback()
+      } else if (time < endTime) {
+        setTimeout(p, interval)
+      } else {
+        errback(new Error(`Timed out`))
+      }
+    } catch (err) {
+      errback(err)
+    }
+  })()
+}
+
 const numberSchema = number()
   .typeError('Must be a number')
   .integer('Must be an integer')


### PR DESCRIPTION
Proactively opening a revert commit for https://github.com/votingworks/arlo/pull/1725 since I believe it's causing issues with the UI continuing to indicate that sample sizes are being calculated even though the worker has finished calculating. Interestingly, the sample size does show up once in a while if I refresh over and over, so there may be a race condition.

Relevant Slack thread: https://votingworks.slack.com/archives/C013V6CT9H9/p1669163895545919