### PR TITLE
Clear old CVR ballots from database in background during CVR file upload

### DIFF
--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -427,7 +427,11 @@ def test_cvrs_clear(
         .order_by(CvrBallot.imprinted_id)
         .all()
     )
-    assert len(cvr_ballots) == 0
+    # Temporarily, we're not deleting the CVR ballots on DELETE of the file and
+    # relying instead on the background task to delete them when uploading a new
+    # CVR file.
+    # assert len(cvr_ballots) == 0
+    assert len(cvr_ballots) > 0
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(


### PR DESCRIPTION
We've been seeing the database query to delete CVR ballot records be slow in production sometimes. While we're getting to the bottom of it, this change ensures that the query is only run in the `process_cvr_file` background task. It's not as safe as our previous approach of deleting the records on file delete, but should be an ok temporary fix.