### PR TITLE
Use negative numbers when num ballots in manifest fewer than expected

### DIFF
--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -177,7 +177,6 @@ describe('Progress screen', () => {
       const footers = within(rows[5]).getAllByRole('cell')
       expect(footers[2]).toHaveTextContent('6,351')
       expect(footers[3]).toHaveTextContent('4,254')
-      expect(footers[4]).toHaveTextContent('10')
     })
   })
 

--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -160,7 +160,7 @@ describe('Progress screen', () => {
       const row1 = within(rows[1]).getAllByRole('cell')
       expect(row1[2]).toHaveTextContent('2,117')
       expect(row1[3]).toHaveTextContent('2,127')
-      expect(row1[4]).toHaveTextContent('10')
+      expect(row1[4]).toHaveTextContent('-10')
       const row2 = within(rows[2]).getAllByRole('cell')
       expect(row2[2]).toHaveTextContent('2,117')
       expect(row2[3]).toHaveTextContent('2,097')
@@ -177,7 +177,7 @@ describe('Progress screen', () => {
       const footers = within(rows[5]).getAllByRole('cell')
       expect(footers[2]).toHaveTextContent('6,351')
       expect(footers[3]).toHaveTextContent('4,254')
-      expect(footers[4]).toHaveTextContent('30')
+      expect(footers[4]).toHaveTextContent('10')
     })
   })
 

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -248,7 +248,7 @@ const Progress: React.FC<IProgressProps> = ({
           expectedBallotManifestNumBallots,
         }) =>
           numBallots !== null && expectedBallotManifestNumBallots !== null
-            ? Math.abs(numBallots - expectedBallotManifestNumBallots)
+            ? numBallots - expectedBallotManifestNumBallots
             : null,
         Cell: formatNumber,
         Footer: totalFooter('Difference From Expected Ballots'),

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -251,7 +251,6 @@ const Progress: React.FC<IProgressProps> = ({
             ? numBallots - expectedBallotManifestNumBallots
             : null,
         Cell: formatNumber,
-        Footer: totalFooter('Difference From Expected Ballots'),
       })
     }
 


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/arlo/issues/1849

This one proved to be even easier than increasing batch audit sample size by 1 :smile:

_Before_

No distinction between more or fewer ballots than expected; confusing total `Difference From Expected Ballots`

<table>
<img src='https://github.com/votingworks/arlo/assets/12616928/806076f8-cede-4175-bb87-b281b2801153' alt='before' width=600 />
</table>

_After_

Distinction between more or fewer ballots than expected; no total `Difference From Expected Ballots`

<table>
<img src='https://github.com/votingworks/arlo/assets/12616928/c7ec0509-3408-4fa8-aebf-a538e816123f' alt='after' width=600 />
</table>

## Testing

- [x] Updated automated tests
- [x] Tested manually