### PR TITLE
Fix contests before passing to athena module to avoid 0 or 1 margins.

### DIFF
--- a/server/tests/audit_math/test_minerva.py
+++ b/server/tests/audit_math/test_minerva.py
@@ -88,6 +88,24 @@ def test_get_sample_size_landslide():
     }
 
 
+def test_get_sample_size_landslide_third_party():
+    c = minerva.make_arlo_contest({"a": 1000, "b": 900, "c": 0})
+    res = minerva.get_sample_size(10, c, None, None)
+    assert res == {
+        "0.7": {"prob": 0.7, "size": 1464, "type": None},
+        "0.8": {"prob": 0.8, "size": 1868, "type": None},
+        "0.9": {"prob": 0.9, "size": 2488, "type": None},
+    }
+
+    c = minerva.make_arlo_contest({"a": 100, "b": 0, "c": 0})
+    res = minerva.get_sample_size(10, c, None, None)
+    assert res == {
+        "0.7": {"prob": 0.7, "size": 4, "type": None},
+        "0.8": {"prob": 0.8, "size": 4, "type": None},
+        "0.9": {"prob": 0.9, "size": 4, "type": None},
+    }
+
+
 def test_get_sample_size_big():
     # Binary search result, just over approximation threshold of 1.5% margin
     c = minerva.make_arlo_contest({"a": 5076, "b": 4925})


### PR DESCRIPTION
This PR fixes the issue described in 1728 and is a simplification of the closed PR 1715.

Currently, minerva calculates the margins between all the candidates that are fed to it. Athena will throw a valueError when a margin is 0 or 1. This means that in a tight race between A and B where candidate C registered but got no votes, athena will throw a ValueError and Minerva will suggest pulling only 4 ballots.

This PR adds a function that ensures that 0 vote candidates are removed before being passed to Athena. In the case where only one candidate gets a vote, it puts back one 0 vote candidate so minerva doesn't suggest a sample size of 0.