### PR TITLE
Update backend to support multi-contest batch audits

### DIFF
--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -60,8 +60,13 @@ def items_list_to_dict(items):
 def process_batch_inventory_cvr_file(jurisdiction_id: str):
     batch_inventory_data = BatchInventoryData.query.get(jurisdiction_id)
     jurisdiction = Jurisdiction.query.get(jurisdiction_id)
-    assert len(list(jurisdiction.contests)) == 1
-    contest = jurisdiction.contests[0]
+
+    contests = list(jurisdiction.contests)
+    contest = contests[0]
+    if len(contests) != 1:  # pragma: no cover
+        raise UserError(
+            "Batch inventory flow does not yet support multi-contest batch audits"
+        )
 
     cvr_file = retrieve_file(batch_inventory_data.cvr_file.storage_path)
     cvrs = csv_reader_for_cvr(cvr_file)

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -95,7 +95,7 @@ def process_batch_tallies_file(
                     f"The total votes for batch \"{row[BATCH_NAME]}\" ({format_count(total_tallies, 'vote', 'votes')})"
                     + f" cannot exceed {allowed_tallies} - the number of ballots from the manifest"
                     + f" ({format_count(num_ballots_by_batch[row[BATCH_NAME]], 'ballot', 'ballots')}) multiplied by the number"
-                    + f" of votes allowed for the contest ({format_count(contest.votes_allowed, 'vote', 'votes')} per ballot)."
+                    + f" of votes allowed for the contest \"{contest.name}\" ({format_count(contest.votes_allowed, 'vote', 'votes')} per ballot)."
                 )
 
         return {

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import datetime
 from typing import Dict, Optional, Tuple
 import uuid
@@ -123,14 +124,12 @@ def process_batch_tallies_file(
 
         # Save the tallies as a JSON blob in the format needed by the audit_math.macro module
         # { batch_name: { contest_id: { choice_id: vote_count } } }
-        batch_tallies: Dict[str, Dict[str, Dict[str, int]]] = {}
+        batch_tallies: Dict[str, Dict[str, Dict[str, int]]] = defaultdict(dict)
         for contest in contests:
             batch_tallies_for_contest = process_batch_tallies_for_contest(
                 contest, contest_choice_csv_headers
             )
             for batch_name, batch_votes in batch_tallies_for_contest.items():
-                if not batch_name in batch_tallies:
-                    batch_tallies[batch_name] = {}
                 batch_tallies[batch_name][contest.id] = batch_votes
 
         jurisdiction.batch_tallies = batch_tallies

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -41,7 +41,7 @@ def process_batch_tallies_file(
     jurisdiction_admin_email: str,
     support_user_email: Optional[str],
 ):
-    jurisdiction = Jurisdiction.query.get(jurisdiction_id)
+    jurisdiction: Jurisdiction = Jurisdiction.query.get(jurisdiction_id)
 
     def process_batch_tallies_for_contest(
         contest: Contest,
@@ -111,7 +111,7 @@ def process_batch_tallies_file(
 
     def process() -> None:
         contests = list(jurisdiction.contests)
-        is_multi_contest_audit = len(jurisdiction.election.contests) > 1
+        is_multi_contest_audit = len(list(jurisdiction.election.contests)) > 1
         contest_choice_csv_headers = {
             # Include contest name in contest choice CSV headers for multi-contest audits just in
             # case two choices in different contests have the same name

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -122,6 +122,7 @@ def process_batch_tallies_file(
         }
 
         # Save the tallies as a JSON blob in the format needed by the audit_math.macro module
+        # { batch_name: { contest_id: { choice_id: vote_count } } }
         batch_tallies: Dict[str, Dict[str, Dict[str, int]]] = {}
         for contest in contests:
             batch_tallies_for_contest = process_batch_tallies_for_contest(

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -92,10 +92,13 @@ def process_batch_tallies_file(
             )
             if total_tallies > allowed_tallies:
                 raise UserError(
-                    f"The total votes for batch \"{row[BATCH_NAME]}\" ({format_count(total_tallies, 'vote', 'votes')})"
-                    + f" cannot exceed {allowed_tallies} - the number of ballots from the manifest"
-                    + f" ({format_count(num_ballots_by_batch[row[BATCH_NAME]], 'ballot', 'ballots')}) multiplied by the number"
-                    + f" of votes allowed for the contest \"{contest.name}\" ({format_count(contest.votes_allowed, 'vote', 'votes')} per ballot)."
+                    f'The total votes for contest "{contest.name}" in batch "{row[BATCH_NAME]}" '
+                    f"({format_count(total_tallies, 'vote', 'votes')}) "
+                    f"cannot exceed {allowed_tallies} - "
+                    f"the number of ballots from the manifest "
+                    f"({format_count(num_ballots_by_batch[row[BATCH_NAME]], 'ballot', 'ballots')}) "
+                    f"multiplied by the number of votes allowed for the contest "
+                    f"({format_count(contest.votes_allowed, 'vote', 'votes')} per ballot)."
                 )
 
         return {

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -204,11 +204,14 @@ def validate_batch_results(
         )
 
     for contest in contests:
-        contest_choice_ids = set(choice.id for choice in contest.choices)
         total_votes = 0
         for tally_sheet in batch_results:
-            for choice_id, count in tally_sheet["results"].items():
-                total_votes += count if choice_id in contest_choice_ids else 0
+            for choice in contest.choices:
+                total_votes += (
+                    tally_sheet["results"][choice.id]
+                    if choice.id in tally_sheet["results"]
+                    else 0
+                )
         assert contest.votes_allowed is not None
         allowed_votes = batch.num_ballots * contest.votes_allowed
         if total_votes > allowed_votes:

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -184,14 +184,16 @@ def validate_batch_results(
 
     validate(batch_results, BATCH_RESULT_TALLY_SHEETS_SCHEMA)
 
-    # We only support one contest for batch audits
-    assert len(list(jurisdiction.contests)) == 1
-    contest = list(jurisdiction.contests)[0]
-    contest_choice_ids = {choice.id for choice in contest.choices}
+    contests = list(jurisdiction.contests)
+    choice_ids_across_contests = set(
+        choice.id for contest in contests for choice in contest.choices
+    )
 
     for tally_sheet in batch_results:
-        if tally_sheet["results"].keys() != contest_choice_ids:
+        if len(tally_sheet["results"].keys() - choice_ids_across_contests) > 0:
             raise BadRequest("Invalid choice ids")
+        if tally_sheet["results"].keys() != choice_ids_across_contests:
+            raise BadRequest("Missing choice ids")
 
     duplicate_tally_sheet_name = find_first_duplicate(
         [tally_sheet["name"] for tally_sheet in batch_results]
@@ -201,17 +203,20 @@ def validate_batch_results(
             f"Tally sheet names must be unique. '{duplicate_tally_sheet_name}' has already been used."
         )
 
-    total_votes = sum(
-        sum(tally_sheet["results"].values()) for tally_sheet in batch_results
-    )
-    assert contest.votes_allowed is not None
-    allowed_votes = batch.num_ballots * contest.votes_allowed
-    if total_votes > allowed_votes:
-        raise BadRequest(
-            f"Total votes for batch {batch.name} should not exceed {allowed_votes}"
-            f" - the number of ballots in the batch ({batch.num_ballots})"
-            f" times the number of votes allowed ({contest.votes_allowed})."
-        )
+    for contest in contests:
+        contest_choice_ids = set(choice.id for choice in contest.choices)
+        total_votes = 0
+        for tally_sheet in batch_results:
+            for choice_id, count in tally_sheet["results"].items():
+                total_votes += count if choice_id in contest_choice_ids else 0
+        assert contest.votes_allowed is not None
+        allowed_votes = batch.num_ballots * contest.votes_allowed
+        if total_votes > allowed_votes:
+            raise BadRequest(
+                f"Total votes for batch {batch.name} contest {contest.name} should not exceed "
+                f"{allowed_votes} - the number of ballots in the batch ({batch.num_ballots}) "
+                f"times the number of votes allowed ({contest.votes_allowed})."
+            )
 
 
 @api.route(

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -207,11 +207,7 @@ def validate_batch_results(
         total_votes = 0
         for tally_sheet in batch_results:
             for choice in contest.choices:
-                total_votes += (
-                    tally_sheet["results"][choice.id]
-                    if choice.id in tally_sheet["results"]
-                    else 0
-                )
+                total_votes += tally_sheet["results"][choice.id]
         assert contest.votes_allowed is not None
         allowed_votes = batch.num_ballots * contest.votes_allowed
         if total_votes > allowed_votes:

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -249,9 +249,6 @@ def validate_contests(contests: List[JSONDict], election: Election):
     if not any(contest["isTargeted"] for contest in contests):
         raise BadRequest("Must have at least one targeted contest")
 
-    if election.audit_type == AuditType.BATCH_COMPARISON and len(contests) > 1:
-        raise BadRequest("Batch comparison audits may only have one contest.")
-
     # TODO some validation for Hybrid?
     if election.audit_type == AuditType.BALLOT_POLLING:
         for contest in contests:

--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -518,6 +518,10 @@ def batch_round_status(election: Election, round: Round) -> Dict[str, JSONDict]:
         )
     )
     contests = list(election.contests)
+
+    # If a batch has a discrepancy in multiple contests, the discrepancy count will be incremented
+    # multiple times. In other words, the discrepancy count represents the number of batch-contest
+    # pairs with discrepancies, not the number of batches with discrepancies.
     for contest in contests:
         reported_results = batch_tallies(contest)
         audited_results = sampled_batch_results(contest, include_non_rla_batches=True)

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -298,9 +298,9 @@ def calculate_risk_measurements(election: Election, round: Round):
             p_value, is_complete = macro.compute_risk(
                 election.risk_limit,
                 sampler_contest.from_db_contest(contest),
-                batch_tallies(election),
-                sampled_batch_results(election),
-                sampled_batches_by_ticket_number(election),
+                batch_tallies(contest),
+                sampled_batch_results(contest),
+                sampled_batches_by_ticket_number(contest),
             )
         elif election.audit_type == AuditType.BALLOT_COMPARISON:
             p_value, is_complete = supersimple.compute_risk(

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -148,8 +148,8 @@ def sample_size_options(election: Election) -> Dict[str, Dict[str, SampleSizeOpt
             sample_size = macro.get_sample_sizes(
                 election.risk_limit,
                 sampler_contest.from_db_contest(contest),
-                rounds.batch_tallies(election),
-                rounds.sampled_batch_results(election),
+                rounds.batch_tallies(contest),
+                rounds.sampled_batch_results(contest),
             )
             return {"macro": {"key": "macro", "size": sample_size, "prob": None}}
 

--- a/server/api/shared.py
+++ b/server/api/shared.py
@@ -695,11 +695,13 @@ def compute_sample_batches(
     round_num: int,
     contest_sample_sizes: List[Tuple[Contest, SampleSize]],
 ) -> List[BatchDraw]:
-    sample_batches: List[BatchDraw] = []
-    for contest, sample_size in contest_sample_sizes:
-        sample_batches += compute_sample_batches_for_contest(
+    sample_batches = [
+        batch
+        for contest, sample_size in contest_sample_sizes
+        for batch in compute_sample_batches_for_contest(
             election, round_num, contest, sample_size
         )
+    ]
     return sample_batches
 
 

--- a/server/api/shared.py
+++ b/server/api/shared.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import random
 from typing import Dict, List, Optional, Tuple, TypedDict, Union
-from sqlalchemy import and_, func, literal, or_
+from sqlalchemy import and_, func, literal, true
 from sqlalchemy.orm import joinedload
 
 
@@ -104,13 +104,12 @@ def sampled_batch_results(
                 # Don't include non-RLA batches unless explicitly requested, e.g., for discrepancy
                 # and audit reports
                 .filter(
-                    or_(
-                        and_(
-                            SampledBatchDraw.contest_id == contest.id,
-                            SampledBatchDraw.ticket_number != EXTRA_TICKET_NUMBER,
-                        ),
-                        include_non_rla_batches,
-                    )
+                    true()
+                    if include_non_rla_batches
+                    else and_(
+                        SampledBatchDraw.contest_id == contest.id,
+                        SampledBatchDraw.ticket_number != EXTRA_TICKET_NUMBER,
+                    ),
                 )
                 .values(Batch.id)
             )

--- a/server/tests/batch_comparison/conftest.py
+++ b/server/tests/batch_comparison/conftest.py
@@ -55,7 +55,7 @@ def contest_ids(client: FlaskClient, election_id: str, jurisdiction_ids: List[st
     return [str(c["id"]) for c in contests]
 
 
-# We only support one contest for now, so this is a convenience fixture
+# A convenience fixture for when there's only one contets
 @pytest.fixture
 def contest_id(contest_ids: List[str]) -> str:
     return contest_ids[0]
@@ -155,7 +155,7 @@ def round_1_id(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
-    contest_id: str,
+    contest_ids,  # pylint: disable=unused-argument
     election_settings,  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
     batch_tallies,  # pylint: disable=unused-argument
@@ -164,12 +164,17 @@ def round_1_id(
     rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     sample_size_options = json.loads(rv.data)["sampleSizes"]
-    sample_size = sample_size_options[contest_id][0]
 
     rv = post_json(
         client,
         f"/api/election/{election_id}/round",
-        {"roundNum": 1, "sampleSizes": {contest_id: sample_size}},
+        {
+            "roundNum": 1,
+            "sampleSizes": {
+                contest_id: sample_size_options_for_contest[0]
+                for contest_id, sample_size_options_for_contest in sample_size_options.items()
+            },
+        },
     )
     assert_ok(rv)
 

--- a/server/tests/batch_comparison/conftest.py
+++ b/server/tests/batch_comparison/conftest.py
@@ -55,7 +55,7 @@ def contest_ids(client: FlaskClient, election_id: str, jurisdiction_ids: List[st
     return [str(c["id"]) for c in contests]
 
 
-# A convenience fixture for when there's only one contets
+# A convenience fixture for when there's only one contest
 @pytest.fixture
 def contest_id(contest_ids: List[str]) -> str:
     return contest_ids[0]

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -44,7 +44,7 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 1,Contest 1,Targeted,7,Yes,0.0825517715,DATETIME,DATETIME,candidate 1: 1700; candidate 2: 850; candidate 3: 850\r
 \r
 ######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Change in Results,Change in Margin,Last Edited By\r
+Jurisdiction Name,Batch Name,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By\r
 J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 3,Round 1: 0.753710009967479876,Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,jurisdiction.admin-UUID@example.com\r
@@ -114,7 +114,7 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 2,Contest 1,Targeted,5,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0\r
 \r
 ######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Change in Results,Change in Margin,Last Edited By\r
+Jurisdiction Name,Batch Name,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By\r
 J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 3,"Round 1: 0.753710009967479876, Round 2: 0.816608705419077476",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
@@ -127,7 +127,7 @@ J2,Batch 4,"Round 2: 0.608147659546583410, 0.868820918994249069",No,,candidate 1
 snapshots[
     "test_batch_comparison_round_2 13"
 ] = """######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Change in Results,Change in Margin,Last Edited By\r
+Jurisdiction Name,Batch Name,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By\r
 J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 3,"Round 1: 0.753710009967479876, Round 2: 0.816608705419077476",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r

--- a/server/tests/batch_comparison/snapshots/snap_test_batches.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batches.py
@@ -30,7 +30,7 @@ Batch 10,,
 snapshots[
     "test_batches_human_sort_order 2"
 ] = """######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Change in Results,Change in Margin,Last Edited By\r
+Jurisdiction Name,Batch Name,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By\r
 J1,Batch 1,Round 1: 0.720194360819624066,No,,,,,\r
 J1,Batch 1 - 1,Round 1: 0.9610467367288398089,No,,,,,\r
 J1,Batch 1 - 2,Round 1: 0.693314966899513707,No,,,,,\r

--- a/server/tests/batch_comparison/snapshots/snap_test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_multi_contest_batch_comparison.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots[
+    "test_multi_contest_batch_comparison_end_to_end 1"
+] = """######## SAMPLED BATCHES ########\r
+Jurisdiction Name,Batch Name,Ticket Numbers: Contest 1,Ticket Numbers: Contest 2,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Results: Contest 2,Reported Results: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2,Last Edited By\r
+J1,Batch 1,,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 3,,Round 1: 0.753710009967479876,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 5,"Round 1: 0.384177151866437890, 0.470460412141498108","Round 1: 0.384177151866437890, 0.470460412141498108",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 6,"Round 1: 0.899217854763070950, 0.9233199163410086672",,Yes,Candidate 1: 49; Candidate 2: 1,Candidate 1: 50; Candidate 2: 0,Candidate 1: +1; Candidate 2: -1,2,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 7,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 49; Candidate 4: 1,Candidate 3: 50; Candidate 4: 0,Candidate 3: +1; Candidate 4: -1,2,jurisdiction.admin-UUID@example.com\r
+J1,Batch 9,,Round 1: 0.734926612730309894,Yes,Candidate 1: 52; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,Candidate 1: -2,-2,Candidate 3: 26; Candidate 4: 24,Candidate 3: 25; Candidate 4: 25,Candidate 3: -1; Candidate 4: +1,-2,jurisdiction.admin-UUID@example.com\r
+"""
+
+snapshots[
+    "test_multi_contest_batch_comparison_end_to_end 2"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+Test Org test_multi_contest_batch_comparison_end_to_end,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
+Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250\r
+Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_multi_contest_batch_comparison_end_to_end,BATCH_COMPARISON,MACRO,10%,1234567890,No\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
+1,Contest 1,Targeted,10,No,,DATETIME,,Candidate 1: 0; Candidate 2: 0\r
+1,Contest 2,Targeted,8,No,,DATETIME,,Candidate 3: 0; Candidate 4: 0\r
+\r
+######## SAMPLED BATCHES ########\r
+Jurisdiction Name,Batch Name,Ticket Numbers: Contest 1,Ticket Numbers: Contest 2,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Results: Contest 2,Reported Results: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2,Last Edited By\r
+J1,Batch 1,,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 3,,Round 1: 0.753710009967479876,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 5,"Round 1: 0.384177151866437890, 0.470460412141498108","Round 1: 0.384177151866437890, 0.470460412141498108",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 6,"Round 1: 0.899217854763070950, 0.9233199163410086672",,Yes,Candidate 1: 49; Candidate 2: 1,Candidate 1: 50; Candidate 2: 0,Candidate 1: +1; Candidate 2: -1,2,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 7,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 49; Candidate 4: 1,Candidate 3: 50; Candidate 4: 0,Candidate 3: +1; Candidate 4: -1,2,jurisdiction.admin-UUID@example.com\r
+J1,Batch 9,,Round 1: 0.734926612730309894,Yes,Candidate 1: 52; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,Candidate 1: -2,-2,Candidate 3: 26; Candidate 4: 24,Candidate 3: 25; Candidate 4: 25,Candidate 3: -1; Candidate 4: +1,-2,jurisdiction.admin-UUID@example.com\r
+J2,Batch 1,"Round 1: 0.562697240648997100, 0.9008218268717084008",,No,,,,,,,,,\r
+J3,Batch 1,Round 1: 0.544165663445275136,,No,,,,,,,,,\r
+"""
+
+snapshots[
+    "test_multi_contest_batch_comparison_end_to_end 3"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+Test Org test_multi_contest_batch_comparison_end_to_end,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
+Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250\r
+Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_multi_contest_batch_comparison_end_to_end,BATCH_COMPARISON,MACRO,10%,1234567890,No\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
+1,Contest 1,Targeted,10,Yes,0.0771277137,DATETIME,DATETIME,Candidate 1: 500; Candidate 2: 52\r
+1,Contest 2,Targeted,8,Yes,0.096146459,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25\r
+\r
+######## SAMPLED BATCHES ########\r
+Jurisdiction Name,Batch Name,Ticket Numbers: Contest 1,Ticket Numbers: Contest 2,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Results: Contest 2,Reported Results: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2,Last Edited By\r
+J1,Batch 1,,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 3,,Round 1: 0.753710009967479876,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 5,"Round 1: 0.384177151866437890, 0.470460412141498108","Round 1: 0.384177151866437890, 0.470460412141498108",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 6,"Round 1: 0.899217854763070950, 0.9233199163410086672",,Yes,Candidate 1: 49; Candidate 2: 1,Candidate 1: 50; Candidate 2: 0,Candidate 1: +1; Candidate 2: -1,2,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 7,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 49; Candidate 4: 1,Candidate 3: 50; Candidate 4: 0,Candidate 3: +1; Candidate 4: -1,2,jurisdiction.admin-UUID@example.com\r
+J1,Batch 9,,Round 1: 0.734926612730309894,Yes,Candidate 1: 52; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,Candidate 1: -2,-2,Candidate 3: 26; Candidate 4: 24,Candidate 3: 25; Candidate 4: 25,Candidate 3: -1; Candidate 4: +1,-2,jurisdiction.admin-UUID@example.com\r
+J2,Batch 1,"Round 1: 0.562697240648997100, 0.9008218268717084008",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
+J3,Batch 1,Round 1: 0.544165663445275136,,Yes,Candidate 1: 74; Candidate 2: 26,Candidate 1: 75; Candidate 2: 25,Candidate 1: +1; Candidate 2: -1,2,,,,,jurisdiction.admin-UUID@example.com\r
+"""
+
+snapshots[
+    "test_multi_contest_batch_comparison_round_2 1"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+Test Org test_multi_contest_batch_comparison_round_2,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
+Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250\r
+Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_multi_contest_batch_comparison_round_2,BATCH_COMPARISON,MACRO,10%,1234567890,No\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
+1,Contest 1,Targeted,10,No,0.1689405441,DATETIME,DATETIME,Candidate 1: 450; Candidate 2: 100\r
+1,Contest 2,Targeted,8,Yes,0.0948645062,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25\r
+\r
+######## SAMPLED BATCHES ########\r
+Jurisdiction Name,Batch Name,Ticket Numbers: Contest 1,Ticket Numbers: Contest 2,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Results: Contest 2,Reported Results: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2,Last Edited By\r
+J1,Batch 1,,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 3,,Round 1: 0.753710009967479876,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 5,"Round 1: 0.384177151866437890, 0.470460412141498108","Round 1: 0.384177151866437890, 0.470460412141498108",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 6,"Round 1: 0.899217854763070950, 0.9233199163410086672",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 7,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 0; Candidate 2: 50,Candidate 1: 50; Candidate 2: 0,Candidate 1: +50; Candidate 2: -50,100,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 9,,Round 1: 0.734926612730309894,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 25; Candidate 4: 25,Candidate 3: 25; Candidate 4: 25,,,jurisdiction.admin-UUID@example.com\r
+J2,Batch 1,"Round 1: 0.562697240648997100, 0.9008218268717084008",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
+J3,Batch 1,Round 1: 0.544165663445275136,,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
+"""
+
+snapshots[
+    "test_multi_contest_batch_comparison_round_2 2"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+Test Org test_multi_contest_batch_comparison_round_2,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
+Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250\r
+Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_multi_contest_batch_comparison_round_2,BATCH_COMPARISON,MACRO,10%,1234567890,No\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
+1,Contest 1,Targeted,10,No,0.1689405441,DATETIME,DATETIME,Candidate 1: 450; Candidate 2: 100\r
+1,Contest 2,Targeted,8,Yes,0.0948645062,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25\r
+2,Contest 1,Targeted,6,No,,DATETIME,,Candidate 1: 0; Candidate 2: 0\r
+\r
+######## SAMPLED BATCHES ########\r
+Jurisdiction Name,Batch Name,Ticket Numbers: Contest 1,Ticket Numbers: Contest 2,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Results: Contest 2,Reported Results: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2,Last Edited By\r
+J1,Batch 1,Round 2: 0.720194360819624066,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 3,Round 2: 0.753710009967479876,Round 1: 0.753710009967479876,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 5,"Round 1: 0.384177151866437890, 0.470460412141498108","Round 1: 0.384177151866437890, 0.470460412141498108",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 6,"Round 1: 0.899217854763070950, 0.9233199163410086672, Round 2: 0.9773691435537901980",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 7,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 0; Candidate 2: 50,Candidate 1: 50; Candidate 2: 0,Candidate 1: +50; Candidate 2: -50,100,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 9,,Round 1: 0.734926612730309894,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 25; Candidate 4: 25,Candidate 3: 25; Candidate 4: 25,,,jurisdiction.admin-UUID@example.com\r
+J2,Batch 1,"Round 1: 0.562697240648997100, 0.9008218268717084008, Round 2: 0.9809620734120025512",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
+J3,Batch 1,"Round 1: 0.544165663445275136, Round 2: 0.651158228740912018",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 8,Round 2: 0.9723790677174592551,,No,,Candidate 1: 50; Candidate 2: 0,,,,Candidate 3: 50; Candidate 4: 0,,,\r
+"""
+
+snapshots[
+    "test_multi_contest_batch_comparison_round_2 3"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+Test Org test_multi_contest_batch_comparison_round_2,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
+Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250\r
+Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_multi_contest_batch_comparison_round_2,BATCH_COMPARISON,MACRO,10%,1234567890,No\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes\r
+1,Contest 1,Targeted,10,No,0.1689405441,DATETIME,DATETIME,Candidate 1: 450; Candidate 2: 100\r
+1,Contest 2,Targeted,8,Yes,0.0948645062,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25\r
+2,Contest 1,Targeted,6,Yes,0.0750846863,DATETIME,DATETIME,Candidate 1: 350; Candidate 2: 50\r
+\r
+######## SAMPLED BATCHES ########\r
+Jurisdiction Name,Batch Name,Ticket Numbers: Contest 1,Ticket Numbers: Contest 2,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Results: Contest 2,Reported Results: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2,Last Edited By\r
+J1,Batch 1,Round 2: 0.720194360819624066,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 2,"Round 1: 0.474971525750860236, 0.555845039101209884",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 3,Round 2: 0.753710009967479876,Round 1: 0.753710009967479876,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 5,"Round 1: 0.384177151866437890, 0.470460412141498108","Round 1: 0.384177151866437890, 0.470460412141498108",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 6,"Round 1: 0.899217854763070950, 0.9233199163410086672, Round 2: 0.9773691435537901980",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 7,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 0; Candidate 2: 50,Candidate 1: 50; Candidate 2: 0,Candidate 1: +50; Candidate 2: -50,100,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 9,,Round 1: 0.734926612730309894,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 25; Candidate 4: 25,Candidate 3: 25; Candidate 4: 25,,,jurisdiction.admin-UUID@example.com\r
+J2,Batch 1,"Round 1: 0.562697240648997100, 0.9008218268717084008, Round 2: 0.9809620734120025512",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
+J3,Batch 1,"Round 1: 0.544165663445275136, Round 2: 0.651158228740912018",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 8,Round 2: 0.9723790677174592551,,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+"""

--- a/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
@@ -26,7 +26,7 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 1,Contest 1,Targeted,7,No,0.1225641097,DATETIME,DATETIME,candidate 1: 1100; candidate 2: 300; candidate 3: 200\r
 \r
 ######## SAMPLED BATCHES ########\r
-Jurisdiction Name,Batch Name,Ticket Numbers,Audited?,Audit Results,Reported Results,Change in Results,Change in Margin,Last Edited By\r
+Jurisdiction Name,Batch Name,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By\r
 J1,Batch 1,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 3,Round 1: 0.753710009967479876,Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -34,52 +34,9 @@ def check_discrepancies(
                 and row["Batch Name"] == batch_name
             )
             assert (
-                parse_vote_deltas(row["Change in Results"], choices)
+                parse_vote_deltas(row["Change in Results: Contest 1"], choices)
                 == batch_discrepancies
             ), f"Discrepancy mismatch for {(jurisdiction_name, batch_name)}"
-
-
-def test_batch_comparison_only_one_contest_allowed(
-    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
-):
-    contests = [
-        {
-            "id": str(uuid.uuid4()),
-            "name": "Contest 1",
-            "isTargeted": True,
-            "choices": [
-                {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 6000},
-                {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 3500},
-                {"id": str(uuid.uuid4()), "name": "candidate 3", "numVotes": 3500},
-            ],
-            "numWinners": 1,
-            "votesAllowed": 2,
-            "jurisdictionIds": jurisdiction_ids[:2],
-        },
-        {
-            "id": str(uuid.uuid4()),
-            "name": "Contest 2",
-            "isTargeted": False,
-            "choices": [
-                {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 6000},
-                {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 3500},
-                {"id": str(uuid.uuid4()), "name": "candidate 3", "numVotes": 3500},
-            ],
-            "numWinners": 1,
-            "votesAllowed": 2,
-            "jurisdictionIds": jurisdiction_ids[:2],
-        },
-    ]
-    rv = put_json(client, f"/api/election/{election_id}/contest", contests)
-    assert rv.status_code == 400
-    assert json.loads(rv.data) == {
-        "errors": [
-            {
-                "errorType": "Bad Request",
-                "message": "Batch comparison audits may only have one contest.",
-            }
-        ]
-    }
 
 
 def test_batch_comparison_sample_size(
@@ -376,10 +333,10 @@ def test_batch_comparison_round_2(
     for row in csv.DictReader(io.StringIO(discrepancy_report)):
         if row["Jurisdiction Name"] == "J2":
             assert row["Audited?"] == "No"
-            assert row["Audit Results"] == ""
-            assert row["Reported Results"] == ""
-            assert row["Change in Results"] == ""
-            assert row["Change in Margin"] == ""
+            assert row["Audit Results: Contest 1"] == ""
+            assert row["Reported Results: Contest 1"] == ""
+            assert row["Change in Results: Contest 1"] == ""
+            assert row["Change in Margin: Contest 1"] == ""
 
     # Finalize the results
     set_logged_in_user(

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -471,7 +471,7 @@ def test_batch_tallies_too_many_tallies(
                 "status": ProcessingStatus.ERRORED,
                 "startedAt": assert_is_date,
                 "completedAt": assert_is_date,
-                "error": 'The total votes for batch "Batch 1" (410 votes) cannot exceed 400 - the number of ballots from the manifest (200 ballots) multiplied by the number of votes allowed for the contest "Contest 1" (2 votes per ballot).',
+                "error": 'The total votes for contest "Contest 1" in batch "Batch 1" (410 votes) cannot exceed 400 - the number of ballots from the manifest (200 ballots) multiplied by the number of votes allowed for the contest (2 votes per ballot).',
             },
         },
     )

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -471,7 +471,7 @@ def test_batch_tallies_too_many_tallies(
                 "status": ProcessingStatus.ERRORED,
                 "startedAt": assert_is_date,
                 "completedAt": assert_is_date,
-                "error": 'The total votes for batch "Batch 1" (410 votes) cannot exceed 400 - the number of ballots from the manifest (200 ballots) multiplied by the number of votes allowed for the contest (2 votes per ballot).',
+                "error": 'The total votes for batch "Batch 1" (410 votes) cannot exceed 400 - the number of ballots from the manifest (200 ballots) multiplied by the number of votes allowed for the contest "Contest 1" (2 votes per ballot).',
             },
         },
     )

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -471,7 +471,7 @@ def test_batch_tallies_too_many_tallies(
                 "status": ProcessingStatus.ERRORED,
                 "startedAt": assert_is_date,
                 "completedAt": assert_is_date,
-                "error": 'The total votes for batch "Batch 1" (410 votes) cannot exceed 400 - the number of ballots from the manifest (200 ballots) multipled by the number of votes allowed for the contest (2 votes per ballot).',
+                "error": 'The total votes for batch "Batch 1" (410 votes) cannot exceed 400 - the number of ballots from the manifest (200 ballots) multiplied by the number of votes allowed for the contest (2 votes per ballot).',
             },
         },
     )

--- a/server/tests/batch_comparison/test_batches.py
+++ b/server/tests/batch_comparison/test_batches.py
@@ -432,7 +432,7 @@ def test_record_batch_results_invalid(
     invalid_results = [
         ({}, "{} is not of type 'array'"),
         ([{"name": "Tally Sheet #1", "results": None}], "None is not of type 'object'"),
-        ([{"name": "Tally Sheet #1", "results": {}}], "Invalid choice ids"),
+        ([{"name": "Tally Sheet #1", "results": {}}], "Missing choice ids"),
         (
             [{"name": "Tally Sheet #1", "results": {"not-a-real-id": 0}}],
             "Invalid choice ids",
@@ -444,7 +444,7 @@ def test_record_batch_results_invalid(
                     "results": {choice_id: 0 for choice_id in choice_ids[:1]},
                 }
             ],
-            "Invalid choice ids",
+            "Missing choice ids",
         ),
         (
             [
@@ -471,7 +471,7 @@ def test_record_batch_results_invalid(
                     "results": {choice_id: 400 for choice_id in choice_ids},
                 }
             ],
-            "Total votes for batch Batch 1 should not exceed 1000 - the number of ballots in the batch (500) times the number of votes allowed (2).",
+            "Total votes for batch Batch 1 contest Contest 1 should not exceed 1000 - the number of ballots in the batch (500) times the number of votes allowed (2).",
         ),
         (
             [
@@ -484,7 +484,7 @@ def test_record_batch_results_invalid(
                     "results": {choice_id: 300 for choice_id in choice_ids},
                 },
             ],
-            "Total votes for batch Batch 1 should not exceed 1000 - the number of ballots in the batch (500) times the number of votes allowed (2).",
+            "Total votes for batch Batch 1 contest Contest 1 should not exceed 1000 - the number of ballots in the batch (500) times the number of votes allowed (2).",
         ),
         (
             [

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -82,7 +82,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 
 VALID_BATCH_TALLIES = [
     # Jurisdiction 1
-    b"Batch Name,Candidate 1,Candidate 2,Candidate 3,Candidate 4\n"
+    b"Batch Name,Contest 1 - Candidate 1,Contest 1 - Candidate 2,Contest 2 - Candidate 3,Contest 2 - Candidate 4\n"
     b"Batch 1,50,0,50,0\n"
     b"Batch 2,50,0,50,0\n"
     b"Batch 3,50,0,50,0\n"
@@ -94,13 +94,13 @@ VALID_BATCH_TALLIES = [
     b"Batch 9,50,0,25,25\n"
     b"Batch 10,0,50,25,25\n",
     # Jurisdiction 2
-    b"Batch Name,Candidate 1,Candidate 2\n"
+    b"Batch Name,Contest 1 - Candidate 1,Contest 1 - Candidate 2\n"
     b"Batch 1,75,25\n"
     b"Batch 2,25,25\n"
     b"Batch 3,25,25\n"
     b"Batch 4,25,25\n",
     # Jurisdiction 3
-    b"Batch Name,Candidate 1,Candidate 2\n"
+    b"Batch Name,Contest 1 - Candidate 1,Contest 1 - Candidate 2\n"
     b"Batch 1,75,25\n"
     b"Batch 2,25,25\n"
     b"Batch 3,25,25\n"
@@ -165,40 +165,48 @@ def test_multi_contest_batch_comparison_jurisdiction_upload_validation(
         (
             jurisdiction_ids[0],
             # Missing contest 2 columns for jurisdiction with both contests
-            io.BytesIO(b"Batch Name,Candidate 1,Candidate 2\n"),
-            "Missing required columns: Candidate 3, Candidate 4.",
+            io.BytesIO(b"Batch Name,Contest 1 - Candidate 1,Contest 1 - Candidate 2\n"),
+            "Missing required columns: Contest 2 - Candidate 3, Contest 2 - Candidate 4.",
         ),
         (
             jurisdiction_ids[0],
             # Missing contest 1 columns for jurisdiction with both contests
-            io.BytesIO(b"Batch Name,Candidate 3,Candidate 4\n"),
-            "Missing required columns: Candidate 1, Candidate 2.",
+            io.BytesIO(b"Batch Name,Contest 2 - Candidate 3,Contest 2 - Candidate 4\n"),
+            "Missing required columns: Contest 1 - Candidate 1, Contest 1 - Candidate 2.",
         ),
         (
             jurisdiction_ids[0],
             # Extra column
             io.BytesIO(
-                b"Batch Name,Candidate 1,Candidate 2,Candidate 3,Candidate 4,Candidate 5\n"
+                b"Batch Name,Contest 1 - Candidate 1,Contest 1 - Candidate 2,Contest 2 - Candidate 3,Contest 2 - Candidate 4,Contest 2 - Candidate 5\n"
             ),
-            "Found unexpected columns. Allowed columns: Batch Name, Candidate 1, Candidate 2, Candidate 3, Candidate 4.",
+            "Found unexpected columns. Allowed columns: Batch Name, Contest 1 - Candidate 1, Contest 1 - Candidate 2, Contest 2 - Candidate 3, Contest 2 - Candidate 4.",
+        ),
+        (
+            jurisdiction_ids[0],
+            # Missing contest name in contest choice CSV headers
+            io.BytesIO(b"Batch Name,Candidate 1,Candidate 2,Candidate 3,Candidate 4\n"),
+            "Missing required columns: Contest 1 - Candidate 1, Contest 1 - Candidate 2, Contest 2 - Candidate 3, Contest 2 - Candidate 4.",
         ),
         (
             jurisdiction_ids[1],
             # Missing contest 1 column for jurisdiction with only contest 1
-            io.BytesIO(b"Batch Name,Candidate 1\n"),
-            "Missing required column: Candidate 2.",
+            io.BytesIO(b"Batch Name,Contest 1 - Candidate 1\n"),
+            "Missing required column: Contest 1 - Candidate 2.",
         ),
         (
             jurisdiction_ids[1],
             # Including contest 2 columns for jurisdiction with only contest 1
-            io.BytesIO(b"Batch Name,Candidate 1,Candidate 2,Candidate 3,Candidate 4\n"),
-            "Found unexpected columns. Allowed columns: Batch Name, Candidate 1, Candidate 2.",
+            io.BytesIO(
+                b"Batch Name,Contest 1 - Candidate 1,Contest 1 - Candidate 2,Contest 2 - Candidate 3,Contest 2 - Candidate 4\n"
+            ),
+            "Found unexpected columns. Allowed columns: Batch Name, Contest 1 - Candidate 1, Contest 1 - Candidate 2.",
         ),
         (
             jurisdiction_ids[0],
             # Too many votes for contest 1
             io.BytesIO(
-                b"Batch Name,Candidate 1,Candidate 2,Candidate 3,Candidate 4\n"
+                b"Batch Name,Contest 1 - Candidate 1,Contest 1 - Candidate 2,Contest 2 - Candidate 3,Contest 2 - Candidate 4\n"
                 b"Batch 1,100,1,0,0\n"
                 b"Batch 2,0,0,0,0\n"
                 b"Batch 3,0,0,0,0\n"
@@ -218,7 +226,7 @@ def test_multi_contest_batch_comparison_jurisdiction_upload_validation(
             jurisdiction_ids[0],
             # Too many votes for contest 2
             io.BytesIO(
-                b"Batch Name,Candidate 1,Candidate 2,Candidate 3,Candidate 4\n"
+                b"Batch Name,Contest 1 - Candidate 1,Contest 1 - Candidate 2,Contest 2 - Candidate 3,Contest 2 - Candidate 4\n"
                 b"Batch 1,0,0,200,1\n"
                 b"Batch 2,0,0,0,0\n"
                 b"Batch 3,0,0,0,0\n"

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -218,9 +218,9 @@ def test_multi_contest_batch_comparison_jurisdiction_upload_validation(
                 b"Batch 9,0,0,0,0\n"
                 b"Batch 10,0,0,0,0\n"
             ),
-            'The total votes for batch "Batch 1" (101 votes) cannot exceed 100 - '
+            'The total votes for contest "Contest 1" in batch "Batch 1" (101 votes) cannot exceed 100 - '
             "the number of ballots from the manifest (100 ballots) "
-            'multiplied by the number of votes allowed for the contest "Contest 1" (1 vote per ballot).',
+            "multiplied by the number of votes allowed for the contest (1 vote per ballot).",
         ),
         (
             jurisdiction_ids[0],
@@ -238,9 +238,9 @@ def test_multi_contest_batch_comparison_jurisdiction_upload_validation(
                 b"Batch 9,0,0,0,0\n"
                 b"Batch 10,0,0,0,0\n"
             ),
-            'The total votes for batch "Batch 1" (201 votes) cannot exceed 200 - '
+            'The total votes for contest "Contest 2" in batch "Batch 1" (201 votes) cannot exceed 200 - '
             "the number of ballots from the manifest (100 ballots) "
-            'multiplied by the number of votes allowed for the contest "Contest 2" (2 votes per ballot).',
+            "multiplied by the number of votes allowed for the contest (2 votes per ballot).",
         ),
     ]
 

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -220,7 +220,7 @@ def test_multi_contest_batch_comparison_jurisdiction_upload_validation(
             ),
             'The total votes for batch "Batch 1" (101 votes) cannot exceed 100 - '
             "the number of ballots from the manifest (100 ballots) "
-            "multiplied by the number of votes allowed for the contest (1 vote per ballot).",
+            'multiplied by the number of votes allowed for the contest "Contest 1" (1 vote per ballot).',
         ),
         (
             jurisdiction_ids[0],
@@ -240,7 +240,7 @@ def test_multi_contest_batch_comparison_jurisdiction_upload_validation(
             ),
             'The total votes for batch "Batch 1" (201 votes) cannot exceed 200 - '
             "the number of ballots from the manifest (100 ballots) "
-            "multiplied by the number of votes allowed for the contest (2 votes per ballot).",
+            'multiplied by the number of votes allowed for the contest "Contest 2" (2 votes per ballot).',
         ),
     ]
 

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -1,0 +1,1003 @@
+from typing import Dict, List
+import pytest
+from flask.testing import FlaskClient
+
+from ...models import *  # pylint: disable=wildcard-import
+from ..helpers import *  # pylint: disable=wildcard-import
+
+
+@pytest.fixture
+def contest_ids(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    contests = [
+        {
+            "id": str(uuid.uuid4()),
+            "name": "Contest 1",
+            "isTargeted": True,
+            "choices": [
+                {"id": str(uuid.uuid4()), "name": "Candidate 1", "numVotes": 750},
+                {"id": str(uuid.uuid4()), "name": "Candidate 2", "numVotes": 250},
+            ],
+            "numWinners": 1,
+            "votesAllowed": 1,
+            "jurisdictionIds": jurisdiction_ids,
+        },
+        {
+            "id": str(uuid.uuid4()),
+            "name": "Contest 2",
+            "isTargeted": True,
+            "choices": [
+                {"id": str(uuid.uuid4()), "name": "Candidate 3", "numVotes": 450},
+                {"id": str(uuid.uuid4()), "name": "Candidate 4", "numVotes": 50},
+            ],
+            "numWinners": 1,
+            "votesAllowed": 2,
+            "jurisdictionIds": [jurisdiction_ids[0]],
+        },
+    ]
+    rv = put_json(client, f"/api/election/{election_id}/contest", contests)
+    assert_ok(rv)
+    return [str(c["id"]) for c in contests]
+
+
+@pytest.fixture
+def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    manifests_by_jurisdiction = {
+        jurisdiction_ids[0]: io.BytesIO(
+            b"Batch Name,Number of Ballots\n"
+            b"Batch 1,100\n"
+            b"Batch 2,100\n"
+            b"Batch 3,100\n"
+            b"Batch 4,100\n"
+            b"Batch 5,100\n"
+            b"Batch 6,100\n"
+            b"Batch 7,100\n"
+            b"Batch 8,100\n"
+            b"Batch 9,100\n"
+            b"Batch 10,100\n"
+        ),
+        jurisdiction_ids[1]: io.BytesIO(
+            b"Batch Name,Number of Ballots\n"
+            b"Batch 1,100\n"
+            b"Batch 2,50\n"
+            b"Batch 3,50\n"
+            b"Batch 4,50\n"
+        ),
+        jurisdiction_ids[2]: io.BytesIO(
+            b"Batch Name,Number of Ballots\n"
+            b"Batch 1,100\n"
+            b"Batch 2,50\n"
+            b"Batch 3,50\n"
+            b"Batch 4,50\n"
+        ),
+    }
+    for jurisdiction_id, manifest in manifests_by_jurisdiction.items():
+        rv = client.put(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/ballot-manifest",
+            data={"manifest": (manifest, "manifest.csv",)},
+        )
+        assert_ok(rv)
+
+
+VALID_BATCH_TALLIES = [
+    # Jurisdiction 1
+    b"Batch Name,Candidate 1,Candidate 2,Candidate 3,Candidate 4\n"
+    b"Batch 1,50,0,50,0\n"
+    b"Batch 2,50,0,50,0\n"
+    b"Batch 3,50,0,50,0\n"
+    b"Batch 4,50,0,50,0\n"
+    b"Batch 5,50,0,50,0\n"
+    b"Batch 6,50,0,50,0\n"
+    b"Batch 7,50,0,50,0\n"
+    b"Batch 8,50,0,50,0\n"
+    b"Batch 9,50,0,25,25\n"
+    b"Batch 10,0,50,25,25\n",
+    # Jurisdiction 2
+    b"Batch Name,Candidate 1,Candidate 2\n"
+    b"Batch 1,75,25\n"
+    b"Batch 2,25,25\n"
+    b"Batch 3,25,25\n"
+    b"Batch 4,25,25\n",
+    # Jurisdiction 3
+    b"Batch Name,Candidate 1,Candidate 2\n"
+    b"Batch 1,75,25\n"
+    b"Batch 2,25,25\n"
+    b"Batch 3,25,25\n"
+    b"Batch 4,25,25\n",
+]
+
+
+@pytest.fixture
+def batch_tallies(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_ids,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    batch_tallies_by_jurisdiction = {
+        jurisdiction_ids[0]: io.BytesIO(VALID_BATCH_TALLIES[0]),
+        jurisdiction_ids[1]: io.BytesIO(VALID_BATCH_TALLIES[1]),
+        jurisdiction_ids[2]: io.BytesIO(VALID_BATCH_TALLIES[2]),
+    }
+    for (jurisdiction_id, batch_tallies_file,) in batch_tallies_by_jurisdiction.items():
+        rv = client.put(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-tallies",
+            data={"batchTallies": (batch_tallies_file, "batchTallies.csv",)},
+        )
+        assert_ok(rv)
+
+
+def put_batch_results(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_id: str,
+    round_id: str,
+    batch_id: str,
+    results: List[Dict[str, int]],
+):
+    return put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_id}/batches/{batch_id}/results",
+        [
+            {"name": f"Tally Sheet #{i}", "results": sheet_results}
+            for i, sheet_results in enumerate(results)
+        ],
+    )
+
+
+def test_multi_contest_batch_comparison_jurisdiction_upload_validation(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_ids,  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+):
+    test_cases = [
+        # Success cases
+        (jurisdiction_ids[0], io.BytesIO(VALID_BATCH_TALLIES[0]), None),
+        (jurisdiction_ids[1], io.BytesIO(VALID_BATCH_TALLIES[1]), None),
+        (jurisdiction_ids[2], io.BytesIO(VALID_BATCH_TALLIES[2]), None),
+        # Error cases
+        (
+            jurisdiction_ids[0],
+            # Missing contest 2 columns for jurisdiction with both contests
+            io.BytesIO(b"Batch Name,Candidate 1,Candidate 2\n"),
+            "Missing required columns: Candidate 3, Candidate 4.",
+        ),
+        (
+            jurisdiction_ids[0],
+            # Missing contest 1 columns for jurisdiction with both contests
+            io.BytesIO(b"Batch Name,Candidate 3,Candidate 4\n"),
+            "Missing required columns: Candidate 1, Candidate 2.",
+        ),
+        (
+            jurisdiction_ids[0],
+            # Extra column
+            io.BytesIO(
+                b"Batch Name,Candidate 1,Candidate 2,Candidate 3,Candidate 4,Candidate 5\n"
+            ),
+            "Found unexpected columns. Allowed columns: Batch Name, Candidate 1, Candidate 2, Candidate 3, Candidate 4.",
+        ),
+        (
+            jurisdiction_ids[1],
+            # Missing contest 1 column for jurisdiction with only contest 1
+            io.BytesIO(b"Batch Name,Candidate 1\n"),
+            "Missing required column: Candidate 2.",
+        ),
+        (
+            jurisdiction_ids[1],
+            # Including contest 2 columns for jurisdiction with only contest 1
+            io.BytesIO(b"Batch Name,Candidate 1,Candidate 2,Candidate 3,Candidate 4\n"),
+            "Found unexpected columns. Allowed columns: Batch Name, Candidate 1, Candidate 2.",
+        ),
+        (
+            jurisdiction_ids[0],
+            # Too many votes for contest 1
+            io.BytesIO(
+                b"Batch Name,Candidate 1,Candidate 2,Candidate 3,Candidate 4\n"
+                b"Batch 1,100,1,0,0\n"
+                b"Batch 2,0,0,0,0\n"
+                b"Batch 3,0,0,0,0\n"
+                b"Batch 4,0,0,0,0\n"
+                b"Batch 5,0,0,0,0\n"
+                b"Batch 6,0,0,0,0\n"
+                b"Batch 7,0,0,0,0\n"
+                b"Batch 8,0,0,0,0\n"
+                b"Batch 9,0,0,0,0\n"
+                b"Batch 10,0,0,0,0\n"
+            ),
+            'The total votes for batch "Batch 1" (101 votes) cannot exceed 100 - '
+            "the number of ballots from the manifest (100 ballots) "
+            "multiplied by the number of votes allowed for the contest (1 vote per ballot).",
+        ),
+        (
+            jurisdiction_ids[0],
+            # Too many votes for contest 2
+            io.BytesIO(
+                b"Batch Name,Candidate 1,Candidate 2,Candidate 3,Candidate 4\n"
+                b"Batch 1,0,0,200,1\n"
+                b"Batch 2,0,0,0,0\n"
+                b"Batch 3,0,0,0,0\n"
+                b"Batch 4,0,0,0,0\n"
+                b"Batch 5,0,0,0,0\n"
+                b"Batch 6,0,0,0,0\n"
+                b"Batch 7,0,0,0,0\n"
+                b"Batch 8,0,0,0,0\n"
+                b"Batch 9,0,0,0,0\n"
+                b"Batch 10,0,0,0,0\n"
+            ),
+            'The total votes for batch "Batch 1" (201 votes) cannot exceed 200 - '
+            "the number of ballots from the manifest (100 ballots) "
+            "multiplied by the number of votes allowed for the contest (2 votes per ballot).",
+        ),
+    ]
+
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+
+    for jurisdiction_id, batch_tallies_file, expected_error in test_cases:
+        rv = client.put(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-tallies",
+            data={"batchTallies": (batch_tallies_file, "batchTallies.csv",)},
+        )
+        assert_ok(rv)
+
+        rv = client.get(f"/api/election/{election_id}/jurisdiction")
+        assert rv.status_code == 200
+        jurisdictions = json.loads(rv.data)["jurisdictions"]
+        jurisdiction = [j for j in jurisdictions if j["id"] == jurisdiction_id][0]
+        batch_tallies_status = jurisdiction["batchTallies"]["processing"]
+
+        if expected_error is None:
+            assert batch_tallies_status["status"] == "PROCESSED"
+            assert batch_tallies_status["error"] is None
+        else:
+            assert batch_tallies_status["status"] == "ERRORED"
+            assert batch_tallies_status["error"] == expected_error
+
+
+def test_multi_contest_batch_comparison_batch_results_validation(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_ids,  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    batch_tallies,  # pylint: disable=unused-argument
+    round_1_id: str,
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/contest")
+    assert rv.status_code == 200
+    contests = json.loads(rv.data)["contests"]
+    contest_1_choice_ids = [choice["id"] for choice in contests[0]["choices"]]
+    contest_2_choice_ids = [choice["id"] for choice in contests[1]["choices"]]
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches"
+    )
+    jurisdiction_1_batches = json.loads(rv.data)["batches"]
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/batches"
+    )
+    jurisdiction_2_batches = json.loads(rv.data)["batches"]
+
+    test_cases = [
+        # Success cases
+        (
+            jurisdiction_ids[0],
+            jurisdiction_1_batches[0]["id"],
+            [
+                {
+                    contest_1_choice_ids[0]: 0,
+                    contest_1_choice_ids[1]: 0,
+                    contest_2_choice_ids[0]: 0,
+                    contest_2_choice_ids[1]: 0,
+                }
+            ],
+            None,
+        ),
+        (
+            jurisdiction_ids[1],
+            jurisdiction_1_batches[1]["id"],
+            [{contest_1_choice_ids[0]: 0, contest_1_choice_ids[1]: 0}],
+            None,
+        ),
+        (
+            jurisdiction_ids[0],
+            jurisdiction_1_batches[0]["id"],
+            [
+                # Multiple tally sheets
+                {
+                    contest_1_choice_ids[0]: 25,
+                    contest_1_choice_ids[1]: 25,
+                    contest_2_choice_ids[0]: 25,
+                    contest_2_choice_ids[1]: 25,
+                },
+                {
+                    contest_1_choice_ids[0]: 25,
+                    contest_1_choice_ids[1]: 25,
+                    contest_2_choice_ids[0]: 25,
+                    contest_2_choice_ids[1]: 25,
+                },
+            ],
+            None,
+        ),
+        # Error cases
+        (
+            jurisdiction_ids[0],
+            jurisdiction_1_batches[0]["id"],
+            [{"non-existent-choice-id": 0}],
+            "Invalid choice ids",
+        ),
+        (
+            jurisdiction_ids[0],
+            jurisdiction_1_batches[0]["id"],
+            [{contest_1_choice_ids[0]: 0}],
+            "Missing choice ids",
+        ),
+        (
+            jurisdiction_ids[1],
+            jurisdiction_2_batches[0]["id"],
+            [
+                {
+                    contest_1_choice_ids[0]: 0,
+                    contest_1_choice_ids[1]: 0,
+                    # Contest 2 not relevant for this jurisdiction
+                    contest_2_choice_ids[0]: 0,
+                    contest_2_choice_ids[1]: 0,
+                }
+            ],
+            "Invalid choice ids",
+        ),
+        (
+            jurisdiction_ids[0],
+            jurisdiction_1_batches[0]["id"],
+            [
+                {
+                    contest_1_choice_ids[0]: 100,
+                    contest_1_choice_ids[1]: 1,
+                    contest_2_choice_ids[0]: 0,
+                    contest_2_choice_ids[1]: 0,
+                }
+            ],
+            "Total votes for batch Batch 1 contest Contest 1 should not exceed 100 - "
+            "the number of ballots in the batch (100) times the number of votes allowed (1).",
+        ),
+        (
+            jurisdiction_ids[0],
+            jurisdiction_1_batches[0]["id"],
+            [
+                {
+                    contest_1_choice_ids[0]: 0,
+                    contest_1_choice_ids[1]: 0,
+                    contest_2_choice_ids[0]: 200,
+                    contest_2_choice_ids[1]: 1,
+                }
+            ],
+            "Total votes for batch Batch 1 contest Contest 2 should not exceed 200 - "
+            "the number of ballots in the batch (100) times the number of votes allowed (2).",
+        ),
+        (
+            jurisdiction_ids[0],
+            jurisdiction_1_batches[0]["id"],
+            [
+                # Multiple tally sheets
+                {
+                    contest_1_choice_ids[0]: 100,
+                    contest_1_choice_ids[1]: 0,
+                    contest_2_choice_ids[0]: 0,
+                    contest_2_choice_ids[1]: 0,
+                },
+                {
+                    contest_1_choice_ids[0]: 1,
+                    contest_1_choice_ids[1]: 0,
+                    contest_2_choice_ids[0]: 0,
+                    contest_2_choice_ids[1]: 0,
+                },
+            ],
+            "Total votes for batch Batch 1 contest Contest 1 should not exceed 100 - "
+            "the number of ballots in the batch (100) times the number of votes allowed (1).",
+        ),
+    ]
+
+    for jurisdiction_id, batch_id, batch_results, expected_error_message in test_cases:
+        rv = put_batch_results(
+            client, election_id, jurisdiction_id, round_1_id, batch_id, batch_results,
+        )
+        if expected_error_message is None:
+            assert_ok(rv)
+        else:
+            assert rv.status_code == 400
+            assert json.loads(rv.data)["errors"][0]["message"] == expected_error_message
+
+
+def test_multi_contest_batch_comparison_end_to_end(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_ids: List[str],
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    batch_tallies,  # pylint: disable=unused-argument
+    snapshot,
+):
+    #
+    # Start audit
+    #
+
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
+    assert rv.status_code == 200
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    assert len(sample_size_options) == 2
+    assert sample_size_options[contest_ids[0]][0]["size"] == 10
+    assert sample_size_options[contest_ids[1]][0]["size"] == 8
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 1,
+            "sampleSizes": {
+                contest_ids[0]: sample_size_options[contest_ids[0]][0],
+                contest_ids[1]: sample_size_options[contest_ids[1]][0],
+            },
+        },
+    )
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/round")
+    assert rv.status_code == 200
+    rounds = json.loads(rv.data)["rounds"]
+    round_1_id = rounds[0]["id"]
+
+    #
+    # Check sampled batches
+    #
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches"
+    )
+    jurisdiction_1_batches = json.loads(rv.data)["batches"]
+    assert [batch["name"] for batch in jurisdiction_1_batches] == [
+        "Batch 1",
+        "Batch 2",
+        "Batch 3",
+        "Batch 5",
+        "Batch 6",
+        "Batch 7",
+        "Batch 9",
+    ]
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/batches"
+    )
+    jurisdiction_2_batches = json.loads(rv.data)["batches"]
+    assert [batch["name"] for batch in jurisdiction_2_batches] == ["Batch 1"]
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, f"j3-{election_id}@example.com"
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[2]}/round/{round_1_id}/batches"
+    )
+    jurisdiction_3_batches = json.loads(rv.data)["batches"]
+    assert [batch["name"] for batch in jurisdiction_3_batches] == ["Batch 1"]
+
+    # Since batches can be drawn multiple times, count the underlying batch draws rather than the
+    # batches returned above
+    for contest_index in [0, 1]:
+        batch_draws = SampledBatchDraw.query.filter_by(
+            round_id=round_1_id, contest_id=contest_ids[contest_index]
+        ).all()
+        expected_num_batch_draws = sample_size_options[contest_ids[contest_index]][0][
+            "size"
+        ]
+        assert len(batch_draws) == expected_num_batch_draws
+
+    #
+    # Enter batch results
+    #
+
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/contest")
+    assert rv.status_code == 200
+    contests = json.loads(rv.data)["contests"]
+    contest_1_choice_ids = [choice["id"] for choice in contests[0]["choices"]]
+    contest_2_choice_ids = [choice["id"] for choice in contests[1]["choices"]]
+
+    # Enter jurisdiction 1 batch results
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    reported_results_for_batches_1_through_8 = {
+        contest_1_choice_ids[0]: 50,
+        contest_1_choice_ids[1]: 0,
+        contest_2_choice_ids[0]: 50,
+        contest_2_choice_ids[1]: 0,
+    }
+    jurisdiction_1_batch_results = {
+        # Batch 1 (with no discrepancies)
+        jurisdiction_1_batches[0]["id"]: [reported_results_for_batches_1_through_8],
+        # Batch 2 (with no discrepancies)
+        jurisdiction_1_batches[1]["id"]: [reported_results_for_batches_1_through_8],
+        # Batch 3 (with no discrepancies)
+        jurisdiction_1_batches[2]["id"]: [reported_results_for_batches_1_through_8],
+        # Batch 5 (with no discrepancies)
+        jurisdiction_1_batches[3]["id"]: [
+            # Multiple tally sheets
+            {
+                contest_1_choice_ids[0]: 25,
+                contest_1_choice_ids[1]: 0,
+                contest_2_choice_ids[0]: 25,
+                contest_2_choice_ids[1]: 0,
+            },
+            {
+                contest_1_choice_ids[0]: 25,
+                contest_1_choice_ids[1]: 0,
+                contest_2_choice_ids[0]: 25,
+                contest_2_choice_ids[1]: 0,
+            },
+        ],
+        # Batch 6 (with contest 1 discrepancy)
+        jurisdiction_1_batches[4]["id"]: [
+            {
+                contest_1_choice_ids[0]: 49,
+                contest_1_choice_ids[1]: 1,
+                contest_2_choice_ids[0]: 50,
+                contest_2_choice_ids[1]: 0,
+            }
+        ],
+        # Batch 7 (with contest 2 discrepancy)
+        jurisdiction_1_batches[5]["id"]: [
+            {
+                contest_1_choice_ids[0]: 50,
+                contest_1_choice_ids[1]: 0,
+                contest_2_choice_ids[0]: 49,
+                contest_2_choice_ids[1]: 1,
+            }
+        ],
+        # Batch 9 (with contest 1 and contest 2 discrepancies)
+        jurisdiction_1_batches[6]["id"]: [
+            {
+                contest_1_choice_ids[0]: 52,
+                contest_1_choice_ids[1]: 0,
+                contest_2_choice_ids[0]: 26,
+                contest_2_choice_ids[1]: 24,
+            }
+        ],
+    }
+    for batch_id, results in jurisdiction_1_batch_results.items():
+        rv = put_batch_results(
+            client, election_id, jurisdiction_ids[0], round_1_id, batch_id, results
+        )
+        assert_ok(rv)
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches/finalize",
+    )
+    assert_ok(rv)
+
+    # Get jurisdiction admin report
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/report"
+    )
+    assert rv.status_code == 200
+    assert_match_report(rv.data, snapshot)
+
+    # Get audit admin report
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert_match_report(rv.data, snapshot)
+
+    # Enter jurisdiction 2 batch results
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    jurisdiction_2_batch_results = {
+        # Batch 1 (with no discrepancies)
+        jurisdiction_2_batches[0]["id"]: [
+            {contest_1_choice_ids[0]: 75, contest_1_choice_ids[1]: 25}
+        ],
+    }
+    for batch_id, results in jurisdiction_2_batch_results.items():
+        rv = put_batch_results(
+            client, election_id, jurisdiction_ids[1], round_1_id, batch_id, results
+        )
+        assert_ok(rv)
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/batches/finalize",
+    )
+    assert_ok(rv)
+
+    # Enter jurisdiction 3 batch results
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, f"j3-{election_id}@example.com"
+    )
+
+    jurisdiction_3_batch_results = {
+        # Batch 1 (with contest 1 discrepancy)
+        jurisdiction_3_batches[0]["id"]: [
+            {contest_1_choice_ids[0]: 74, contest_1_choice_ids[1]: 26,}
+        ],
+    }
+    for batch_id, results in jurisdiction_3_batch_results.items():
+        rv = put_batch_results(
+            client, election_id, jurisdiction_ids[2], round_1_id, batch_id, results
+        )
+        assert_ok(rv)
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[2]}/round/{round_1_id}/batches/finalize",
+    )
+    assert_ok(rv)
+
+    # Check discrepancy counts
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/jurisdiction")
+    assert rv.status_code == 200
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+    assert jurisdictions[0]["currentRoundStatus"]["numDiscrepancies"] == 4
+    assert jurisdictions[1]["currentRoundStatus"]["numDiscrepancies"] == 0
+    assert jurisdictions[2]["currentRoundStatus"]["numDiscrepancies"] == 1
+
+    #
+    # Finish audit
+    #
+
+    rv = client.post(f"/api/election/{election_id}/round/current/finish")
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/round")
+    assert rv.status_code == 200
+    rounds = json.loads(rv.data)["rounds"]
+    assert rounds[0]["isAuditComplete"]
+
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert rv.status_code == 200
+    assert_match_report(rv.data, snapshot)
+
+
+def test_multi_contest_batch_comparison_round_2(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_ids,  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    batch_tallies,  # pylint: disable=unused-argument
+    round_1_id: str,
+    snapshot,
+):
+    #
+    # Check sampled batches
+    #
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches"
+    )
+    jurisdiction_1_batches = json.loads(rv.data)["batches"]
+    assert [batch["name"] for batch in jurisdiction_1_batches] == [
+        "Batch 1",
+        "Batch 2",
+        "Batch 3",
+        "Batch 5",
+        "Batch 6",
+        "Batch 7",
+        "Batch 9",
+    ]
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/batches"
+    )
+    jurisdiction_2_batches = json.loads(rv.data)["batches"]
+    assert [batch["name"] for batch in jurisdiction_2_batches] == ["Batch 1"]
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, f"j3-{election_id}@example.com"
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[2]}/round/{round_1_id}/batches"
+    )
+    jurisdiction_3_batches = json.loads(rv.data)["batches"]
+    assert [batch["name"] for batch in jurisdiction_3_batches] == ["Batch 1"]
+
+    #
+    # Enter batch results
+    #
+
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/contest")
+    assert rv.status_code == 200
+    contests = json.loads(rv.data)["contests"]
+    contest_1_choice_ids = [choice["id"] for choice in contests[0]["choices"]]
+    contest_2_choice_ids = [choice["id"] for choice in contests[1]["choices"]]
+
+    # Enter jurisdiction 1 batch results
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    reported_results_for_batches_1_through_8 = {
+        contest_1_choice_ids[0]: 50,
+        contest_1_choice_ids[1]: 0,
+        contest_2_choice_ids[0]: 50,
+        contest_2_choice_ids[1]: 0,
+    }
+    jurisdiction_1_batch_results = {
+        # Batch 1 (with no discrepancies)
+        jurisdiction_1_batches[0]["id"]: [reported_results_for_batches_1_through_8],
+        # Batch 2 (with no discrepancies)
+        jurisdiction_1_batches[1]["id"]: [reported_results_for_batches_1_through_8],
+        # Batch 3 (with no discrepancies)
+        jurisdiction_1_batches[2]["id"]: [reported_results_for_batches_1_through_8],
+        # Batch 5 (with no discrepancies)
+        jurisdiction_1_batches[3]["id"]: [reported_results_for_batches_1_through_8],
+        # Batch 6 (with no discrepancies)
+        jurisdiction_1_batches[4]["id"]: [reported_results_for_batches_1_through_8],
+        # Batch 7 (with large contest 1 discrepancy)
+        jurisdiction_1_batches[5]["id"]: [
+            {
+                contest_1_choice_ids[0]: 0,
+                contest_1_choice_ids[1]: 50,
+                contest_2_choice_ids[0]: 50,
+                contest_2_choice_ids[1]: 0,
+            }
+        ],
+        # Batch 9 (with no discrepancies)
+        jurisdiction_1_batches[6]["id"]: [
+            {
+                contest_1_choice_ids[0]: 50,
+                contest_1_choice_ids[1]: 0,
+                contest_2_choice_ids[0]: 25,
+                contest_2_choice_ids[1]: 25,
+            }
+        ],
+    }
+    for batch_id, results in jurisdiction_1_batch_results.items():
+        rv = put_batch_results(
+            client, election_id, jurisdiction_ids[0], round_1_id, batch_id, results
+        )
+        assert_ok(rv)
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches/finalize",
+    )
+    assert_ok(rv)
+
+    # Enter jurisdiction 2 batch results
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    jurisdiction_2_batch_results = {
+        # Batch 1 (with no discrepancies)
+        jurisdiction_2_batches[0]["id"]: [
+            {contest_1_choice_ids[0]: 75, contest_1_choice_ids[1]: 25}
+        ],
+    }
+    for batch_id, results in jurisdiction_2_batch_results.items():
+        rv = put_batch_results(
+            client, election_id, jurisdiction_ids[1], round_1_id, batch_id, results
+        )
+        assert_ok(rv)
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/batches/finalize",
+    )
+    assert_ok(rv)
+
+    # Enter jurisdiction 3 batch results
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, f"j3-{election_id}@example.com"
+    )
+
+    jurisdiction_3_batch_results = {
+        # Batch 1 (with no discrepancies)
+        jurisdiction_3_batches[0]["id"]: [
+            {contest_1_choice_ids[0]: 75, contest_1_choice_ids[1]: 25}
+        ],
+    }
+    for batch_id, results in jurisdiction_3_batch_results.items():
+        rv = put_batch_results(
+            client, election_id, jurisdiction_ids[2], round_1_id, batch_id, results
+        )
+        assert_ok(rv)
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[2]}/round/{round_1_id}/batches/finalize",
+    )
+    assert_ok(rv)
+
+    # Check discrepancy counts
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/jurisdiction")
+    assert rv.status_code == 200
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+    assert jurisdictions[0]["currentRoundStatus"]["numDiscrepancies"] == 1
+    assert jurisdictions[1]["currentRoundStatus"]["numDiscrepancies"] == 0
+    assert jurisdictions[2]["currentRoundStatus"]["numDiscrepancies"] == 0
+
+    #
+    # End round 1
+    #
+
+    rv = client.post(f"/api/election/{election_id}/round/current/finish")
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/round")
+    assert rv.status_code == 200
+    rounds = json.loads(rv.data)["rounds"]
+    assert not rounds[0]["isAuditComplete"]
+
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert rv.status_code == 200
+    assert_match_report(rv.data, snapshot)
+
+    #
+    # Start round 2
+    #
+
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/2")
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 2,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/round")
+    assert rv.status_code == 200
+    rounds = json.loads(rv.data)["rounds"]
+    round_2_id = rounds[1]["id"]
+
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert rv.status_code == 200
+    assert_match_report(rv.data, snapshot)
+
+    #
+    # Check sampled batches
+    #
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/batches"
+    )
+    jurisdiction_1_batches = json.loads(rv.data)["batches"]
+    assert [batch["name"] for batch in jurisdiction_1_batches] == ["Batch 8"]
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_2_id}/batches"
+    )
+    jurisdiction_2_batches = json.loads(rv.data)["batches"]
+    assert len(jurisdiction_2_batches) == 0
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, f"j3-{election_id}@example.com"
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[2]}/round/{round_2_id}/batches"
+    )
+    jurisdiction_3_batches = json.loads(rv.data)["batches"]
+    assert len(jurisdiction_3_batches) == 0
+
+    #
+    # Enter batch results
+    #
+
+    # Enter jurisdiction 1 batch results
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    jurisdiction_1_batch_results = {
+        # Batch 8 (with no discrepancies)
+        jurisdiction_1_batches[0]["id"]: [reported_results_for_batches_1_through_8],
+    }
+    for batch_id, results in jurisdiction_1_batch_results.items():
+        rv = put_batch_results(
+            client, election_id, jurisdiction_ids[0], round_2_id, batch_id, results
+        )
+        assert_ok(rv)
+
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/batches/finalize",
+    )
+    assert_ok(rv)
+
+    # Enter jurisdiction 2 batch results (nothing to enter, just need to finalize)
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_2_id}/batches/finalize",
+    )
+    assert_ok(rv)
+
+    # Enter jurisdiction 3 batch results (nothing to enter, just need to finalize)
+
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, f"j3-{election_id}@example.com"
+    )
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[2]}/round/{round_2_id}/batches/finalize",
+    )
+    assert_ok(rv)
+
+    # Check discrepancy counts
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/jurisdiction")
+    assert rv.status_code == 200
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+    assert jurisdictions[0]["currentRoundStatus"]["numDiscrepancies"] == 0
+    assert jurisdictions[1]["currentRoundStatus"]["numDiscrepancies"] == 0
+    assert jurisdictions[2]["currentRoundStatus"]["numDiscrepancies"] == 0
+
+    #
+    # End round 2 / finish audit
+    #
+
+    rv = client.post(f"/api/election/{election_id}/round/current/finish")
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/round")
+    assert rv.status_code == 200
+    rounds = json.loads(rv.data)["rounds"]
+    assert rounds[1]["isAuditComplete"]
+
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert rv.status_code == 200
+    assert_match_report(rv.data, snapshot)

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -280,7 +280,7 @@ DATETIME_REGEX = re.compile(
 )
 
 TEST_JURISDICTION_ADMIN_EMAIL_REGEX = re.compile(
-    r"jurisdiction.admin-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}@example.com"
+    r"(jurisdiction\.admin|j3)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}@example\.com"
 )
 
 


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/arlo/issues/1815

This PR updates the Arlo backend to support multi-contest batch audits. Note that the batch audit creation UI still doesn't support creating audits with multiple contests.

We're keeping things simple for now and avoiding any updates to the audit math. Jurisdiction admins will still upload a single candidate-totals-by-batch file, where that file includes counts for candidates across all contests (in that jurisdiction). Sample sizes will be calculated and sample batches will be drawn for each contest independently. Even if a batch is selected for only one contest, batch results will be collected for all contests. While we'll display discrepancies for all collected data, only the batches that were actually selected by the audit math will be used to determine whether the audit is complete. Audit reports will include all collected data while also indicating which batches were actually selected for which contests.

While it might seem like we're having jurisdictions do extra work by auditing all contests in a batch regardless of whether or not the batch was actually selected for all contests by the audit math, we've decided that this is actually logistically simpler than having jurisdictions audit subsets of contests in some batches. And as a perk, if an audit goes to a second round, the extra collected data may decrease the amount of data that has to be collected in that second round.

## Testing

- [x] Updated existing automated tests
- [x] Added new automated tests
- [x] Tweaked the UI to support creating a multi-contest batch audit and tested end-to-end manually