### PR TITLE
Update batch audit creation UI to support creating audits with multiple contests

### DIFF
--- a/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
@@ -229,7 +229,6 @@ const ContestForm: React.FC<IProps> = ({
     },
   ]
 
-  const isBatch = auditType === 'BATCH_COMPARISON'
   const isHybrid = auditType === 'HYBRID'
   const isBallotPolling = auditType === 'BALLOT_POLLING'
 
@@ -520,19 +519,17 @@ const ContestForm: React.FC<IProps> = ({
                       </Card>
                     )
                   })}
-                  {!isBatch && ( // TODO support multiple contests in batch comparison audits
-                    <div style={{ paddingTop: '15px' }}>
-                      <Button
-                        icon="add"
-                        type="button"
-                        onClick={() =>
-                          contestsArrayHelpers.push({ ...contestValues[0] })
-                        }
-                      >
-                        Add Contest
-                      </Button>
-                    </div>
-                  )}
+                  <div style={{ paddingTop: '15px' }}>
+                    <Button
+                      icon="add"
+                      type="button"
+                      onClick={() =>
+                        contestsArrayHelpers.push({ ...contestValues[0] })
+                      }
+                    >
+                      Add Contest
+                    </Button>
+                  </div>
                 </>
               )}
             />

--- a/client/src/components/AuditAdmin/Setup/Contests/_mocks.ts
+++ b/client/src/components/AuditAdmin/Setup/Contests/_mocks.ts
@@ -7,6 +7,22 @@ export const contestsInputMocks = {
     { key: 'Votes for Candidate/Choice 2', value: '20' },
     { key: 'Total Ballot Cards Cast for Contest', value: '30' },
   ],
+  batchAuditInputs: {
+    contest1: [
+      { key: 'Contest Name', value: 'Contest One' },
+      { key: 'Name of Candidate/Choice 1', value: 'Choice One' },
+      { key: 'Name of Candidate/Choice 2', value: 'Choice Two' },
+      { key: 'Votes for Candidate/Choice 1', value: '10' },
+      { key: 'Votes for Candidate/Choice 2', value: '20' },
+    ],
+    contest2: [
+      { key: 'Contest 2 Name', value: 'Contest Two' },
+      { key: 'Name of Candidate/Choice 1', index: 1, value: 'Choice Three' },
+      { key: 'Name of Candidate/Choice 2', index: 1, value: 'Choice Four' },
+      { key: 'Votes for Candidate/Choice 1', index: 1, value: '30' },
+      { key: 'Votes for Candidate/Choice 2', index: 1, value: '40' },
+    ],
+  },
   errorInputs: [
     { key: 'Contest Name', value: '', error: 'Required' },
     {

--- a/client/src/components/AuditAdmin/Setup/Review/Review.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.tsx
@@ -699,7 +699,8 @@ const SelectSampleSizes: React.FC<ISelectSampleSizesProps> = ({
                       using the ballot polling or batch comparison audit type.
                     </div>
                   )}
-                  {auditType === 'BALLOT_POLLING' &&
+                  {(auditType === 'BALLOT_POLLING' ||
+                    auditType === 'BATCH_COMPARISON') &&
                     targetedContests.length > 1 && (
                       <div>
                         Arlo supports running a full hand tally for audits with

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -1937,11 +1937,15 @@ export const aaApiCalls = {
     url: '/api/election/1/standardized-contests/file',
     response,
   }),
-  getContests: (contests: IContest[]) => ({
+  getContests: (
+    contests: (IContest | Omit<IContest, 'totalBallotsCast'>)[]
+  ) => ({
     url: '/api/election/1/contest',
     response: { contests },
   }),
-  putContests: (contests: IContest[]) => ({
+  putContests: (
+    contests: (IContest | Omit<IContest, 'totalBallotsCast'>)[]
+  ) => ({
     url: '/api/election/1/contest',
     options: {
       method: 'PUT',


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/arlo/issues/1815

This PR updates the batch audit creation UI to support creating audits with multiple contests, now that the backend is ready. We're using the exact same UI as the other audit types.

<table>
<img alt='add-contest-button' src='https://github.com/votingworks/arlo/assets/12616928/bbb17460-f4a4-4345-985c-c57dcf05786f' width=400 />
</table>

## Testing

- [x] Updated automated tests
- [x] Tested manually