### PR TITLE
Fix Cypress tests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -123,7 +123,7 @@
     "@testing-library/react-hooks": "^3.3.0",
     "@testing-library/user-event": "^12.3.0",
     "@types/node": "12.0.7",
-    "cypress": "^10.7.0",
+    "cypress": "^11.0.0",
     "cypress-file-upload": "^4.1.1",
     "is-ci-cli": "^1.1.1",
     "jest-canvas-mock": "^2.1.1",

--- a/client/run-cypress-tests.sh
+++ b/client/run-cypress-tests.sh
@@ -12,4 +12,11 @@ fi
 trap 'kill 0' SIGINT SIGHUP EXIT
 cd "$(dirname "${BASH_SOURCE[0]}")"
 FLASK_ENV=test ../run-dev.sh &
-yarn run cypress run --browser chrome
+
+until $(curl --output /dev/null --silent --head --fail http://localhost:3000/api/me); do
+    echo 'Waiting for dev server...'
+    sleep 1
+done
+echo 'Dev server ready'
+
+yarn run cypress run

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3722,10 +3722,10 @@ cypress-file-upload@^4.1.1:
   dependencies:
     mime "^2.4.4"
 
-cypress@^10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.7.0.tgz#2d37f8b9751c6de33ee48639cb7e67a2ce593231"
-  integrity sha512-gTFvjrUoBnqPPOu9Vl5SBHuFlzx/Wxg/ZXIz2H4lzoOLFelKeF7mbwYUOzgzgF0oieU2WhJAestQdkgwJMMTvQ==
+cypress@^11.0.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.2.0.tgz#63edef8c387b687066c5493f6f0ad7b9ced4b2b7"
+  integrity sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -3746,7 +3746,7 @@ cypress@^10.7.0:
     dayjs "^1.10.4"
     debug "^4.3.2"
     enquirer "^2.3.6"
-    eventemitter2 "^6.4.3"
+    eventemitter2 "6.4.7"
     execa "4.1.0"
     executable "^4.1.1"
     extract-zip "2.0.1"
@@ -4933,10 +4933,10 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-eventemitter2@^6.4.3:
-  version "6.4.5"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.5.tgz#97380f758ae24ac15df8353e0cc27f8b95644655"
-  integrity sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==
+eventemitter2@6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
+  integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
 eventemitter3@^3.0.0:
   version "3.1.2"


### PR DESCRIPTION
Cypress tests were failing consistently, hanging at the start of the tests when trying to do the initial audit admin login. These changes seemed to help, though I'm not totally sure what the root cause was.