### PR TITLE
Compute "Valid Voted Ballots in Batches" for multi-contest batch audits

### DIFF
--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -438,10 +438,21 @@ def test_multi_contest_batch_comparison_end_to_end(
     snapshot,
 ):
     #
-    # Start audit
+    # Check jurisdictions
     #
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+
+    rv = client.get(f"/api/election/{election_id}/jurisdiction")
+    assert rv.status_code == 200
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+    assert [
+        jurisdiction["batchTallies"]["numBallots"] for jurisdiction in jurisdictions
+    ] == [500, 250, 250]
+
+    #
+    # Start audit
+    #
 
     rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/arlo/issues/1815

I missed this logic while working on https://github.com/votingworks/arlo/pull/1884 (backend support for multi-contest batch audits). Missed it since the current code just continues if the number of contests isn't 1, instead of failing.

Before this PR, the "Valid Voted Ballots in Batches" column was mistakenly left empty for multi-contest batch audits.

<table><tr><td>
<img alt='audit-progress' src='https://github.com/votingworks/arlo/assets/12616928/0c1536d8-d635-47d1-854e-87261c4b8371' width=600 />
</tr></td></table>

For more context on what this column represents, see https://votingworks.slack.com/archives/CKCVA0F9S/p1623087428052300.

## Testing

- [x] Updated automated tests
- [x] Tested manually