### PR TITLE
Add button to audit admin UI for downloading reported results summed by jurisdiction as CSV

### DIFF
--- a/arlo.code-workspace
+++ b/arlo.code-workspace
@@ -17,7 +17,7 @@
     ],
     "typescript.tsdk": "client/node_modules/typescript/lib",
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "[python]": {
       "editor.defaultFormatter": "ms-python.black-formatter"
     }

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.test.tsx
@@ -428,7 +428,7 @@ describe('JurisdictionDetail', () => {
       })
       expect(downloadTemplateLink).toHaveAttribute(
         'href',
-        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies/template'
+        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies/template-csv'
       )
       const talliesLink = within(talliesCard).getByRole('button', {
         name: /Download$/,

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
@@ -30,7 +30,7 @@ import {
 import AuditBoardsTable from './AuditBoardsTable'
 import DownloadBatchRetrievalListButton from '../../JurisdictionAdmin/BatchRoundSteps/DownloadBatchRetrievalListButton'
 import DownloadBatchTallySheetsButton from '../../JurisdictionAdmin/BatchRoundSteps/DownloadBatchTallySheetsButton'
-import { candidateTotalsByBatchTemplateFilePath } from '../../JurisdictionAdmin/candidateTotalsByBatchTemplates'
+import { candidateTotalsByBatchTemplateCsvPath } from '../../JurisdictionAdmin/candidateTotalsByBatchTemplateCsv'
 
 const StatusCard = styled(Card)`
   &:not(:last-child) {
@@ -99,7 +99,7 @@ const JurisdictionDetail: React.FC<IJurisdictionDetailProps> = ({
                 acceptFileTypes={['csv']}
                 uploadDisabled={!isManifestUploaded || round !== null}
                 deleteDisabled={round !== null}
-                templateFileUrl={candidateTotalsByBatchTemplateFilePath({
+                templateFileUrl={candidateTotalsByBatchTemplateCsvPath({
                   electionId,
                   jurisdictionId: jurisdiction.id,
                 })}

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -3,7 +3,13 @@ import React, { useState, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { Column, Cell, TableInstance, SortingRule } from 'react-table'
-import { Button, Switch, ITagProps, Icon } from '@blueprintjs/core'
+import {
+  Button,
+  Switch,
+  ITagProps,
+  Icon,
+  AnchorButton,
+} from '@blueprintjs/core'
 import H2Title from '../../Atoms/H2Title'
 import {
   JurisdictionRoundStatus,
@@ -371,6 +377,47 @@ const Progress: React.FC<IProgressProps> = ({
     [sortAndFilterState, setSortAndFilterState]
   )
 
+  const downloadButtons = (
+    <div style={{ display: 'flex', alignSelf: 'end', gap: '5px' }}>
+      <AnchorButton
+        icon="download"
+        href={`/api/election/${electionId}/batch-tallies/summed-by-jurisdiction-csv`}
+      >
+        Download Reported Results
+      </AnchorButton>
+      <Button
+        icon="download"
+        onClick={() => {
+          downloadTableAsCSV({
+            tableId: 'progress-table',
+            fileName: `audit-progress-${
+              auditSettings.auditName
+            }-${new Date().toISOString()}.csv`,
+          })
+        }}
+      >
+        Download Table as CSV
+      </Button>
+      {showDiscrepancies && (
+        <AsyncButton
+          onClick={() =>
+            apiDownload(`/election/${electionId}/discrepancy-report`)
+          }
+          icon={
+            <Icon
+              icon="flag"
+              intent={someJurisdictionHasDiscrepancies ? 'danger' : 'none'}
+            />
+          }
+        >
+          Download Discrepancy Report
+        </AsyncButton>
+      )}
+    </div>
+  )
+
+  const splitTableControlsAcrossTwoRows = Boolean(showDiscrepancies)
+
   return (
     <Wrapper>
       <H2Title>Audit Progress</H2Title>
@@ -382,58 +429,40 @@ const Progress: React.FC<IProgressProps> = ({
           auditType={auditType}
         />
       )}
-      <TableControls>
-        <div style={{ flexGrow: 1 }}>
-          <FilterInput
-            placeholder="Filter by jurisdiction name..."
-            value={filter}
-            onChange={value =>
-              setSortAndFilterState({
-                ...sortAndFilterState,
-                filter: value || undefined,
-              })
-            }
-          />
-        </div>
-        {round && (
-          <Switch
-            checked={isShowingUnique}
-            label={`Count unique sampled ${ballotsOrBatches.toLowerCase()}`}
-            onChange={() => setIsShowingUnique(!isShowingUnique)}
-            style={{ marginBottom: 0 }}
-          />
-        )}
-        <div>
-          <Button
-            icon="download"
-            onClick={() => {
-              downloadTableAsCSV({
-                tableId: 'progress-table',
-                fileName: `audit-progress-${
-                  auditSettings.auditName
-                }-${new Date().toISOString()}.csv`,
-              })
-            }}
-          >
-            Download Table as CSV
-          </Button>
-          {showDiscrepancies && (
-            <AsyncButton
-              onClick={() =>
-                apiDownload(`/election/${electionId}/discrepancy-report`)
+      <TableControls
+        style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '10px',
+            width: '100%',
+          }}
+        >
+          <div style={{ flexGrow: 1 }}>
+            <FilterInput
+              placeholder="Filter by jurisdiction name..."
+              value={filter}
+              onChange={value =>
+                setSortAndFilterState({
+                  ...sortAndFilterState,
+                  filter: value || undefined,
+                })
               }
-              icon={
-                <Icon
-                  icon="flag"
-                  intent={someJurisdictionHasDiscrepancies ? 'danger' : 'none'}
-                />
-              }
-              style={{ marginLeft: '5px' }}
-            >
-              Download Discrepancy Report
-            </AsyncButton>
+            />
+          </div>
+          {round && (
+            <Switch
+              checked={isShowingUnique}
+              label={`Count unique sampled ${ballotsOrBatches.toLowerCase()}`}
+              onChange={() => setIsShowingUnique(!isShowingUnique)}
+              style={{ marginBottom: 0 }}
+            />
           )}
+          {!splitTableControlsAcrossTwoRows && downloadButtons}
         </div>
+        {splitTableControlsAcrossTwoRows && downloadButtons}
       </TableControls>
       <Table
         data={filteredJurisdictions}

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
@@ -125,7 +125,7 @@ describe('JA setup', () => {
       })[1]
       expect(talliesTemplateButton).toHaveAttribute(
         'href',
-        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies/template'
+        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies/template-csv'
       )
 
       userEvent.click(talliesButton)

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.tsx
@@ -21,7 +21,7 @@ import { StatusBar, AuditHeading } from '../Atoms/StatusBar'
 import { assert } from '../utilities'
 import { useAuthDataContext } from '../UserContext'
 import { Column } from '../Atoms/Layout'
-import { candidateTotalsByBatchTemplateFilePath } from './candidateTotalsByBatchTemplates'
+import { candidateTotalsByBatchTemplateCsvPath } from './candidateTotalsByBatchTemplateCsv'
 
 const JurisdictionAdminView: React.FC = () => {
   const { electionId, jurisdictionId } = useParams<{
@@ -179,7 +179,7 @@ const JurisdictionAdminView: React.FC = () => {
                   to store ballots for this particular election, plus a count of
                   how many votes were counted for each candidate in each of
                   those containers.'
-                  sampleFileLink={candidateTotalsByBatchTemplateFilePath({
+                  sampleFileLink={candidateTotalsByBatchTemplateCsvPath({
                     electionId,
                     jurisdictionId,
                   })}

--- a/client/src/components/JurisdictionAdmin/candidateTotalsByBatchTemplateCsv.ts
+++ b/client/src/components/JurisdictionAdmin/candidateTotalsByBatchTemplateCsv.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line import/prefer-default-export
-export function candidateTotalsByBatchTemplateFilePath({
+export function candidateTotalsByBatchTemplateCsvPath({
   electionId,
   jurisdictionId,
 }: {
   electionId: string
   jurisdictionId: string
 }): string {
-  return `/api/election/${electionId}/jurisdiction/${jurisdictionId}/batch-tallies/template`
+  return `/api/election/${electionId}/jurisdiction/${jurisdictionId}/batch-tallies/template-csv`
 }

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -579,7 +579,9 @@ def download_batch_inventory_batch_tallies(
             "Batch inventory must be signed off before downloading batch tallies."
         )
 
-    contest_choice_csv_headers = construct_contest_choice_csv_headers(jurisdiction)
+    contest_choice_csv_headers = construct_contest_choice_csv_headers(
+        election, jurisdiction
+    )
 
     csv_io = io.StringIO()
     batch_tallies = csv.writer(csv_io)

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -325,7 +325,7 @@ def download_batch_tallies_template_csv(
 @api.route(
     "/election/<election_id>/batch-tallies/summed-by-jurisdiction-csv", methods=["GET"],
 )
-@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
+@restrict_access([UserType.AUDIT_ADMIN])
 def download_batch_tallies_summed_by_jurisdiction_csv(election: Election):
     string_io = io.StringIO()
     csv_writer = csv.writer(string_io)

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -24,7 +24,11 @@ from ..util.file import (
     store_file,
     timestamp_filename,
 )
-from ..util.csv_download import csv_response, jurisdiction_timestamp_name
+from ..util.csv_download import (
+    csv_response,
+    election_timestamp_name,
+    jurisdiction_timestamp_name,
+)
 from ..util.csv_parse import (
     parse_csv,
     CSVValueType,
@@ -42,10 +46,11 @@ BATCH_NAME = "Batch Name"
 
 
 def construct_contest_choice_csv_headers(
-    jurisdiction: Jurisdiction,
+    election: Election, jurisdiction: Optional[Jurisdiction] = None,
 ) -> ContestChoiceCsvHeaders:
-    contests = list(jurisdiction.contests)
-    is_multi_contest_audit = len(list(jurisdiction.election.contests)) > 1
+    audit_contests = list(election.contests)
+    contests = audit_contests if jurisdiction is None else list(jurisdiction.contests)
+    is_multi_contest_audit = len(audit_contests) > 1
     contest_choice_csv_headers = {
         # Include contest name in contest choice CSV headers for multi-contest audits just in
         # case two choices in different contests have the same name
@@ -137,7 +142,9 @@ def process_batch_tallies_file(
 
     def process() -> None:
         contests = list(jurisdiction.contests)
-        contest_choice_csv_headers = construct_contest_choice_csv_headers(jurisdiction)
+        contest_choice_csv_headers = construct_contest_choice_csv_headers(
+            jurisdiction.election, jurisdiction
+        )
 
         # Save the tallies as a JSON blob in the format needed by the audit_math.macro module
         # { batch_name: { contest_id: { choice_id: vote_count } } }
@@ -286,17 +293,19 @@ def clear_batch_tallies(
 
 
 @api.route(
-    "/election/<election_id>/jurisdiction/<jurisdiction_id>/batch-tallies/template",
+    "/election/<election_id>/jurisdiction/<jurisdiction_id>/batch-tallies/template-csv",
     methods=["GET"],
 )
 @restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
-def download_batch_tallies_template(
+def download_batch_tallies_template_csv(
     election: Election, jurisdiction: Jurisdiction  # pylint: disable=unused-argument
 ):
     string_io = io.StringIO()
     template = csv.writer(string_io)
 
-    contest_choice_csv_headers = construct_contest_choice_csv_headers(jurisdiction)
+    contest_choice_csv_headers = construct_contest_choice_csv_headers(
+        jurisdiction.election, jurisdiction
+    )
     csv_headers = [
         BATCH_NAME,
         *contest_choice_csv_headers.values(),
@@ -310,4 +319,58 @@ def download_batch_tallies_template(
     return csv_response(
         string_io,
         filename=f"candidate-totals-by-batch-template-{jurisdiction_timestamp_name(election, jurisdiction)}.csv",
+    )
+
+
+@api.route(
+    "/election/<election_id>/batch-tallies/summed-by-jurisdiction-csv", methods=["GET"],
+)
+@restrict_access([UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN])
+def download_batch_tallies_summed_by_jurisdiction_csv(election: Election):
+    string_io = io.StringIO()
+    csv_writer = csv.writer(string_io)
+
+    contest_choice_csv_headers = construct_contest_choice_csv_headers(election)
+    csv_headers = [
+        "Jurisdiction",
+        *contest_choice_csv_headers.values(),
+        "Total Ballots",
+    ]
+    csv_writer.writerow(csv_headers)
+
+    running_totals = [0] * (len(contest_choice_csv_headers) + 1)
+    for jurisdiction in election.jurisdictions:
+        # Sum vote counts across batches
+        # { (contest_id, choice_id): vote_count }
+        vote_counts: Dict[Tuple[str, str], int] = defaultdict(int)
+        if jurisdiction.batch_tallies is not None:
+            assert not isinstance(jurisdiction.batch_tallies, list)
+            for batch_tallies in jurisdiction.batch_tallies.values():
+                for contest_id, batch_tallies_for_contest in batch_tallies.items():
+                    for choice_id, vote_count in batch_tallies_for_contest.items():
+                        vote_counts[(contest_id, choice_id)] += vote_count
+
+        batches = list(jurisdiction.batches)
+        total_ballot_count = (
+            sum(batch.num_ballots for batch in batches) if len(batches) > 0 else None
+        )
+
+        counts = [
+            vote_counts.get(key, None) for key in contest_choice_csv_headers.keys()
+        ] + [total_ballot_count]
+
+        row = [jurisdiction.name, *counts]
+        csv_writer.writerow(row)
+
+        running_totals = [
+            running_total + (count or 0)
+            for running_total, count in zip(running_totals, counts)
+        ]
+
+    total_row = ["Total", *running_totals]
+    csv_writer.writerow(total_row)
+
+    string_io.seek(0)
+    return csv_response(
+        string_io, filename=f"reported-results-{election_timestamp_name(election)}.csv",
     )

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -747,3 +747,28 @@ def test_batch_comparison_sample_preview(
         assert preview["name"] == jurisdiction["name"]
         assert preview["numSamples"] == jurisdiction["currentRoundStatus"]["numSamples"]
         assert preview["numUnique"] == jurisdiction["currentRoundStatus"]["numUnique"]
+
+
+def test_batch_tallies_summed_by_jurisdiction_csv_generation(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids,  # pylint: disable=unused-argument
+    contest_ids,  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    batch_tallies,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+
+    rv = client.get(
+        f"/api/election/{election_id}/batch-tallies/summed-by-jurisdiction-csv"
+    )
+    assert rv.status_code == 200
+    csv_contents = rv.data.decode("utf-8")
+    assert csv_contents == (
+        "Jurisdiction,candidate 1,candidate 2,candidate 3,Total Ballots\r\n"
+        "J1,2500,1250,1250,2500\r\n"
+        "J2,2200,1100,1100,2500\r\n"
+        "J3,,,,\r\n"
+        "Total,4700,2350,2350,5000\r\n"
+    )

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -685,11 +685,11 @@ def test_batch_tallies_reprocess_after_manifest_reupload(
     assert Jurisdiction.query.get(jurisdiction_ids[0]).batch_tallies is not None
 
 
-def test_batch_tallies_template_generation(
+def test_batch_tallies_template_csv_generation(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],
-    contest_ids: List[str],  # pylint: disable=unused-argument
+    contest_ids,  # pylint: disable=unused-argument
 ):
     for user_type, user_email in [
         (UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL),
@@ -698,11 +698,11 @@ def test_batch_tallies_template_generation(
         set_logged_in_user(client, user_type, user_email)
 
         rv = client.get(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies/template"
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies/template-csv"
         )
         assert rv.status_code == 200
-        template_contents = rv.data.decode("utf-8")
-        assert template_contents == (
+        csv_contents = rv.data.decode("utf-8")
+        assert csv_contents == (
             "Batch Name,candidate 1,candidate 2,candidate 3\r\n"
             "Batch 1,0,0,0\r\n"
             "Batch 2,0,0,0\r\n"


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/arlo/issues/1867

During previous batch audits, our audit specialists have manually downloaded every jurisdiction's candidate-totals-by-batch file, summed the numbers across batches, and prepared [a summary file to compare against state-published results](https://docs.google.com/spreadsheets/d/1g8X2-HGZ12rZ_orW1Jo82AoOqYsaw2pC9t8Bo0aAOcE/edit?usp=sharing). A very cumbersome task 😅.

This PR builds the generation of this summary file into the product.

_Before audit launch_

<img width="600" alt="before-launch" src="https://github.com/votingworks/arlo/assets/12616928/f723078e-e937-48c9-81c6-7d15c1b089a9">

_After audit launch_

<img width="600" alt="after-launch" src="https://github.com/votingworks/arlo/assets/12616928/974a3bfd-69b8-4f78-978c-86ccb0ee89ea">

_Sample CSV before all jurisdiction files have been uploaded_

```
Jurisdiction,Contest 1 - Choice 1,Contest 1 - Choice 2,Contest 2 - Choice 3,Contest 2 - Choice 4,Total Ballots
J1,0,0,99,1,100
J2,40,10,,,50
J3,,,,,
Total,40,10,99,1,150
```

_Sample CSV after all jurisdiction files have been uploaded_

Some entries are still blank because Contest 2 only exists in Jurisdiction 1.

```
Jurisdiction,Contest 1 - Choice 1,Contest 1 - Choice 2,Contest 2 - Choice 3,Contest 2 - Choice 4,Total Ballots
J1,0,0,99,1,100
J2,40,10,,,50
J3,40,10,,,50
Total,80,20,99,1,200
```

For single-contest batch audits, the headers don't include contest names.

## Testing

- [x] Updated automated tests
- [x] Tested manually

