### PR TITLE
Guard against finishing a round multiple times

### DIFF
--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -623,6 +623,8 @@ def finish_round(election: Election):
         raise Conflict("Audit not started")
     if not is_round_ready_to_finish(election, current_round):
         raise Conflict("Auditing is still in progress")
+    if current_round.ended_at:
+        raise Conflict("Round already finished")
 
     count_audited_votes(election, current_round)
     calculate_risk_measurements(election, current_round)

--- a/server/tests/api/test_rounds.py
+++ b/server/tests/api/test_rounds.py
@@ -422,6 +422,20 @@ def test_rounds_bad_sample_sizes(
         }
 
 
+def test_finish_round_after_round_already_finished(
+    client: FlaskClient, election_id: str, contest_ids: List[str], round_1_id: str
+):
+    run_audit_round(round_1_id, contest_ids[0], contest_ids, 0.5)
+    rv = client.post(f"/api/election/{election_id}/round/current/finish")
+    assert_ok(rv)
+
+    rv = client.post(f"/api/election/{election_id}/round/current/finish")
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [{"message": "Round already finished", "errorType": "Conflict",}]
+    }
+
+
 def test_finish_round_before_launch(client: FlaskClient, election_id: str):
     rv = client.post(f"/api/election/{election_id}/round/current/finish")
     assert rv.status_code == 409

--- a/server/tests/ballot_polling/test_ballot_polling.py
+++ b/server/tests/ballot_polling/test_ballot_polling.py
@@ -51,7 +51,9 @@ def test_not_found_ballots(
         )
     )
 
+    # Un-finish the round
     round = Round.query.get(round_1_id)
+    round.ended_at = None
     for round_contest in round.round_contests:
         round_contest.results = []
 


### PR DESCRIPTION
Previously, if you tried to finish a round that was already finished, you would get a database integrity error. No harm caused, but not the nicest UX (and causes an unnecessary alert). Instead, add a guard and a nice error message.

Note that it's not totally clear how you would do this in the UI, but potentially possible if you had two tabs open with the same audit and clicked the "Finish Round" button in each one in succession.