### PR TITLE
Handle Dominion CVR CSVs with equal signs in front of values

### DIFF
--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -104,9 +104,23 @@ def process_batch_inventory_cvr_file(jurisdiction_id: str):
         return int(vote if vote != "" else 0)
 
     for row_index, row in enumerate(cvrs):
-        cvr_number = column_value(row, "CvrNumber", row_index + 1, header_indices)
-        tabulator_number = column_value(row, "TabulatorNum", cvr_number, header_indices)
-        batch_id = column_value(row, "BatchId", cvr_number, header_indices)
+        cvr_number = column_value(
+            row,
+            "CvrNumber",
+            row_index + 1,
+            header_indices,
+            remove_leading_equal_sign=True,
+        )
+        tabulator_number = column_value(
+            row,
+            "TabulatorNum",
+            cvr_number,
+            header_indices,
+            remove_leading_equal_sign=True,
+        )
+        batch_id = column_value(
+            row, "BatchId", cvr_number, header_indices, remove_leading_equal_sign=True,
+        )
         counting_group = column_value(row, "CountingGroup", cvr_number, header_indices)
 
         batch_key = (tabulator_number, batch_id)

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
@@ -48,3 +48,45 @@ Tabulator 1 - BATCH2,2,1\r
 Tabulator 2 - BATCH1,2,1\r
 Tabulator 2 - BATCH2,2,0\r
 """
+
+snapshots[
+    "test_batch_inventory_happy_path_cvr_with_leading_equal_signs 1"
+] = """Batch Inventory Worksheet\r
+\r
+Section 1: Check Ballot Groups\r
+1. Compare the CVR Ballot Count for each ballot group to your voter check-in data.\r
+2. Ensure that the numbers reconcile. If there is a large discrepancy contact your SOS liaison.\r
+\r
+Ballot Group,CVR Ballot Count,Checked? (Type Yes/No)\r
+Election Day,13,\r
+Mail,2,\r
+\r
+Section 2: Check Batches\r
+1. Locate each batch in storage.\r
+2. Confirm the CVR Ballot Count is correct using associated documentation. Do NOT count the ballots. If there is a large discrepancy contact your SOS liaison.\r
+3. Make sure there are no batches missing from this worksheet.\r
+\r
+Batch,CVR Ballot Count,Checked? (Type Yes/No)\r
+Tabulator 1 - BATCH1,3,\r
+Tabulator 1 - BATCH2,3,\r
+Tabulator 2 - BATCH1,3,\r
+Tabulator 2 - BATCH2,6,\r
+"""
+
+snapshots[
+    "test_batch_inventory_happy_path_cvr_with_leading_equal_signs 2"
+] = """Container,Batch Name,Number of Ballots\r
+Election Day,Tabulator 1 - BATCH1,3\r
+Election Day,Tabulator 1 - BATCH2,3\r
+Mail,Tabulator 2 - BATCH1,3\r
+Election Day,Tabulator 2 - BATCH2,6\r
+"""
+
+snapshots[
+    "test_batch_inventory_happy_path_cvr_with_leading_equal_signs 3"
+] = """Batch Name,Choice 1-1,Choice 1-2\r
+Tabulator 1 - BATCH1,1,2\r
+Tabulator 1 - BATCH2,2,1\r
+Tabulator 2 - BATCH1,2,1\r
+Tabulator 2 - BATCH2,2,0\r
+"""

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -24,6 +24,27 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortio
 15,TABULATOR2,BATCH2,6,2-2-6,Election Day,12345,CITY,,,1,0,1
 """
 
+TEST_CVRS_WITH_LEADING_EQUAL_SIGNS = """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
+,,,,,,,,Contest 1 (Vote For=1),Contest 1 (Vote For=1),Contest 2 (Vote For=2),Contest 2 (Vote For=2),Contest 2 (Vote For=2)
+,,,,,,,,Choice 1-1,Choice 1-2,Choice 2-1,Choice 2-2,Choice 2-3
+CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM,LBR,IND,,
+="1",="TABULATOR1",="BATCH1",="1",="1-1-1",Election Day,12345,COUNTY,0,1,1,1,0
+="2",="TABULATOR1",="BATCH1",="2",="1-1-2",Election Day,12345,COUNTY,1,0,1,0,1
+="3",="TABULATOR1",="BATCH1",="3",="1-1-3",Election Day,12345,COUNTY,0,1,1,1,0
+="4",="TABULATOR1",="BATCH2",="1",="1-2-1",Election Day,12345,COUNTY,1,0,1,0,1
+="5",="TABULATOR1",="BATCH2",="2",="1-2-2",Election Day,12345,COUNTY,0,1,1,1,0
+="6",="TABULATOR1",="BATCH2",="3",="1-2-3",Election Day,12345,COUNTY,1,0,1,0,1
+="7",="TABULATOR2",="BATCH1",="1",="2-1-1",Election Day,12345,COUNTY,0,1,1,1,0
+="8",="TABULATOR2",="BATCH1",="2",="2-1-2",Mail,12345,COUNTY,1,0,1,0,1
+="9",="TABULATOR2",="BATCH1",="3",="2-1-3",Mail,12345,COUNTY,1,0,1,1,0
+="10",="TABULATOR2",="BATCH2",="1",="2-2-1",Election Day,12345,COUNTY,1,0,1,0,1
+="11",="TABULATOR2",="BATCH2",="2",="2-2-2",Election Day,12345,COUNTY,1,1,1,1,0
+="12",="TABULATOR2",="BATCH2",="3",="2-2-3",Election Day,12345,COUNTY,1,0,1,0,1
+="13",="TABULATOR2",="BATCH2",="4",="2-2-4",Election Day,12345,CITY,,,1,0,1
+="14",="TABULATOR2",="BATCH2",="5",="2-2-5",Election Day,12345,CITY,,,1,1,0
+="15",="TABULATOR2",="BATCH2",="6",="2-2-6",Election Day,12345,CITY,,,1,0,1
+"""
+
 TEST_TABULATOR_STATUS = """<?xml version="1.0" standalone="yes"?>
 <ExportName>
    <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
@@ -241,6 +262,191 @@ def test_batch_inventory_happy_path(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr/file"
     )
     assert rv.data.decode("utf-8") == TEST_CVR
+
+    # Download tabulator status file
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status/file"
+    )
+    assert rv.data.decode("utf-8") == TEST_TABULATOR_STATUS
+
+
+def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_id: str,  # pylint: disable=unused-argument
+    snapshot,
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    # Load batch inventory starting state (simulate JA loading the page)
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr"
+    )
+    cvr = json.loads(rv.data)
+    assert cvr == dict(file=None, processing=None)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status"
+    )
+    tabulator_status = json.loads(rv.data)
+    assert tabulator_status == dict(file=None, processing=None)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/sign-off"
+    )
+    sign_off = json.loads(rv.data)
+    assert sign_off == dict(signedOffAt=None)
+
+    # Upload CVR file
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
+        data={
+            "cvr": (
+                io.BytesIO(TEST_CVRS_WITH_LEADING_EQUAL_SIGNS.encode()),
+                "cvrs.csv",
+            ),
+        },
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr"
+    )
+    compare_json(
+        json.loads(rv.data),
+        {
+            "file": {"name": "cvrs.csv", "uploadedAt": assert_is_date},
+            "processing": {
+                "status": ProcessingStatus.PROCESSED,
+                "startedAt": assert_is_date,
+                "completedAt": assert_is_date,
+                "error": None,
+            },
+        },
+    )
+
+    # Upload tabulator status file
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
+        data={
+            "tabulatorStatus": (
+                io.BytesIO(TEST_TABULATOR_STATUS.encode()),
+                "tabulator-status.xml",
+            ),
+        },
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status"
+    )
+    compare_json(
+        json.loads(rv.data),
+        {
+            "file": {"name": "tabulator-status.xml", "uploadedAt": assert_is_date},
+            "processing": {
+                "status": ProcessingStatus.PROCESSED,
+                "startedAt": assert_is_date,
+                "completedAt": assert_is_date,
+                "error": None,
+            },
+        },
+    )
+
+    # Download worksheet
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/worksheet"
+    )
+    snapshot.assert_match(rv.data.decode("utf-8"))
+
+    # Sign off
+    rv = client.post(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/sign-off"
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/sign-off"
+    )
+    compare_json(json.loads(rv.data), {"signedOffAt": assert_is_date})
+    batch_inventory_data = BatchInventoryData.query.get(jurisdiction_ids[0])
+    assert (
+        batch_inventory_data.sign_off_user_id
+        == User.query.filter_by(email=default_ja_email(election_id)).one().id
+    )
+
+    # Download manifest
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/ballot-manifest"
+    )
+    ballot_manifest = rv.data.decode("utf-8")
+    snapshot.assert_match(ballot_manifest)
+
+    # Download batch tallies
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/batch-tallies"
+    )
+    batch_tallies = rv.data.decode("utf-8")
+    snapshot.assert_match(batch_tallies)
+
+    # Upload manifest
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
+        data={
+            "manifest": (io.BytesIO(ballot_manifest.encode()), "ballot-manifest.csv",),
+        },
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest"
+    )
+    compare_json(
+        json.loads(rv.data),
+        {
+            "file": {"name": "ballot-manifest.csv", "uploadedAt": assert_is_date},
+            "processing": {
+                "status": ProcessingStatus.PROCESSED,
+                "startedAt": assert_is_date,
+                "completedAt": assert_is_date,
+                "error": None,
+            },
+        },
+    )
+
+    # Upload batch tallies
+    rv = client.put(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
+        data={
+            "batchTallies": (io.BytesIO(batch_tallies.encode()), "batch-tallies.csv",)
+        },
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies"
+    )
+    compare_json(
+        json.loads(rv.data),
+        {
+            "file": {"name": "batch-tallies.csv", "uploadedAt": assert_is_date},
+            "processing": {
+                "status": ProcessingStatus.PROCESSED,
+                "startedAt": assert_is_date,
+                "completedAt": assert_is_date,
+                "error": None,
+            },
+        },
+    )
+
+    # Download CVR file
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr/file"
+    )
+    assert rv.data.decode("utf-8") == TEST_CVRS_WITH_LEADING_EQUAL_SIGNS
 
     # Download tabulator status file
     rv = client.get(


### PR DESCRIPTION
# Overview

Issue link: https://github.com/votingworks/arlo/issues/1736

Dominion sometimes exports CVR CSVs with equal signs in front of certain columns' values, e.g.

```
="3",="1002",="1",="10",="1002-1-10","Mail-in",...
```

We currently have customers open these CSVs in an editor like Excel and resave, which removes the leading equal signs. But this case is becoming common enough that we've decided to just handle it in code.

# Testing

- [x] Updated unit tests
- [x] Manually tested that a file that was previously failing to upload now uploads successfully