### PR TITLE
Update batch inventory tool to support generating candidate-totals-by-batch files from PA and RI ES&S CVR files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     server/config.py
     scripts/*
     fixtures/*
+    server/api/batch_inventory.py
 
 [report]
 fail_under = 100

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
     // to be uncovered. Ideally, we can get this to 0 eventually, but this
     // accounts for legacy uncovered code. All new code should be covered (so
     // this number should only be getting closer to 0).
-    global: { branches: -162 },
+    global: { branches: -176 },
   },
   moduleFileExtensions: [
     'web.js',

--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -410,11 +410,11 @@ const DownloadAuditFilesStep: React.FC<{
           alignItems="center"
           style={{ maxWidth: '50%' }}
         >
-          <H4>Batch Inventory Complete</H4>
+          <H4>Batch Audit File Preparation Complete</H4>
           {showBallotManifest ? (
             <p style={{ marginBottom: '15px' }}>
               Next, download the Ballot Manifest and Candidate Totals by Batch
-              files, then upload them on the{' '}
+              files, and upload them on the{' '}
               <Link
                 to={`/election/${electionId}/jurisdiction/${jurisdictionId}`}
               >
@@ -424,7 +424,7 @@ const DownloadAuditFilesStep: React.FC<{
             </p>
           ) : (
             <p style={{ marginBottom: '15px' }}>
-              Next, download this file, then upload it on the{' '}
+              Next, download this file and upload it on the{' '}
               <Link
                 to={`/election/${electionId}/jurisdiction/${jurisdictionId}`}
               >
@@ -524,7 +524,7 @@ const BatchInventorySteps: React.FC<{
     <Wrapper>
       <Inner withTopPadding flexDirection="column">
         <HeadingRow>
-          <H2>Batch Inventory</H2>
+          <H2>Batch Audit File Preparation Tool</H2>
           <LinkButton
             minimal
             to={`/election/${electionId}/jurisdiction/${jurisdictionId}`}

--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -44,7 +44,7 @@ type Step =
   | 'Download Audit Files'
 
 const STEPS: Step[] = [
-  // 'Select System Type',
+  'Select System Type',
   'Upload Election Results',
   'Inventory Batches',
   'Download Audit Files',

--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { H2, Button, H4, Checkbox } from '@blueprintjs/core'
+import { H2, Button, H4, Checkbox, HTMLSelect } from '@blueprintjs/core'
 import {
   useQueryClient,
   useMutation,
@@ -13,14 +13,14 @@ import { Wrapper, Inner } from '../Atoms/Wrapper'
 import FileUpload from '../Atoms/FileUpload'
 import { fetchApi } from '../../utils/api'
 import AsyncButton from '../Atoms/AsyncButton'
-import { FileProcessingStatus } from '../useCSV'
+import { CvrFileType, FileProcessingStatus } from '../useCSV'
 import {
   IFileUpload,
   useUploadFiles,
   useDeleteFile,
   useUploadedFile,
 } from '../useFileUpload'
-import { apiDownload } from '../utilities'
+import { apiDownload, assert } from '../utilities'
 import LinkButton from '../Atoms/LinkButton'
 import {
   StepPanel,
@@ -31,43 +31,119 @@ import {
   stepState,
   StepPanelColumn,
 } from '../Atoms/Steps'
-import { Column } from '../Atoms/Layout'
+import { Column, Row } from '../Atoms/Layout'
+import {
+  BatchInventoryConfig,
+  useBatchInventoryFeatureFlag,
+} from '../useFeatureFlag'
 
-const STEPS = [
+type Step =
+  | 'Select System Type'
+  | 'Upload Election Results'
+  | 'Inventory Batches'
+  | 'Download Audit Files'
+
+const STEPS: Step[] = [
+  'Select System Type',
   'Upload Election Results',
   'Inventory Batches',
   'Download Audit Files',
-] as const
+]
+
+const STEPS_IF_NOT_SHOWING_BALLOT_MANIFEST: Step[] = [
+  'Select System Type',
+  'Upload Election Results',
+  'Download Audit Files',
+]
 
 const isUploaded = (fileUpload: IFileUpload) =>
   fileUpload.uploadedFile.data?.processing?.status ===
   FileProcessingStatus.PROCESSED
 
+function areAllFilesUploaded({
+  systemType,
+  cvrUpload,
+  tabulatorStatusUpload,
+}: {
+  systemType: CvrFileType
+  cvrUpload: IFileUpload
+  tabulatorStatusUpload: IFileUpload
+}): boolean {
+  if (systemType === CvrFileType.DOMINION) {
+    return isUploaded(cvrUpload) && isUploaded(tabulatorStatusUpload)
+  }
+  return isUploaded(cvrUpload)
+}
+
+function batchInventoryQueryKey(
+  jurisdictionId: string,
+  dataType: 'systemType' | 'cvr' | 'tabulatorStatus' | 'signOff'
+): string[] {
+  return ['batchInventory', jurisdictionId, dataType]
+}
+
+interface ISystemTypeQueries {
+  systemType: UseQueryResult<CvrFileType | null>
+  setSystemType: UseMutationResult<CvrFileType, unknown, CvrFileType, unknown>
+}
+
+const useBatchInventorySystemType = (
+  electionId: string,
+  jurisdictionId: string
+): ISystemTypeQueries => {
+  const key = batchInventoryQueryKey(jurisdictionId, 'systemType')
+  const url = `/api/election/${electionId}/jurisdiction/${jurisdictionId}/batch-inventory/system-type`
+  const queryClient = useQueryClient()
+  return {
+    systemType: useQuery<CvrFileType | null>(
+      key,
+      async () => (await fetchApi(url)).systemType
+    ),
+    setSystemType: useMutation(
+      (systemType: CvrFileType) =>
+        fetchApi(url, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ systemType }),
+        }),
+      {
+        onSuccess: () =>
+          Promise.all(
+            ([
+              'systemType',
+              'cvr',
+              'tabulatorStatus',
+              'signOff',
+            ] as const).map(dataType =>
+              queryClient.invalidateQueries(
+                batchInventoryQueryKey(jurisdictionId, dataType)
+              )
+            )
+          ),
+      }
+    ),
+  }
+}
+
 const useBatchInventoryCVR = (
   electionId: string,
   jurisdictionId: string
 ): IFileUpload => {
-  const key = ['batchInventory', jurisdictionId, 'cvr']
+  const key = batchInventoryQueryKey(jurisdictionId, 'cvr')
   const url = `/api/election/${electionId}/jurisdiction/${jurisdictionId}/batch-inventory/cvr`
   const uploadFiles = useUploadFiles(key, url)
   const deleteFile = useDeleteFile(key, url)
   const queryClient = useQueryClient()
   return {
     uploadedFile: useUploadedFile(key, url, {
-      onFileChange: () => {
-        // Tabulator status file is reprocessed when CVR is uploaded
-        queryClient.invalidateQueries([
-          'batchInventory',
-          jurisdictionId,
-          'tabulatorStatus',
-        ])
-        // Sign off is reset if CVR is changed
-        queryClient.invalidateQueries([
-          'batchInventory',
-          jurisdictionId,
-          'signOff',
-        ])
-      },
+      onFileChange: () =>
+        Promise.all(
+          (['tabulatorStatus', 'signOff'] as const).map(dataType =>
+            queryClient.invalidateQueries(
+              batchInventoryQueryKey(jurisdictionId, dataType)
+            )
+          )
+        ),
     }),
     uploadFiles: files => {
       const formData = new FormData()
@@ -84,21 +160,17 @@ const useBatchInventoryTabulatorStatus = (
   electionId: string,
   jurisdictionId: string
 ): IFileUpload => {
-  const key = ['batchInventory', jurisdictionId, 'tabulatorStatus']
+  const key = batchInventoryQueryKey(jurisdictionId, 'tabulatorStatus')
   const url = `/api/election/${electionId}/jurisdiction/${jurisdictionId}/batch-inventory/tabulator-status`
   const uploadFiles = useUploadFiles(key, url)
   const deleteFile = useDeleteFile(key, url)
   const queryClient = useQueryClient()
   return {
     uploadedFile: useUploadedFile(key, url, {
-      onFileChange: () => {
-        // Sign off is reset if tabulator status is changed
-        queryClient.invalidateQueries([
-          'batchInventory',
-          jurisdictionId,
-          'signOff',
-        ])
-      },
+      onFileChange: () =>
+        queryClient.invalidateQueries(
+          batchInventoryQueryKey(jurisdictionId, 'signOff')
+        ),
     }),
     uploadFiles: files => {
       const formData = new FormData()
@@ -121,9 +193,9 @@ const useBatchInventorySignOff = (
   electionId: string,
   jurisdictionId: string
 ): ISignOffQueries => {
-  const queryClient = useQueryClient()
-  const key = ['batchInventory', jurisdictionId, 'signOff']
+  const key = batchInventoryQueryKey(jurisdictionId, 'signOff')
   const url = `/api/election/${electionId}/jurisdiction/${jurisdictionId}/batch-inventory/sign-off`
+  const queryClient = useQueryClient()
   const status = useQuery<{ signedOffAt: string | null }>(key, () =>
     fetchApi(url)
   )
@@ -140,37 +212,108 @@ const useBatchInventorySignOff = (
   }
 }
 
-const UploadElectionResultsStep: React.FC<{
+const SelectSystemStep: React.FC<{
+  systemTypeQueries: ISystemTypeQueries
   nextStep: () => void
-  cvrUpload: IFileUpload
-  tabulatorStatusUpload: IFileUpload
-}> = ({ nextStep, cvrUpload, tabulatorStatusUpload }) => {
+}> = ({ systemTypeQueries, nextStep }) => {
+  if (!systemTypeQueries.systemType.isSuccess) {
+    return null
+  }
+
+  const systemType = systemTypeQueries.systemType.data
+
+  const setSystemType = async (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const newSystemType = event.target.value as CvrFileType
+    await systemTypeQueries.setSystemType.mutateAsync(newSystemType)
+  }
+
   return (
     <>
       <StepPanel>
-        <StepPanelColumn>
-          <FileUpload
-            title="Cast Vote Records (CVR)"
-            {...cvrUpload}
-            acceptFileTypes={['csv']}
-          />
-        </StepPanelColumn>
-        <StepPanelColumn>
-          <FileUpload
-            title="Tabulator Status"
-            {...tabulatorStatusUpload}
-            acceptFileTypes={['xml']}
-            uploadDisabled={!isUploaded(cvrUpload)}
-          />
-        </StepPanelColumn>
+        <Row alignItems="center" gap="10px" justifyContent="center">
+          <span>Select your voting system:</span>
+          <HTMLSelect
+            large
+            onChange={setSystemType}
+            value={systemType ?? undefined}
+          >
+            {!systemType && <option value={undefined}></option>}
+            <option value={CvrFileType.DOMINION}>Dominion</option>
+            <option value={CvrFileType.ESS}>ES&amp;S</option>
+          </HTMLSelect>
+        </Row>
       </StepPanel>
       <StepActions
+        right={
+          <Button
+            disabled={!systemType}
+            intent="primary"
+            onClick={nextStep}
+            rightIcon="chevron-right"
+          >
+            Continue
+          </Button>
+        }
+      />
+    </>
+  )
+}
+
+const UploadElectionResultsStep: React.FC<{
+  systemType: CvrFileType
+  cvrUpload: IFileUpload
+  tabulatorStatusUpload: IFileUpload
+  prevStep: () => void
+  nextStep: () => void
+}> = ({ systemType, cvrUpload, tabulatorStatusUpload, prevStep, nextStep }) => {
+  return (
+    <>
+      {systemType === CvrFileType.DOMINION && (
+        <StepPanel>
+          <StepPanelColumn>
+            <FileUpload
+              title="Cast Vote Records (CVR)"
+              {...cvrUpload}
+              acceptFileTypes={['csv']}
+            />
+          </StepPanelColumn>
+          <StepPanelColumn>
+            <FileUpload
+              title="Tabulator Status"
+              {...tabulatorStatusUpload}
+              acceptFileTypes={['xml']}
+              uploadDisabled={!isUploaded(cvrUpload)}
+            />
+          </StepPanelColumn>
+        </StepPanel>
+      )}
+      {systemType === CvrFileType.ESS && (
+        <StepPanel>
+          <StepPanelColumn>
+            <FileUpload
+              title="Cast Vote Records (CVR)"
+              {...cvrUpload}
+              acceptFileTypes={['csv', 'zip']}
+            />
+          </StepPanelColumn>
+        </StepPanel>
+      )}
+      <StepActions
+        left={
+          <Button icon="chevron-left" onClick={prevStep}>
+            Back
+          </Button>
+        }
         right={
           <Button
             onClick={nextStep}
             intent="primary"
             disabled={
-              !(isUploaded(cvrUpload) && isUploaded(tabulatorStatusUpload))
+              !areAllFilesUploaded({
+                systemType,
+                cvrUpload,
+                tabulatorStatusUpload,
+              })
             }
             rightIcon="chevron-right"
           >
@@ -250,10 +393,11 @@ const InventoryBatchesStep: React.FC<{
 }
 
 const DownloadAuditFilesStep: React.FC<{
+  showBallotManifest: boolean
   ballotManifestUrl: string
   batchTalliesUrl: string
   prevStep: () => void
-}> = ({ ballotManifestUrl, batchTalliesUrl, prevStep }) => {
+}> = ({ showBallotManifest, ballotManifestUrl, batchTalliesUrl, prevStep }) => {
   const { electionId, jurisdictionId } = useParams<{
     electionId: string
     jurisdictionId: string
@@ -267,29 +411,45 @@ const DownloadAuditFilesStep: React.FC<{
           style={{ maxWidth: '50%' }}
         >
           <H4>Batch Inventory Complete</H4>
-          <p style={{ marginBottom: '15px' }}>
-            Next, download the Ballot Manifest and Candidate Totals by Batch
-            files, then upload them on the{' '}
-            <Link to={`/election/${electionId}/jurisdiction/${jurisdictionId}`}>
-              Audit Setup
-            </Link>{' '}
-            page.
-          </p>
+          {showBallotManifest ? (
+            <p style={{ marginBottom: '15px' }}>
+              Next, download the Ballot Manifest and Candidate Totals by Batch
+              files, then upload them on the{' '}
+              <Link
+                to={`/election/${electionId}/jurisdiction/${jurisdictionId}`}
+              >
+                Audit Setup
+              </Link>{' '}
+              page.
+            </p>
+          ) : (
+            <p style={{ marginBottom: '15px' }}>
+              Next, download this file, then upload it on the{' '}
+              <Link
+                to={`/election/${electionId}/jurisdiction/${jurisdictionId}`}
+              >
+                Audit Setup
+              </Link>{' '}
+              page.
+            </p>
+          )}
           <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <AsyncButton
-              intent="primary"
-              large
-              icon="download"
-              onClick={() => apiDownload(ballotManifestUrl)}
-            >
-              Download Ballot Manifest
-            </AsyncButton>
+            {showBallotManifest && (
+              <AsyncButton
+                intent="primary"
+                large
+                icon="download"
+                onClick={() => apiDownload(ballotManifestUrl)}
+                style={{ marginBottom: '10px' }}
+              >
+                Download Ballot Manifest
+              </AsyncButton>
+            )}
             <AsyncButton
               intent="primary"
               large
               icon="download"
               onClick={() => apiDownload(batchTalliesUrl)}
-              style={{ marginTop: '10px' }}
             >
               Download Candidate Totals by Batch
             </AsyncButton>
@@ -324,30 +484,41 @@ const HeadingRow = styled.div`
 `
 
 const BatchInventorySteps: React.FC<{
+  batchInventoryConfig: BatchInventoryConfig
+  systemTypeQueries: ISystemTypeQueries
   cvrUpload: IFileUpload
   tabulatorStatusUpload: IFileUpload
   signOffQueries: ISignOffQueries
-}> = ({ cvrUpload, tabulatorStatusUpload, signOffQueries }) => {
+}> = ({
+  batchInventoryConfig,
+  systemTypeQueries,
+  cvrUpload,
+  tabulatorStatusUpload,
+  signOffQueries,
+}) => {
   const { electionId, jurisdictionId } = useParams<{
     electionId: string
     jurisdictionId: string
   }>()
 
+  const steps = batchInventoryConfig.showBallotManifest
+    ? STEPS
+    : STEPS_IF_NOT_SHOWING_BALLOT_MANIFEST
+
   // Start on the step that's most relevant given progress so far (e.g. if the
   // user left and came back)
-  const areFilesUploaded =
-    isUploaded(cvrUpload) && isUploaded(tabulatorStatusUpload)
+  const systemType = systemTypeQueries.systemType.data
   const isSignedOff = signOffQueries.status.data?.signedOffAt !== null
-  const initialStep = !areFilesUploaded
+  const initialStep = !systemType
+    ? 'Select System Type'
+    : !areAllFilesUploaded({ systemType, cvrUpload, tabulatorStatusUpload })
     ? 'Upload Election Results'
-    : !isSignedOff
+    : batchInventoryConfig.showBallotManifest && !isSignedOff
     ? 'Inventory Batches'
     : 'Download Audit Files'
 
-  const [currentStep, setCurrentStep] = useState<typeof STEPS[number]>(
-    initialStep
-  )
-  const currentStepNumber = STEPS.indexOf(currentStep) + 1
+  const [currentStep, setCurrentStep] = useState<Step>(initialStep)
+  const currentStepNumber = steps.indexOf(currentStep) + 1
 
   return (
     <Wrapper>
@@ -364,7 +535,7 @@ const BatchInventorySteps: React.FC<{
         </HeadingRow>
         <Steps>
           <StepList>
-            {STEPS.map((step, index) => (
+            {steps.map((step, index) => (
               <StepListItem
                 key={step}
                 stepNumber={index + 1}
@@ -376,14 +547,31 @@ const BatchInventorySteps: React.FC<{
           </StepList>
           {(() => {
             switch (currentStep) {
-              case 'Upload Election Results':
+              case 'Select System Type':
                 return (
-                  <UploadElectionResultsStep
-                    cvrUpload={cvrUpload}
-                    tabulatorStatusUpload={tabulatorStatusUpload}
-                    nextStep={() => setCurrentStep('Inventory Batches')}
+                  <SelectSystemStep
+                    systemTypeQueries={systemTypeQueries}
+                    nextStep={() => setCurrentStep('Upload Election Results')}
                   />
                 )
+              case 'Upload Election Results': {
+                assert(systemType !== undefined && systemType !== null)
+                return (
+                  <UploadElectionResultsStep
+                    systemType={systemType}
+                    cvrUpload={cvrUpload}
+                    tabulatorStatusUpload={tabulatorStatusUpload}
+                    prevStep={() => setCurrentStep('Select System Type')}
+                    nextStep={() =>
+                      setCurrentStep(
+                        batchInventoryConfig.showBallotManifest
+                          ? 'Inventory Batches'
+                          : 'Download Audit Files'
+                      )
+                    }
+                  />
+                )
+              }
               case 'Inventory Batches':
                 return (
                   <InventoryBatchesStep
@@ -393,14 +581,22 @@ const BatchInventorySteps: React.FC<{
                     nextStep={() => setCurrentStep('Download Audit Files')}
                   />
                 )
-              case 'Download Audit Files':
+              case 'Download Audit Files': {
                 return (
                   <DownloadAuditFilesStep
+                    showBallotManifest={batchInventoryConfig.showBallotManifest}
                     ballotManifestUrl={`/election/${electionId}/jurisdiction/${jurisdictionId}/batch-inventory/ballot-manifest`}
                     batchTalliesUrl={`/election/${electionId}/jurisdiction/${jurisdictionId}/batch-inventory/batch-tallies`}
-                    prevStep={() => setCurrentStep('Inventory Batches')}
+                    prevStep={() =>
+                      setCurrentStep(
+                        batchInventoryConfig.showBallotManifest
+                          ? 'Inventory Batches'
+                          : 'Upload Election Results'
+                      )
+                    }
                   />
                 )
+              }
               default:
                 throw new Error('Unknown step')
             }
@@ -416,15 +612,22 @@ const BatchInventory: React.FC = () => {
     electionId: string
     jurisdictionId: string
   }>()
+  const systemTypeQueries = useBatchInventorySystemType(
+    electionId,
+    jurisdictionId
+  )
   const cvrUpload = useBatchInventoryCVR(electionId, jurisdictionId)
   const tabulatorStatusUpload = useBatchInventoryTabulatorStatus(
     electionId,
     jurisdictionId
   )
   const signOffQueries = useBatchInventorySignOff(electionId, jurisdictionId)
+  const batchInventoryConfig = useBatchInventoryFeatureFlag(jurisdictionId)
+  assert(batchInventoryConfig !== undefined)
 
   if (
     !(
+      systemTypeQueries.systemType.isSuccess &&
       cvrUpload.uploadedFile.isSuccess &&
       tabulatorStatusUpload.uploadedFile.isSuccess &&
       signOffQueries.status.isSuccess
@@ -435,6 +638,8 @@ const BatchInventory: React.FC = () => {
 
   return (
     <BatchInventorySteps
+      batchInventoryConfig={batchInventoryConfig}
+      systemTypeQueries={systemTypeQueries}
       cvrUpload={cvrUpload}
       tabulatorStatusUpload={tabulatorStatusUpload}
       signOffQueries={signOffQueries}

--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -44,7 +44,7 @@ type Step =
   | 'Download Audit Files'
 
 const STEPS: Step[] = [
-  'Select System Type',
+  // 'Select System Type',
   'Upload Election Results',
   'Inventory Batches',
   'Download Audit Files',

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
@@ -607,9 +607,9 @@ describe('JA setup', () => {
     await withMockFetch(expectedCalls, async () => {
       renderView()
       await screen.findByText('Audit Setup')
-      screen.getByRole('heading', { name: 'Batch Inventory' })
+      screen.getByRole('heading', { name: 'Batch Audit File Preparation Tool' })
       const button = screen.getByRole('button', {
-        name: 'Go to Batch Inventory',
+        name: 'Go to Batch Audit File Preparation Tool',
       })
       expect(button).toHaveAttribute(
         'href',

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.tsx
@@ -29,7 +29,9 @@ const JurisdictionAdminView: React.FC = () => {
     jurisdictionId: string
   }>()
   const auth = useAuthDataContext()
-  const isBatchInventoryEnabled = useBatchInventoryFeatureFlag(jurisdictionId)
+  const isBatchInventoryEnabled = Boolean(
+    useBatchInventoryFeatureFlag(jurisdictionId)
+  )
 
   const auditSettings = useAuditSettingsJurisdictionAdmin(
     electionId,

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.tsx
@@ -29,9 +29,7 @@ const JurisdictionAdminView: React.FC = () => {
     jurisdictionId: string
   }>()
   const auth = useAuthDataContext()
-  const isBatchInventoryEnabled = Boolean(
-    useBatchInventoryFeatureFlag(jurisdictionId)
-  )
+  const batchInventoryConfig = useBatchInventoryFeatureFlag(jurisdictionId)
 
   const auditSettings = useAuditSettingsJurisdictionAdmin(
     electionId,
@@ -110,19 +108,22 @@ const JurisdictionAdminView: React.FC = () => {
                 </div>
               </Callout>
             )}
-            {isBatchComparison && isBatchInventoryEnabled && (
+            {isBatchComparison && batchInventoryConfig && (
               <Card elevation={1}>
-                <H4>Batch Inventory</H4>
+                <H4>Batch Audit File Preparation Tool</H4>
                 <p>
-                  Create your Ballot Manifest and Candidate Totals by Batch
-                  files using the batch inventory worksheet.
+                  Create your{' '}
+                  {batchInventoryConfig.showBallotManifest
+                    ? 'Ballot Manifest and Candidate Totals by Batch files'
+                    : 'Candidate Totals by Batch file'}{' '}
+                  using the batch audit file preparation tool.
                 </p>
                 <p>
                   <LinkButton
                     to={`/election/${electionId}/jurisdiction/${jurisdictionId}/batch-inventory`}
                     intent="primary"
                   >
-                    Go to Batch Inventory
+                    Go to Batch Audit File Preparation Tool
                   </LinkButton>
                 </p>
               </Card>

--- a/client/src/components/useFeatureFlag.ts
+++ b/client/src/components/useFeatureFlag.ts
@@ -1,26 +1,55 @@
 import { useAuthDataContext } from './UserContext'
 import { assert } from './utilities'
 
-const ENABLE_BATCH_INVENTORY_ORGANIZATION_IDS = [
-  'b216ad0d-1481-44e4-a2c1-95da40175084', // Georgia
-  'a67791e3-90a0-4d4e-a5e7-929f82bf4ce6', // VotingWorks Internal Sandbox
-  'b45800ff-a239-42b3-b285-414cb94d2b6b', // Ginny's Sandbox
-  'b7b99303-b1ac-4b52-8a02-22c10846cff3', // Audit Specialist Sandbox
-  'e348fcfd-bd23-4b96-a003-6c3a79abd240', // Verified Voting Sandbox
-]
+export interface BatchInventoryConfig {
+  showBallotManifest: boolean
+}
+
+const BATCH_INVENTORY_CONFIGS: {
+  [organizationId: string]: BatchInventoryConfig
+} = {
+  // Georgia
+  'b216ad0d-1481-44e4-a2c1-95da40175084': {
+    showBallotManifest: true,
+  },
+  // Pennsylvania
+  '210727d0-98c7-4448-a1d1-bcb1545c3ca3': {
+    showBallotManifest: false,
+  },
+  // Rhode Island
+  '0225f953-c201-46c8-8582-617eb72ce2b4': {
+    showBallotManifest: false,
+  },
+
+  // Audit Specialist Sandbox
+  'b7b99303-b1ac-4b52-8a02-22c10846cff3': {
+    showBallotManifest: true,
+  },
+  // Ginny's Sandbox
+  'b45800ff-a239-42b3-b285-414cb94d2b6b': {
+    showBallotManifest: true,
+  },
+  // Verified Voting Sandbox
+  'e348fcfd-bd23-4b96-a003-6c3a79abd240': {
+    showBallotManifest: true,
+  },
+  // VotingWorks Internal Sandbox
+  'a67791e3-90a0-4d4e-a5e7-929f82bf4ce6': {
+    showBallotManifest: false,
+  },
+}
 
 // eslint-disable-next-line import/prefer-default-export
 export const useBatchInventoryFeatureFlag = (
   jurisdictionId: string
-): boolean => {
+): BatchInventoryConfig | undefined => {
   const auth = useAuthDataContext()
   assert(auth?.user?.type === 'jurisdiction_admin')
   const jurisdiction = auth.user.jurisdictions.find(
     j => j.id === jurisdictionId
   )
   const { organizationId } = jurisdiction?.election || {}
-  return (
-    organizationId !== undefined &&
-    ENABLE_BATCH_INVENTORY_ORGANIZATION_IDS.includes(organizationId)
-  )
+  return organizationId === undefined
+    ? undefined
+    : BATCH_INVENTORY_CONFIGS[organizationId]
 }

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -271,8 +271,8 @@ def process_batch_inventory_cvr_file(
             file_names = [
                 entry_name
                 for entry_name in entry_names
-                if entry_name.endswith(".csv")
-                and not entry_name.startswith(".")
+                if entry_name.endswith(".csv") and not entry_name.startswith(".")
+                # ZIP files created on Macs include a hidden __MACOSX folder
                 and not entry_name.startswith("__")
             ]
             cvr_file.close()
@@ -367,6 +367,14 @@ def process_batch_inventory_cvr_file(
                     ballot_count_by_batch[batch_key] += 1
                     if choice_id:
                         batch_tallies[batch_key][choice_id] += 1
+
+        # Set explicit zeros for choices with zero votes in a batch to avoid KeyErrors when
+        # generating files
+        for batch_key in batch_tallies.keys():
+            for contest in contests:
+                for choice in contest.choices:
+                    if choice.id not in batch_tallies[batch_key]:
+                        batch_tallies[batch_key][choice.id] = 0
 
         election_results: ElectionResults = dict(
             ballot_count_by_batch=dict_to_items_list(ballot_count_by_batch),

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -866,7 +866,7 @@ def download_batch_inventory_ballot_manifest(
     ballot_manifest = csv.writer(csv_io)
 
     # We originally didn't have a batch_to_counting_group key at all, so we protect against the key
-    # not existing by using .get
+    # not existing by using .get for backwards compatibility
     batch_to_counting_group = items_list_to_dict(
         election_results.get("batch_to_counting_group", None) or []
     )

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -663,11 +663,6 @@ def download_batch_inventory_ballot_manifest(
     batch_inventory_data = get_or_404(BatchInventoryData, jurisdiction.id)
     election_results: ElectionResults = batch_inventory_data.election_results
 
-    if not batch_inventory_data.signed_off_at:
-        raise Conflict(
-            "Batch inventory must be signed off before downloading ballot manifest."
-        )
-
     csv_io = io.StringIO()
     ballot_manifest = csv.writer(csv_io)
 
@@ -705,11 +700,6 @@ def download_batch_inventory_batch_tallies(
 ):
     batch_inventory_data = get_or_404(BatchInventoryData, jurisdiction.id)
     election_results: ElectionResults = batch_inventory_data.election_results
-
-    if not batch_inventory_data.signed_off_at:
-        raise Conflict(
-            "Batch inventory must be signed off before downloading batch tallies."
-        )
 
     contest_choice_csv_headers = construct_contest_choice_csv_headers(
         election, jurisdiction

--- a/server/migrations/versions/cb8de251c1a5_batchinventorydata_system_type.py
+++ b/server/migrations/versions/cb8de251c1a5_batchinventorydata_system_type.py
@@ -1,0 +1,36 @@
+# pylint: disable=invalid-name
+"""BatchInventoryData.system_type
+
+Revision ID: cb8de251c1a5
+Revises: c012fa6b13a9
+Create Date: 2024-03-27 19:17:15.548250+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "cb8de251c1a5"
+down_revision = "c012fa6b13a9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "batch_inventory_data",
+        sa.Column("system_type", sa.String(length=200), nullable=True),
+    )
+
+    # Populate the field for existing BatchInventoryData entries
+    op.execute(
+        """
+        UPDATE batch_inventory_data
+        SET system_type = 'DOMINION'
+        """
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -1016,6 +1016,8 @@ class BatchInventoryData(BaseModel):
         primary_key=True,
     )
 
+    system_type = Column(String(200))
+
     cvr_file_id = Column(String(200), ForeignKey("file.id", ondelete="set null"))
     cvr_file = relationship(
         "File",

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -183,7 +183,7 @@ def test_ballot_manifest_upload_bad_csv(
         "errors": [
             {
                 "errorType": "Bad Request",
-                "message": "Please submit a valid CSV. If you are working with an Excel spreadsheet, make sure you export it as a .csv file before uploading",
+                "message": "Please submit a valid CSV. If you are working with an Excel spreadsheet, make sure you export it as a .csv file before uploading.",
             }
         ]
     }

--- a/server/tests/api/test_jurisdictions_file.py
+++ b/server/tests/api/test_jurisdictions_file.py
@@ -27,7 +27,7 @@ def test_bad_csv_file(client: FlaskClient, election_id: str):
     assert json.loads(rv.data) == {
         "errors": [
             {
-                "message": "Please submit a valid CSV. If you are working with an Excel spreadsheet, make sure you export it as a .csv file before uploading",
+                "message": "Please submit a valid CSV. If you are working with an Excel spreadsheet, make sure you export it as a .csv file before uploading.",
                 "errorType": "Bad Request",
             }
         ]

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -536,7 +536,7 @@ def test_cvrs_upload_bad_csv(
         "errors": [
             {
                 "errorType": "Bad Request",
-                "message": "Please submit a valid CSV. If you are working with an Excel spreadsheet, make sure you export it as a .csv file before uploading",
+                "message": "Please submit a valid CSV. If you are working with an Excel spreadsheet, make sure you export it as a .csv file before uploading.",
             }
         ]
     }

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -228,7 +228,7 @@ def test_standardized_contests_bad_csv(
         "errors": [
             {
                 "errorType": "Bad Request",
-                "message": "Please submit a valid CSV. If you are working with an Excel spreadsheet, make sure you export it as a .csv file before uploading",
+                "message": "Please submit a valid CSV. If you are working with an Excel spreadsheet, make sure you export it as a .csv file before uploading.",
             }
         ]
     }

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -140,6 +140,13 @@ def test_batch_inventory_happy_path(
     )
 
     # Load batch inventory starting state (simulate JA loading the page)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type"
+    )
+    response = json.loads(rv.data)
+    assert response == dict(systemType=None)
+
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr"
     )
@@ -157,6 +164,19 @@ def test_batch_inventory_happy_path(
     )
     sign_off = json.loads(rv.data)
     assert sign_off == dict(signedOffAt=None)
+
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type"
+    )
+    compare_json(json.loads(rv.data), {"systemType": CvrFileType.DOMINION})
 
     # Upload CVR file
     rv = client.put(
@@ -320,6 +340,13 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     )
 
     # Load batch inventory starting state (simulate JA loading the page)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type"
+    )
+    response = json.loads(rv.data)
+    assert response == dict(systemType=None)
+
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr"
     )
@@ -337,6 +364,19 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     )
     sign_off = json.loads(rv.data)
     assert sign_off == dict(signedOffAt=None)
+
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type"
+    )
+    compare_json(json.loads(rv.data), {"systemType": CvrFileType.DOMINION})
 
     # Upload CVR file
     rv = client.put(
@@ -505,6 +545,13 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     )
 
     # Load batch inventory starting state (simulate JA loading the page)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type"
+    )
+    response = json.loads(rv.data)
+    assert response == dict(systemType=None)
+
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr"
     )
@@ -522,6 +569,19 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     )
     sign_off = json.loads(rv.data)
     assert sign_off == dict(signedOffAt=None)
+
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type"
+    )
+    compare_json(json.loads(rv.data), {"systemType": CvrFileType.DOMINION})
 
     # Upload CVR file
     rv = client.put(
@@ -706,6 +766,14 @@ def test_batch_inventory_invalid_file_uploads(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
 
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
     # Upload invalid CVR files
     invalid_cvrs = [
         (
@@ -837,6 +905,14 @@ def test_batch_inventory_missing_data_multi_contest_batch_comparison(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
 
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
     invalid_cvrs = [
         (
             TEST_CVR.replace("Contest 2", "Contest X"),
@@ -881,6 +957,14 @@ def test_batch_inventory_wrong_tabulator_status_file(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
+
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
 
     # Upload CVR file
     rv = client.put(
@@ -1130,6 +1214,14 @@ def test_batch_inventory_undo_sign_off(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
 
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
     # Upload CVR file
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
@@ -1177,6 +1269,14 @@ def test_batch_inventory_delete_cvr_after_sign_off(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
+
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
 
     # Upload CVR file
     rv = client.put(
@@ -1226,6 +1326,14 @@ def test_batch_inventory_delete_tabulator_status_after_sign_off(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
 
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
     # Upload CVR file
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
@@ -1271,6 +1379,14 @@ def test_batch_inventory_upload_cvr_before_contests(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
 
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
         data={"cvr": (io.BytesIO(TEST_CVR.encode()), "cvrs.csv",),},
@@ -1279,62 +1395,7 @@ def test_batch_inventory_upload_cvr_before_contests(
         "errors": [
             {
                 "errorType": "Conflict",
-                "message": "Jurisdiction does not have any contests assigned",
-            }
-        ]
-    }
-
-
-def test_batch_inventory_download_files_before_sign_off(
-    client: FlaskClient,
-    election_id: str,
-    jurisdiction_ids: List[str],
-    contest_id: str,  # pylint: disable=unused-argument
-):
-    set_logged_in_user(
-        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
-    )
-
-    # Upload CVR and tabulator status files
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={"cvr": (io.BytesIO(TEST_CVR.encode()), "cvrs.csv",),},
-    )
-    assert_ok(rv)
-
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
-        data={
-            "tabulatorStatus": (
-                io.BytesIO(TEST_TABULATOR_STATUS.encode()),
-                "tabulator-status.xml",
-            ),
-        },
-    )
-    assert_ok(rv)
-
-    # Try to download ballot manifest before signing off
-    rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/ballot-manifest"
-    )
-    assert json.loads(rv.data) == {
-        "errors": [
-            {
-                "errorType": "Conflict",
-                "message": "Batch inventory must be signed off before downloading ballot manifest.",
-            }
-        ]
-    }
-
-    # Try to download batch tallies before signing off
-    rv = client.get(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/batch-tallies"
-    )
-    assert json.loads(rv.data) == {
-        "errors": [
-            {
-                "errorType": "Conflict",
-                "message": "Batch inventory must be signed off before downloading batch tallies.",
+                "message": "Jurisdiction does not have any contests assigned.",
             }
         ]
     }
@@ -1349,6 +1410,14 @@ def test_batch_inventory_upload_tabulator_status_before_cvr(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
+
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
 
     rv = client.put(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -315,7 +315,7 @@ def test_batch_tallies_upload_bad_csv(
         "errors": [
             {
                 "errorType": "Bad Request",
-                "message": "Please submit a valid CSV. If you are working with an Excel spreadsheet, make sure you export it as a .csv file before uploading",
+                "message": "Please submit a valid CSV. If you are working with an Excel spreadsheet, make sure you export it as a .csv file before uploading.",
             }
         ]
     }

--- a/server/tests/util/test_csv_parse.py
+++ b/server/tests/util/test_csv_parse.py
@@ -10,6 +10,7 @@ from ...util.csv_parse import (
     CSVColumnType,
     CSVValueType,
     validate_csv_mimetype,
+    does_file_have_zip_mimetype,
 )
 
 BALLOT_MANIFEST_COLUMNS = [
@@ -977,14 +978,22 @@ def test_parse_csv_real_world_examples():
             return list(parse_csv(csv, columns))
         return list(parse_csv_binary(csv, columns))
 
-    for (csv, expected_error, columns) in REAL_WORLD_REJECTED_CSVS:
+    for csv, expected_error, columns in REAL_WORLD_REJECTED_CSVS:
         with pytest.raises(CSVParseError) as error:
             do_parse(csv, columns)
         assert str(error.value) == expected_error
 
-    for (csv, expected_rows, columns) in REAL_WORLD_ACCEPTED_CSVS:
+    for csv, expected_rows, columns in REAL_WORLD_ACCEPTED_CSVS:
         parsed = do_parse(csv, columns)
         assert len(parsed) == expected_rows
+
+
+def test_does_file_have_zip_mimetype():
+    assert does_file_have_zip_mimetype(FileStorage(b"", content_type="application/zip"))
+    assert does_file_have_zip_mimetype(
+        FileStorage(b"", content_type="application/x-zip-compressed")
+    )
+    assert not does_file_have_zip_mimetype(FileStorage(b"", content_type="text/csv"))
 
 
 def test_validate_csv_mimetype():
@@ -1001,7 +1010,7 @@ def test_validate_csv_mimetype():
             assert error.value.description == (
                 "Please submit a valid CSV."
                 " If you are working with an Excel spreadsheet,"
-                " make sure you export it as a .csv file before uploading"
+                " make sure you export it as a .csv file before uploading."
             )
 
 
@@ -1015,7 +1024,7 @@ def test_parse_csv_excel_file():
         assert str(error.value) == (
             "Please submit a valid CSV."
             " If you are working with an Excel spreadsheet,"
-            " make sure you export it as a .csv file before uploading"
+            " make sure you export it as a .csv file before uploading."
         )
 
 
@@ -1040,7 +1049,7 @@ def test_parse_csv_cant_detect_encoding():
     assert str(error.value) == (
         "Please submit a valid CSV."
         " If you are working with an Excel spreadsheet,"
-        " make sure you export it as a .csv file before uploading"
+        " make sure you export it as a .csv file before uploading."
     )
 
 
@@ -1054,7 +1063,7 @@ def test_parse_csv_xls_mislabeled_as_csv():
     assert str(error.value) == (
         "Please submit a valid CSV."
         " If you are working with an Excel spreadsheet,"
-        " make sure you export it as a .csv file before uploading"
+        " make sure you export it as a .csv file before uploading."
         "\n\nAdditional details: Unable to decode file assuming Windows-1254 encoding"
     )
 

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -53,7 +53,7 @@ CSVDictIterator = Iterator[Dict[str, Any]]
 INVALID_CSV_ERROR = (
     "Please submit a valid CSV."
     " If you are working with an Excel spreadsheet,"
-    " make sure you export it as a .csv file before uploading"
+    " make sure you export it as a .csv file before uploading."
 )
 
 
@@ -85,6 +85,10 @@ def parse_csv(file: BinaryIO, columns: List[CSVColumnType]) -> CSVDictIterator:
 def does_file_have_csv_mimetype(file: FileStorage) -> bool:
     # In Windows, CSVs have mimetype application/vnd.ms-excel
     return file.mimetype in ["text/csv", "application/vnd.ms-excel"]
+
+
+def does_file_have_zip_mimetype(file: FileStorage) -> bool:
+    return file.mimetype in ["application/zip", "application/x-zip-compressed"]
 
 
 def validate_csv_mimetype(file: FileStorage) -> None:
@@ -192,7 +196,7 @@ def skip_empty_trailing_columns(csv: CSVIterator) -> CSVIterator:
     else:
         yield headers[0:-empty_trailing_header_count]
         for r, row in enumerate(csv):  # pylint: disable=invalid-name
-            for (empty_trailing_column_index, cell) in enumerate(
+            for empty_trailing_column_index, cell in enumerate(
                 row[-empty_trailing_header_count:]
             ):
                 if len(cell) > 0:


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/arlo/issues/1866

Jurisdictions often struggle to prepare their files for batch audits. We've built a "batch inventory" tool for Georgia that helps them prepare these files from their CVR files, while also still making sure that they still physically inventory their ballots (though part of audit setup, an audit of its own, in a way).

For Pennsylvania and Rhode Island's upcoming audits, we want to try a permutation of the above model. We're going to have PA and RI jurisdictions upload their CVR files and auto-generate one of the two batch audit files, the candidate-totals-by-batch file. We'll still have them prepare ballot manifests manually.

Also of note is that PA and RI use ES&S (GA uses Dominion). So I've added a screen to the batch inventory tool to select your system type and updated the backend to support parsing ES&S CVR files, given example files we've received from both states plus our existing knowledge of ES&S CVR files. Some jurisdictions will have a single CSV with all relevant information (this is a new format that we're seeing for the first time). Others will have the multiple files that we're accustomed to (one core CVR file and one or many "ballots" files with additional metadata). For the latter, we'll expect users to bundle all their files into a single ZIP file.

As we generalize this tool, we're rebranding it the "Batch Audit File Preparation Tool". Note that we'll eventually want to replace this tool with something more seamless/integrated into the audit setup UI. It's definitely clunky, uploading files to generate new files which you then have to upload again 😅.

### UI for GA after this update

The "Select System Type" screen is new. We still prepare both ballot manifests and candidate-totals-by-batch files for GA.

![GA](https://github.com/votingworks/arlo/assets/12616928/26a4250e-67a8-43d4-8543-c1e92bfa34c4)

### UI for PA and RI

We'll only prepare candidate-totals-by-batch files, not ballot manifests, for PA and RI. The "Inventory Batches" step was only relevant for auto-generated ballot manifests so dropped that for PA and RI.

![PA and RI](https://github.com/votingworks/arlo/assets/12616928/9a30464a-07cd-4409-89e3-8bac1bc265d6)

### PA and RI in action

https://github.com/votingworks/arlo/assets/12616928/302117cc-e4f5-43dc-9319-0723f26ab98e

## Testing

Lots of manual testing with representative files. Did the bare minimum re automated tests. Planning to add more in a follow-up PR as I'm on a bit of a time crunch (RI may audit next week).