### PR TITLE
Audit progress: Persist filter/sort in URL

### DIFF
--- a/client/src/components/Atoms/Table.tsx
+++ b/client/src/components/Atoms/Table.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { useTable, useSortBy, Column, Row } from 'react-table'
+import React, { useEffect } from 'react'
+import { useTable, useSortBy, Column, Row, SortingRule } from 'react-table'
 import styled from 'styled-components'
 import { Icon, HTMLTable, Button } from '@blueprintjs/core'
 import { downloadFile } from '../utilities'
@@ -81,6 +81,8 @@ interface ITableProps<T extends object> {
   data: T[]
   columns: Column<T>[]
   id?: string
+  initialSortBy?: SortingRule<T>[]
+  onSortByChange?: (sortBy: SortingRule<T>[]) => void
 }
 
 /**
@@ -91,6 +93,8 @@ export const Table = <T extends object>({
   data,
   columns,
   id,
+  initialSortBy,
+  onSortByChange,
 }: ITableProps<T>): React.ReactElement => {
   const {
     getTableProps,
@@ -98,14 +102,20 @@ export const Table = <T extends object>({
     headers,
     rows,
     prepareRow,
+    state: { sortBy },
   } = useTable(
     {
       data: React.useMemo(() => data, [data]),
       columns: React.useMemo(() => columns, [columns]),
       autoResetSortBy: false,
+      initialState: initialSortBy && { sortBy: initialSortBy },
     },
     useSortBy
   )
+
+  useEffect(() => {
+    if (onSortByChange) onSortByChange(sortBy)
+  }, [sortBy, onSortByChange])
 
   /* eslint-disable react/jsx-key */
   /* All the keys are added automatically by react-table */

--- a/client/src/components/useSearchParams.ts
+++ b/client/src/components/useSearchParams.ts
@@ -1,0 +1,33 @@
+import { useHistory, useLocation } from 'react-router-dom'
+import { useMemo, useCallback } from 'react'
+
+type SearchParams = Record<string, string | undefined>
+
+const useSearchParams = <T extends SearchParams>(): [
+  T | undefined,
+  (newState: T) => void
+] => {
+  const history = useHistory()
+  const { search } = useLocation()
+
+  const searchParams = useMemo(
+    () => Object.fromEntries(new URLSearchParams(search)) as T | undefined,
+    [search]
+  )
+
+  const setSearchParams = useCallback(
+    (newParams: SearchParams) => {
+      const params = new URLSearchParams(
+        Object.entries(newParams).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined
+        )
+      )
+      history.replace({ search: params.toString() })
+    },
+    [history]
+  )
+
+  return [searchParams, setSearchParams]
+}
+
+export default useSearchParams


### PR DESCRIPTION
Closes #1513 

In order to allow audit admins to track a specific jurisdiction or a few jurisdictions over time, save the filter/sort state of the audit progress table in the URL. This will allow the user to refresh the page for updates (or even bookmark/share it) while keeping the focus on the desired jurisdictions.


https://github.com/votingworks/arlo/assets/530106/cf977281-0726-4ad2-9804-ab72df361388

