### PR TITLE
Improve error message for Dominion CVR files with percent values

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -1255,6 +1255,15 @@ def process_cvr_file(
                     ):
                         continue
 
+                    # Dominions CVR files sometimes contain percent values, which interfere with
+                    # integer parsing, e.g., "0 (0%)" or "1 (97%)"
+                    for interpretation in contest_interpretations.values():
+                        if re.search(r"\(\d+%\)", interpretation):
+                            raise UserError(
+                                f"Encountered an unexpected percent value: '{interpretation}'. "
+                                "Please export the CVR file without percent values."
+                            )
+
                     # Skip overvotes
                     votes = sum(
                         int(interpretation)

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -868,6 +868,36 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,UniqueVotingIdentifier,REP,D
             "DOMINION",
         ),
         (
+            """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
+,,,,,,,,"Contest 1 (Vote For=1)","Contest 1 (Vote For=1)"
+,,,,,,,,Choice 1-1,Choice 1-2
+CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
+1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0 (0%),1 (97%)
+""",
+            "Encountered an unexpected percent value: '0 (0%)'. Please export the CVR file without percent values.",
+            "DOMINION",
+        ),
+        (
+            """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
+,,,,,,,,"Contest 1 (Vote For=1)","Contest 1 (Vote For=1)"
+,,,,,,,,Choice 1-1,Choice 1-2
+CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
+1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,1 (97%),0 (0%)
+""",
+            "Encountered an unexpected percent value: '1 (97%)'. Please export the CVR file without percent values.",
+            "DOMINION",
+        ),
+        (
+            """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
+,,,,,,,,"Contest 1 (Vote For=1)","Contest 1 (Vote For=1)"
+,,,,,,,,Choice 1-1,Choice 1-2
+CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
+1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,1 (100%),0 (0%)
+""",
+            "Encountered an unexpected percent value: '1 (100%)'. Please export the CVR file without percent values.",
+            "DOMINION",
+        ),
+        (
             """RowNumber,BoxID,BoxPosition,BallotID,PrecinctID,BallotStyleID,PrecinctStyleName,ScanComputerName,Status,Remade,Choice_1_1:Contest 1:Vote For 1:Choice 1-1:Non-Partisan,Choice_210_1:Contest 1:Vote For 1:Choice 1-2:Non-Partisan,Choice_34_1:Contest 2:Vote For 2:Choice 2-1:Non-Partisan,Choice_4_1:Contest 2:Vote For 2:Choice 2-2:Non-Partisan,Choice_173_1:Contest 2:Vote For 2:Choice 2-3:Non-Partisan
 1,BATCH1,1,1-1-1,p,bs,ps,TABULATO1,s,r,0,1,1,1,0
 """,


### PR DESCRIPTION
## Overview

We've received a few Dominion CVR files from Nevada containing percent values, which interfere with integer parsing:

```
invalid literal for int() with base 10: '0 (0%)'
```

This PR improves the user-facing error message (currently the opaque catch-all "Could not parse CVR file"). And in doing so also no longer has this error trigger PagerDuty.

<table><tr><td>
<img src='https://github.com/votingworks/arlo/assets/12616928/a5cd53a5-fc50-4327-a4e8-ebb3c2fed575' alt='new-error-message' />
</td></tr></table>

## Testing

- [x] Added automated tests
- [x] Tested manually