### PR TITLE
Update batch tally entry UI to support multiple contests

### DIFF
--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-dqBHgY jSKysA"
+        class="bp3-card bp3-elevation-0 sc-gxMtzJ dzikUU"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -122,18 +122,18 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-lhVmIH hSVOFV"
+            class="sc-bYSBpT dWeuEb"
           >
             <div
-              class="sc-bYSBpT eFidgo"
+              class="sc-elJkPf jTzEQh"
             >
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -148,12 +148,12 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -169,15 +169,15 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <div
-              class="sc-bYSBpT eFidgo"
+              class="sc-elJkPf jTzEQh"
             >
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -192,12 +192,12 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -213,7 +213,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <p
-              class="sc-kTUwUJ kWFRUA"
+              class="sc-dqBHgY goZYTp"
             >
               Add a new candidate/choice
             </p>
@@ -324,7 +324,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
       </div>
     </div>
     <div
-      class="sc-btzYZH hOMNvX"
+      class="sc-lhVmIH hRaoXy"
       style="margin-top: 15px;"
     >
       <button
@@ -405,7 +405,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-dqBHgY jSKysA"
+        class="bp3-card bp3-elevation-0 sc-gxMtzJ dzikUU"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -512,18 +512,18 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-lhVmIH hSVOFV"
+            class="sc-bYSBpT dWeuEb"
           >
             <div
-              class="sc-bYSBpT eFidgo"
+              class="sc-elJkPf jTzEQh"
             >
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -538,12 +538,12 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -559,15 +559,15 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-bYSBpT eFidgo"
+              class="sc-elJkPf jTzEQh"
             >
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -582,12 +582,12 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -603,7 +603,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-kTUwUJ kWFRUA"
+              class="sc-dqBHgY goZYTp"
             >
               Add a new candidate/choice
             </p>
@@ -714,7 +714,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-btzYZH hOMNvX"
+      class="sc-lhVmIH hRaoXy"
       style="margin-top: 15px;"
     >
       <button
@@ -795,7 +795,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-dqBHgY jSKysA"
+        class="bp3-card bp3-elevation-0 sc-gxMtzJ dzikUU"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -902,18 +902,18 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-lhVmIH hSVOFV"
+            class="sc-bYSBpT dWeuEb"
           >
             <div
-              class="sc-bYSBpT eFidgo"
+              class="sc-elJkPf jTzEQh"
             >
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -928,12 +928,12 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -949,15 +949,15 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <div
-              class="sc-bYSBpT eFidgo"
+              class="sc-elJkPf jTzEQh"
             >
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -972,12 +972,12 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -993,7 +993,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <p
-              class="sc-kTUwUJ kWFRUA"
+              class="sc-dqBHgY goZYTp"
             >
               Add a new candidate/choice
             </p>
@@ -1104,7 +1104,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
       </div>
     </div>
     <div
-      class="sc-btzYZH hOMNvX"
+      class="sc-lhVmIH hRaoXy"
       style="margin-top: 15px;"
     >
       <button
@@ -1185,7 +1185,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-dqBHgY jSKysA"
+        class="bp3-card bp3-elevation-0 sc-gxMtzJ dzikUU"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -1292,18 +1292,18 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-lhVmIH hSVOFV"
+            class="sc-bYSBpT dWeuEb"
           >
             <div
-              class="sc-bYSBpT eFidgo"
+              class="sc-elJkPf jTzEQh"
             >
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1318,12 +1318,12 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1339,15 +1339,15 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-bYSBpT eFidgo"
+              class="sc-elJkPf jTzEQh"
             >
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1362,12 +1362,12 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1383,7 +1383,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-kTUwUJ kWFRUA"
+              class="sc-dqBHgY goZYTp"
             >
               Add a new candidate/choice
             </p>
@@ -1494,7 +1494,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-btzYZH hOMNvX"
+      class="sc-lhVmIH hRaoXy"
       style="margin-top: 15px;"
     >
       <button

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-dqBHgY jSKysA"
+        class="bp3-card bp3-elevation-0 sc-gxMtzJ dzikUU"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -42,7 +42,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                Name
               <br />
               <div
-                class="bp3-html-select sc-dfVpRl khgCIW"
+                class="bp3-html-select sc-gzOgki hzfmIs"
               >
                 <select
                   field="[object Object]"
@@ -158,18 +158,18 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-lhVmIH hSVOFV"
+            class="sc-bYSBpT dWeuEb"
           >
             <div
-              class="sc-bYSBpT eFidgo"
+              class="sc-elJkPf jTzEQh"
             >
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -184,12 +184,12 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -205,15 +205,15 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <div
-              class="sc-bYSBpT eFidgo"
+              class="sc-elJkPf jTzEQh"
             >
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -228,12 +228,12 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-jtRfpW xkJJK"
+                class="bp3-label sc-kTUwUJ fEUeVD"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-elJkPf kPpSXP sc-gqjmRU egaEhI"
+                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -249,7 +249,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <p
-              class="sc-kTUwUJ kWFRUA"
+              class="sc-dqBHgY goZYTp"
             >
               Add a new candidate/choice
             </p>
@@ -291,7 +291,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
       </div>
     </div>
     <div
-      class="sc-btzYZH hOMNvX"
+      class="sc-lhVmIH hRaoXy"
       style="margin-top: 15px;"
     >
       <button

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -61,19 +61,19 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-gFaPwZ leMNNE"
+          class="sc-fhYwyz icxIeN"
         >
           <div
-            class="sc-fhYwyz cHvNai"
+            class="sc-jzgbtB bSIaiB"
           >
             <div
-              class="sc-jzgbtB dFzWSe"
+              class="sc-gJWqzi gEscEe"
             >
               <div
-                class="sc-bMvGRv oTmEh"
+                class="sc-CtfFt jjLuAa"
               >
                 <button
-                  class="bp3-button bp3-minimal sc-rBLzX eStSUD"
+                  class="bp3-button bp3-minimal sc-bMvGRv lfkdzN"
                   href="/election/1/audit-board/audit-board-1"
                   type="button"
                 >
@@ -103,56 +103,56 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                   </span>
                 </button>
                 <h3
-                  class="bp3-heading sc-bnXvFD cmlEmW"
+                  class="bp3-heading sc-gFaPwZ YcgUN"
                 >
                   Audit Ballot Selections
                 </h3>
               </div>
               <div
-                class="bp3-divider sc-exAgwC mLCeC"
+                class="bp3-divider sc-cQFLBn rSWpj"
               />
               <div
-                class="sc-gHboQg dNSImC"
+                class="sc-eilVRo iliFTQ"
               >
                 <div>
                   <h5
-                    class="bp3-heading sc-fOKMvo jrRYHn"
+                    class="bp3-heading sc-dUjcNx cPXRfC"
                   >
                     Tabulator
                   </h5>
                   <h4
-                    class="bp3-heading sc-eilVRo wICGS"
+                    class="bp3-heading sc-eerKOB haOSjM"
                   >
                     11
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-fOKMvo jrRYHn"
+                    class="bp3-heading sc-dUjcNx cPXRfC"
                   >
                     Batch
                   </h5>
                   <h4
-                    class="bp3-heading sc-eilVRo wICGS"
+                    class="bp3-heading sc-eerKOB haOSjM"
                   >
                     0003-04-Precinct 19 (Jonesboro Fire Department)
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-fOKMvo jrRYHn"
+                    class="bp3-heading sc-dUjcNx cPXRfC"
                   >
                     Ballot Number
                   </h5>
                   <h4
-                    class="bp3-heading sc-eilVRo wICGS"
+                    class="bp3-heading sc-eerKOB haOSjM"
                   >
                     2112
                   </h4>
                 </div>
                 <div>
                   <button
-                    class="bp3-button bp3-large bp3-intent-danger sc-eerKOB qoZgi"
+                    class="bp3-button bp3-large bp3-intent-danger sc-emmjRN cjiaDr"
                     type="button"
                   >
                     <span
@@ -164,36 +164,36 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 </div>
               </div>
               <div
-                class="bp3-divider sc-exAgwC mLCeC"
+                class="bp3-divider sc-cQFLBn rSWpj"
               />
               <div
-                class="sc-cQFLBn hvTegF"
+                class="sc-gojNiO kCQXPO"
               >
                 <div
                   class="ballot-main"
                 >
                   <h5
-                    class="bp3-heading sc-fOKMvo jrRYHn"
+                    class="bp3-heading sc-dUjcNx cPXRfC"
                   >
                     Ballot Contests
                   </h5>
                   <form>
                     <div
-                      class="sc-gojNiO cMpjBy"
+                      class="sc-daURTG fcIHKg"
                     >
                       <div
-                        class="sc-cbkKFq kHbGfu"
+                        class="sc-krvtoX bAbmxr"
                       >
                         <div
-                          class="sc-krvtoX fIrVmx"
+                          class="sc-fYiAbW hOwRmO"
                         >
                           <h3
-                            class="bp3-heading sc-cpmLhU jFtXJP"
+                            class="bp3-heading sc-dymIpo fcXrwH"
                           >
                             Contest 1
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-dUjcNx gPEaQX"
+                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
                           >
                             <input
                               type="checkbox"
@@ -209,7 +209,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dUjcNx gPEaQX"
+                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
                           >
                             <input
                               type="checkbox"
@@ -226,10 +226,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-fYiAbW ivALwK"
+                          class="sc-fOKMvo jakMvu"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-dUjcNx gPEaQX"
+                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
                           >
                             <input
                               type="checkbox"
@@ -245,7 +245,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dUjcNx gPEaQX"
+                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
                           >
                             <input
                               type="checkbox"
@@ -261,7 +261,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dUjcNx gPEaQX"
+                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
                           >
                             <input
                               type="checkbox"
@@ -277,7 +277,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-emmjRN iGYvir"
+                            class="bp3-input sc-cpmLhU exuBpI"
                             name="comment-Contest 1"
                             placeholder="Add Note"
                           />
@@ -285,21 +285,21 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-gojNiO cMpjBy"
+                      class="sc-daURTG fcIHKg"
                     >
                       <div
-                        class="sc-cbkKFq kHbGfu"
+                        class="sc-krvtoX bAbmxr"
                       >
                         <div
-                          class="sc-krvtoX fIrVmx"
+                          class="sc-fYiAbW hOwRmO"
                         >
                           <h3
-                            class="bp3-heading sc-cpmLhU jFtXJP"
+                            class="bp3-heading sc-dymIpo fcXrwH"
                           >
                             Contest 2
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-dUjcNx gPEaQX"
+                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
                           >
                             <input
                               type="checkbox"
@@ -315,7 +315,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dUjcNx gPEaQX"
+                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
                           >
                             <input
                               type="checkbox"
@@ -332,10 +332,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-fYiAbW ivALwK"
+                          class="sc-fOKMvo jakMvu"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-dUjcNx gPEaQX"
+                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
                           >
                             <input
                               type="checkbox"
@@ -351,7 +351,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dUjcNx gPEaQX"
+                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
                           >
                             <input
                               type="checkbox"
@@ -367,7 +367,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dUjcNx gPEaQX"
+                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
                           >
                             <input
                               type="checkbox"
@@ -383,7 +383,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-emmjRN iGYvir"
+                            class="bp3-input sc-cpmLhU exuBpI"
                             name="comment-Contest 2"
                             placeholder="Add Note"
                           />
@@ -391,10 +391,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-bXGyLb cQSKLz"
+                      class="sc-lkqHmb dSHWIf"
                     >
                       <button
-                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-dymIpo eGbMjx sc-dnqmqq iQfLYL"
+                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-bnXvFD iGplTJ sc-dnqmqq iQfLYL"
                         disabled=""
                         tabindex="-1"
                         type="submit"
@@ -421,7 +421,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
               </div>
             </div>
             <div
-              class="sc-gJWqzi hZNvPE"
+              class="sc-rBLzX hifYMt"
             >
               <h4
                 class="bp3-heading"
@@ -429,7 +429,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 Instructions
               </h4>
               <ol
-                class="bp3-list sc-CtfFt fwYQle"
+                class="bp3-list sc-laTMn dPpMdm"
               >
                 <li>
                   Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -534,13 +534,13 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
       class="board-table-container"
     >
       <div
-        class="sc-bsbRJL lkbHpH"
+        class="sc-hZSUBg blRWYv"
       >
         <div
-          class="sc-bwzfXH sc-hZSUBg iwFVXc"
+          class="sc-bwzfXH sc-cMhqgX gksGAs"
         >
           <div
-            class="sc-epnACN iuJcsW"
+            class="sc-iQNlJl cdIcB"
           >
             <p>
               18
@@ -549,23 +549,23 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-gqPbQI eQbbTJ"
+              class="summary-label sc-hORach cZKLaE"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-hORach hKYSRY"
+              class="summary-label sc-bMVAic iQIqRK"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-iQNlJl fBdKEw"
+            class="sc-bsbRJL dEwQsZ"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bAeIUo dlozQd"
+              class="bp3-button bp3-intent-success sc-iujRgT kJAYyn"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -582,10 +582,10 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-cMhqgX bINDfX"
+          class="sc-iuJeZd jIISPh"
         >
           <div
-            class="sc-iuJeZd ejjqhb"
+            class="sc-esOvli yrFmX"
           >
             <h3
               class="bp3-heading"
@@ -594,7 +594,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Audit Board #1
             </h3>
             <div
-              class="sc-esOvli esnGth"
+              class="sc-cmthru fxjRhw"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -799,7 +799,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -809,7 +809,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -819,7 +819,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -829,7 +829,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -858,7 +858,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -877,7 +877,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -886,7 +886,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -895,7 +895,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -904,7 +904,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -913,7 +913,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -934,7 +934,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -944,7 +944,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -954,7 +954,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -964,7 +964,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -993,7 +993,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -1012,7 +1012,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1022,7 +1022,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1032,7 +1032,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1042,7 +1042,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1071,7 +1071,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -1090,7 +1090,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -1099,7 +1099,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1108,7 +1108,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -1117,7 +1117,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -1126,7 +1126,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -1147,7 +1147,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1157,7 +1157,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1167,7 +1167,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1177,7 +1177,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1206,7 +1206,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -1225,7 +1225,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1235,7 +1235,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1245,7 +1245,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1255,7 +1255,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1284,7 +1284,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -1303,7 +1303,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -1312,7 +1312,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1321,7 +1321,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -1330,7 +1330,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -1339,7 +1339,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -1360,7 +1360,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1370,7 +1370,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1380,7 +1380,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1390,7 +1390,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1419,7 +1419,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -1438,7 +1438,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1448,7 +1448,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1458,7 +1458,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1468,7 +1468,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1497,7 +1497,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -1516,7 +1516,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -1525,7 +1525,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1534,7 +1534,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -1543,7 +1543,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -1552,7 +1552,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -1573,7 +1573,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1583,7 +1583,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1593,7 +1593,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1603,7 +1603,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1632,7 +1632,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -1651,7 +1651,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1661,7 +1661,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1671,7 +1671,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1681,7 +1681,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1710,7 +1710,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -1729,7 +1729,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -1738,7 +1738,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1747,7 +1747,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -1756,7 +1756,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -1765,7 +1765,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -1786,7 +1786,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1796,7 +1796,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1806,7 +1806,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1816,7 +1816,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1845,7 +1845,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -1864,7 +1864,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1874,7 +1874,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1884,7 +1884,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1894,7 +1894,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1923,7 +1923,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -1942,7 +1942,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -1951,7 +1951,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1960,7 +1960,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -1969,7 +1969,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -1978,7 +1978,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -1999,7 +1999,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2009,7 +2009,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2019,7 +2019,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2029,7 +2029,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2058,7 +2058,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -2077,7 +2077,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2087,7 +2087,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2097,7 +2097,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2107,7 +2107,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2136,7 +2136,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -2155,7 +2155,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -2164,7 +2164,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2173,7 +2173,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -2182,7 +2182,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -2191,7 +2191,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -2212,7 +2212,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2222,7 +2222,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2232,7 +2232,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2242,7 +2242,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2271,7 +2271,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -2290,7 +2290,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2300,7 +2300,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2310,7 +2310,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2320,7 +2320,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2349,7 +2349,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -2368,7 +2368,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -2377,7 +2377,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2386,7 +2386,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -2395,7 +2395,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -2404,7 +2404,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -2425,7 +2425,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2435,7 +2435,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2445,7 +2445,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2455,7 +2455,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2484,7 +2484,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -2503,7 +2503,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2513,7 +2513,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2523,7 +2523,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2533,7 +2533,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2562,7 +2562,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -2581,7 +2581,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -2590,7 +2590,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2599,7 +2599,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -2608,7 +2608,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -2617,7 +2617,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -2638,7 +2638,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2648,7 +2648,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2658,7 +2658,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2668,7 +2668,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2697,7 +2697,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -2713,7 +2713,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-iujRgT gVqjyR"
+              class="bp3-button bp3-disabled bp3-large sc-GMQeP dgoJfs"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -2727,7 +2727,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
             </button>
           </div>
           <div
-            class="sc-cmthru fPQhqY"
+            class="sc-hMFtBS eVxguM"
           >
             <h4
               class="bp3-heading"
@@ -2735,7 +2735,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bMVAic bieIKK"
+              class="bp3-list sc-bAeIUo hsKqcp"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -2815,13 +2815,13 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
       class="board-table-container"
     >
       <div
-        class="sc-bsbRJL lkbHpH"
+        class="sc-hZSUBg blRWYv"
       >
         <div
-          class="sc-bwzfXH sc-hZSUBg iwFVXc"
+          class="sc-bwzfXH sc-cMhqgX gksGAs"
         >
           <div
-            class="sc-epnACN iuJcsW"
+            class="sc-iQNlJl cdIcB"
           >
             <p>
               0
@@ -2830,23 +2830,23 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-gqPbQI eQbbTJ"
+              class="summary-label sc-hORach cZKLaE"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-hORach hKYSRY"
+              class="summary-label sc-bMVAic iQIqRK"
             >
               Not Audited: 
               27
             </span>
           </div>
           <div
-            class="sc-iQNlJl fBdKEw"
+            class="sc-bsbRJL dEwQsZ"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bAeIUo dlozQd"
+              class="bp3-button bp3-intent-success sc-iujRgT kJAYyn"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
               type="button"
             >
@@ -2863,10 +2863,10 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-cMhqgX bINDfX"
+          class="sc-iuJeZd jIISPh"
         >
           <div
-            class="sc-iuJeZd ejjqhb"
+            class="sc-esOvli yrFmX"
           >
             <h3
               class="bp3-heading"
@@ -2875,7 +2875,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Audit Board #1
             </h3>
             <div
-              class="sc-esOvli esnGth"
+              class="sc-cmthru fxjRhw"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -3080,7 +3080,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3089,7 +3089,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3098,7 +3098,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         313
                       </p>
@@ -3107,7 +3107,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3116,7 +3116,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -3137,7 +3137,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3146,7 +3146,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3155,7 +3155,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -3164,7 +3164,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3173,7 +3173,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -3194,7 +3194,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3203,7 +3203,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3212,7 +3212,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         1789
                       </p>
@@ -3221,7 +3221,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3230,7 +3230,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -3251,7 +3251,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3260,7 +3260,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3269,7 +3269,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         313
                       </p>
@@ -3278,7 +3278,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3287,7 +3287,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -3308,7 +3308,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3317,7 +3317,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3326,7 +3326,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -3335,7 +3335,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3344,7 +3344,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -3365,7 +3365,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3374,7 +3374,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3383,7 +3383,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         1789
                       </p>
@@ -3392,7 +3392,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3401,7 +3401,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -3422,7 +3422,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3431,7 +3431,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3440,7 +3440,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         313
                       </p>
@@ -3449,7 +3449,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3458,7 +3458,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -3479,7 +3479,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3488,7 +3488,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3497,7 +3497,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -3506,7 +3506,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3515,7 +3515,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -3536,7 +3536,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3545,7 +3545,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3554,7 +3554,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         1789
                       </p>
@@ -3563,7 +3563,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3572,7 +3572,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -3593,7 +3593,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3602,7 +3602,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3611,7 +3611,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         313
                       </p>
@@ -3620,7 +3620,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3629,7 +3629,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -3650,7 +3650,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3659,7 +3659,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3668,7 +3668,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -3677,7 +3677,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3686,7 +3686,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -3707,7 +3707,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3716,7 +3716,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3725,7 +3725,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         1789
                       </p>
@@ -3734,7 +3734,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3743,7 +3743,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -3764,7 +3764,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3773,7 +3773,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3782,7 +3782,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         313
                       </p>
@@ -3791,7 +3791,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3800,7 +3800,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -3821,7 +3821,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3830,7 +3830,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3839,7 +3839,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -3848,7 +3848,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3857,7 +3857,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -3878,7 +3878,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3887,7 +3887,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3896,7 +3896,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         1789
                       </p>
@@ -3905,7 +3905,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3914,7 +3914,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -3935,7 +3935,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -3944,7 +3944,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3953,7 +3953,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         313
                       </p>
@@ -3962,7 +3962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -3971,7 +3971,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -3992,7 +3992,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -4001,7 +4001,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4010,7 +4010,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -4019,7 +4019,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -4028,7 +4028,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -4049,7 +4049,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -4058,7 +4058,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4067,7 +4067,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         1789
                       </p>
@@ -4076,7 +4076,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -4085,7 +4085,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -4106,7 +4106,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -4115,7 +4115,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4124,7 +4124,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         313
                       </p>
@@ -4133,7 +4133,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -4142,7 +4142,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -4163,7 +4163,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -4172,7 +4172,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4181,7 +4181,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -4190,7 +4190,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -4199,7 +4199,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -4220,7 +4220,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -4229,7 +4229,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4238,7 +4238,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         1789
                       </p>
@@ -4247,7 +4247,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -4256,7 +4256,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -4277,7 +4277,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -4286,7 +4286,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4295,7 +4295,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         313
                       </p>
@@ -4304,7 +4304,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -4313,7 +4313,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -4334,7 +4334,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -4343,7 +4343,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4352,7 +4352,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -4361,7 +4361,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -4370,7 +4370,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -4391,7 +4391,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -4400,7 +4400,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4409,7 +4409,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         1789
                       </p>
@@ -4418,7 +4418,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -4427,7 +4427,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -4448,7 +4448,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -4457,7 +4457,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4466,7 +4466,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         313
                       </p>
@@ -4475,7 +4475,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -4484,7 +4484,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -4505,7 +4505,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -4514,7 +4514,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4523,7 +4523,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -4532,7 +4532,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -4541,7 +4541,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -4562,7 +4562,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -4571,7 +4571,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4580,7 +4580,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         1789
                       </p>
@@ -4589,7 +4589,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -4598,7 +4598,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -4616,7 +4616,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-iujRgT gVqjyR"
+              class="bp3-button bp3-disabled bp3-large sc-GMQeP dgoJfs"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -4630,7 +4630,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
             </button>
           </div>
           <div
-            class="sc-cmthru fPQhqY"
+            class="sc-hMFtBS eVxguM"
           >
             <h4
               class="bp3-heading"
@@ -4638,7 +4638,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bMVAic bieIKK"
+              class="bp3-list sc-bAeIUo hsKqcp"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -4718,13 +4718,13 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
       class="board-table-container"
     >
       <div
-        class="sc-bsbRJL lkbHpH"
+        class="sc-hZSUBg blRWYv"
       >
         <div
-          class="sc-bwzfXH sc-hZSUBg iwFVXc"
+          class="sc-bwzfXH sc-cMhqgX gksGAs"
         >
           <div
-            class="sc-epnACN iuJcsW"
+            class="sc-iQNlJl cdIcB"
           >
             <p>
               0
@@ -4733,23 +4733,23 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-gqPbQI eQbbTJ"
+              class="summary-label sc-hORach cZKLaE"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-hORach hKYSRY"
+              class="summary-label sc-bMVAic iQIqRK"
             >
               Not Audited: 
               0
             </span>
           </div>
           <div
-            class="sc-iQNlJl fBdKEw"
+            class="sc-bsbRJL dEwQsZ"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bAeIUo dlozQd"
+              class="bp3-button bp3-intent-success sc-iujRgT kJAYyn"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4766,10 +4766,10 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-cMhqgX bINDfX"
+          class="sc-iuJeZd jIISPh"
         >
           <div
-            class="sc-iuJeZd ejjqhb"
+            class="sc-esOvli yrFmX"
           >
             <h3
               class="bp3-heading"
@@ -4778,7 +4778,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Audit Board #1
             </h3>
             <div
-              class="sc-esOvli esnGth"
+              class="sc-cmthru fxjRhw"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -4942,7 +4942,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               </table>
             </div>
             <button
-              class="bp3-button bp3-large bp3-intent-success sc-iujRgT gVqjyR"
+              class="bp3-button bp3-large bp3-intent-success sc-GMQeP dgoJfs"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4954,7 +4954,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
             </button>
           </div>
           <div
-            class="sc-cmthru fPQhqY"
+            class="sc-hMFtBS eVxguM"
           >
             <h4
               class="bp3-heading"
@@ -4962,7 +4962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bMVAic bieIKK"
+              class="bp3-list sc-bAeIUo hsKqcp"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -5042,13 +5042,13 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
       class="board-table-container"
     >
       <div
-        class="sc-bsbRJL lkbHpH"
+        class="sc-hZSUBg blRWYv"
       >
         <div
-          class="sc-bwzfXH sc-hZSUBg iwFVXc"
+          class="sc-bwzfXH sc-cMhqgX gksGAs"
         >
           <div
-            class="sc-epnACN iuJcsW"
+            class="sc-iQNlJl cdIcB"
           >
             <p>
               18
@@ -5057,23 +5057,23 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-gqPbQI eQbbTJ"
+              class="summary-label sc-hORach cZKLaE"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-hORach hKYSRY"
+              class="summary-label sc-bMVAic iQIqRK"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-iQNlJl fBdKEw"
+            class="sc-bsbRJL dEwQsZ"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bAeIUo dlozQd"
+              class="bp3-button bp3-intent-success sc-iujRgT kJAYyn"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -5090,10 +5090,10 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-cMhqgX bINDfX"
+          class="sc-iuJeZd jIISPh"
         >
           <div
-            class="sc-iuJeZd ejjqhb"
+            class="sc-esOvli yrFmX"
           >
             <h3
               class="bp3-heading"
@@ -5102,7 +5102,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Audit Board #1
             </h3>
             <div
-              class="sc-esOvli esnGth"
+              class="sc-cmthru fxjRhw"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -5307,7 +5307,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5317,7 +5317,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5327,7 +5327,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5337,7 +5337,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5366,7 +5366,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -5385,7 +5385,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -5394,7 +5394,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5403,7 +5403,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -5412,7 +5412,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -5421,7 +5421,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -5442,7 +5442,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5452,7 +5452,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5462,7 +5462,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5472,7 +5472,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5501,7 +5501,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -5520,7 +5520,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5530,7 +5530,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5540,7 +5540,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5550,7 +5550,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5579,7 +5579,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -5598,7 +5598,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -5607,7 +5607,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5616,7 +5616,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -5625,7 +5625,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -5634,7 +5634,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -5655,7 +5655,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5665,7 +5665,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5675,7 +5675,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5685,7 +5685,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5714,7 +5714,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -5733,7 +5733,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5743,7 +5743,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5753,7 +5753,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5763,7 +5763,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5792,7 +5792,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -5811,7 +5811,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -5820,7 +5820,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5829,7 +5829,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -5838,7 +5838,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -5847,7 +5847,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -5868,7 +5868,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5878,7 +5878,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5888,7 +5888,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5898,7 +5898,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5927,7 +5927,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -5946,7 +5946,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5956,7 +5956,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5966,7 +5966,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5976,7 +5976,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6005,7 +6005,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -6024,7 +6024,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -6033,7 +6033,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6042,7 +6042,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -6051,7 +6051,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -6060,7 +6060,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -6081,7 +6081,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6091,7 +6091,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6101,7 +6101,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6111,7 +6111,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6140,7 +6140,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -6159,7 +6159,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6169,7 +6169,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6179,7 +6179,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6189,7 +6189,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6218,7 +6218,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -6237,7 +6237,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -6246,7 +6246,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6255,7 +6255,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -6264,7 +6264,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -6273,7 +6273,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -6294,7 +6294,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6304,7 +6304,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6314,7 +6314,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6324,7 +6324,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6353,7 +6353,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -6372,7 +6372,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6382,7 +6382,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6392,7 +6392,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6402,7 +6402,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6431,7 +6431,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -6450,7 +6450,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -6459,7 +6459,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6468,7 +6468,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -6477,7 +6477,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -6486,7 +6486,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -6507,7 +6507,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6517,7 +6517,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6527,7 +6527,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6537,7 +6537,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6566,7 +6566,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -6585,7 +6585,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6595,7 +6595,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6605,7 +6605,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6615,7 +6615,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6644,7 +6644,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -6663,7 +6663,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -6672,7 +6672,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6681,7 +6681,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -6690,7 +6690,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -6699,7 +6699,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -6720,7 +6720,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6730,7 +6730,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6740,7 +6740,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6750,7 +6750,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6779,7 +6779,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -6798,7 +6798,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6808,7 +6808,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6818,7 +6818,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6828,7 +6828,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6857,7 +6857,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -6876,7 +6876,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -6885,7 +6885,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6894,7 +6894,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -6903,7 +6903,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -6912,7 +6912,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -6933,7 +6933,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6943,7 +6943,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6953,7 +6953,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6963,7 +6963,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6992,7 +6992,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -7011,7 +7011,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7021,7 +7021,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -7031,7 +7031,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -7041,7 +7041,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7070,7 +7070,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -7089,7 +7089,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         11
                       </p>
@@ -7098,7 +7098,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -7107,7 +7107,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                       >
                         2112
                       </p>
@@ -7116,7 +7116,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-hORach hKYSRY"
+                        class="sc-bMVAic iQIqRK"
                       >
                         Not Audited
                       </span>
@@ -7125,7 +7125,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -7146,7 +7146,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7156,7 +7156,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -7166,7 +7166,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -7176,7 +7176,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-GMQeP cfVzdL"
+                        class="sc-exAgwC ccEBA"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7205,7 +7205,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-hMFtBS gNYXnq"
+                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -7221,7 +7221,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-iujRgT gVqjyR"
+              class="bp3-button bp3-disabled bp3-large sc-GMQeP dgoJfs"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -7235,7 +7235,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
             </button>
           </div>
           <div
-            class="sc-cmthru fPQhqY"
+            class="sc-hMFtBS eVxguM"
           >
             <h4
               class="bp3-heading"
@@ -7243,7 +7243,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bMVAic bieIKK"
+              class="bp3-list sc-bAeIUo hsKqcp"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundSteps.test.tsx
@@ -67,7 +67,7 @@ describe('BatchRoundSteps', () => {
   it('navigates between steps using buttons or links', async () => {
     const expectedCalls = [
       jaApiCalls.getBatches(batchesMocks.emptyInitial),
-      jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
+      jaApiCalls.getJurisdictionContests(contestMocks.one),
       jaApiCalls.getTallyEntryAccountStatus(
         tallyEntryAccountStatusMocks.turnedOff
       ),
@@ -135,7 +135,7 @@ describe('BatchRoundSteps', () => {
   it('defaults to Enter Tallies step if any tallies have been entered', async () => {
     const expectedCalls = [
       jaApiCalls.getBatches(batchesMocks.complete),
-      jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
+      jaApiCalls.getJurisdictionContests(contestMocks.one),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderComponent()
@@ -152,7 +152,7 @@ describe('BatchRoundSteps', () => {
 
     const expectedCalls = [
       jaApiCalls.getBatches(batchesMocks.emptyInitial),
-      jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
+      jaApiCalls.getJurisdictionContests(contestMocks.one),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderComponent('/prepare-batches')
@@ -197,7 +197,7 @@ describe('BatchRoundSteps', () => {
   it('handles failures to generate batch tally sheets PDF', async () => {
     const expectedCalls = [
       jaApiCalls.getBatches(batchesMocks.emptyInitial),
-      jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
+      jaApiCalls.getJurisdictionContests(contestMocks.one),
     ]
     mockSavePDF.mockImplementationOnce(() => Promise.reject(new Error('Whoa!')))
     await withMockFetch(expectedCalls, async () => {
@@ -427,7 +427,7 @@ describe('BatchRoundSteps', () => {
   it('shows Step 3: Enter Tallies', async () => {
     const expectedCalls = [
       jaApiCalls.getBatches(batchesMocks.emptyInitial),
-      jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
+      jaApiCalls.getJurisdictionContests(contestMocks.one),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderComponent('/enter-tallies')
@@ -447,7 +447,7 @@ describe('BatchRoundSteps', () => {
         ...batchesMocks.complete,
         resultsFinalizedAt: null,
       }),
-      jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
+      jaApiCalls.getJurisdictionContests(contestMocks.one),
       jaApiCalls.finalizeBatchResults,
       jaApiCalls.getBatches(batchesMocks.complete),
     ]
@@ -483,7 +483,7 @@ describe('BatchRoundSteps', () => {
         ...batchesMocks.complete,
         resultsFinalizedAt: null,
       }),
-      jaApiCalls.getJurisdictionContests(contestMocks.oneTargeted),
+      jaApiCalls.getJurisdictionContests(contestMocks.one),
       serverError('finalizeBatchResults', jaApiCalls.finalizeBatchResults),
     ]
     await withMockFetch(expectedCalls, async () => {

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundTallyEntry/BatchRoundTallyEntry.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundTallyEntry/BatchRoundTallyEntry.test.tsx
@@ -71,7 +71,7 @@ describe('Batch comparison data entry', () => {
   it('shows a table of batches and a button to edit results for each batch', async () => {
     const expectedCalls = [
       apiCalls.getBatches(batchesMocks.emptyInitial),
-      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getJAContests({ contests: contestMocks.one }),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderComponent()
@@ -84,20 +84,21 @@ describe('Batch comparison data entry', () => {
         const batchTable = screen.getByRole('table')
 
         const headers = within(batchTable).getAllByRole('columnheader')
-        expect(headers).toHaveLength(2)
-        expect(headers[0]).toHaveTextContent('Choice')
-        expect(headers[1]).toHaveTextContent('Votes')
+        expect(headers).toHaveLength(3)
+        expect(headers[0]).toHaveTextContent('Contest 1')
+        expect(headers[1]).toHaveTextContent('Choice')
+        expect(headers[2]).toHaveTextContent('Votes')
 
         const rows = within(batchTable).getAllByRole('row')
-        expect(rows).toHaveLength(3)
+        expect(rows).toHaveLength(4)
 
-        const row1 = within(rows[1]).getAllByRole('cell')
+        const row1 = within(rows[2]).getAllByRole('cell')
+        const row2 = within(rows[3]).getAllByRole('cell')
         expect(row1).toHaveLength(2)
+        expect(row2).toHaveLength(2)
+
         expect(row1[0]).toHaveTextContent('Choice One')
         expect(row1[1]).toHaveTextContent('')
-
-        const row2 = within(rows[2]).getAllByRole('cell')
-        expect(row2).toHaveLength(2)
         expect(row2[0]).toHaveTextContent('Choice Two')
         expect(row2[1]).toHaveTextContent('')
 
@@ -116,7 +117,7 @@ describe('Batch comparison data entry', () => {
     }
     const expectedCalls = [
       apiCalls.getBatches(batchesMocks.emptyInitial),
-      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getJAContests({ contests: contestMocks.one }),
       apiCalls.putBatchResults('batch-1', [tallySheet1]),
       apiCalls.getBatches({
         ...batchesMocks.emptyInitial,
@@ -129,12 +130,13 @@ describe('Batch comparison data entry', () => {
 
       userEvent.click(screen.getByRole('button', { name: /Edit Tallies/ }))
 
+      batchTable = await screen.findByRole('table')
       let rows = within(batchTable).getAllByRole('row')
-      let row1 = within(rows[1]).getAllByRole('cell')
+      let row1 = within(rows[2]).getAllByRole('cell')
+      let row2 = within(rows[3]).getAllByRole('cell')
       const choice1VotesInput = within(row1[1]).getByRole('spinbutton')
-      userEvent.type(choice1VotesInput, '1')
-      let row2 = within(rows[2]).getAllByRole('cell')
       let choice2VotesInput = within(row2[1]).getByRole('spinbutton')
+      userEvent.type(choice1VotesInput, '1')
       userEvent.clear(choice2VotesInput)
 
       // Try saving before filling out all choices
@@ -159,8 +161,8 @@ describe('Batch comparison data entry', () => {
 
       batchTable = screen.getByRole('table')
       rows = within(batchTable).getAllByRole('row')
-      row1 = within(rows[1]).getAllByRole('cell')
-      row2 = within(rows[2]).getAllByRole('cell')
+      row1 = within(rows[2]).getAllByRole('cell')
+      row2 = within(rows[3]).getAllByRole('cell')
       expect(row1[1]).toHaveTextContent('1')
       expect(row2[1]).toHaveTextContent('2')
       screen.getByText('Last edited by: ja@example.com')
@@ -170,7 +172,7 @@ describe('Batch comparison data entry', () => {
   it('cancels editing the results for a batch', async () => {
     const expectedCalls = [
       apiCalls.getBatches(batchesMocks.emptyInitial),
-      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getJAContests({ contests: contestMocks.one }),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderComponent()
@@ -178,12 +180,13 @@ describe('Batch comparison data entry', () => {
 
       userEvent.click(screen.getByRole('button', { name: /Edit Tallies/ }))
 
+      batchTable = await screen.findByRole('table')
       let rows = within(batchTable).getAllByRole('row')
-      let row1 = within(rows[1]).getAllByRole('cell')
+      let row1 = within(rows[2]).getAllByRole('cell')
+      let row2 = within(rows[3]).getAllByRole('cell')
       const choice1VotesInput = within(row1[1]).getByRole('spinbutton')
-      userEvent.type(choice1VotesInput, '1')
-      let row2 = within(rows[2]).getAllByRole('cell')
       const choice2VotesInput = within(row2[1]).getByRole('spinbutton')
+      userEvent.type(choice1VotesInput, '1')
       userEvent.type(choice2VotesInput, '2')
 
       const discardChangesButton = await screen.findByRole('button', {
@@ -198,14 +201,14 @@ describe('Batch comparison data entry', () => {
 
       batchTable = await screen.findByRole('table')
       rows = within(batchTable).getAllByRole('row')
-      row1 = within(rows[1]).getAllByRole('cell')
-      row2 = within(rows[2]).getAllByRole('cell')
+      row1 = within(rows[2]).getAllByRole('cell')
+      row2 = within(rows[3]).getAllByRole('cell')
       expect(row1[1]).toHaveTextContent('')
       expect(row2[1]).toHaveTextContent('')
     })
   })
 
-  it('edits multiple tally sheets for a batch', async () => {
+  it('edits the results for a batch with multiple tally sheets', async () => {
     const tallySheet1BeforeEdit = {
       name: 'Sheet 1',
       results: {
@@ -236,7 +239,7 @@ describe('Batch comparison data entry', () => {
     }
     const expectedCalls = [
       apiCalls.getBatches(batchesMocks.emptyInitial),
-      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getJAContests({ contests: contestMocks.one }),
       apiCalls.putBatchResults('batch-1', [tallySheet1BeforeEdit, tallySheet2]),
       apiCalls.getBatches({
         ...batchesMocks.emptyInitial,
@@ -284,18 +287,19 @@ describe('Batch comparison data entry', () => {
 
       batchTable = await screen.findByRole('table')
       const headers = within(batchTable).getAllByRole('columnheader')
-      expect(headers).toHaveLength(2)
-      expect(headers[0]).toHaveTextContent('Choice')
-      expect(headers[1]).toHaveTextContent('Votes')
+      expect(headers).toHaveLength(3)
+      expect(headers[0]).toHaveTextContent('Contest 1')
+      expect(headers[1]).toHaveTextContent('Choice')
+      expect(headers[2]).toHaveTextContent('Votes')
       let rows = within(batchTable).getAllByRole('row')
-      expect(rows).toHaveLength(3)
-      let row1 = within(rows[1]).getAllByRole('cell')
-      let row2 = within(rows[2]).getAllByRole('cell')
+      expect(rows).toHaveLength(4)
+      let row1 = within(rows[2]).getAllByRole('cell')
+      let row2 = within(rows[3]).getAllByRole('cell')
       expect(row1).toHaveLength(2)
       expect(row2).toHaveLength(2)
       let choice1VotesInput = within(row1[1]).getByRole('spinbutton')
-      expect(choice1VotesInput).toHaveTextContent('')
       let choice2VotesInput = within(row2[1]).getByRole('spinbutton')
+      expect(choice1VotesInput).toHaveTextContent('')
       expect(choice2VotesInput).toHaveTextContent('')
 
       // Fill out one choice validly and the other invalidly
@@ -328,7 +332,7 @@ describe('Batch comparison data entry', () => {
       userEvent.click(screen.getByRole('button', { name: /Edit Sheet/ }))
       batchTable = await screen.findByRole('table')
       rows = within(batchTable).getAllByRole('row')
-      row2 = within(rows[2]).getAllByRole('cell')
+      row2 = within(rows[3]).getAllByRole('cell')
       choice2VotesInput = within(row2[1]).getByRole('spinbutton')
       userEvent.clear(choice2VotesInput)
       userEvent.type(choice2VotesInput, '2')
@@ -367,11 +371,11 @@ describe('Batch comparison data entry', () => {
       userEvent.type(sheetNameInput, 'Sheet Three')
       batchTable = screen.getByRole('table')
       rows = within(batchTable).getAllByRole('row')
-      row1 = within(rows[1]).getAllByRole('cell')
-      row2 = within(rows[2]).getAllByRole('cell')
+      row1 = within(rows[2]).getAllByRole('cell')
+      row2 = within(rows[3]).getAllByRole('cell')
       choice1VotesInput = within(row1[1]).getByRole('spinbutton')
-      userEvent.type(choice1VotesInput, '3')
       choice2VotesInput = within(row2[1]).getByRole('spinbutton')
+      userEvent.type(choice1VotesInput, '3')
       userEvent.type(choice2VotesInput, '4')
       userEvent.click(screen.getByRole('button', { name: /Save Sheet/ }))
       await waitFor(() =>
@@ -387,8 +391,8 @@ describe('Batch comparison data entry', () => {
       expect(voteTotalsTab).toHaveAttribute('aria-selected', 'true')
       batchTable = await screen.findByRole('table')
       rows = within(batchTable).getAllByRole('row')
-      row1 = within(rows[1]).getAllByRole('cell')
-      row2 = within(rows[2]).getAllByRole('cell')
+      row1 = within(rows[2]).getAllByRole('cell')
+      row2 = within(rows[3]).getAllByRole('cell')
       expect(row1[1]).toHaveTextContent(`${1 + 3}`)
       expect(row2[1]).toHaveTextContent(`${2 + 4}`)
 
@@ -411,8 +415,8 @@ describe('Batch comparison data entry', () => {
       expect(voteTotalsTab).toHaveAttribute('aria-selected', 'true')
       batchTable = await screen.findByRole('table')
       rows = within(batchTable).getAllByRole('row')
-      row1 = within(rows[1]).getAllByRole('cell')
-      row2 = within(rows[2]).getAllByRole('cell')
+      row1 = within(rows[2]).getAllByRole('cell')
+      row2 = within(rows[3]).getAllByRole('cell')
       expect(row1[1]).toHaveTextContent('3')
       expect(row2[1]).toHaveTextContent('4')
 
@@ -440,10 +444,226 @@ describe('Batch comparison data entry', () => {
     })
   })
 
+  it('edits the results for a batch with multiple contests', async () => {
+    const tallySheet1 = {
+      name: 'Sheet 1',
+      results: {
+        'choice-id-1': 1,
+        'choice-id-2': 2,
+        'choice-id-3': 3,
+        'choice-id-4': 4,
+      },
+    }
+    const expectedCalls = [
+      apiCalls.getBatches(batchesMocks.emptyInitial),
+      apiCalls.getJAContests({ contests: contestMocks.two }),
+      apiCalls.putBatchResults('batch-1', [tallySheet1]),
+      apiCalls.getBatches({
+        ...batchesMocks.emptyInitial,
+        batches: batchesWithResults([tallySheet1]),
+      }),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderComponent()
+      let batchTables = await screen.findAllByRole('table')
+
+      userEvent.click(screen.getByRole('button', { name: /Edit Tallies/ }))
+
+      const table1Headers = within(batchTables[0]).getAllByRole('columnheader')
+      expect(table1Headers).toHaveLength(3)
+      expect(table1Headers[0]).toHaveTextContent('Contest 1')
+      expect(table1Headers[1]).toHaveTextContent('Choice')
+      expect(table1Headers[2]).toHaveTextContent('Votes')
+      let table1Rows = within(batchTables[0]).getAllByRole('row')
+      let table1Row1 = within(table1Rows[2]).getAllByRole('cell')
+      let table1Row2 = within(table1Rows[3]).getAllByRole('cell')
+      const choice1VotesInput = within(table1Row1[1]).getByRole('spinbutton')
+      const choice2VotesInput = within(table1Row2[1]).getByRole('spinbutton')
+      userEvent.type(choice1VotesInput, '1')
+      userEvent.type(choice2VotesInput, '2')
+
+      // Try saving before filling out choices for all contests
+      const saveButton = screen.getByRole('button', { name: /Save Tallies/ })
+      userEvent.click(saveButton)
+
+      // Should get a validation error
+      const table2Headers = within(batchTables[1]).getAllByRole('columnheader')
+      expect(table2Headers).toHaveLength(3)
+      expect(table2Headers[0]).toHaveTextContent('Contest 2')
+      expect(table2Headers[1]).toHaveTextContent('Choice')
+      expect(table2Headers[2]).toHaveTextContent('Votes')
+      let table2Rows = within(batchTables[1]).getAllByRole('row')
+      let table2Row1 = within(table2Rows[2]).getAllByRole('cell')
+      let table2Row2 = within(table2Rows[3]).getAllByRole('cell')
+      const choice3VotesInput = within(table2Row1[1]).getByRole('spinbutton')
+      const choice4VotesInput = within(table2Row2[1]).getByRole('spinbutton')
+      await waitFor(() => {
+        expect(choice3VotesInput).toHaveClass(Classes.INTENT_DANGER)
+        expect(choice4VotesInput).toHaveClass(Classes.INTENT_DANGER)
+      })
+      expect(choice3VotesInput).toHaveFocus()
+
+      // Fill out the rest of the choices
+      userEvent.type(choice3VotesInput, '3')
+      userEvent.type(choice4VotesInput, '4')
+      userEvent.click(saveButton)
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('button', { name: /Save Tallies/ })
+        ).not.toBeInTheDocument()
+      )
+
+      batchTables = screen.getAllByRole('table')
+      table1Rows = within(batchTables[0]).getAllByRole('row')
+      table2Rows = within(batchTables[1]).getAllByRole('row')
+      table1Row1 = within(table1Rows[2]).getAllByRole('cell')
+      table1Row2 = within(table1Rows[3]).getAllByRole('cell')
+      table2Row1 = within(table2Rows[2]).getAllByRole('cell')
+      table2Row2 = within(table2Rows[3]).getAllByRole('cell')
+      expect(table1Row1[1]).toHaveTextContent('1')
+      expect(table1Row2[1]).toHaveTextContent('2')
+      expect(table2Row1[1]).toHaveTextContent('3')
+      expect(table2Row2[1]).toHaveTextContent('4')
+      screen.getByText('Last edited by: ja@example.com')
+    })
+  })
+
+  it('edits the results for a batch with multiple contests and multiple tally sheets', async () => {
+    const tallySheet1 = {
+      name: 'Sheet 1',
+      results: {
+        'choice-id-1': 1,
+        'choice-id-2': 2,
+        'choice-id-3': 3,
+        'choice-id-4': 4,
+      },
+    }
+    const tallySheet2BeforeEdit = {
+      name: 'Sheet 2',
+      results: {
+        'choice-id-1': 0,
+        'choice-id-2': 0,
+        'choice-id-3': 0,
+        'choice-id-4': 0,
+      },
+    }
+    const tallySheet2AfterEdit = {
+      name: 'Sheet 2',
+      results: {
+        'choice-id-1': 5,
+        'choice-id-2': 6,
+        'choice-id-3': 7,
+        'choice-id-4': 8,
+      },
+    }
+    const expectedCalls = [
+      apiCalls.getBatches(batchesMocks.emptyInitial),
+      apiCalls.getJAContests({ contests: contestMocks.two }),
+      apiCalls.putBatchResults('batch-1', [tallySheet1, tallySheet2BeforeEdit]),
+      apiCalls.getBatches({
+        ...batchesMocks.emptyInitial,
+        batches: batchesWithResults([tallySheet1, tallySheet2BeforeEdit]),
+      }),
+      apiCalls.putBatchResults('batch-1', [tallySheet1, tallySheet2AfterEdit]),
+      apiCalls.getBatches({
+        ...batchesMocks.emptyInitial,
+        batches: batchesWithResults([tallySheet1, tallySheet2AfterEdit]),
+      }),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderComponent()
+      let batchTables = await screen.findAllByRole('table')
+
+      userEvent.click(
+        screen.getByRole('button', { name: /Additional Actions/ })
+      )
+      userEvent.click(screen.getByText('Use Multiple Tally Sheets'))
+
+      batchTables = await screen.findAllByRole('table')
+      let table1Rows = within(batchTables[0]).getAllByRole('row')
+      let table2Rows = within(batchTables[1]).getAllByRole('row')
+      let table1Row1 = within(table1Rows[2]).getAllByRole('cell')
+      let table1Row2 = within(table1Rows[3]).getAllByRole('cell')
+      let table2Row1 = within(table2Rows[2]).getAllByRole('cell')
+      let table2Row2 = within(table2Rows[3]).getAllByRole('cell')
+      let choice1VotesInput = within(table1Row1[1]).getByRole('spinbutton')
+      let choice2VotesInput = within(table1Row2[1]).getByRole('spinbutton')
+      let choice3VotesInput = within(table2Row1[1]).getByRole('spinbutton')
+      let choice4VotesInput = within(table2Row2[1]).getByRole('spinbutton')
+      expect(choice1VotesInput).toHaveTextContent('')
+      expect(choice2VotesInput).toHaveTextContent('')
+      expect(choice3VotesInput).toHaveTextContent('')
+      expect(choice4VotesInput).toHaveTextContent('')
+
+      userEvent.type(choice1VotesInput, '1')
+      userEvent.type(choice2VotesInput, '2')
+      userEvent.type(choice3VotesInput, '3')
+      userEvent.type(choice4VotesInput, '4')
+      userEvent.click(screen.getByRole('button', { name: /Save Sheet/ }))
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('button', { name: /Save Sheet/ })
+        ).not.toBeInTheDocument()
+      )
+
+      let voteTotalsTab = screen.getByRole('tab', { name: 'Vote Totals' })
+      const sheet1Tab = screen.getByRole('tab', { name: 'Sheet 1' })
+      const sheet2Tab = screen.getByRole('tab', { name: 'Sheet 2' })
+      expect(sheet1Tab).toHaveAttribute('aria-selected', 'true')
+      userEvent.click(sheet2Tab)
+      await waitFor(() =>
+        expect(sheet2Tab).toHaveAttribute('aria-selected', 'true')
+      )
+      userEvent.click(screen.getByRole('button', { name: /Edit Sheet/ }))
+
+      batchTables = await screen.findAllByRole('table')
+      table1Rows = within(batchTables[0]).getAllByRole('row')
+      table2Rows = within(batchTables[1]).getAllByRole('row')
+      table1Row1 = within(table1Rows[2]).getAllByRole('cell')
+      table1Row2 = within(table1Rows[3]).getAllByRole('cell')
+      table2Row1 = within(table2Rows[2]).getAllByRole('cell')
+      table2Row2 = within(table2Rows[3]).getAllByRole('cell')
+      choice1VotesInput = within(table1Row1[1]).getByRole('spinbutton')
+      choice2VotesInput = within(table1Row2[1]).getByRole('spinbutton')
+      choice3VotesInput = within(table2Row1[1]).getByRole('spinbutton')
+      choice4VotesInput = within(table2Row2[1]).getByRole('spinbutton')
+      expect(choice1VotesInput).toHaveTextContent('')
+      expect(choice2VotesInput).toHaveTextContent('')
+      expect(choice3VotesInput).toHaveTextContent('')
+      expect(choice4VotesInput).toHaveTextContent('')
+
+      userEvent.type(choice1VotesInput, '5')
+      userEvent.type(choice2VotesInput, '6')
+      userEvent.type(choice3VotesInput, '7')
+      userEvent.type(choice4VotesInput, '8')
+      userEvent.click(screen.getByRole('button', { name: /Save Sheet/ }))
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('button', { name: /Save Sheet/ })
+        ).not.toBeInTheDocument()
+      )
+
+      voteTotalsTab = screen.getByRole('tab', { name: 'Vote Totals' })
+      userEvent.click(voteTotalsTab)
+      expect(voteTotalsTab).toHaveAttribute('aria-selected', 'true')
+      batchTables = await screen.findAllByRole('table')
+      table1Rows = within(batchTables[0]).getAllByRole('row')
+      table2Rows = within(batchTables[1]).getAllByRole('row')
+      table1Row1 = within(table1Rows[2]).getAllByRole('cell')
+      table1Row2 = within(table1Rows[3]).getAllByRole('cell')
+      table2Row1 = within(table2Rows[2]).getAllByRole('cell')
+      table2Row2 = within(table2Rows[3]).getAllByRole('cell')
+      expect(table1Row1[1]).toHaveTextContent('6')
+      expect(table1Row2[1]).toHaveTextContent('8')
+      expect(table2Row1[1]).toHaveTextContent('10')
+      expect(table2Row2[1]).toHaveTextContent('12')
+    })
+  })
+
   it('handles errors on save', async () => {
     const expectedCalls = [
       apiCalls.getBatches(batchesMocks.emptyInitial),
-      apiCalls.getJAContests({ contests: contestMocks.oneTargeted }),
+      apiCalls.getJAContests({ contests: contestMocks.one }),
       serverError(
         'putBatchResults',
         apiCalls.putBatchResults('batch-1', [
@@ -463,11 +683,11 @@ describe('Batch comparison data entry', () => {
       userEvent.click(screen.getByRole('button', { name: /Edit Tallies/ }))
 
       const rows = within(batchTable).getAllByRole('row')
-      const row1 = within(rows[1]).getAllByRole('cell')
+      const row1 = within(rows[2]).getAllByRole('cell')
+      const row2 = within(rows[3]).getAllByRole('cell')
       const choice1Input = within(row1[1]).getByRole('spinbutton')
-      userEvent.type(choice1Input, '1')
-      const row2 = within(rows[2]).getAllByRole('cell')
       const choice2Input = within(row2[1]).getByRole('spinbutton')
+      userEvent.type(choice1Input, '1')
       userEvent.type(choice2Input, '2')
 
       const saveButton = await screen.findByRole('button', {

--- a/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundTallyEntry/BatchRoundTallyEntry.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchRoundSteps/BatchRoundTallyEntry/BatchRoundTallyEntry.tsx
@@ -38,8 +38,7 @@ const BatchRoundTallyEntry: React.FC<IProps> = ({
   }
 
   const { batches, resultsFinalizedAt } = batchesQuery.data
-  // Batch comparison audits only support a single contest
-  const [contest] = contestsQuery.data
+  const contests = contestsQuery.data
 
   if (batches.length === 0) {
     return null
@@ -49,7 +48,7 @@ const BatchRoundTallyEntry: React.FC<IProps> = ({
     <BatchRoundTallyEntryContent
       areResultsFinalized={Boolean(resultsFinalizedAt)}
       batches={batches}
-      contest={contest}
+      contests={contests}
       electionId={electionId}
       jurisdictionId={jurisdictionId}
       roundId={roundId}
@@ -60,7 +59,7 @@ const BatchRoundTallyEntry: React.FC<IProps> = ({
 interface IBatchRoundTallyEntryContentProps {
   areResultsFinalized: boolean
   batches: IBatch[]
-  contest: IContest
+  contests: IContest[]
   electionId: string
   jurisdictionId: string
   roundId: string
@@ -69,7 +68,7 @@ interface IBatchRoundTallyEntryContentProps {
 const BatchRoundTallyEntryContent: React.FC<IBatchRoundTallyEntryContentProps> = ({
   areResultsFinalized,
   batches,
-  contest,
+  contests,
   electionId,
   jurisdictionId,
   roundId,
@@ -147,7 +146,7 @@ const BatchRoundTallyEntryContent: React.FC<IBatchRoundTallyEntryContentProps> =
       <BatchDetail
         areResultsFinalized={areResultsFinalized}
         batch={selectedBatch}
-        contest={contest}
+        contests={contests}
         isEditing={isEditing}
         key={selectedBatch.id}
         saveBatchResults={async (

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -1064,6 +1064,85 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
 
 export const contestMocks = mocksOfType<IContest[]>()({
   empty: [],
+  one: [
+    {
+      id: 'contest-id-1',
+      name: 'Contest 1',
+      isTargeted: true,
+      totalBallotsCast: 30,
+      numWinners: 1,
+      votesAllowed: 1,
+      jurisdictionIds: [
+        'jurisdiction-id-1',
+        'jurisdiction-id-2',
+        'jurisdiction-id-3',
+      ],
+      choices: [
+        {
+          id: 'choice-id-1',
+          name: 'Choice One',
+          numVotes: 10,
+        },
+        {
+          id: 'choice-id-2',
+          name: 'Choice Two',
+          numVotes: 20,
+        },
+      ],
+    },
+  ],
+  two: [
+    {
+      id: 'contest-id-1',
+      name: 'Contest 1',
+      isTargeted: true,
+      totalBallotsCast: 30,
+      numWinners: 1,
+      votesAllowed: 1,
+      jurisdictionIds: [
+        'jurisdiction-id-1',
+        'jurisdiction-id-2',
+        'jurisdiction-id-3',
+      ],
+      choices: [
+        {
+          id: 'choice-id-1',
+          name: 'Choice One',
+          numVotes: 10,
+        },
+        {
+          id: 'choice-id-2',
+          name: 'Choice Two',
+          numVotes: 20,
+        },
+      ],
+    },
+    {
+      id: 'contest-id-2',
+      name: 'Contest 2',
+      isTargeted: true,
+      totalBallotsCast: 30,
+      numWinners: 1,
+      votesAllowed: 1,
+      jurisdictionIds: [
+        'jurisdiction-id-1',
+        'jurisdiction-id-2',
+        'jurisdiction-id-3',
+      ],
+      choices: [
+        {
+          id: 'choice-id-3',
+          name: 'Choice Three',
+          numVotes: 10,
+        },
+        {
+          id: 'choice-id-4',
+          name: 'Choice Four',
+          numVotes: 20,
+        },
+      ],
+    },
+  ],
   oneTargeted: [
     {
       id: 'contest-id-1',


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/arlo/issues/1815

This PR updates the batch tally entry UI to support multiple contests. Note that the batch audit creation UI still doesn't support creating audits with multiple contests.

_Two contests_

<table>
<img src='https://github.com/votingworks/arlo/assets/12616928/dbaaa410-14ce-43e7-a8e8-0da74cb28c5e' alt='two-contests' width=600 />
</table>

_One contest_

I chose to keep the contest header even when there's only one contest, for consistency.

<table>
<img src='https://github.com/votingworks/arlo/assets/12616928/4116d4fd-05a7-44b7-a0b4-6b2638c02d9c' alt='one-contest' width=600 />
</table>

## Testing

- [x] Updated automated tests
- [x] Cherry-picked changes from my proof-of-concept branch to test manally