### PR TITLE
Remove providence from frontend per Oliver's concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ As part of the audit, Arlo:
 
 Arlo currently supports multiple risk-limiting audit methods, including:
 
-- ballot polling (BRAVO, Minerva, and Providence)
+- ballot polling (BRAVO and Minerva)
 - batch comparison
 - ballot comparison
 - hybrid (SUITE, combining ballot polling & ballot comparison)

--- a/client/src/components/HomeScreen.tsx
+++ b/client/src/components/HomeScreen.tsx
@@ -515,7 +515,6 @@ const CreateAudit = ({ organizations }: { organizations: IOrganization[] }) => {
                         selectedValue={values.auditMathType}
                       >
                         <Radio value="BRAVO">BRAVO</Radio>
-                        <Radio value="PROVIDENCE">Providence (Beta)</Radio>
                         <Radio value="MINERVA">Minerva (Beta)</Radio>
                       </RadioGroup>
                     </label>


### PR DESCRIPTION
Oliver raised some concerns about how we use random seeds for Providence. Until we can sort out a solution, we should disable Providence on the frontend.