### PR TITLE
Add contest ID to SampledBatchDraw model

### DIFF
--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -364,6 +364,7 @@ def draw_sample_batches(
         sampled_batch_draw = SampledBatchDraw(
             batch_id=batch_draw["batch_id"],
             round_id=round.id,
+            contest_id=batch_draw["contest_id"],
             ticket_number=batch_draw["ticket_number"],
         )
         db_session.add(sampled_batch_draw)

--- a/server/api/shared.py
+++ b/server/api/shared.py
@@ -528,6 +528,7 @@ class BallotDraw(TypedDict):
 
 class BatchDraw(TypedDict):
     batch_id: str
+    contest_id: str
     ticket_number: str
 
 
@@ -567,7 +568,11 @@ def compute_sample_batches(
     )
 
     sample_batches = [
-        BatchDraw(batch_id=batch_key_to_id[batch_key], ticket_number=ticket_number)
+        BatchDraw(
+            batch_id=batch_key_to_id[batch_key],
+            contest_id=contest.id,
+            ticket_number=ticket_number,
+        )
         for ticket_number, batch_key in sample
     ]
 
@@ -619,7 +624,9 @@ def compute_sample_batches(
                 extra_batch_ids.add(extra_bmd_batch_id)
                 sample_batches.append(
                     BatchDraw(
-                        batch_id=extra_bmd_batch_id, ticket_number=EXTRA_TICKET_NUMBER
+                        batch_id=extra_bmd_batch_id,
+                        contest_id=contest.id,
+                        ticket_number=EXTRA_TICKET_NUMBER,
                     )
                 )
             # If we didn't sample any HMPB batches, add one to the sample
@@ -628,7 +635,9 @@ def compute_sample_batches(
                 extra_batch_ids.add(extra_hmpb_batch_id)
                 sample_batches.append(
                     BatchDraw(
-                        batch_id=extra_hmpb_batch_id, ticket_number=EXTRA_TICKET_NUMBER
+                        batch_id=extra_hmpb_batch_id,
+                        contest_id=contest.id,
+                        ticket_number=EXTRA_TICKET_NUMBER,
                     )
                 )
 
@@ -658,7 +667,9 @@ def compute_sample_batches(
                 extra_batch_ids.add(extra_batch_id)
                 sample_batches.append(
                     BatchDraw(
-                        batch_id=extra_batch_id, ticket_number=EXTRA_TICKET_NUMBER
+                        batch_id=extra_batch_id,
+                        contest_id=contest.id,
+                        ticket_number=EXTRA_TICKET_NUMBER,
                     )
                 )
 

--- a/server/migrations/versions/c012fa6b13a9_sampledbatchdraw_contest_id.py
+++ b/server/migrations/versions/c012fa6b13a9_sampledbatchdraw_contest_id.py
@@ -1,0 +1,57 @@
+# pylint: disable=invalid-name
+"""SampledBatchDraw.contest_id
+
+Revision ID: c012fa6b13a9
+Revises: 83bc53b14021
+Create Date: 2024-02-09 15:38:22.522331+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c012fa6b13a9"
+down_revision = "83bc53b14021"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add SampledBatchDraw.contest_id
+    op.add_column("sampled_batch_draw", sa.Column("contest_id", sa.String(length=200)))
+    op.create_foreign_key(
+        op.f("sampled_batch_draw_contest_id_fkey"),
+        "sampled_batch_draw",
+        "contest",
+        ["contest_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+
+    # Populate the field for existing SampledBatchDraws
+    op.execute(
+        """
+        UPDATE sampled_batch_draw
+        SET contest_id = contest.id
+        FROM contest
+        JOIN election ON election.id = contest.election_id
+        JOIN round ON election.id = round.election_id
+        WHERE round.id = sampled_batch_draw.round_id
+        """
+    )
+
+    # Make the field required
+    op.alter_column("sampled_batch_draw", "contest_id", nullable=False)
+
+    # Update the SampledBatchDraw primary key
+    op.drop_constraint(op.f("sampled_batch_draw_pkey"), "sampled_batch_draw")
+    op.create_primary_key(
+        op.f("sampled_batch_draw_pkey"),
+        "sampled_batch_draw",
+        ["batch_id", "round_id", "contest_id", "ticket_number"],
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -877,13 +877,21 @@ class SampledBatchDraw(BaseModel):
         String(200), ForeignKey("batch.id", ondelete="cascade"), nullable=False,
     )
     batch = relationship("Batch")
+
     round_id = Column(
         String(200), ForeignKey("round.id", ondelete="cascade"), nullable=False
     )
 
+    contest_id = Column(
+        String(200), ForeignKey("contest.id", ondelete="cascade"), nullable=False
+    )
+    contest = relationship("Contest")
+
     ticket_number = Column(String(200), nullable=False)
 
-    __table_args__ = (PrimaryKeyConstraint("batch_id", "round_id", "ticket_number"),)
+    __table_args__ = (
+        PrimaryKeyConstraint("batch_id", "round_id", "contest_id", "ticket_number"),
+    )
 
 
 # (Experimental) To we add extra batches on top of the sample, give them a


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/arlo/issues/1815

This PR adds contest ID to the `SampledBatchDraw` model in preparation for multi-contest batch comparison audits. This should be the only data model update necessary.

## Testing

Ran the migration locally on the latest prod data and verified that it worked as expected.