### PR TITLE
Fetch jurisdictions discrepancy counts from separate endpoint

### DIFF
--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -239,7 +239,14 @@ describe('Progress screen', () => {
   })
 
   it('shows round status for ballot comparison', async () => {
-    const expectedCalls = [aaApiCalls.getMapData]
+    const expectedCalls = [
+      aaApiCalls.getMapData,
+      aaApiCalls.getDiscrepancyCounts({
+        [jurisdictionMocks.allComplete[0].id]: 0,
+        [jurisdictionMocks.allComplete[1].id]: 2,
+        [jurisdictionMocks.allComplete[2].id]: 1,
+      }),
+    ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = render({
         auditSettings: auditSettingsMocks.ballotComparisonAll,
@@ -249,6 +256,10 @@ describe('Progress screen', () => {
 
       expect(container.querySelectorAll('.d3-component').length).toBe(1)
 
+      // One spinner for each jurisdiction's discrepancy count
+      expect(container.querySelectorAll('.bp3-spinner').length).toBe(
+        1 + jurisdictionMocks.allComplete.length
+      )
       await waitFor(() => {
         expect(container.querySelectorAll('.bp3-spinner').length).toBe(0)
       })
@@ -315,7 +326,14 @@ describe('Progress screen', () => {
   })
 
   it('shows round status for batch comparison', async () => {
-    const expectedCalls = [aaApiCalls.getMapData]
+    const expectedCalls = [
+      aaApiCalls.getMapData,
+      aaApiCalls.getDiscrepancyCounts({
+        [jurisdictionMocks.oneComplete[0].id]: 3,
+        [jurisdictionMocks.oneComplete[1].id]: 2,
+        [jurisdictionMocks.oneComplete[2].id]: 1,
+      }),
+    ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = render({
         auditSettings: auditSettingsMocks.batchComparisonAll,
@@ -346,6 +364,7 @@ describe('Progress screen', () => {
       expect(row1[0]).toHaveTextContent('Jurisdiction 1')
       expectStatusTag(row1[1], 'In progress', 'warning')
       expect(row1[2]).toHaveTextContent('2,117')
+      // Discrepancies hidden until jurisdiction is complete
       expect(row1[3]).toHaveTextContent('')
       expect(row1[4]).toHaveTextContent('4')
       expect(row1[5]).toHaveTextContent('6')
@@ -353,6 +372,7 @@ describe('Progress screen', () => {
       expect(row2[0]).toHaveTextContent('Jurisdiction 2')
       expectStatusTag(row2[1], 'Not started', 'none')
       expect(row2[2]).toHaveTextContent('2,117')
+      // Discrepancies hidden until jurisdiction is complete
       expect(row2[3]).toHaveTextContent('')
       expect(row2[4]).toHaveTextContent('0')
       expect(row2[5]).toHaveTextContent('0')
@@ -595,7 +615,14 @@ describe('Progress screen', () => {
   })
 
   it('shows a different toggle label for batch audits', async () => {
-    const expectedCalls = [aaApiCalls.getMapData]
+    const expectedCalls = [
+      aaApiCalls.getMapData,
+      aaApiCalls.getDiscrepancyCounts({
+        [jurisdictionMocks.oneComplete[0].id]: 0,
+        [jurisdictionMocks.oneComplete[1].id]: 0,
+        [jurisdictionMocks.oneComplete[2].id]: 0,
+      }),
+    ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = render({
         jurisdictions: jurisdictionMocks.oneComplete,

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -21,6 +21,7 @@ import {
   IBallotManifestInfo,
   IBatchTalliesFileInfo,
   IJurisdiction,
+  DiscrepancyCountsByJurisdiction,
 } from './useJurisdictions'
 import { IStandardizedContest } from './useStandardizedContests'
 import { ISampleSizesResponse } from './AuditAdmin/Setup/Review/useSampleSizes'
@@ -686,7 +687,6 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 10,
         numSamplesAudited: 5,
         numSamples: 11,
-        numDiscrepancies: null,
       },
     },
     {
@@ -701,7 +701,6 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 20,
         numSamplesAudited: 0,
         numSamples: 22,
-        numDiscrepancies: null,
       },
     },
     {
@@ -716,7 +715,6 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 30,
         numSamplesAudited: 31,
         numSamples: 31,
-        numDiscrepancies: 1,
       },
     },
   ],
@@ -733,7 +731,6 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 10,
         numSamplesAudited: 11,
         numSamples: 11,
-        numDiscrepancies: 0,
       },
     },
     {
@@ -748,7 +745,6 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 20,
         numSamplesAudited: 22,
         numSamples: 22,
-        numDiscrepancies: 2,
       },
     },
     {
@@ -763,7 +759,6 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 30,
         numSamplesAudited: 31,
         numSamples: 31,
-        numDiscrepancies: 1,
       },
     },
   ],
@@ -833,7 +828,6 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 10,
         numSamplesAudited: 0,
         numSamples: 11,
-        numDiscrepancies: null,
       },
     },
     {
@@ -848,7 +842,6 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 20,
         numSamplesAudited: 0,
         numSamples: 22,
-        numDiscrepancies: null,
       },
     },
     {
@@ -863,7 +856,6 @@ export const jurisdictionMocks = mocksOfType<IJurisdiction[]>()({
         numUnique: 30,
         numSamplesAudited: 31,
         numSamples: 31,
-        numDiscrepancies: 0,
       },
     },
   ],
@@ -2015,6 +2007,10 @@ export const aaApiCalls = {
     url: '/us-states-counties.json',
     response: mapTopology,
   },
+  getDiscrepancyCounts: (response: DiscrepancyCountsByJurisdiction) => ({
+    url: '/api/election/1/discrepancy-counts',
+    response,
+  }),
   reopenAuditBoard: {
     url:
       '/api/election/1/jurisdiction/jurisdiction-id-1/round/round-1/audit-board/audit-board-1/sign-off',

--- a/client/src/components/useJurisdictions.ts
+++ b/client/src/components/useJurisdictions.ts
@@ -50,7 +50,6 @@ export interface IJurisdiction {
     numUnique: number
     numUniqueAudited: number
     numBatchesAudited?: number
-    numDiscrepancies?: number | null
   } | null
 }
 
@@ -143,4 +142,26 @@ export const useJurisdictions = (
     )
     return response.jurisdictions
   })
+}
+
+// { jurisidictionId: discrepancyCount }
+export type DiscrepancyCountsByJurisdiction = Record<string, number>
+
+const discrepancyCountsQueryKey = (electionId: string): string[] =>
+  jurisdictionsQueryKey(electionId).concat('discrepancy-counts')
+
+export const useDiscrepancyCountsByJurisdiction = (
+  electionId: string,
+  options: { enabled?: boolean }
+): UseQueryResult<DiscrepancyCountsByJurisdiction, ApiError> => {
+  return useQuery(
+    discrepancyCountsQueryKey(electionId),
+    async () => {
+      const response: DiscrepancyCountsByJurisdiction = await fetchApi(
+        `/api/election/${electionId}/discrepancy-counts`
+      )
+      return response
+    },
+    options
+  )
 }

--- a/server/tests/api/test_jurisdictions.py
+++ b/server/tests/api/test_jurisdictions.py
@@ -382,3 +382,33 @@ def test_jurisdictions_round_status_offline(
     jurisdictions = json.loads(rv.data)["jurisdictions"]
 
     snapshot.assert_match(jurisdictions[0]["currentRoundStatus"])
+
+
+def test_discrepancy_counts_wrong_audit_type(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+    round_1_id: str,  # pylint: disable=unused-argument
+):
+    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Conflict",
+                "message": "Discrepancy counts are only available for ballot comparison and batch comparison audits",
+            }
+        ]
+    }
+
+
+def test_discrepancy_counts_before_audit_launch(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+):
+    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [{"errorType": "Conflict", "message": "Audit not started",}]
+    }

--- a/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_ballot_comparison.py
@@ -80,7 +80,6 @@ snapshots["test_ballot_comparison_two_rounds 1"] = {
 }
 
 snapshots["test_ballot_comparison_two_rounds 10"] = {
-    "numDiscrepancies": 1,
     "numSamples": 6,
     "numSamplesAudited": 6,
     "numUnique": 5,
@@ -142,7 +141,6 @@ J2,TABULATOR2,BATCH2,4,2-2-5,Round 2: 0.583133559190710795,AUDITED,CONTEST_NOT_O
 """
 
 snapshots["test_ballot_comparison_two_rounds 2"] = {
-    "numDiscrepancies": None,
     "numSamples": 9,
     "numSamplesAudited": 0,
     "numUnique": 8,
@@ -151,7 +149,6 @@ snapshots["test_ballot_comparison_two_rounds 2"] = {
 }
 
 snapshots["test_ballot_comparison_two_rounds 3"] = {
-    "numDiscrepancies": None,
     "numSamples": 11,
     "numSamplesAudited": 0,
     "numUnique": 9,
@@ -160,7 +157,6 @@ snapshots["test_ballot_comparison_two_rounds 3"] = {
 }
 
 snapshots["test_ballot_comparison_two_rounds 4"] = {
-    "numDiscrepancies": 7,
     "numSamples": 9,
     "numSamplesAudited": 9,
     "numUnique": 8,
@@ -169,7 +165,6 @@ snapshots["test_ballot_comparison_two_rounds 4"] = {
 }
 
 snapshots["test_ballot_comparison_two_rounds 5"] = {
-    "numDiscrepancies": None,
     "numSamples": 11,
     "numSamplesAudited": 11,
     "numUnique": 9,
@@ -178,7 +173,6 @@ snapshots["test_ballot_comparison_two_rounds 5"] = {
 }
 
 snapshots["test_ballot_comparison_two_rounds 6"] = {
-    "numDiscrepancies": 7,
     "numSamples": 9,
     "numSamplesAudited": 9,
     "numUnique": 8,
@@ -187,7 +181,6 @@ snapshots["test_ballot_comparison_two_rounds 6"] = {
 }
 
 snapshots["test_ballot_comparison_two_rounds 7"] = {
-    "numDiscrepancies": 4,
     "numSamples": 11,
     "numSamplesAudited": 11,
     "numUnique": 9,
@@ -242,7 +235,6 @@ J2,TABULATOR2,BATCH2,6,,Round 1: 0.414184312862040881,AUDITED,Choice 1-1,,Ballot
 """
 
 snapshots["test_ballot_comparison_two_rounds 9"] = {
-    "numDiscrepancies": 5,
     "numSamples": 4,
     "numSamplesAudited": 4,
     "numUnique": 4,
@@ -257,25 +249,5 @@ snapshots["test_set_contest_metadata_on_contest_creation 1"] = {
         {"name": "Choice 2-3", "num_votes": 14},
     ],
     "total_ballots_cast": 30,
-    "votes_allowed": 2,
-}
-
-snapshots["test_set_contest_metadata_on_manifest_and_cvr_upload 1"] = {
-    "choices": [
-        {"name": "Choice 2-1", "num_votes": 24},
-        {"name": "Choice 2-2", "num_votes": 10},
-        {"name": "Choice 2-3", "num_votes": 14},
-    ],
-    "total_ballots_cast": 30,
-    "votes_allowed": 2,
-}
-
-snapshots["test_set_contest_metadata_on_manifest_and_cvr_upload 2"] = {
-    "choices": [
-        {"name": "Choice 2-1", "num_votes": 18},
-        {"name": "Choice 2-2", "num_votes": 8},
-        {"name": "Choice 2-3", "num_votes": 10},
-    ],
-    "total_ballots_cast": 24,
     "votes_allowed": 2,
 }

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -8,7 +8,6 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots["test_batch_comparison_batches_sampled_multiple_times 1"] = {
-    "numDiscrepancies": 0,
     "numSamples": 5,
     "numSamplesAudited": 5,
     "numUnique": 4,
@@ -17,7 +16,6 @@ snapshots["test_batch_comparison_batches_sampled_multiple_times 1"] = {
 }
 
 snapshots["test_batch_comparison_batches_sampled_multiple_times 2"] = {
-    "numDiscrepancies": 0,
     "numSamples": 2,
     "numSamplesAudited": 2,
     "numUnique": 1,
@@ -53,7 +51,6 @@ J2,Batch 3,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1
 """
 
 snapshots["test_batch_comparison_round_1 1"] = {
-    "numDiscrepancies": None,
     "numSamples": 9,
     "numSamplesAudited": 0,
     "numUnique": 6,
@@ -62,7 +59,6 @@ snapshots["test_batch_comparison_round_1 1"] = {
 }
 
 snapshots["test_batch_comparison_round_1 2"] = {
-    "numDiscrepancies": None,
     "numSamples": 5,
     "numSamplesAudited": 0,
     "numUnique": 2,
@@ -71,7 +67,6 @@ snapshots["test_batch_comparison_round_1 2"] = {
 }
 
 snapshots["test_batch_comparison_round_2 1"] = {
-    "numDiscrepancies": None,
     "numSamples": 5,
     "numSamplesAudited": 2,
     "numUnique": 4,
@@ -80,7 +75,6 @@ snapshots["test_batch_comparison_round_2 1"] = {
 }
 
 snapshots["test_batch_comparison_round_2 10"] = {
-    "numDiscrepancies": None,
     "numSamples": 2,
     "numSamplesAudited": 0,
     "numUnique": 1,
@@ -136,7 +130,6 @@ J1,Batch 4,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate
 """
 
 snapshots["test_batch_comparison_round_2 2"] = {
-    "numDiscrepancies": None,
     "numSamples": 5,
     "numSamplesAudited": 3,
     "numUnique": 4,
@@ -145,7 +138,6 @@ snapshots["test_batch_comparison_round_2 2"] = {
 }
 
 snapshots["test_batch_comparison_round_2 3"] = {
-    "numDiscrepancies": None,
     "numSamples": 5,
     "numSamplesAudited": 4,
     "numUnique": 4,
@@ -154,7 +146,6 @@ snapshots["test_batch_comparison_round_2 3"] = {
 }
 
 snapshots["test_batch_comparison_round_2 4"] = {
-    "numDiscrepancies": None,
     "numSamples": 5,
     "numSamplesAudited": 5,
     "numUnique": 4,
@@ -163,7 +154,6 @@ snapshots["test_batch_comparison_round_2 4"] = {
 }
 
 snapshots["test_batch_comparison_round_2 5"] = {
-    "numDiscrepancies": 4,
     "numSamples": 5,
     "numSamplesAudited": 5,
     "numUnique": 4,
@@ -172,7 +162,6 @@ snapshots["test_batch_comparison_round_2 5"] = {
 }
 
 snapshots["test_batch_comparison_round_2 6"] = {
-    "numDiscrepancies": None,
     "numSamples": 2,
     "numSamplesAudited": 0,
     "numUnique": 1,
@@ -181,7 +170,6 @@ snapshots["test_batch_comparison_round_2 6"] = {
 }
 
 snapshots["test_batch_comparison_round_2 7"] = {
-    "numDiscrepancies": 4,
     "numSamples": 5,
     "numSamplesAudited": 5,
     "numUnique": 4,
@@ -190,7 +178,6 @@ snapshots["test_batch_comparison_round_2 7"] = {
 }
 
 snapshots["test_batch_comparison_round_2 8"] = {
-    "numDiscrepancies": 1,
     "numSamples": 2,
     "numSamplesAudited": 2,
     "numUnique": 1,
@@ -199,7 +186,6 @@ snapshots["test_batch_comparison_round_2 8"] = {
 }
 
 snapshots["test_batch_comparison_round_2 9"] = {
-    "numDiscrepancies": None,
     "numSamples": 3,
     "numSamplesAudited": 1,
     "numUnique": 2,

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -677,12 +677,11 @@ def test_multi_contest_batch_comparison_end_to_end(
 
     # Check discrepancy counts
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/jurisdiction")
-    assert rv.status_code == 200
-    jurisdictions = json.loads(rv.data)["jurisdictions"]
-    assert jurisdictions[0]["currentRoundStatus"]["numDiscrepancies"] == 4
-    assert jurisdictions[1]["currentRoundStatus"]["numDiscrepancies"] == 0
-    assert jurisdictions[2]["currentRoundStatus"]["numDiscrepancies"] == 1
+    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
+    discrepancy_counts = json.loads(rv.data)
+    assert discrepancy_counts[jurisdictions[0]["id"]] == 4
+    assert discrepancy_counts[jurisdictions[1]["id"]] == 0
+    assert discrepancy_counts[jurisdictions[2]["id"]] == 1
 
     #
     # Finish audit
@@ -866,12 +865,11 @@ def test_multi_contest_batch_comparison_round_2(
 
     # Check discrepancy counts
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/jurisdiction")
-    assert rv.status_code == 200
-    jurisdictions = json.loads(rv.data)["jurisdictions"]
-    assert jurisdictions[0]["currentRoundStatus"]["numDiscrepancies"] == 1
-    assert jurisdictions[1]["currentRoundStatus"]["numDiscrepancies"] == 0
-    assert jurisdictions[2]["currentRoundStatus"]["numDiscrepancies"] == 0
+    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
+    discrepancy_counts = json.loads(rv.data)
+    assert discrepancy_counts[jurisdiction_ids[0]] == 1
+    assert discrepancy_counts[jurisdiction_ids[1]] == 0
+    assert discrepancy_counts[jurisdiction_ids[2]] == 0
 
     #
     # End round 1
@@ -998,12 +996,11 @@ def test_multi_contest_batch_comparison_round_2(
 
     # Check discrepancy counts
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/jurisdiction")
-    assert rv.status_code == 200
-    jurisdictions = json.loads(rv.data)["jurisdictions"]
-    assert jurisdictions[0]["currentRoundStatus"]["numDiscrepancies"] == 0
-    assert jurisdictions[1]["currentRoundStatus"]["numDiscrepancies"] == 0
-    assert jurisdictions[2]["currentRoundStatus"]["numDiscrepancies"] == 0
+    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
+    discrepancy_counts = json.loads(rv.data)
+    assert discrepancy_counts[jurisdiction_ids[0]] == 0
+    assert discrepancy_counts[jurisdiction_ids[1]] == 0
+    assert discrepancy_counts[jurisdiction_ids[2]] == 0
 
     #
     # End round 2 / finish audit


### PR DESCRIPTION
Previously, discrepancy counts were included in jurisdiction round status. This can be a slow calculation, since we need to load all the sampled ballot interpretations. Since the jurisdictions endpoint blocks page load, it's not great to have a slow calculation as part of that endpoint. Instead, we load the discrepancy counts separately and show a spinner while they are loading.

https://github.com/votingworks/arlo/assets/530106/d4256457-2774-426d-a0ee-027d670b1f10


