### PR TITLE
Discrepancy indicators

### DIFF
--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -119,7 +119,7 @@ describe('Progress screen', () => {
     })
   })
 
-  it('shows round status', async () => {
+  it('shows round status for ballot polling', async () => {
     const expectedCalls = [aaApiCalls.getMapData]
     await withMockFetch(expectedCalls, async () => {
       const { container } = render({
@@ -144,7 +144,7 @@ describe('Progress screen', () => {
       expect(headers[4]).toHaveTextContent('Ballots Remaining')
 
       const rows = screen.getAllByRole('row')
-      expect(rows).toHaveLength(jurisdictionMocks.oneManifest.length + 2) // includes headers and footers
+      expect(rows).toHaveLength(jurisdictionMocks.oneComplete.length + 2) // includes headers and footers
       const row1 = within(rows[1]).getAllByRole('cell')
       expect(row1[0]).toHaveTextContent('Jurisdiction 1')
       expectStatusTag(row1[1], 'In progress', 'warning')
@@ -156,7 +156,7 @@ describe('Progress screen', () => {
       expectStatusTag(row2[1], 'Not started', 'none')
       expect(row2[2]).toHaveTextContent('2,117')
       expect(row2[3]).toHaveTextContent('0')
-      expect(row2[4]).toHaveTextContent('0')
+      expect(row2[4]).toHaveTextContent('20')
       const row3 = within(rows[3]).getAllByRole('cell')
       expect(row3[0]).toHaveTextContent('Jurisdiction 3')
       expectStatusTag(row3[1], 'Complete', 'success')
@@ -170,6 +170,126 @@ describe('Progress screen', () => {
       expect(footers[2]).toHaveTextContent('6,351')
       expect(footers[3]).toHaveTextContent('34')
       expect(footers[4]).toHaveTextContent('26')
+    })
+  })
+
+  it('shows round status for ballot comparison', async () => {
+    const expectedCalls = [aaApiCalls.getMapData]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = render({
+        auditSettings: auditSettingsMocks.ballotComparisonAll,
+        jurisdictions: jurisdictionMocks.allComplete,
+        round: roundMocks.singleIncomplete[0],
+      })
+
+      expect(container.querySelectorAll('.d3-component').length).toBe(1)
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('.bp3-spinner').length).toBe(0)
+      })
+
+      screen.getByText('Audit Progress')
+
+      const headers = screen.getAllByRole('columnheader')
+      expect(headers).toHaveLength(6)
+      expect(headers[0]).toHaveTextContent('Jurisdiction')
+      expect(headers[1]).toHaveTextContent('Status')
+      expect(headers[2]).toHaveTextContent('Ballots in Manifest')
+      expect(headers[3]).toHaveTextContent('Discrepancies')
+      expect(headers[4]).toHaveTextContent('Ballots Audited')
+      expect(headers[5]).toHaveTextContent('Ballots Remaining')
+
+      const rows = screen.getAllByRole('row')
+      expect(rows).toHaveLength(jurisdictionMocks.oneComplete.length + 2) // includes headers and footers
+      const row1 = within(rows[1]).getAllByRole('cell')
+      expect(row1[0]).toHaveTextContent('Jurisdiction 1')
+      expectStatusTag(row1[1], 'Complete', 'success')
+      expect(row1[2]).toHaveTextContent('2,117')
+      expect(row1[3]).toHaveTextContent('')
+      expect(row1[4]).toHaveTextContent('10')
+      expect(row1[5]).toHaveTextContent('0')
+      const row2 = within(rows[2]).getAllByRole('cell')
+      expect(row2[0]).toHaveTextContent('Jurisdiction 2')
+      expectStatusTag(row2[1], 'Complete', 'success')
+      expect(row2[2]).toHaveTextContent('2,117')
+      expect(row2[3]).toHaveTextContent('2')
+      expect(row2[4]).toHaveTextContent('20')
+      expect(row2[5]).toHaveTextContent('0')
+      const row3 = within(rows[3]).getAllByRole('cell')
+      expect(row3[0]).toHaveTextContent('Jurisdiction 3')
+      expectStatusTag(row3[1], 'Complete', 'success')
+      expect(row3[2]).toHaveTextContent('2,117')
+      expect(row3[3]).toHaveTextContent('1')
+      expect(row3[4]).toHaveTextContent('30')
+      expect(row3[5]).toHaveTextContent('0')
+
+      const footers = within(rows[4]).getAllByRole('cell')
+      expect(footers[0]).toHaveTextContent('Total')
+      expect(footers[1]).toHaveTextContent('3/3 complete')
+      expect(footers[2]).toHaveTextContent('6,351')
+      expect(footers[3]).toHaveTextContent('3')
+      expect(footers[4]).toHaveTextContent('60')
+      expect(footers[5]).toHaveTextContent('0')
+    })
+  })
+
+  it('shows round status for batch comparison', async () => {
+    const expectedCalls = [aaApiCalls.getMapData]
+    await withMockFetch(expectedCalls, async () => {
+      const { container } = render({
+        auditSettings: auditSettingsMocks.batchComparisonAll,
+        jurisdictions: jurisdictionMocks.oneComplete,
+        round: roundMocks.singleIncomplete[0],
+      })
+
+      expect(container.querySelectorAll('.d3-component').length).toBe(1)
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('.bp3-spinner').length).toBe(0)
+      })
+
+      screen.getByText('Audit Progress')
+
+      const headers = screen.getAllByRole('columnheader')
+      expect(headers).toHaveLength(6)
+      expect(headers[0]).toHaveTextContent('Jurisdiction')
+      expect(headers[1]).toHaveTextContent('Status')
+      expect(headers[2]).toHaveTextContent('Ballots in Manifest')
+      expect(headers[3]).toHaveTextContent('Discrepancies')
+      expect(headers[4]).toHaveTextContent('Batches Audited')
+      expect(headers[5]).toHaveTextContent('Batches Remaining')
+
+      const rows = screen.getAllByRole('row')
+      expect(rows).toHaveLength(jurisdictionMocks.oneComplete.length + 2) // includes headers and footers
+      const row1 = within(rows[1]).getAllByRole('cell')
+      expect(row1[0]).toHaveTextContent('Jurisdiction 1')
+      expectStatusTag(row1[1], 'In progress', 'warning')
+      expect(row1[2]).toHaveTextContent('2,117')
+      expect(row1[3]).toHaveTextContent('')
+      expect(row1[4]).toHaveTextContent('4')
+      expect(row1[5]).toHaveTextContent('6')
+      const row2 = within(rows[2]).getAllByRole('cell')
+      expect(row2[0]).toHaveTextContent('Jurisdiction 2')
+      expectStatusTag(row2[1], 'Not started', 'none')
+      expect(row2[2]).toHaveTextContent('2,117')
+      expect(row2[3]).toHaveTextContent('')
+      expect(row2[4]).toHaveTextContent('0')
+      expect(row2[5]).toHaveTextContent('0')
+      const row3 = within(rows[3]).getAllByRole('cell')
+      expect(row3[0]).toHaveTextContent('Jurisdiction 3')
+      expectStatusTag(row3[1], 'Complete', 'success')
+      expect(row3[2]).toHaveTextContent('2,117')
+      expect(row3[3]).toHaveTextContent('1')
+      expect(row3[4]).toHaveTextContent('30')
+      expect(row3[5]).toHaveTextContent('0')
+
+      const footers = within(rows[4]).getAllByRole('cell')
+      expect(footers[0]).toHaveTextContent('Total')
+      expect(footers[1]).toHaveTextContent('1/3 complete')
+      expect(footers[2]).toHaveTextContent('6,351')
+      expect(footers[3]).toHaveTextContent('1')
+      expect(footers[4]).toHaveTextContent('34')
+      expect(footers[5]).toHaveTextContent('26')
     })
   })
 

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { Column, Cell, TableInstance } from 'react-table'
-import { Button, Switch, ITagProps } from '@blueprintjs/core'
+import { Button, Switch, ITagProps, Icon } from '@blueprintjs/core'
 import H2Title from '../../Atoms/H2Title'
 import {
   JurisdictionRoundStatus,
@@ -256,6 +256,21 @@ const Progress: React.FC<IProgressProps> = ({
   }
 
   if (round) {
+    if (auditType === 'BALLOT_COMPARISON' || auditType === 'BATCH_COMPARISON') {
+      columns.push({
+        Header: 'Discrepancies',
+        accessor: ({ currentRoundStatus: s }) => s && s.numDiscrepancies,
+        Cell: ({ value }: { value: number | null }) => {
+          if (!value) return null
+          return (
+            <>
+              <Icon icon="flag" intent="danger" /> {value.toLocaleString()}
+            </>
+          )
+        },
+        Footer: totalFooter('Discrepancies'),
+      })
+    }
     columns.push(
       {
         Header: `${ballotsOrBatches} Audited`,

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -664,6 +664,7 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 10,
         numSamplesAudited: 5,
         numSamples: 11,
+        numDiscrepancies: null,
       },
     },
     {
@@ -677,6 +678,7 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 20,
         numSamplesAudited: 0,
         numSamples: 22,
+        numDiscrepancies: null,
       },
     },
     {
@@ -690,6 +692,7 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 30,
         numSamplesAudited: 31,
         numSamples: 31,
+        numDiscrepancies: 1,
       },
     },
   ],
@@ -705,6 +708,7 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 10,
         numSamplesAudited: 11,
         numSamples: 11,
+        numDiscrepancies: 0,
       },
     },
     {
@@ -718,6 +722,7 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 20,
         numSamplesAudited: 22,
         numSamples: 22,
+        numDiscrepancies: 2,
       },
     },
     {
@@ -731,6 +736,7 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 30,
         numSamplesAudited: 31,
         numSamples: 31,
+        numDiscrepancies: 1,
       },
     },
   ],
@@ -793,6 +799,7 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 10,
         numSamplesAudited: 0,
         numSamples: 11,
+        numDiscrepancies: null,
       },
     },
     {
@@ -806,6 +813,7 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 20,
         numSamplesAudited: 0,
         numSamples: 22,
+        numDiscrepancies: null,
       },
     },
     {
@@ -819,6 +827,7 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 30,
         numSamplesAudited: 31,
         numSamples: 31,
+        numDiscrepancies: 0,
       },
     },
   ],

--- a/client/src/components/useJurisdictions.ts
+++ b/client/src/components/useJurisdictions.ts
@@ -49,6 +49,7 @@ export interface IJurisdiction {
     numUnique: number
     numUniqueAudited: number
     numBatchesAudited?: number
+    numDiscrepancies?: number | null
   } | null
 }
 

--- a/server/api/discrepancies.py
+++ b/server/api/discrepancies.py
@@ -1,10 +1,10 @@
 from typing import Dict, Optional, Union
 
-from ..audit_math import supersimple
+from ..audit_math import supersimple, macro
 from ..models import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 
-# { contest_choice_id: vote delta }
+# { choice_id: vote delta }
 ContestVoteDeltas = Dict[str, int]
 
 
@@ -45,11 +45,12 @@ def ballot_vote_deltas(
 
 
 def batch_vote_deltas(
-    reported_results: Dict[str, int], audited_results: Dict[str, int],
+    reported_results: macro.ChoiceVotes, audited_results: macro.ChoiceVotes
 ) -> Optional[ContestVoteDeltas]:
     deltas = {
         choice_id: reported_results[choice_id] - audited_results[choice_id]
         for choice_id in reported_results.keys()
+        if choice_id != "ballots"
     }
 
     if all(delta == 0 for delta in deltas.values()):

--- a/server/api/discrepancies.py
+++ b/server/api/discrepancies.py
@@ -1,0 +1,52 @@
+from typing import Dict, Optional, Union
+
+from ..audit_math import supersimple
+from ..models import *  # pylint: disable=wildcard-import,unused-wildcard-import
+
+
+# { contest_choice_id: vote delta }
+ContestVoteDeltas = Dict[str, int]
+
+
+def ballot_vote_deltas(
+    contest: Contest,
+    reported_cvr: Optional[supersimple.CVR],
+    audited_cvr: Optional[supersimple.CVR],
+) -> Optional[Union[str, ContestVoteDeltas]]:
+    if audited_cvr is None:
+        return "Ballot not found"
+    if reported_cvr is None:
+        return "Ballot not in CVR"
+
+    reported = reported_cvr.get(contest.id)
+    audited = audited_cvr.get(contest.id)
+
+    if audited is None and reported is None:
+        return None
+    if audited is None:
+        audited = {choice.id: "0" for choice in contest.choices}
+    if reported is None:
+        reported = {choice.id: "0" for choice in contest.choices}
+
+    deltas = {}
+    for choice in contest.choices:
+        reported_vote = (
+            0 if reported[choice.id] in ["o", "u"] else int(reported[choice.id])
+        )
+        audited_vote = (
+            0 if audited[choice.id] in ["o", "u"] else int(audited[choice.id])
+        )
+        deltas[choice.id] = reported_vote - audited_vote
+
+    return deltas
+
+
+def batch_vote_deltas(
+    reported_results: Dict[str, int], audited_results: Optional[Dict[str, int]],
+) -> Union[str, Dict[str, int]]:
+    if audited_results is None:
+        return "Batch not audited"
+    return {
+        choice_id: reported_results[choice_id] - audited_results[choice_id]
+        for choice_id in reported_results.keys()
+    }

--- a/server/api/discrepancies.py
+++ b/server/api/discrepancies.py
@@ -38,15 +38,21 @@ def ballot_vote_deltas(
         )
         deltas[choice.id] = reported_vote - audited_vote
 
+    if all(delta == 0 for delta in deltas.values()):
+        return None
+
     return deltas
 
 
 def batch_vote_deltas(
-    reported_results: Dict[str, int], audited_results: Optional[Dict[str, int]],
-) -> Union[str, Dict[str, int]]:
-    if audited_results is None:
-        return "Batch not audited"
-    return {
+    reported_results: Dict[str, int], audited_results: Dict[str, int],
+) -> Optional[ContestVoteDeltas]:
+    deltas = {
         choice_id: reported_results[choice_id] - audited_results[choice_id]
         for choice_id in reported_results.keys()
     }
+
+    if all(delta == 0 for delta in deltas.values()):
+        return None
+
+    return deltas

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -160,39 +160,23 @@ def pretty_cvr_interpretation(
     )
 
 
-def contest_vote_deltas(
-    contest: Contest,
-    reported_cvrs: supersimple.CVRS,
-    audited_cvrs: supersimple.SAMPLECVRS,
-) -> Dict[str, Optional[Union[str, ContestVoteDeltas]]]:
-    return {
-        ballot_id: ballot_vote_deltas(
-            contest, reported_cvrs.get(ballot_id), audited_cvr["cvr"]
-        )
-        for ballot_id, audited_cvr in audited_cvrs.items()
-    }
-
-
 def add_sign(value: int) -> str:
     return f"+{value}" if value > 0 else str(value)
 
 
 def pretty_vote_deltas(
-    ballot: SampledBallot,
-    contest: Contest,
-    vote_deltas: Dict[str, Optional[Union[str, ContestVoteDeltas]]],
+    contest: Contest, vote_deltas: Optional[Union[str, ContestVoteDeltas]],
 ) -> str:
-    ballot_vote_deltas = vote_deltas.get(ballot.id)
-    if ballot_vote_deltas is None:
+    if vote_deltas is None:
         return ""
-    if isinstance(ballot_vote_deltas, str):
-        return ballot_vote_deltas
+    if isinstance(vote_deltas, str):
+        return vote_deltas
 
     return pretty_choice_votes(
         {
-            choice.name: add_sign(ballot_vote_deltas[choice.id])
+            choice.name: add_sign(vote_deltas[choice.id])
             for choice in contest.choices
-            if ballot_vote_deltas[choice.id] != 0
+            if vote_deltas[choice.id] != 0
         }
     )
 
@@ -216,18 +200,6 @@ def pretty_choice_votes(
             if not_found is not None
             else []
         )
-    )
-
-
-def pretty_batch_vote_deltas(vote_deltas: Union[str, Dict[str, int]],) -> str:
-    if isinstance(vote_deltas, str):
-        return vote_deltas
-    return pretty_choice_votes(
-        {
-            choice_id: add_sign(vote_delta)
-            for choice_id, vote_delta in vote_deltas.items()
-            if vote_delta != 0
-        }
     )
 
 
@@ -681,14 +653,6 @@ def sampled_ballot_rows(election: Election, jurisdiction: Jurisdiction = None):
             )
             for contest in election.contests
         }
-        vote_deltas_by_contest = {
-            contest.id: contest_vote_deltas(
-                contest,
-                cvrs_by_contest[contest.id],
-                audited_cvrs_by_contest[contest.id],
-            )
-            for contest in election.contests
-        }
 
     for ballot in ballots:
         (
@@ -711,11 +675,13 @@ def sampled_ballot_rows(election: Election, jurisdiction: Jurisdiction = None):
                         ballot, contest, cvrs_by_contest[contest.id]
                     )
                     result_values.append(cvr_interpretation)
-                    result_values.append(
-                        pretty_vote_deltas(
-                            ballot, contest, vote_deltas_by_contest[contest.id]
-                        )
+                    audited_result = audited_cvrs_by_contest[contest.id].get(ballot.id)
+                    vote_deltas = audited_result and ballot_vote_deltas(
+                        contest,
+                        cvrs_by_contest[contest.id].get(ballot.id),
+                        audited_result["cvr"],
                     )
+                    result_values.append(pretty_vote_deltas(contest, vote_deltas))
                     result_values.append(
                         pretty_discrepancy(ballot, discrepancies_by_contest[contest.id])
                     )
@@ -792,22 +758,25 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
         ]
     )
     for batch in batches:
-        reported_results = {
-            choice.name: batch.jurisdiction.batch_tallies[batch.name][contest.id][
-                choice.id
-            ]
+        reported_results = batch.jurisdiction.batch_tallies[batch.name][contest.id]
+        reported_results_by_name = {
+            choice.name: reported_results[choice.id]
+            for choice in contest.choices
             for choice in contest.choices
         }
 
         is_audited = batch.id in audit_results_by_batch
         audit_results = (
             {
-                choice.name: audit_results_by_batch[batch.id].get(choice.id, 0)
+                choice.id: audit_results_by_batch[batch.id].get(choice.id, 0)
                 for choice in contest.choices
             }
             if is_audited
             else None
         )
+        audit_results_by_name = audit_results and {
+            choice.name: audit_results[choice.id] for choice in contest.choices
+        }
         error = (
             macro.compute_error(
                 batch.jurisdiction.batch_tallies[batch.name],
@@ -829,10 +798,18 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
                 batch.name,
                 pretty_batch_ticket_numbers(batch, round_id_to_num),
                 pretty_boolean(is_audited),
-                pretty_choice_votes(audit_results) if audit_results else "",
-                pretty_choice_votes(reported_results),
-                pretty_batch_vote_deltas(
-                    batch_vote_deltas(reported_results, audit_results)
+                (
+                    pretty_choice_votes(audit_results_by_name)
+                    if audit_results_by_name
+                    else ""
+                ),
+                pretty_choice_votes(reported_results_by_name),
+                (
+                    pretty_vote_deltas(
+                        contest, batch_vote_deltas(reported_results, audit_results)
+                    )
+                    if audit_results
+                    else ""
                 ),
                 error["counted_as"] if error else "",
                 construct_batch_last_edited_by_string(batch),

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -211,9 +211,7 @@ def samples_not_found_by_round(contest: Contest) -> Dict[str, int]:
 
 
 # { batch_key: { contest_id: { choice_id: votes }}}
-BatchTallies = Dict[
-    sampler.BatchKey, ballot_polling_types.BALLOT_POLLING_SAMPLE_RESULTS
-]
+BatchTallies = Dict[macro.BatchKey, macro.BatchResults]
 
 
 def batch_tallies(election: Election) -> BatchTallies:
@@ -230,7 +228,7 @@ def batch_tallies(election: Election) -> BatchTallies:
     }
 
 
-def sampled_batch_results(election: Election,) -> BatchTallies:
+def sampled_batch_results(election: Election) -> BatchTallies:
     results_by_batch_and_choice = (
         Batch.query.filter(
             Batch.id.in_(

--- a/server/audit_math/macro.py
+++ b/server/audit_math/macro.py
@@ -15,6 +15,10 @@ from typing import Dict, Tuple, TypeVar, TypedDict, Optional, List, cast
 from .sampler_contest import Contest
 
 BatchKey = TypeVar("BatchKey")
+# { choice_id: num_votes }
+ChoiceVotes = Dict[str, int]
+# { contest_id: ChoiceVotes }
+BatchResults = Dict[str, ChoiceVotes]
 
 
 class BatchError(TypedDict):
@@ -23,9 +27,7 @@ class BatchError(TypedDict):
 
 
 def compute_error(
-    batch_results: Dict[str, Dict[str, int]],
-    sampled_results: Dict[str, Dict[str, int]],
-    contest: Contest,
+    batch_results: BatchResults, sampled_results: BatchResults, contest: Contest,
 ) -> Optional[BatchError]:
     """
     Computes the error in this batch
@@ -78,9 +80,7 @@ def compute_error(
     return max(errors, key=lambda error: error["weighted_error"])
 
 
-def compute_max_error(
-    batch_results: Dict[str, Dict[str, int]], contest: Contest
-) -> Decimal:
+def compute_max_error(batch_results: BatchResults, contest: Contest) -> Decimal:
     """
     Computes the maximum possible error in this batch for this contest
 
@@ -129,8 +129,8 @@ def compute_max_error(
 
 
 def compute_U(
-    reported_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
-    sample_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
+    reported_results: Dict[BatchKey, BatchResults],
+    sample_results: Dict[BatchKey, BatchResults],
     contest: Contest,
 ) -> Decimal:
     """
@@ -172,8 +172,8 @@ def compute_U(
 def get_sample_sizes(
     risk_limit: int,
     contest: Contest,
-    reported_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
-    sample_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
+    reported_results: Dict[BatchKey, BatchResults],
+    sample_results: Dict[BatchKey, BatchResults],
 ) -> int:
     """
     Computes initial sample sizes parameterized by likelihood that the
@@ -242,8 +242,8 @@ def get_sample_sizes(
 def compute_risk(
     risk_limit: int,
     contest: Contest,
-    reported_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
-    sample_results: Dict[BatchKey, Dict[str, Dict[str, int]]],
+    reported_results: Dict[BatchKey, BatchResults],
+    sample_results: Dict[BatchKey, BatchResults],
     sample_ticket_numbers: Dict[str, BatchKey],
 ) -> Tuple[float, bool]:
     """

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -80,6 +80,7 @@ snapshots["test_ballot_comparison_two_rounds 1"] = {
 }
 
 snapshots["test_ballot_comparison_two_rounds 2"] = {
+    "numDiscrepancies": None,
     "numSamples": 9,
     "numSamplesAudited": 0,
     "numUnique": 8,
@@ -88,6 +89,7 @@ snapshots["test_ballot_comparison_two_rounds 2"] = {
 }
 
 snapshots["test_ballot_comparison_two_rounds 3"] = {
+    "numDiscrepancies": None,
     "numSamples": 11,
     "numSamplesAudited": 0,
     "numUnique": 9,
@@ -95,8 +97,26 @@ snapshots["test_ballot_comparison_two_rounds 3"] = {
     "status": "NOT_STARTED",
 }
 
+snapshots["test_ballot_comparison_two_rounds 4"] = {
+    "numDiscrepancies": 7,
+    "numSamples": 9,
+    "numSamplesAudited": 9,
+    "numUnique": 8,
+    "numUniqueAudited": 8,
+    "status": "COMPLETE",
+}
+
+snapshots["test_ballot_comparison_two_rounds 5"] = {
+    "numDiscrepancies": 4,
+    "numSamples": 11,
+    "numSamplesAudited": 11,
+    "numUnique": 9,
+    "numUniqueAudited": 9,
+    "status": "COMPLETE",
+}
+
 snapshots[
-    "test_ballot_comparison_two_rounds 4"
+    "test_ballot_comparison_two_rounds 6"
 ] = """######## ELECTION INFO ########\r
 Organization,Election Name,State\r
 Test Org test_ballot_comparison_two_rounds,Test Election,CA\r
@@ -141,8 +161,26 @@ J2,TABULATOR2,BATCH2,5,2-2-6,Round 1: 0.462119987445142117,AUDITED,CONTEST_NOT_O
 J2,TABULATOR2,BATCH2,6,,Round 1: 0.414184312862040881,AUDITED,Choice 1-1,,Ballot not in CVR,2,"Choice 2-1, Choice 2-3",,Ballot not in CVR,2\r
 """
 
+snapshots["test_ballot_comparison_two_rounds 7"] = {
+    "numDiscrepancies": 5,
+    "numSamples": 4,
+    "numSamplesAudited": 4,
+    "numUnique": 4,
+    "numUniqueAudited": 4,
+    "status": "COMPLETE",
+}
+
+snapshots["test_ballot_comparison_two_rounds 8"] = {
+    "numDiscrepancies": 1,
+    "numSamples": 6,
+    "numSamplesAudited": 6,
+    "numUnique": 5,
+    "numUniqueAudited": 5,
+    "status": "COMPLETE",
+}
+
 snapshots[
-    "test_ballot_comparison_two_rounds 5"
+    "test_ballot_comparison_two_rounds 9"
 ] = """######## ELECTION INFO ########\r
 Organization,Election Name,State\r
 Test Org test_ballot_comparison_two_rounds,Test Election,CA\r
@@ -159,6 +197,8 @@ Test Audit test_ballot_comparison_two_rounds,BALLOT_COMPARISON,SUPERSIMPLE,10%,1
 ######## AUDIT BOARDS ########\r
 Jurisdiction Name,Audit Board Name,Member 1 Name,Member 1 Affiliation,Member 2 Name,Member 2 Affiliation\r
 J1,Audit Board #1,,,,\r
+J1,Audit Board #1,,,,\r
+J2,Audit Board #1,,,,\r
 J2,Audit Board #1,,,,\r
 \r
 ######## ROUNDS ########\r

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -7,8 +7,26 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots["test_batch_comparison_batches_sampled_multiple_times 1"] = {
+    "numDiscrepancies": 0,
+    "numSamples": 4,
+    "numSamplesAudited": 4,
+    "numUnique": 3,
+    "numUniqueAudited": 3,
+    "status": "COMPLETE",
+}
+
+snapshots["test_batch_comparison_batches_sampled_multiple_times 2"] = {
+    "numDiscrepancies": 0,
+    "numSamples": 2,
+    "numSamplesAudited": 2,
+    "numUnique": 1,
+    "numUniqueAudited": 1,
+    "status": "COMPLETE",
+}
+
 snapshots[
-    "test_batch_comparison_batches_sampled_multiple_times 1"
+    "test_batch_comparison_batches_sampled_multiple_times 3"
 ] = """######## ELECTION INFO ########\r
 Organization,Election Name,State\r
 Test Org test_batch_comparison_batches_sampled_multiple_times,Test Election,CA\r
@@ -34,6 +52,7 @@ J2,Batch 3,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1
 """
 
 snapshots["test_batch_comparison_round_1 1"] = {
+    "numDiscrepancies": None,
     "numSamples": 9,
     "numSamplesAudited": 0,
     "numUnique": 6,
@@ -42,6 +61,7 @@ snapshots["test_batch_comparison_round_1 1"] = {
 }
 
 snapshots["test_batch_comparison_round_1 2"] = {
+    "numDiscrepancies": None,
     "numSamples": 5,
     "numSamplesAudited": 0,
     "numUnique": 2,
@@ -50,6 +70,7 @@ snapshots["test_batch_comparison_round_1 2"] = {
 }
 
 snapshots["test_batch_comparison_round_2 1"] = {
+    "numDiscrepancies": None,
     "numSamples": 4,
     "numSamplesAudited": 2,
     "numUnique": 3,
@@ -89,9 +110,9 @@ J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1
 J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J2,Batch 3,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 100; candidate 2: 100; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +400; candidate 2: +150; candidate 3: +210,250,jurisdiction.admin-UUID@example.com\r
-J1,Batch 3,Round 2: 0.753710009967479876,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,Batch not audited,,\r
-J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,Batch not audited,,\r
-J2,Batch 4,"Round 2: 0.608147659546583410, 0.868820918994249069",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,Batch not audited,,\r
+J1,Batch 3,Round 2: 0.753710009967479876,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
+J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
+J2,Batch 4,"Round 2: 0.608147659546583410, 0.868820918994249069",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
 """
 
 snapshots[
@@ -101,11 +122,12 @@ Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Resu
 J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
-J1,Batch 3,Round 2: 0.753710009967479876,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,Batch not audited,,\r
-J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,Batch not audited,,\r
+J1,Batch 3,Round 2: 0.753710009967479876,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
+J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
 """
 
 snapshots["test_batch_comparison_round_2 2"] = {
+    "numDiscrepancies": None,
     "numSamples": 4,
     "numSamplesAudited": 3,
     "numUnique": 3,
@@ -114,6 +136,7 @@ snapshots["test_batch_comparison_round_2 2"] = {
 }
 
 snapshots["test_batch_comparison_round_2 3"] = {
+    "numDiscrepancies": None,
     "numSamples": 4,
     "numSamplesAudited": 4,
     "numUnique": 3,
@@ -122,6 +145,7 @@ snapshots["test_batch_comparison_round_2 3"] = {
 }
 
 snapshots["test_batch_comparison_round_2 4"] = {
+    "numDiscrepancies": 3,
     "numSamples": 4,
     "numSamplesAudited": 4,
     "numUnique": 3,
@@ -130,6 +154,7 @@ snapshots["test_batch_comparison_round_2 4"] = {
 }
 
 snapshots["test_batch_comparison_round_2 5"] = {
+    "numDiscrepancies": None,
     "numSamples": 2,
     "numSamplesAudited": 0,
     "numUnique": 1,
@@ -138,6 +163,7 @@ snapshots["test_batch_comparison_round_2 5"] = {
 }
 
 snapshots["test_batch_comparison_round_2 6"] = {
+    "numDiscrepancies": 3,
     "numSamples": 4,
     "numSamplesAudited": 4,
     "numUnique": 3,
@@ -146,6 +172,7 @@ snapshots["test_batch_comparison_round_2 6"] = {
 }
 
 snapshots["test_batch_comparison_round_2 7"] = {
+    "numDiscrepancies": 1,
     "numSamples": 2,
     "numSamplesAudited": 2,
     "numUnique": 1,
@@ -154,6 +181,7 @@ snapshots["test_batch_comparison_round_2 7"] = {
 }
 
 snapshots["test_batch_comparison_round_2 8"] = {
+    "numDiscrepancies": None,
     "numSamples": 3,
     "numSamplesAudited": 0,
     "numUnique": 2,
@@ -162,6 +190,7 @@ snapshots["test_batch_comparison_round_2 8"] = {
 }
 
 snapshots["test_batch_comparison_round_2 9"] = {
+    "numDiscrepancies": None,
     "numSamples": 2,
     "numSamplesAudited": 0,
     "numUnique": 1,

--- a/server/tests/batch_comparison/snapshots/snap_test_batches.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batches.py
@@ -28,10 +28,10 @@ snapshots[
     "test_batches_human_sort_order 2"
 ] = """######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Change in Results,Change in Margin,Last Edited By\r
-J1,Batch 1 - 1,"Round 1: 0.9610467367288398089, 0.9743784458526487453",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,Batch not audited,,\r
-J1,Batch 1 - 10,Round 1: 0.109576900310237874,No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,Batch not audited,,\r
-J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,Batch not audited,,\r
-J1,Batch 10,"Round 1: 0.772049767819343419, 0.875085546411266410",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,Batch not audited,,\r
+J1,Batch 1 - 1,"Round 1: 0.9610467367288398089, 0.9743784458526487453",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,,,\r
+J1,Batch 1 - 10,Round 1: 0.109576900310237874,No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,,,\r
+J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,,,\r
+J1,Batch 10,"Round 1: 0.772049767819343419, 0.875085546411266410",No,,candidate 1: 10; candidate 2: 5; candidate 3: 5,,,\r
 """
 
 snapshots["test_record_batch_results 1"] = {


### PR DESCRIPTION
Task: #1813 

_Review by commit_

Adds a Discrepancies column to the audit admin Audit Progress screen for ballot comparison and batch comparison audits. This column shows a count of the number of discrepancies in the audit results after a jurisdiction finalizes their results. It's based on the same data that goes in the "Change in Results" audit report column (aka vote deltas) rather than the "Change in Margins" column (which is the internal audit math discrepancy value) since that data has been designed to flag any discrepancy between audit results and reported results, rather than just the ones that will impact the outcome of the statistical audit.

Next PR will include access to a discrepancy report.

To ensure this change will not slow down the jurisdictions endpoint (which is already one of our slowest), I tested this on some large elections. I found that the loading of CVRs was the bottleneck, and optimized it accordingly. The endpoint is still not the fastest, but now the impact of adding this new logic to calculate discrepancies has no noticeable impact on the overall time (at least not in my testing).

<img width="1057" alt="Screenshot 2023-09-27 at 10 07 27 AM" src="https://github.com/votingworks/arlo/assets/530106/9fe17c53-1d55-44af-93a4-e5e3dd4cf229">

<img width="1011" alt="Screenshot 2023-09-27 at 9 55 52 AM" src="https://github.com/votingworks/arlo/assets/530106/f4344e41-7ddd-44bc-84bb-ea06889b460d">
