### PR TITLE
Catch all failures to parse Dominion interpretation values as integers

### DIFF
--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -874,7 +874,7 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,UniqueVotingIdentifier,REP,D
 CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
 1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0 (0%),1 (97%)
 """,
-            "Encountered an unexpected percent value: '0 (0%)'. Please export the CVR file without percent values.",
+            "Unable to parse '0 (0%)' as an integer. Please export the CVR file with plain integer values.",
             "DOMINION",
         ),
         (
@@ -882,19 +882,9 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortio
 ,,,,,,,,"Contest 1 (Vote For=1)","Contest 1 (Vote For=1)"
 ,,,,,,,,Choice 1-1,Choice 1-2
 CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
-1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,1 (97%),0 (0%)
+1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0 (0),1 (97)
 """,
-            "Encountered an unexpected percent value: '1 (97%)'. Please export the CVR file without percent values.",
-            "DOMINION",
-        ),
-        (
-            """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
-,,,,,,,,"Contest 1 (Vote For=1)","Contest 1 (Vote For=1)"
-,,,,,,,,Choice 1-1,Choice 1-2
-CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM
-1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,1 (100%),0 (0%)
-""",
-            "Encountered an unexpected percent value: '1 (100%)'. Please export the CVR file without percent values.",
+            "Unable to parse '0 (0)' as an integer. Please export the CVR file with plain integer values.",
             "DOMINION",
         ),
         (


### PR DESCRIPTION
## Overview

Welp, as soon as we rolled out https://github.com/votingworks/arlo/pull/1885, we encountered a Dominion CVR file with a value that couldn't be parsed but that also didn't contain a percent:

```
invalid literal for int() with base 10: '0 (0)'
```

I'm changing course and now catching all failures to parse Dominion interpretation values as integers:

<table><tr><td>
<img src='https://github.com/votingworks/arlo/assets/12616928/467ffb98-e5f4-46e3-b407-c3becc8ebc9a' alt='screenshot-1' />
</td></tr></table>

<table><tr><td>
<img src='https://github.com/votingworks/arlo/assets/12616928/e478b803-f6e6-4e85-b2fc-21978df13d2f' alt='screenshot-2' />
</td></tr></table>

## Testing

- [x] Updated automated tests
- [x] Tested manually
