### PR TITLE
Move cvr ballot deletion to background task

### DIFF
--- a/arlo.code-workspace
+++ b/arlo.code-workspace
@@ -15,12 +15,11 @@
         "remotePort": 3000
       }
     ],
-    "python.formatting.provider": "black",
     "typescript.tsdk": "client/node_modules/typescript/lib",
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "[python]": {
-      "editor.defaultFormatter": "ms-python.python"
+      "editor.defaultFormatter": "ms-python.black-formatter"
     }
   }
 }

--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -151,7 +151,8 @@ def process_ballot_manifest_file(
         # If CVR file already uploaded, try reprocessing it, since it depends on
         # batch names from the manifest
         if jurisdiction.cvr_file:
-            cvrs.clear_cvr_data(jurisdiction)
+            cvrs.clear_cvr_contests_metadata(jurisdiction)
+            cvrs.clear_cvr_ballots(jurisdiction.id)
             jurisdiction.cvr_file.task = create_background_task(
                 cvrs.process_cvr_file,
                 dict(

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -983,9 +983,9 @@ def parse_hart_cvrs(
                 )
             scanned_ballot_information_by_cvr_id[cvr_id] = row
 
-    cvr_file_paths: Dict[
-        Tuple[str, str], str
-    ] = {}  # { (zip_file_name, file_name): file_path }
+    cvr_file_paths: Dict[Tuple[str, str], str] = (
+        {}
+    )  # { (zip_file_name, file_name): file_path }
     for cvr_zip_file_name, cvr_zip_file in cvr_zip_files.items():
         sub_working_directory = tempfile.mkdtemp(dir=working_directory)
         cvr_file_names = unzip_files(cvr_zip_file, sub_working_directory)
@@ -1263,9 +1263,9 @@ def process_cvr_file(
 
                     # Dominions CVR files sometimes contain interpretation values that can't be
                     # parsed as integers
-                    parsed_contest_interpretations: Dict[
-                        str, int
-                    ] = {}  # { choice_name: parsed_interpretation }
+                    parsed_contest_interpretations: Dict[str, int] = (
+                        {}
+                    )  # { choice_name: parsed_interpretation }
                     for choice_name, interpretation in contest_interpretations.items():
                         try:
                             parsed_interpretation = int(interpretation)

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -427,11 +427,7 @@ def test_cvrs_clear(
         .order_by(CvrBallot.imprinted_id)
         .all()
     )
-    # Temporarily, we're not deleting the CVR ballots on DELETE of the file and
-    # relying instead on the background task to delete them when uploading a new
-    # CVR file.
-    # assert len(cvr_ballots) == 0
-    assert len(cvr_ballots) > 0
+    assert len(cvr_ballots) == 0
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(


### PR DESCRIPTION
In order to safely delete CvrBallot records, ensure the db query is
always run in a background task. We can't rely on the query planner to
consistently use the appropriate indices for this query, so this is a
safe option to ensure we don't timeout any requests.