### PR TITLE
Fix Heroku builds by locking python-poetry-buildpack version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ deps:
 	# Install node: https://github.com/nodesource/distributions/blob/master/README.md#deb		
 	curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 	sudo apt-get install -y nodejs
-	# Install poetry: https://python-poetry.org/docs/master/#osx--linux--bashonwindows-install-instructions 
-	curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.1.13 python3.8 -
+	# Install poetry: https://python-poetry.org/docs/master/#osx--linux--bashonwindows-install-instructions
+	# Keep the local dev POETRY_VERSION in sync with the Heroku config var
+	curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.1.15 python3.8 -
 	sudo npm install -g yarn
 	sudo apt install -y postgresql
 	sudo systemctl start postgresql

--- a/app.json
+++ b/app.json
@@ -2,7 +2,9 @@
   "addons": ["heroku-postgresql:hobby-free"],
   "buildpacks": [
     { "url": "heroku/nodejs" },
-    { "url": "https://github.com/moneymeets/python-poetry-buildpack.git" },
+    {
+      "url": "https://github.com/moneymeets/python-poetry-buildpack.git#0bbaf48423f0caac527e185b1517abac1610dc46"
+    },
     { "url": "heroku/python" },
     { "url": "heroku-community/cli" }
   ],


### PR DESCRIPTION
## Overview

Heroku builds recently started failing. On the left is a successful build, and on the right is a failed build:

![heroku](https://github.com/votingworks/arlo/assets/12616928/62426a80-5032-4da9-a37f-08f6f0a84271)

Recent updates to the [python-poetry-buildpack](https://github.com/moneymeets/python-poetry-buildpack) seem to be responsible. Simplest fix for now is to lock to a specific version of the buildpack [by specifying a commit hash](https://devcenter.heroku.com/articles/buildpacks#buildpack-references). Others have also used this technique to bypass issues with the buildpack, [as noted in this comment](https://github.com/moneymeets/python-poetry-buildpack/issues/67#issuecomment-1810362297). Through trial-and-error, I've found the latest commit that still works for us.

Note that I'm not sure how the `app.json` file and Heroku console interact. It's possible that, even after merging this, I'll have to manually update the buildpacks section of the console.

## Testing

Manually updated the buildpacks section of the console for staging and deployed successfully