### PR TITLE
Provide template candidate-totals-by-batch files for batch audits

### DIFF
--- a/client/src/components/Atoms/CSVForm.tsx
+++ b/client/src/components/Atoms/CSVForm.tsx
@@ -8,6 +8,7 @@ import {
   H4,
   ProgressBar,
   Intent,
+  AnchorButton,
 } from '@blueprintjs/core'
 import * as Yup from 'yup'
 import { CvrFileType, IFileInfo, FileProcessingStatus } from '../useCSV'
@@ -91,22 +92,7 @@ const CSVFile: React.FC<IProps> = ({
           <FormWrapper>
             <div>
               {title && <H4>{title}</H4>}
-              <FormSectionDescription>
-                {description}
-                {sampleFileLink && (
-                  <>
-                    <br />
-                    <br />
-                    <a
-                      href={sampleFileLink}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      (Click here to view a sample file in the correct format.)
-                    </a>
-                  </>
-                )}
-              </FormSectionDescription>
+              <FormSectionDescription>{description}</FormSectionDescription>
             </div>
             {showCvrFileType && (
               <p>
@@ -216,6 +202,16 @@ const CSVFile: React.FC<IProps> = ({
                   >
                     Upload File
                   </FormButton>
+                  {sampleFileLink && (
+                    <AnchorButton
+                      href={sampleFileLink}
+                      rel="noopener noreferrer"
+                      style={{ marginLeft: '5px' }}
+                      target="_blank"
+                    >
+                      Download Template
+                    </AnchorButton>
+                  )}
                 </div>
               </>
             ) : (
@@ -260,6 +256,16 @@ const CSVFile: React.FC<IProps> = ({
                       >
                         Delete File
                       </AsyncButton>
+                    )}
+                    {sampleFileLink && (
+                      <AnchorButton
+                        href={sampleFileLink}
+                        rel="noopener noreferrer"
+                        style={{ marginLeft: '5px' }}
+                        target="_blank"
+                      >
+                        Download Template
+                      </AnchorButton>
                     )}
                   </div>
                 </div>

--- a/client/src/components/Atoms/FileUpload.tsx
+++ b/client/src/components/Atoms/FileUpload.tsx
@@ -25,6 +25,7 @@ export interface IFileUploadProps extends IFileUpload {
   uploadDisabled?: boolean
   deleteDisabled?: boolean
   additionalFields?: React.ReactNode
+  templateFileUrl?: string
 }
 
 const FileUpload: React.FC<IFileUploadProps> = ({
@@ -39,6 +40,7 @@ const FileUpload: React.FC<IFileUploadProps> = ({
   uploadDisabled = false,
   deleteDisabled = false,
   additionalFields,
+  templateFileUrl,
 }: IFileUploadProps) => {
   const { register, handleSubmit, formState, watch, reset } = useForm<{
     files: FileList
@@ -141,20 +143,33 @@ const FileUpload: React.FC<IFileUploadProps> = ({
       </Row>
       <Row style={{ justifyContent: 'flex-end' }}>
         {!processing?.completedAt ? (
-          <Button
-            type="submit"
-            intent="primary"
-            icon="upload"
-            disabled={
-              uploadDisabled ||
-              numSelectedFiles === 0 ||
-              formState.isSubmitting ||
-              (processing !== null && !processing.completedAt)
-            }
-            style={{ width: buttonAndTagWidth }}
-          >
-            Upload
-          </Button>
+          <>
+            {templateFileUrl && (
+              <AnchorButton
+                href={templateFileUrl}
+                icon="download"
+                rel="noopener noreferrer"
+                style={{ marginRight: '5px' }}
+                target="_blank"
+              >
+                Download Template
+              </AnchorButton>
+            )}
+            <Button
+              type="submit"
+              intent="primary"
+              icon="upload"
+              disabled={
+                uploadDisabled ||
+                numSelectedFiles === 0 ||
+                formState.isSubmitting ||
+                (processing !== null && !processing.completedAt)
+              }
+              style={{ width: buttonAndTagWidth }}
+            >
+              Upload
+            </Button>
+          </>
         ) : (
           <>
             <AnchorButton

--- a/client/src/components/Atoms/FileUpload.tsx
+++ b/client/src/components/Atoms/FileUpload.tsx
@@ -172,6 +172,17 @@ const FileUpload: React.FC<IFileUploadProps> = ({
           </>
         ) : (
           <>
+            {templateFileUrl && (
+              <AnchorButton
+                href={templateFileUrl}
+                icon="download"
+                rel="noopener noreferrer"
+                style={{ marginRight: '5px' }}
+                target="_blank"
+              >
+                Download Template
+              </AnchorButton>
+            )}
             <AnchorButton
               icon="download"
               href={downloadFileUrl}

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
@@ -423,8 +423,15 @@ describe('JurisdictionDetail', () => {
         within(talliesCard).getByRole('button', { name: /Upload/ })
       )
       await within(talliesCard).findByText('Uploaded')
+      const downloadTemplateLink = within(talliesCard).getByRole('button', {
+        name: /Download Template/,
+      })
+      expect(downloadTemplateLink).toHaveAttribute(
+        'href',
+        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies/template'
+      )
       const talliesLink = within(talliesCard).getByRole('button', {
-        name: /Download/,
+        name: /Download$/,
       })
       expect(talliesLink).toHaveAttribute(
         'href',
@@ -584,7 +591,7 @@ describe('JurisdictionDetail', () => {
         })
       ).closest('.bp3-card') as HTMLElement
       await within(talliesCard).findByText('Uploaded')
-      within(talliesCard).getByRole('button', { name: /Download/ })
+      within(talliesCard).getByRole('button', { name: /Download$/ })
       expect(
         within(talliesCard).getByRole('button', { name: /Delete/ })
       ).toBeDisabled()

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
@@ -30,6 +30,7 @@ import {
 import AuditBoardsTable from './AuditBoardsTable'
 import DownloadBatchRetrievalListButton from '../../JurisdictionAdmin/BatchRoundSteps/DownloadBatchRetrievalListButton'
 import DownloadBatchTallySheetsButton from '../../JurisdictionAdmin/BatchRoundSteps/DownloadBatchTallySheetsButton'
+import { candidateTotalsByBatchTemplateFilePath } from '../../JurisdictionAdmin/candidateTotalsByBatchTemplates'
 
 const StatusCard = styled(Card)`
   &:not(:last-child) {
@@ -98,6 +99,10 @@ const JurisdictionDetail: React.FC<IJurisdictionDetailProps> = ({
                 acceptFileTypes={['csv']}
                 uploadDisabled={!isManifestUploaded || round !== null}
                 deleteDisabled={round !== null}
+                templateFileUrl={candidateTotalsByBatchTemplateFilePath({
+                  electionId,
+                  jurisdictionId: jurisdiction.id,
+                })}
               />
             </StatusCard>
           )}

--- a/client/src/components/AuditAdmin/__snapshots__/AuditAdminView.test.tsx.snap
+++ b/client/src/components/AuditAdmin/__snapshots__/AuditAdminView.test.tsx.snap
@@ -154,15 +154,6 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
                 class="sc-dnqmqq kGMqKN"
               >
                 Click "Browse" to choose the appropriate file from your computer. This file should be a comma-separated list of all the jurisdictions participating in the audit, plus email addresses for audit administrators in each participating jurisdiction.
-                <br />
-                <br />
-                <a
-                  href="/sample_jurisdiction_filesheet.csv"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  (Click here to view a sample file in the correct format.)
-                </a>
               </div>
             </div>
             <div>
@@ -192,6 +183,21 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
                     Replace File
                   </span>
                 </button>
+                <a
+                  class="bp3-button"
+                  href="/sample_jurisdiction_filesheet.csv"
+                  rel="noopener noreferrer"
+                  role="button"
+                  style="margin-left: 5px;"
+                  tabindex="0"
+                  target="_blank"
+                >
+                  <span
+                    class="bp3-button-text"
+                  >
+                    Download Template
+                  </span>
+                </a>
               </div>
             </div>
           </div>

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
@@ -120,6 +120,13 @@ describe('JA setup', () => {
       await screen.findByText('Audit Setup')
       const talliesInput = screen.getByLabelText('Select a file...')
       const talliesButton = screen.getByRole('button', { name: 'Upload File' })
+      const talliesTemplateButton = screen.getAllByRole('button', {
+        name: 'Download Template',
+      })[1]
+      expect(talliesTemplateButton).toHaveAttribute(
+        'href',
+        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies/template'
+      )
 
       userEvent.click(talliesButton)
       await screen.findByText('You must upload a file')
@@ -128,6 +135,18 @@ describe('JA setup', () => {
       userEvent.click(talliesButton)
       await screen.findByText('Uploaded at 7/8/2020, 9:39:14 PM.')
       screen.getByText('Audit setup complete')
+
+      // Verify that ballot manifests and candidate totals by batch can be replaced or deleted
+      // after upload, and that templates can still be downloaded
+      expect(
+        screen.getAllByRole('button', { name: 'Replace File' })
+      ).toHaveLength(2)
+      expect(
+        screen.getAllByRole('button', { name: 'Delete File' })
+      ).toHaveLength(2)
+      expect(
+        screen.getAllByRole('button', { name: 'Download Template' })
+      ).toHaveLength(2)
     })
   })
 

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.tsx
@@ -21,6 +21,7 @@ import { StatusBar, AuditHeading } from '../Atoms/StatusBar'
 import { assert } from '../utilities'
 import { useAuthDataContext } from '../UserContext'
 import { Column } from '../Atoms/Layout'
+import { candidateTotalsByBatchTemplateFilePath } from './candidateTotalsByBatchTemplates'
 
 const JurisdictionAdminView: React.FC = () => {
   const { electionId, jurisdictionId } = useParams<{
@@ -178,7 +179,10 @@ const JurisdictionAdminView: React.FC = () => {
                   to store ballots for this particular election, plus a count of
                   how many votes were counted for each candidate in each of
                   those containers.'
-                  sampleFileLink="/sample_candidate_totals_by_batch.csv"
+                  sampleFileLink={candidateTotalsByBatchTemplateFilePath({
+                    electionId,
+                    jurisdictionId,
+                  })}
                 />
               </Card>
             )}

--- a/client/src/components/JurisdictionAdmin/candidateTotalsByBatchTemplates.ts
+++ b/client/src/components/JurisdictionAdmin/candidateTotalsByBatchTemplates.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line import/prefer-default-export
+export function candidateTotalsByBatchTemplateFilePath({
+  electionId,
+  jurisdictionId,
+}: {
+  electionId: string
+  jurisdictionId: string
+}): string {
+  return `/api/election/${electionId}/jurisdiction/${jurisdictionId}/batch-tallies/template`
+}

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -683,3 +683,28 @@ def test_batch_tallies_reprocess_after_manifest_reupload(
     )
 
     assert Jurisdiction.query.get(jurisdiction_ids[0]).batch_tallies is not None
+
+
+def test_batch_tallies_template_generation(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_ids: List[str],  # pylint: disable=unused-argument
+):
+    for user_type, user_email in [
+        (UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL),
+        (UserType.JURISDICTION_ADMIN, default_ja_email(election_id)),
+    ]:
+        set_logged_in_user(client, user_type, user_email)
+
+        rv = client.get(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies/template"
+        )
+        assert rv.status_code == 200
+        template_contents = rv.data.decode("utf-8")
+        assert template_contents == (
+            "Batch Name,candidate 1,candidate 2,candidate 3\r\n"
+            "Batch 1,0,0,0\r\n"
+            "Batch 2,0,0,0\r\n"
+            "Batch 3,0,0,0\r\n"
+        )


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/arlo/issues/1856

This PR updates Arlo to provide template candidate-totals-by-batch files. These files are often incorrectly formatted when prepared from scratch, so these templates should reduce user error rates. The templates are audit-specific and jurisdiction-specific. Users should not have to update column names.

I've added buttons to the audit admin and jurisdiction admin UIs.

### Audit admin UI

Notice the new "Download Template" button.

| Before upload | After upload |
| -- | -- |
| <img width="1512" alt="aa-before-upload" src="https://github.com/votingworks/arlo/assets/12616928/88e1f552-6bcd-43bd-be16-8e6c33b4fdb2"> | <img width="1512" alt="aa-after-upload" src="https://github.com/votingworks/arlo/assets/12616928/9a8e8c9d-5833-4a4a-aea1-0aa20fbbd854"> |

_In action_

https://github.com/votingworks/arlo/assets/12616928/49331d67-35b8-4d27-840d-1904d21341d1

### Jurisdiction admin UI

Notice that we replaced the old "Click here to view a sample file" link with a "Download Template" button.

| Before this PR | After this PR |
| -- | -- |
| <img width="1512" alt="ja-before" src="https://github.com/votingworks/arlo/assets/12616928/b69ef57a-4e0e-48c1-ab47-f8951c5a28c9"> | <img width="1512" alt="ja-after" src="https://github.com/votingworks/arlo/assets/12616928/f122b722-2e67-4806-8e65-c9d26c3909b5"> |

### Sample templates

_Sample template for single-contest batch audit_

```
Batch Name,Choice 1,Choice 2
Batch 1,0,0
Batch 2,0,0
Batch 3,0,0
```

_Sample template for multi-contest batch audit_

```
Batch Name,Contest 1 - Choice 1,Contest 1 - Choice 2,Contest 2 - Choice 3,Contest 2 - Choice 4
Batch 1,0,0,0,0
Batch 2,0,0,0,0
Batch 3,0,0,0,0
```

## Testing

- [x] Updated automated tests
- [x] Tested manually