### PR TITLE
Optimize /jurisdictions endpoint to lower risk of timeouts

### DIFF
--- a/client/src/components/AuditAdmin/AuditAdminView.test.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.test.tsx
@@ -288,6 +288,7 @@ describe('AA setup flow', () => {
         options: { method: 'DELETE' },
         response: { status: 'ok' },
       },
+      aaApiCalls.getJurisdictions,
       aaApiCalls.getRounds(roundMocks.empty),
       aaApiCalls.getMapData,
     ]

--- a/client/src/components/AuditAdmin/useRoundsAuditAdmin.ts
+++ b/client/src/components/AuditAdmin/useRoundsAuditAdmin.ts
@@ -9,6 +9,7 @@ import {
 import { FileProcessingStatus } from '../useCSV'
 import { ISampleSizeOption } from './Setup/Review/useSampleSizes'
 import { fetchApi, ApiError } from '../../utils/api'
+import { jurisdictionsQueryKey } from '../useJurisdictions'
 
 export interface IRound {
   id: string
@@ -119,8 +120,9 @@ export const useUndoRoundStart = (
   const queryClient = useQueryClient()
 
   return useMutation(deleteRound, {
-    onSuccess: () => {
-      queryClient.invalidateQueries(roundsQueryKey(electionId))
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(jurisdictionsQueryKey(electionId))
+      await queryClient.invalidateQueries(roundsQueryKey(electionId))
     },
   })
 }

--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -193,7 +193,9 @@ def serialize_jurisdiction(
             CvrBallot.query.join(Batch)
             .filter_by(jurisdiction_id=jurisdiction.id)
             .count()
-            if processing and processing["status"] == ProcessingStatus.PROCESSED
+            if (not round_status)
+            and processing
+            and processing["status"] == ProcessingStatus.PROCESSED
             else None
         )
         json_jurisdiction["cvrs"] = {

--- a/server/api/shared.py
+++ b/server/api/shared.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 import random
 from typing import Dict, List, Optional, Tuple, TypedDict, Union
 from sqlalchemy import and_, func, literal, true
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, load_only
 
 
 from ..models import *  # pylint: disable=wildcard-import
@@ -297,9 +297,11 @@ def sampled_ballot_interpretations_to_cvrs(
         )
 
     ballots = ballots_query.options(
+        load_only(SampledBallot.id, SampledBallot.status),
         joinedload(SampledBallot.interpretations)
+        .load_only(BallotInterpretation.contest_id, BallotInterpretation.interpretation)
         .joinedload(BallotInterpretation.selected_choices)
-        .load_only(ContestChoice.id)
+        .load_only(ContestChoice.id),
     ).all()
 
     # The CVR we build should have a 1 for each choice that got voted for,


### PR DESCRIPTION
Small optimizations to the /jurisdictions endpoint to reduce the risk of multiple slow db queries causing a request timeout. Details in commits.

Since I wasn't able to reproduce hypothetical conditions where a request timeout would occur (when the db decided to do a seq scan for the query to count CVR ballots), I can't confirm that this solves the issue.

Planning a follow up PR to move discrepancy calculation to a separate endpoint because the slow query to load sampled ballots is currently blocking the entire page load, which is a pretty bad UX.