### PR TITLE
Hide batch inventory UI in PA org for now

### DIFF
--- a/client/src/components/useFeatureFlag.ts
+++ b/client/src/components/useFeatureFlag.ts
@@ -12,10 +12,6 @@ const BATCH_INVENTORY_CONFIGS: {
   'b216ad0d-1481-44e4-a2c1-95da40175084': {
     showBallotManifest: true,
   },
-  // Pennsylvania
-  '210727d0-98c7-4448-a1d1-bcb1545c3ca3': {
-    showBallotManifest: false,
-  },
   // Rhode Island
   '0225f953-c201-46c8-8582-617eb72ce2b4': {
     showBallotManifest: false,


### PR DESCRIPTION
@ginvdr asked that we hide the batch inventory UI in the PA org for now since they're not quite ready to use the feature without our assistance. Some jurisdictions may also have ES&S file versions that we can't yet parse. We can either enable the feature for PA next week once we're actively supporting them or create a clone of their audit in one of our sandboxes to help them prepare files.