### PR TITLE
Improve clarity of discrepancy columns in audit report

### DIFF
--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -255,15 +255,19 @@ def pretty_choice_votes(
 
 
 def batch_vote_deltas(
-    reported_results: Dict[str, int], audited_results: Dict[str, int],
-) -> Dict[str, int]:
+    reported_results: Dict[str, int], audited_results: Optional[Dict[str, int]],
+) -> Union[str, Dict[str, int]]:
+    if audited_results is None:
+        return "Batch not audited"
     return {
         choice_id: reported_results[choice_id] - audited_results[choice_id]
         for choice_id in reported_results.keys()
     }
 
 
-def pretty_batch_vote_deltas(vote_deltas: Dict[str, int],) -> str:
+def pretty_batch_vote_deltas(vote_deltas: Union[str, Dict[str, int]],) -> str:
+    if isinstance(vote_deltas, str):
+        return vote_deltas
     return pretty_choice_votes(
         {
             choice_id: add_sign(vote_delta)
@@ -875,9 +879,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
                 pretty_choice_votes(reported_results),
                 pretty_batch_vote_deltas(
                     batch_vote_deltas(reported_results, audit_results)
-                )
-                if audit_results
-                else "",
+                ),
                 error["counted_as"] if error else "",
                 construct_batch_last_edited_by_string(batch),
             ]

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -697,8 +697,8 @@ def sampled_ballot_rows(election: Election, jurisdiction: Jurisdiction = None):
             result_columns.append(f"Audit Result: {contest.name}")
             if show_cvrs:
                 result_columns.append(f"CVR Result: {contest.name}")
-                result_columns.append(f"Vote Delta: {contest.name}")
-                result_columns.append(f"Discrepancy: {contest.name}")
+                result_columns.append(f"Change in Results: {contest.name}")
+                result_columns.append(f"Change in Margin: {contest.name}")
 
     rows.append(
         ["Jurisdiction Name"]
@@ -832,8 +832,8 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
             "Audited?",
             "Audit Results",
             "Reported Results",
-            "Vote Delta",
-            "Discrepancy",
+            "Change in Results",
+            "Change in Margin",
             "Last Edited By",
         ]
     )

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -46,7 +46,7 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 1,Contest 2,Opportunistic,,No,0.5122026667,DATETIME,DATETIME,Choice 2-1: 6; Choice 2-2: 3; Choice 2-3: 4\r
 \r
 ######## SAMPLED BALLOTS ########\r
-Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Vote Delta: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Vote Delta: Contest 2,Discrepancy: Contest 2\r
+Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2\r
 J1,0001,BATCH1,1,0001013415,Round 1: 0.163888857982405419,AUDITED,"Choice 1-1, INVALID_WRITE_IN",Choice 1-1,,,"Choice 2-1, INVALID_WRITE_IN",Choice 2-1,,\r
 J1,0001,BATCH2,2,0001000416,Round 1: 0.420510971092712649,AUDITED,Choice 1-2,Choice 1-2,,,Choice 2-1,Choice 2-1,,\r
 J1,0001,BATCH2,3,0001000417,"Round 1: 0.032225032864873362, 0.160129023760942294, 0.451079782619837640",AUDITED,BLANK,Undervote,,,BLANK,Undervote,,\r
@@ -121,15 +121,15 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 1,Contest 2,Opportunistic,,No,1.0,DATETIME,DATETIME,Choice 2-1: 12; Choice 2-2: 7; Choice 2-3: 8\r
 \r
 ######## SAMPLED BALLOTS ########\r
-Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Vote Delta: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Vote Delta: Contest 2,Discrepancy: Contest 2\r
+Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2\r
 J1,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.243550726331576894,AUDITED,"Choice 1-2, INVALID_WRITE_IN",Choice 1-2,,,"Choice 2-1, Choice 2-2, INVALID_WRITE_IN","Choice 2-1, Choice 2-2",,\r
 J1,TABULATOR1,BATCH2,2,1-2-2,Round 1: 0.125871889047705889,AUDITED,Choice 1-2,Choice 1-2,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",,\r
 J1,TABULATOR1,BATCH2,3,1-2-3,Round 1: 0.126622033568908859,AUDITED,"Choice 1-1, Choice 1-2",Choice 1-1,Choice 1-2: -1,1,"Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-3",Choice 2-1: +1; Choice 2-2: -1,2\r
 J1,TABULATOR2,BATCH2,2,2-2-2,Round 1: 0.053992217600758631,AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",,\r
-J1,TABULATOR2,BATCH2,3,2-2-4,Round 1: 0.255119157791673311,AUDITED,Choice 1-1,Blank,,-1,CONTEST_NOT_ON_BALLOT,"Choice 2-1, Choice 2-3",,1\r
+J1,TABULATOR2,BATCH2,3,2-2-4,Round 1: 0.255119157791673311,AUDITED,Choice 1-1,Blank,Choice 1-1: -1,-1,CONTEST_NOT_ON_BALLOT,"Choice 2-1, Choice 2-3",Choice 2-1: +1; Choice 2-3: +1,1\r
 J1,TABULATOR2,BATCH2,4,2-2-5,"Round 1: 0.064984443990590400, 0.069414660569975443",AUDITED,BLANK,Blank,,,BLANK,Blank,,\r
-J1,TABULATOR2,BATCH2,5,2-2-6,Round 1: 0.442956417641278897,AUDITED,CONTEST_NOT_ON_BALLOT,Blank,,,CONTEST_NOT_ON_BALLOT,"Choice 2-1, Choice 2-3",,1\r
-J1,TABULATOR2,BATCH2,6,,Round 1: 0.300053574780458718,NOT_FOUND,,,,2,,,,2\r
+J1,TABULATOR2,BATCH2,5,2-2-6,Round 1: 0.442956417641278897,AUDITED,CONTEST_NOT_ON_BALLOT,Blank,,,CONTEST_NOT_ON_BALLOT,"Choice 2-1, Choice 2-3",Choice 2-1: +1; Choice 2-3: +1,1\r
+J1,TABULATOR2,BATCH2,6,,Round 1: 0.300053574780458718,NOT_FOUND,,,Ballot not found,2,,,Ballot not found,2\r
 J2,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.476019554092109137,AUDITED,"Choice 1-1, INVALID_WRITE_IN",Choice 1-2,Choice 1-1: -1; Choice 1-2: +1,-2,"Choice 2-1, INVALID_WRITE_IN","Choice 2-1, Choice 2-2",Choice 2-2: +1,-1\r
 J2,TABULATOR1,BATCH1,3,1-1-3,Round 1: 0.242392535590495322,AUDITED,Choice 1-2,Choice 1-2,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",,\r
 J2,TABULATOR1,BATCH2,1,1-2-1,Round 1: 0.200269401620671924,AUDITED,Choice 1-1,Choice 1-1,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",,\r
@@ -138,7 +138,7 @@ J2,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.185417954749015145,AUDITED,Choice 1-1,Ch
 J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",,\r
 J2,TABULATOR2,BATCH2,3,2-2-4,"Round 1: 0.179114059650472941, 0.443867094961314498",AUDITED,CONTEST_NOT_ON_BALLOT,Blank,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",,\r
 J2,TABULATOR2,BATCH2,5,2-2-6,Round 1: 0.462119987445142117,AUDITED,CONTEST_NOT_ON_BALLOT,Blank,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",,\r
-J2,TABULATOR2,BATCH2,6,,Round 1: 0.414184312862040881,AUDITED,Choice 1-1,,,2,"Choice 2-1, Choice 2-3",,,2\r
+J2,TABULATOR2,BATCH2,6,,Round 1: 0.414184312862040881,AUDITED,Choice 1-1,,Ballot not in CVR,2,"Choice 2-1, Choice 2-3",,Ballot not in CVR,2\r
 """
 
 snapshots[
@@ -169,15 +169,15 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 2,Contest 2,Opportunistic,,No,1.0,DATETIME,DATETIME,Choice 2-1: 6; Choice 2-2: 3; Choice 2-3: 6\r
 \r
 ######## SAMPLED BALLOTS ########\r
-Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Vote Delta: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Vote Delta: Contest 2,Discrepancy: Contest 2\r
+Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2\r
 J1,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.243550726331576894,AUDITED,"Choice 1-2, INVALID_WRITE_IN",Choice 1-2,,,"Choice 2-1, Choice 2-2, INVALID_WRITE_IN","Choice 2-1, Choice 2-2",,\r
 J1,TABULATOR1,BATCH2,2,1-2-2,Round 1: 0.125871889047705889,AUDITED,Choice 1-2,Choice 1-2,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",,\r
 J1,TABULATOR1,BATCH2,3,1-2-3,"Round 1: 0.126622033568908859, Round 2: 0.570682515619614792",AUDITED,"Choice 1-1, Choice 1-2",Choice 1-1,Choice 1-2: -1,1,"Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-3",Choice 2-1: +1; Choice 2-2: -1,2\r
 J1,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.053992217600758631, Round 2: 0.528652598036440834",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",,\r
-J1,TABULATOR2,BATCH2,3,2-2-4,Round 1: 0.255119157791673311,AUDITED,Choice 1-1,Blank,,-1,CONTEST_NOT_ON_BALLOT,"Choice 2-1, Choice 2-3",,1\r
+J1,TABULATOR2,BATCH2,3,2-2-4,Round 1: 0.255119157791673311,AUDITED,Choice 1-1,Blank,Choice 1-1: -1,-1,CONTEST_NOT_ON_BALLOT,"Choice 2-1, Choice 2-3",Choice 2-1: +1; Choice 2-3: +1,1\r
 J1,TABULATOR2,BATCH2,4,2-2-5,"Round 1: 0.064984443990590400, 0.069414660569975443",AUDITED,BLANK,Blank,,,BLANK,Blank,,\r
-J1,TABULATOR2,BATCH2,5,2-2-6,"Round 1: 0.442956417641278897, Round 2: 0.492638838970333256",AUDITED,CONTEST_NOT_ON_BALLOT,Blank,,,CONTEST_NOT_ON_BALLOT,"Choice 2-1, Choice 2-3",,1\r
-J1,TABULATOR2,BATCH2,6,,"Round 1: 0.300053574780458718, Round 2: 0.539920212714138536",NOT_FOUND,,,,2,,,,2\r
+J1,TABULATOR2,BATCH2,5,2-2-6,"Round 1: 0.442956417641278897, Round 2: 0.492638838970333256",AUDITED,CONTEST_NOT_ON_BALLOT,Blank,,,CONTEST_NOT_ON_BALLOT,"Choice 2-1, Choice 2-3",Choice 2-1: +1; Choice 2-3: +1,1\r
+J1,TABULATOR2,BATCH2,6,,"Round 1: 0.300053574780458718, Round 2: 0.539920212714138536",NOT_FOUND,,,Ballot not found,2,,,Ballot not found,2\r
 J2,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.476019554092109137,AUDITED,"Choice 1-1, INVALID_WRITE_IN",Choice 1-2,Choice 1-1: -1; Choice 1-2: +1,-2,"Choice 2-1, INVALID_WRITE_IN","Choice 2-1, Choice 2-2",Choice 2-2: +1,-1\r
 J2,TABULATOR1,BATCH1,3,1-1-3,Round 1: 0.242392535590495322,AUDITED,Choice 1-2,Choice 1-2,,,"Choice 2-1, Choice 2-2","Choice 2-1, Choice 2-2",,\r
 J2,TABULATOR1,BATCH2,1,1-2-1,"Round 1: 0.200269401620671924, Round 2: 0.588219390083415326",AUDITED,Choice 1-1,Choice 1-1,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",,\r
@@ -186,7 +186,7 @@ J2,TABULATOR2,BATCH2,1,2-2-1,Round 1: 0.185417954749015145,AUDITED,Choice 1-1,Ch
 J2,TABULATOR2,BATCH2,2,2-2-2,"Round 1: 0.252054739518646128, 0.297145021317217438",AUDITED,"Choice 1-1, Choice 1-2","Choice 1-1, Choice 1-2",,,"Choice 2-1, Choice 2-2, Choice 2-3","Choice 2-1, Choice 2-2, Choice 2-3",,\r
 J2,TABULATOR2,BATCH2,3,2-2-4,"Round 1: 0.179114059650472941, 0.443867094961314498, Round 2: 0.553767880261132538",AUDITED,CONTEST_NOT_ON_BALLOT,Blank,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",,\r
 J2,TABULATOR2,BATCH2,5,2-2-6,Round 1: 0.462119987445142117,AUDITED,CONTEST_NOT_ON_BALLOT,Blank,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",,\r
-J2,TABULATOR2,BATCH2,6,,Round 1: 0.414184312862040881,AUDITED,Choice 1-1,,,2,"Choice 2-1, Choice 2-3",,,2\r
+J2,TABULATOR2,BATCH2,6,,Round 1: 0.414184312862040881,AUDITED,Choice 1-1,,Ballot not in CVR,2,"Choice 2-1, Choice 2-3",,Ballot not in CVR,2\r
 J2,TABULATOR1,BATCH1,2,1-1-2,"Round 2: 0.511105635717372621, 0.583472201399663519",AUDITED,"Choice 1-1, INVALID_WRITE_IN",Choice 1-1,,,"Choice 2-1, Choice 2-3, INVALID_WRITE_IN","Choice 2-1, Choice 2-3",,\r
 J2,TABULATOR1,BATCH2,3,1-2-3,Round 2: 0.556310137163677574,AUDITED,Choice 1-1,Choice 1-1,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",,\r
 J2,TABULATOR2,BATCH2,4,2-2-5,Round 2: 0.583133559190710795,AUDITED,CONTEST_NOT_ON_BALLOT,Blank,,,"Choice 2-1, Choice 2-2",Blank,Choice 2-1: -1; Choice 2-2: -1,-1\r

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison_manifests.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison_manifests.py
@@ -51,7 +51,7 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 1,Contest 1,Targeted,14,No,,DATETIME,,Choice 1-1: 0; Choice 1-2: 0\r
 \r
 ######## SAMPLED BALLOTS ########\r
-Jurisdiction Name,Container,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Vote Delta: Contest 1,Discrepancy: Contest 1\r
+Jurisdiction Name,Container,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1\r
 J1,CONTAINER0,TABULATOR2,BATCH8,47,2-8-47,Round 1: 0.006763450800570999,NOT_AUDITED,,Blank,,\r
 J1,CONTAINER1,TABULATOR2,BATCH1,15,2-1-15,Round 1: 0.006700879199748225,NOT_AUDITED,,Blank,,\r
 J1,CONTAINER1,TABULATOR2,BATCH2,44,2-2-44,Round 1: 0.000676487665235813,NOT_AUDITED,,Blank,,\r

--- a/server/tests/ballot_comparison/snapshots/snap_test_contest_name_standardizations.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_contest_name_standardizations.py
@@ -41,7 +41,7 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 1,Standardized Contest 2,Opportunistic,,No,,DATETIME,,Choice 2-1: 0; Choice 2-2: 0; Choice 2-3: 0\r
 \r
 ######## SAMPLED BALLOTS ########\r
-Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Standardized Contest 1,Audited?,Audit Result: Standardized Contest 1,CVR Result: Standardized Contest 1,Vote Delta: Standardized Contest 1,Discrepancy: Standardized Contest 1,Audit Result: Standardized Contest 2,CVR Result: Standardized Contest 2,Vote Delta: Standardized Contest 2,Discrepancy: Standardized Contest 2\r
+Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Standardized Contest 1,Audited?,Audit Result: Standardized Contest 1,CVR Result: Standardized Contest 1,Change in Results: Standardized Contest 1,Change in Margin: Standardized Contest 1,Audit Result: Standardized Contest 2,CVR Result: Standardized Contest 2,Change in Results: Standardized Contest 2,Change in Margin: Standardized Contest 2\r
 J1,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.243550726331576894,NOT_AUDITED,,Choice 1-2,,,,"Choice 2-1, Choice 2-2",,\r
 J1,TABULATOR1,BATCH2,2,1-2-2,Round 1: 0.125871889047705889,NOT_AUDITED,,Choice 1-2,,,,"Choice 2-1, Choice 2-2",,\r
 J1,TABULATOR1,BATCH2,3,1-2-3,Round 1: 0.126622033568908859,NOT_AUDITED,,Choice 1-1,,,,"Choice 2-1, Choice 2-3",,\r

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -539,8 +539,8 @@ def check_discrepancies(report_data, audit_results):
         )
         parse_discrepancy = lambda d: int(d) if d != "" else None
         assert (
-            parse_discrepancy(row["Discrepancy: Contest 1"]),
-            parse_discrepancy(row["Discrepancy: Contest 2"]),
+            parse_discrepancy(row["Change in Margin: Contest 1"]),
+            parse_discrepancy(row["Change in Margin: Contest 2"]),
         ) == expected_discrepancies, "Discrepancy mismatch for {}".format(ballot)
 
 

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -26,7 +26,7 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 1,Contest 1,Targeted,6,Yes,0.0825517715,DATETIME,DATETIME,candidate 1: 1200; candidate 2: 600; candidate 3: 600\r
 \r
 ######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Vote Delta,Discrepancy,Last Edited By\r
+Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Change in Results,Change in Margin,Last Edited By\r
 J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,jurisdiction.admin-UUID@example.com\r
@@ -84,25 +84,25 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 2,Contest 1,Targeted,5,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
 \r
 ######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Vote Delta,Discrepancy,Last Edited By\r
+Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Change in Results,Change in Margin,Last Edited By\r
 J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J2,Batch 3,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 100; candidate 2: 100; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +400; candidate 2: +150; candidate 3: +210,250,jurisdiction.admin-UUID@example.com\r
-J1,Batch 3,Round 2: 0.753710009967479876,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
-J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
-J2,Batch 4,"Round 2: 0.608147659546583410, 0.868820918994249069",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
+J1,Batch 3,Round 2: 0.753710009967479876,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,Batch not audited,,\r
+J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,Batch not audited,,\r
+J2,Batch 4,"Round 2: 0.608147659546583410, 0.868820918994249069",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,Batch not audited,,\r
 """
 
 snapshots[
     "test_batch_comparison_round_2 12"
 ] = """######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Vote Delta,Discrepancy,Last Edited By\r
+Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Change in Results,Change in Margin,Last Edited By\r
 J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
-J1,Batch 3,Round 2: 0.753710009967479876,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
-J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
+J1,Batch 3,Round 2: 0.753710009967479876,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,Batch not audited,,\r
+J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,Batch not audited,,\r
 """
 
 snapshots["test_batch_comparison_round_2 2"] = {

--- a/server/tests/batch_comparison/snapshots/snap_test_batches.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batches.py
@@ -27,11 +27,11 @@ Batch 10,,
 snapshots[
     "test_batches_human_sort_order 2"
 ] = """######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Vote Delta,Discrepancy,Last Edited By\r
-J1,Batch 1 - 1,"Round 1: 0.9610467367288398089, 0.9743784458526487453",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,,,\r
-J1,Batch 1 - 10,Round 1: 0.109576900310237874,No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,,,\r
-J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,,,\r
-J1,Batch 10,"Round 1: 0.772049767819343419, 0.875085546411266410",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,,,\r
+Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Change in Results,Change in Margin,Last Edited By\r
+J1,Batch 1 - 1,"Round 1: 0.9610467367288398089, 0.9743784458526487453",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,Batch not audited,,\r
+J1,Batch 1 - 10,Round 1: 0.109576900310237874,No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,Batch not audited,,\r
+J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,Batch not audited,,\r
+J1,Batch 10,"Round 1: 0.772049767819343419, 0.875085546411266410",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,Batch not audited,,\r
 """
 
 snapshots["test_record_batch_results 1"] = {

--- a/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
@@ -26,7 +26,7 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 1,Contest 1,Targeted,6,No,0.1857414858,DATETIME,DATETIME,candidate 1: 700; candidate 2: 250; candidate 3: 160\r
 \r
 ######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Vote Delta,Discrepancy,Last Edited By\r
+Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Change in Results,Change in Margin,Last Edited By\r
 J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r

--- a/server/tests/hybrid/snapshots/snap_test_hybrid.py
+++ b/server/tests/hybrid/snapshots/snap_test_hybrid.py
@@ -60,7 +60,7 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 1,Contest 2,Opportunistic,,No,1.0,DATETIME,DATETIME,Choice 2-1: 9; Choice 2-2: 4; Choice 2-3: 3,Choice 2-1: 4; Choice 2-2: 3; Choice 2-3: 3,Choice 2-1: 5; Choice 2-2: 1; Choice 2-3: 0\r
 \r
 ######## SAMPLED BALLOTS ########\r
-Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Vote Delta: Contest 1,Discrepancy: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Vote Delta: Contest 2,Discrepancy: Contest 2\r
+Jurisdiction Name,Tabulator,Batch Name,Ballot Position,Imprinted ID,Ticket Numbers: Contest 1,Audited?,Audit Result: Contest 1,CVR Result: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Result: Contest 2,CVR Result: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2\r
 J1,TABULATOR1,BATCH1,1,1-1-1,Round 1: 0.243550726331576894,AUDITED,"Choice 1-2, INVALID_WRITE_IN",Choice 1-2,,,"Choice 2-1, Choice 2-2, INVALID_WRITE_IN","Choice 2-1, Choice 2-2",,\r
 J1,TABULATOR1,BATCH2,2,1-2-2,Round 1: 0.125871889047705889,AUDITED,"Choice 1-1, Choice 1-2",Choice 1-2,Choice 1-1: -1,-1,Choice 2-2,"Choice 2-1, Choice 2-2",Choice 2-1: +1,1\r
 J1,TABULATOR1,BATCH2,3,1-2-3,Round 1: 0.126622033568908859,AUDITED,Choice 1-1,Choice 1-1,,,"Choice 2-1, Choice 2-3","Choice 2-1, Choice 2-3",,\r


### PR DESCRIPTION
Instead of only showing vote deltas when there are both audited and reported votes, show any mismatch between the audited result and the reported result. This makes this column the one-stop shop for any audit discrepancy (instead of having to also look in the discrepancy column, which most users find confusing).

Also renames the "Vote Delta" to "Change in Results" and "Discrepancy" to "Change in Margin" to try to make those values a bit clearer.

_Review by commit_