### PR TITLE
adding/removing candidate texts no longer span entire container

### DIFF
--- a/client/src/components/Atoms/Form/styledBits.tsx
+++ b/client/src/components/Atoms/Form/styledBits.tsx
@@ -31,11 +31,12 @@ export const InputLabel = styled(Label)`
   display: inline-block;
   flex-grow: 2;
   width: unset;
+  flex-basis: 50%;
 `
 
 export const Action = styled.p`
   margin: 5px 0 0 0;
-  width: 100%;
+  width: max-content;
   color: #000088;
   &:hover {
     cursor: pointer;

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               class="sc-bYSBpT hroDAy"
             >
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Name of Candidate/Choice 
                 1
@@ -146,7 +146,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Votes for Candidate/Choice 
                 1
@@ -170,7 +170,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               class="sc-bYSBpT hroDAy"
             >
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Name of Candidate/Choice 
                 2
@@ -190,7 +190,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Votes for Candidate/Choice 
                 2
@@ -211,7 +211,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <p
-              class="sc-kTUwUJ hRSfTz"
+              class="sc-kTUwUJ kWFRUA"
             >
               Add a new candidate/choice
             </p>
@@ -458,7 +458,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               class="sc-bYSBpT hroDAy"
             >
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Name of Candidate/Choice 
                 1
@@ -478,7 +478,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Votes for Candidate/Choice 
                 1
@@ -502,7 +502,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               class="sc-bYSBpT hroDAy"
             >
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Name of Candidate/Choice 
                 2
@@ -522,7 +522,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Votes for Candidate/Choice 
                 2
@@ -543,7 +543,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-kTUwUJ hRSfTz"
+              class="sc-kTUwUJ kWFRUA"
             >
               Add a new candidate/choice
             </p>
@@ -790,7 +790,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               class="sc-bYSBpT hroDAy"
             >
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Name of Candidate/Choice 
                 1
@@ -810,7 +810,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Votes for Candidate/Choice 
                 1
@@ -834,7 +834,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               class="sc-bYSBpT hroDAy"
             >
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Name of Candidate/Choice 
                 2
@@ -854,7 +854,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Votes for Candidate/Choice 
                 2
@@ -875,7 +875,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <p
-              class="sc-kTUwUJ hRSfTz"
+              class="sc-kTUwUJ kWFRUA"
             >
               Add a new candidate/choice
             </p>
@@ -1122,7 +1122,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               class="sc-bYSBpT hroDAy"
             >
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Name of Candidate/Choice 
                 1
@@ -1142,7 +1142,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Votes for Candidate/Choice 
                 1
@@ -1166,7 +1166,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               class="sc-bYSBpT hroDAy"
             >
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Name of Candidate/Choice 
                 2
@@ -1186,7 +1186,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Votes for Candidate/Choice 
                 2
@@ -1207,7 +1207,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-kTUwUJ hRSfTz"
+              class="sc-kTUwUJ kWFRUA"
             >
               Add a new candidate/choice
             </p>

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               class="sc-bYSBpT hroDAy"
             >
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Name of Candidate/Choice 
                 1
@@ -182,7 +182,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Votes for Candidate/Choice 
                 1
@@ -206,7 +206,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               class="sc-bYSBpT hroDAy"
             >
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Name of Candidate/Choice 
                 2
@@ -226,7 +226,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW lkNSpp"
+                class="bp3-label sc-jtRfpW xkJJK"
               >
                 Votes for Candidate/Choice 
                 2
@@ -247,7 +247,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <p
-              class="sc-kTUwUJ hRSfTz"
+              class="sc-kTUwUJ kWFRUA"
             >
               Add a new candidate/choice
             </p>


### PR DESCRIPTION
## What
Fix for issue #1761. Modified the CSS styling of components used on the target contests screen, "add/remove candidate" buttons no longer invisibly span the screen.

Modified the screenshot tests since changing the styling of these components changed their generated class names.

## Details
Invisible span was caused by the p element (which was responsible for the onClick event) having a width of 100%. By changing to `width: max-content`, the p element only spans the width of the text it contains. Adding the `flex-basis: 50%` ensures that the InputLabels take up enough space in the flexbox to force the buttons into a new row (which was previously accomplished by `width: 100%`).


## Alternatives Considered
This form is implemented using a flexbox which is designed to have its items stretch to fill the entire width of the parent container. Rather than modifying `width` and `flex-basis`, we could replace the flexbox layout with a grid layout, which is intended to have its items fill a similar amount of space. However, getting the flexbox item to maintain its size only took two changes and this is the only place these stylized components are used, so I figured this was a simpler change.