### PR TITLE
Implement contest choice name standardization flow

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
     // to be uncovered. Ideally, we can get this to 0 eventually, but this
     // accounts for legacy uncovered code. All new code should be covered (so
     // this number should only be getting closer to 0).
-    global: { branches: -176 },
+    global: { branches: -191 },
   },
   moduleFileExtensions: [
     'web.js',

--- a/client/src/components/AuditAdmin/AuditAdminView.test.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.test.tsx
@@ -201,6 +201,7 @@ describe('AA setup flow', () => {
       aaApiCalls.getStandardizedContestsFileWithResponse(
         standardizedContestsFileMocks.processed
       ),
+      aaApiCalls.getContests(contestMocks.filledTargeted),
     ]
     await withMockFetch(expectedCalls, async () => {
       render()
@@ -243,6 +244,8 @@ describe('AA setup flow', () => {
     const expectedCalls = [
       aaApiCalls.getUser,
       ...setupApiCalls,
+      aaApiCalls.getStandardizedContests([]),
+      aaApiCalls.getContestChoiceNameStandardizations(),
       aaApiCalls.getSampleSizes(sampleSizeMock.ballotPolling),
       aaApiCalls.postRound({
         'contest-id': sampleSizeMock.ballotPolling.sampleSizes![

--- a/client/src/components/AuditAdmin/Setup/Participants/Participants.tsx
+++ b/client/src/components/AuditAdmin/Setup/Participants/Participants.tsx
@@ -69,7 +69,7 @@ const Participants: React.FC<IParticipantsProps> = ({
               return true
             }}
             title="Standardized Contests"
-            description='Click "Browse" to choose the appropriate file from your computer. This file should be a comma-separated list of all the contests on the ballot, the vote choices available in each, and the jurisdiction(s) where each contest appeared on the ballot.'
+            description='Click "Browse" to choose the appropriate file from your computer. This file should be a comma-separated list of all the contests on the ballot, the jurisdiction(s) where each contest appeared on the ballot, and optionally the vote choices available in each.'
             sampleFileLink="/sample_standardized_contests.csv"
             enabled={isFileProcessed(jurisdictionsFileUpload.uploadedFile.data)}
           />

--- a/client/src/components/AuditAdmin/Setup/Review/CvrChoiceNameConsistencyError.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/CvrChoiceNameConsistencyError.tsx
@@ -1,6 +1,16 @@
+import { Callout } from '@blueprintjs/core'
 import React from 'react'
+import styled from 'styled-components'
 
 import { ICvrChoiceNameConsistencyError } from '../../../../types'
+
+const CalloutWithBottomMargin = styled(Callout)`
+  margin-bottom: 16px;
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+`
 
 interface IProps {
   error: ICvrChoiceNameConsistencyError
@@ -28,20 +38,25 @@ const CvrChoiceNameConsistencyError: React.FC<IProps> = ({
     jurisdictionNamesById[jurisdictionIdWithMostCvrChoices].name
 
   return (
-    <span>
-      Some choice names in {anomalousJurisdictionName} do not match other
-      counties.
-      <br />
-      <strong>
-        Choice names in {anomalousJurisdictionName} without matches:
-      </strong>{' '}
-      {anomalousCvrChoiceNames.join(' · ')}
-      <br />
-      <strong>
-        Choice names in {jurisdictionNameWithMostCvrChoices}:
-      </strong>{' '}
-      {cvrChoiceNamesInJurisdictionWithMostCvrChoices.join(' · ')}
-    </span>
+    <CalloutWithBottomMargin intent="warning">
+      <p>
+        Choice names do not match across jurisdictions. Below is an example of a
+        mismatch. Address these inconsistencies by adding choice names to your
+        standardized contests file or updating your CVR files.
+      </p>
+      <p>
+        <strong>
+          Choice names in {anomalousJurisdictionName} not found in{' '}
+          {jurisdictionNameWithMostCvrChoices}:
+        </strong>{' '}
+        {anomalousCvrChoiceNames.join(' · ')}
+        <br />
+        <strong>
+          Choice names in {jurisdictionNameWithMostCvrChoices}:
+        </strong>{' '}
+        {cvrChoiceNamesInJurisdictionWithMostCvrChoices.join(' · ')}
+      </p>
+    </CalloutWithBottomMargin>
   )
 }
 

--- a/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.test.tsx
@@ -29,6 +29,11 @@ import {
   aaApiCalls,
 } from '../../../_mocks'
 import { ISamplePreview, ISampleSizes } from '../../useRoundsAuditAdmin'
+import {
+  IContestChoiceNameStandardizations,
+  IContestChoiceNameStandardizationsResponse,
+} from '../../../useContestChoiceNameStandardizations'
+import { IStandardizedContest } from '../../../useStandardizedContests'
 
 const apiCalls = {
   getSettings: (response: IAuditSettings) => ({
@@ -78,11 +83,11 @@ const apiCalls = {
     url: '/api/election/1/contest',
     response: { contests },
   }),
-  getStandardizations: (response: IContestNameStandardizations) => ({
+  getContestNameStandardizations: (response: IContestNameStandardizations) => ({
     url: '/api/election/1/contest/standardizations',
     response,
   }),
-  putStandardizations: (
+  putContestNameStandardizations: (
     standardizations: IContestNameStandardizations['standardizations']
   ) => ({
     url: '/api/election/1/contest/standardizations',
@@ -94,6 +99,31 @@ const apiCalls = {
       },
       method: 'PUT',
     },
+  }),
+  getContestChoiceNameStandardizations: (
+    response: IContestChoiceNameStandardizationsResponse = {
+      standardizations: {},
+    }
+  ) => ({
+    url: '/api/election/1/contest/choice-name-standardizations',
+    response,
+  }),
+  putContestChoiceNameStandardizations: (
+    standardizations: IContestChoiceNameStandardizations
+  ) => ({
+    url: '/api/election/1/contest/choice-name-standardizations',
+    response: { status: 'ok' },
+    options: {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(standardizations),
+    },
+  }),
+  getStandardizedContests: (
+    standardizedContests: IStandardizedContest[] = []
+  ) => ({
+    url: '/api/election/1/standardized-contests',
+    response: standardizedContests,
   }),
 }
 
@@ -134,7 +164,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -255,7 +287,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getContestChoiceNameStandardizations(),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -287,7 +321,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifestsAllTallies,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.batchComparison),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -316,9 +352,11 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifestsWithCVRs,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getStandardizedContestsFile,
-      apiCalls.getStandardizations({
+      apiCalls.getContestNameStandardizations({
         standardizations: {},
         cvrContestNames: {},
       }),
@@ -402,9 +440,11 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifestsWithCVRs,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargeted),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getStandardizedContestsFile,
-      apiCalls.getStandardizations({
+      apiCalls.getContestNameStandardizations({
         standardizations: {},
         cvrContestNames: {},
       }),
@@ -453,9 +493,11 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifestsSomeCVRs,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getStandardizedContestsFile,
-      apiCalls.getStandardizations({
+      apiCalls.getContestNameStandardizations({
         standardizations: {},
         cvrContestNames: {},
       }),
@@ -491,7 +533,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -517,7 +561,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -543,7 +589,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -572,7 +620,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -616,9 +666,11 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getStandardizedContestsFile,
-      apiCalls.getStandardizations({
+      apiCalls.getContestNameStandardizations({
         standardizations: {},
         cvrContestNames: {},
       }),
@@ -649,7 +701,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifestsAllTallies,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.batchComparison),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -677,9 +731,11 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifestsWithCVRs,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getStandardizedContestsFile,
-      apiCalls.getStandardizations({
+      apiCalls.getContestNameStandardizations({
         standardizations: {},
         cvrContestNames: {},
       }),
@@ -710,7 +766,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions({
         ...sampleSizeMock.ballotPolling,
         selected: { 'contest-id': { key: 'custom', size: 100, prob: null } },
@@ -765,13 +823,15 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifestsWithCVRs,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getStandardizedContestsFile,
-      apiCalls.getStandardizations({
+      apiCalls.getContestNameStandardizations({
         standardizations,
         cvrContestNames,
       }),
-      apiCalls.putStandardizations({
+      apiCalls.putContestNameStandardizations({
         'jurisdiction-id-1': {
           'Contest 1': 'Contest One',
         },
@@ -779,14 +839,16 @@ describe('Audit Setup > Review & Launch', () => {
           'Contest 2': null,
         },
       }),
-      apiCalls.getStandardizations({
+      apiCalls.getContestNameStandardizations({
         standardizations: {
           ...standardizations,
           'jurisdiction-id-1': { 'Contest 1': 'Contest One' },
         },
         cvrContestNames,
       }),
-      apiCalls.putStandardizations({
+      apiCalls.getContestChoiceNameStandardizations(),
+      apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
+      apiCalls.putContestNameStandardizations({
         'jurisdiction-id-1': {
           'Contest 1': 'Contest One',
         },
@@ -794,14 +856,16 @@ describe('Audit Setup > Review & Launch', () => {
           'Contest 2': 'Contest Two',
         },
       }),
-      apiCalls.getStandardizations({
+      apiCalls.getContestNameStandardizations({
         standardizations: {
           'jurisdiction-id-1': { 'Contest 1': 'Contest One' },
           'jurisdiction-id-2': { 'Contest 2': 'Contest Two' },
         },
         cvrContestNames,
       }),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.ballotComparison),
+      apiCalls.getContests(contestMocks.filledTargetedAndOpportunistic),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderView()
@@ -818,7 +882,7 @@ describe('Audit Setup > Review & Launch', () => {
 
       // Open the dialog
       screen.getByText(
-        'Some contest names in the CVR files do not match the target/opportunistic contest names.'
+        'Some contest names in the uploaded CVR files do not match the standardized contest names.'
       )
       userEvent.click(
         screen.getByRole('button', { name: 'Standardize Contest Names' })
@@ -834,7 +898,7 @@ describe('Audit Setup > Review & Launch', () => {
         within(dialog)
           .getAllByRole('columnheader')
           .map(header => header.textContent)
-      ).toEqual(['Jurisdiction', 'Target/Opportunistic Contest', 'CVR Contest'])
+      ).toEqual(['Jurisdiction', 'Standardized Contest', 'CVR Contest'])
       let rows = within(dialog).getAllByRole('row')
       within(rows[1]).getByRole('cell', { name: 'Jurisdiction 1' })
       within(rows[1]).getByRole('cell', { name: 'Contest 1' })
@@ -852,7 +916,7 @@ describe('Audit Setup > Review & Launch', () => {
 
       // Should still show warning since we didn't finish standardizing
       screen.getByText(
-        'Some contest names in the CVR files do not match the target/opportunistic contest names.'
+        'Some contest names in the uploaded CVR files do not match the standardized contest names.'
       )
 
       // Reopen the form - should show the standardization we already did
@@ -877,7 +941,7 @@ describe('Audit Setup > Review & Launch', () => {
 
       // Warning is gone, sample sizes are shown
       screen.getByText(
-        'All contest names in the CVR files have been standardized to match the target/opportunistic contest names.'
+        'All contest names in the uploaded CVR files have been standardized.'
       )
       screen.getByText(
         'Choose the initial sample size for each contest you would like to use for Round 1 of the audit from the options below.'
@@ -904,7 +968,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargeted),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -935,6 +1001,7 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests([
         contestMocks.filledTargeted[0],
         {
@@ -943,6 +1010,7 @@ describe('Audit Setup > Review & Launch', () => {
           id: 'contest-id-2',
         },
       ]),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions({
         ...sampleSizeMock.ballotPolling,
         sampleSizes: {
@@ -984,7 +1052,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargeted),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -1020,9 +1090,11 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifestsWithCVRs,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargeted),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getStandardizedContestsFile,
-      apiCalls.getStandardizations({
+      apiCalls.getContestNameStandardizations({
         standardizations: {},
         cvrContestNames: {},
       }),
@@ -1052,7 +1124,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifestsAllTallies,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargeted),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -1076,7 +1150,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargeted),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getSampleSizeOptions(sampleSizeMock.ballotPolling),
       apiCalls.postComputeSamplePreview({
         'contest-id': sampleSizeMock.ballotPolling.sampleSizes![
@@ -1138,7 +1214,9 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifests,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests(contestMocks.filledTargetedWithJurisdictionId),
+      apiCalls.getContestChoiceNameStandardizations(),
       aaApiCalls.getSampleSizes(sampleSizeMock.calculating),
       aaApiCalls.getSampleSizes(sampleSizeMock.ballotPolling),
     ]
@@ -1175,6 +1253,7 @@ describe('Audit Setup > Review & Launch', () => {
         jurisdictions: jurisdictionMocks.allManifestsWithCVRs,
       }),
       apiCalls.getJurisdictionFile,
+      apiCalls.getStandardizedContests(),
       apiCalls.getContests([
         {
           // Inconsistent choice names
@@ -1225,8 +1304,9 @@ describe('Audit Setup > Review & Launch', () => {
           cvrChoiceNameConsistencyError: undefined,
         },
       ]),
+      apiCalls.getContestChoiceNameStandardizations(),
       apiCalls.getStandardizedContestsFile,
-      apiCalls.getStandardizations({
+      apiCalls.getContestNameStandardizations({
         cvrContestNames: {},
         standardizations: {},
       }),
@@ -1234,33 +1314,34 @@ describe('Audit Setup > Review & Launch', () => {
     await withMockFetch(expectedCalls, async () => {
       renderView()
 
-      await screen.findByText(
+      expect(
+        await screen.findAllByText(
+          'Choice names do not match across jurisdictions. ' +
+            'Below is an example of a mismatch. ' +
+            'Address these inconsistencies by adding choice names to your standardized contests file or updating your CVR files.'
+        )
+      ).toHaveLength(2)
+      screen.getByText(
         hasTextAcrossElements(
-          'Some choice names in Jurisdiction 2 do not match other counties.' +
-            'Choice names in Jurisdiction 2 without matches: CHOICE 1 · CHOICE 2' +
+          'Choice names in Jurisdiction 2 not found in Jurisdiction 1: CHOICE 1 · CHOICE 2' +
             'Choice names in Jurisdiction 1: Choice 1 · Choice 2'
         )
       )
       screen.getByText(
         hasTextAcrossElements(
-          'Some choice names in Jurisdiction 2 do not match other counties.' +
-            'Choice names in Jurisdiction 2 without matches: Choice 3' +
+          'Choice names in Jurisdiction 2 not found in Jurisdiction 1: Choice 3' +
             'Choice names in Jurisdiction 1: Choice 1 · Choice 2'
         )
       )
 
-      screen.getByText('The following contests have inconsistent choice names:')
+      screen.getByText(
+        hasTextAcrossElements(
+          'The following contests have inconsistent choice names: Contest 1, Contest 2. ' +
+            'Resolve these inconsistencies in order to calculate the sample size.'
+        )
+      )
       screen.getByRole('link', { name: 'Contest 1' })
       screen.getByRole('link', { name: 'Contest 2' })
-      expect(
-        screen.queryByRole('link', { name: 'Contest 3' })
-      ).not.toBeInTheDocument()
-      expect(
-        screen.queryByRole('link', { name: 'Contest 4' })
-      ).not.toBeInTheDocument()
-      screen.getByText(
-        'Address these inconsistencies by updating your CVR files in order to calculate the sample size.'
-      )
 
       expect(
         screen.getByRole('button', { name: 'Launch Audit' })

--- a/client/src/components/AuditAdmin/Setup/Review/Review.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.tsx
@@ -383,9 +383,8 @@ const Review: React.FC<IProps> = ({
                   newStandardizations
                 )
               }}
-              // Reset the form state within the dialog component any time persisted
-              // standardizations change
-              key={JSON.stringify(contestChoiceNameStandardizations)}
+              // Reset the form state within the dialog component any time the dialog is opened
+              key={isContestChoiceNameStandardizationDialogOpen.toString()}
             />
             <div style={{ display: 'flex' }}>
               {!cvrsUploaded ? (

--- a/client/src/components/AuditAdmin/Setup/Review/Review.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.tsx
@@ -39,6 +39,12 @@ import { sum } from '../../../../utils/number'
 import { useJurisdictions, IJurisdiction } from '../../../useJurisdictions'
 import { isFileProcessed } from '../../../useCSV'
 import useContestNameStandardizations from '../../../useContestNameStandardizations'
+import {
+  IContestChoiceNameStandardizations,
+  useContestChoiceNameStandardizations,
+  useUpdateContestChoiceNameStandardizations,
+} from '../../../useContestChoiceNameStandardizations'
+import useStandardizedContests from '../../../useStandardizedContests'
 import { isSetupComplete, allCvrsUploaded } from '../../../Atoms/StatusBox'
 import { useAuditSettings, AuditType } from '../../../useAuditSettings'
 import { useContests } from '../../../useContests'
@@ -50,6 +56,11 @@ import SamplePreview from './SamplePreview'
 import StandardizeContestNamesDialog from './StandardizeContestNames'
 import LabeledValue from './LabeledValue'
 import CvrChoiceNameConsistencyError from './CvrChoiceNameConsistencyError'
+import {
+  isContestChoiceNameStandardizationComplete as isContestChoiceNameStandardizationCompleteHelper,
+  StandardizeContestChoiceNamesCallout,
+  StandardizeContestChoiceNamesDialog,
+} from './StandardizeContestChoiceNamesDialog'
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: 'percent',
@@ -93,6 +104,7 @@ const Review: React.FC<IProps> = ({
     electionId,
     { enabled: isStandardizedContestsFileEnabled }
   )
+  const standardizedContests = useStandardizedContests(electionId)
   const contestsQuery = useContests(electionId)
   const computeSamplePreview = useComputeSamplePreview(electionId)
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false)
@@ -101,31 +113,27 @@ const Review: React.FC<IProps> = ({
   )
 
   const [
-    standardizations,
-    updateStandardizations,
+    contestNameStandardizations,
+    updateContestNameStandardizations,
   ] = useContestNameStandardizations(
     electionId,
     auditSettingsQuery.data || null
   )
   const [
-    isStandardizationsDialogOpen,
-    setIsStandardizationsDialogOpen,
+    isContestNameStandardizationDialogOpen,
+    setIsContestNameStandardizationDialogOpen,
   ] = useState(false)
 
-  const standardizationNeeded =
-    !!standardizations &&
-    Object.values(standardizations.standardizations).length > 0
-  const standardizationOutstanding =
-    !!standardizations &&
-    Object.values(
-      standardizations.standardizations
-    ).some(jurisdictionStandardizations =>
-      Object.values(jurisdictionStandardizations).some(
-        cvrContestName => cvrContestName === null
-      )
-    )
-  const standardizationComplete =
-    !!standardizations && !(standardizationNeeded && standardizationOutstanding)
+  const contestChoiceNameStandardizationsQuery = useContestChoiceNameStandardizations(
+    electionId
+  )
+  const updateContestChoiceNameStandardizations = useUpdateContestChoiceNameStandardizations(
+    electionId
+  )
+  const [
+    isContestChoiceNameStandardizationDialogOpen,
+    setIsContestChoiceNameStandardizationDialogOpen,
+  ] = useState(false)
 
   const setupComplete =
     jurisdictionsQuery.isSuccess &&
@@ -137,14 +145,41 @@ const Review: React.FC<IProps> = ({
       auditSettingsQuery.data
     )
 
+  const isContestNameStandardizationNeeded =
+    !!contestNameStandardizations &&
+    Object.values(contestNameStandardizations.standardizations).length > 0
+  const isContestNameStandardizationOutstanding =
+    !!contestNameStandardizations &&
+    Object.values(
+      contestNameStandardizations.standardizations
+    ).some(jurisdictionStandardizations =>
+      Object.values(jurisdictionStandardizations).some(
+        cvrContestName => cvrContestName === null
+      )
+    )
+  const isContestNameStandardizationComplete =
+    !!contestNameStandardizations &&
+    !(
+      isContestNameStandardizationNeeded &&
+      isContestNameStandardizationOutstanding
+    )
+
+  const isContestChoiceNameStandardizationComplete =
+    contestChoiceNameStandardizationsQuery.isSuccess &&
+    isContestChoiceNameStandardizationCompleteHelper(
+      contestChoiceNameStandardizationsQuery.data.standardizations
+    )
+
   const areChoiceNamesConsistentForAllContests = (
     contestsQuery.data ?? []
   ).every(contest => !contest.cvrChoiceNameConsistencyError)
 
   const shouldLoadSampleSizes =
     setupComplete &&
-    standardizationComplete &&
+    isContestNameStandardizationComplete &&
+    isContestChoiceNameStandardizationComplete &&
     areChoiceNamesConsistentForAllContests
+
   const sampleSizesQuery = useSampleSizes(electionId, 1, {
     enabled: shouldLoadSampleSizes,
     refetchInterval: sampleSizesResponse =>
@@ -155,9 +190,11 @@ const Review: React.FC<IProps> = ({
   if (
     !jurisdictionsQuery.isSuccess ||
     !contestsQuery.isSuccess ||
-    !auditSettingsQuery.isSuccess
-  )
+    !auditSettingsQuery.isSuccess ||
+    !contestChoiceNameStandardizationsQuery.isSuccess
+  ) {
     return null // Still loading
+  }
   const jurisdictions = jurisdictionsQuery.data
   const contests = contestsQuery.data
   const {
@@ -167,6 +204,8 @@ const Review: React.FC<IProps> = ({
     online,
     auditType,
   } = auditSettingsQuery.data
+  const contestChoiceNameStandardizations =
+    contestChoiceNameStandardizationsQuery.data.standardizations
 
   const participatingJurisdictions = jurisdictions.filter(({ id }) =>
     contests.some(c => c.jurisdictionIds.includes(id))
@@ -237,17 +276,19 @@ const Review: React.FC<IProps> = ({
       </section>
       <section>
         <H4>Contests</H4>
-        {standardizations && standardizationNeeded && (
+        {contestNameStandardizations && isContestNameStandardizationNeeded && (
           <>
-            {standardizationOutstanding ? (
+            {isContestNameStandardizationOutstanding ? (
               <Callout intent="warning">
                 <p>
-                  Some contest names in the CVR files do not match the
-                  target/opportunistic contest names.
+                  Some contest names in the uploaded CVR files do not match the
+                  standardized contest names.
                 </p>
                 <Button
                   intent="primary"
-                  onClick={() => setIsStandardizationsDialogOpen(true)}
+                  onClick={() =>
+                    setIsContestNameStandardizationDialogOpen(true)
+                  }
                 >
                   Standardize Contest Names
                 </Button>
@@ -255,11 +296,13 @@ const Review: React.FC<IProps> = ({
             ) : (
               <Callout intent="success">
                 <p>
-                  All contest names in the CVR files have been standardized to
-                  match the target/opportunistic contest names.
+                  All contest names in the uploaded CVR files have been
+                  standardized.
                 </p>
                 <Button
-                  onClick={() => setIsStandardizationsDialogOpen(true)}
+                  onClick={() =>
+                    setIsContestNameStandardizationDialogOpen(true)
+                  }
                   disabled={locked}
                 >
                   Edit Standardized Contest Names
@@ -267,10 +310,10 @@ const Review: React.FC<IProps> = ({
               </Callout>
             )}
             <StandardizeContestNamesDialog
-              isOpen={isStandardizationsDialogOpen}
-              onClose={() => setIsStandardizationsDialogOpen(false)}
-              standardizations={standardizations}
-              updateStandardizations={updateStandardizations}
+              isOpen={isContestNameStandardizationDialogOpen}
+              onClose={() => setIsContestNameStandardizationDialogOpen(false)}
+              standardizations={contestNameStandardizations}
+              updateStandardizations={updateContestNameStandardizations}
               jurisdictionsById={jurisdictionsById}
             />
             <br />
@@ -305,14 +348,45 @@ const Review: React.FC<IProps> = ({
                 ballots cast
               </p>
             )}
-            {cvrsUploaded && contest.cvrChoiceNameConsistencyError && (
-              <Callout intent="warning" style={{ marginBottom: '10px' }}>
+            {cvrsUploaded &&
+              isContestChoiceNameStandardizationComplete &&
+              contest.cvrChoiceNameConsistencyError && (
                 <CvrChoiceNameConsistencyError
                   error={contest.cvrChoiceNameConsistencyError}
                   jurisdictionNamesById={jurisdictionsById}
                 />
-              </Callout>
-            )}
+              )}
+            <StandardizeContestChoiceNamesCallout
+              contest={contest}
+              disabled={locked}
+              openDialog={() =>
+                setIsContestChoiceNameStandardizationDialogOpen(true)
+              }
+              standardizations={contestChoiceNameStandardizations}
+            />
+            <StandardizeContestChoiceNamesDialog
+              contest={contest}
+              isOpen={isContestChoiceNameStandardizationDialogOpen}
+              jurisdictionsById={jurisdictionsById}
+              onClose={() =>
+                setIsContestChoiceNameStandardizationDialogOpen(false)
+              }
+              standardizations={contestChoiceNameStandardizations}
+              standardizedContestChoiceNames={
+                (standardizedContests ?? []).find(c => c.name === contest.name)
+                  ?.choiceNames ?? []
+              }
+              updateStandardizations={async (
+                newStandardizations: IContestChoiceNameStandardizations
+              ) => {
+                await updateContestChoiceNameStandardizations.mutateAsync(
+                  newStandardizations
+                )
+              }}
+              // Reset the form state within the dialog component any time persisted
+              // standardizations change
+              key={JSON.stringify(contestChoiceNameStandardizations)}
+            />
             <div style={{ display: 'flex' }}>
               {!cvrsUploaded ? (
                 <div style={{ minWidth: '300px', marginRight: '20px' }}>
@@ -491,14 +565,6 @@ const Review: React.FC<IProps> = ({
                 return (
                   <form>
                     {(() => {
-                      if (!standardizationComplete)
-                        return (
-                          <p>
-                            All contest names must be standardized in order to
-                            calculate the sample size.
-                          </p>
-                        )
-
                       if (!setupComplete)
                         return (
                           <>
@@ -514,32 +580,40 @@ const Review: React.FC<IProps> = ({
                           </>
                         )
 
+                      if (!isContestNameStandardizationComplete)
+                        return (
+                          <p>
+                            All contest names must be standardized in order to
+                            calculate the sample size.
+                          </p>
+                        )
+
+                      if (!isContestChoiceNameStandardizationComplete)
+                        return (
+                          <p>
+                            All contest choice names must be standardized in
+                            order to calculate the sample size.
+                          </p>
+                        )
+
                       if (!areChoiceNamesConsistentForAllContests) {
                         return (
-                          <>
-                            <p>
-                              The following contests have inconsistent choice
-                              names:
-                            </p>
-                            <ul>
-                              {contests
-                                .filter(
-                                  contest =>
-                                    contest.cvrChoiceNameConsistencyError
-                                )
-                                .map(contest => (
-                                  <li key={contest.id}>
-                                    <a href={`#${contest.id}`}>
-                                      {contest.name}
-                                    </a>
-                                  </li>
-                                ))}
-                            </ul>
-                            <p>
-                              Address these inconsistencies by updating your CVR
-                              files in order to calculate the sample size.
-                            </p>
-                          </>
+                          <p>
+                            The following contests have inconsistent choice
+                            names:{' '}
+                            {contests
+                              .filter(
+                                contest => contest.cvrChoiceNameConsistencyError
+                              )
+                              .map((contest, i, filteredContests) => (
+                                <React.Fragment key={contest.id}>
+                                  <a href={`#${contest.id}`}>{contest.name}</a>
+                                  {i < filteredContests.length - 1 && ', '}
+                                </React.Fragment>
+                              ))}
+                            . Resolve these inconsistencies in order to
+                            calculate the sample size.
+                          </p>
                         )
                       }
 
@@ -604,7 +678,8 @@ const Review: React.FC<IProps> = ({
                             locked ||
                             !sampleSizeOptions ||
                             !setupComplete ||
-                            !standardizationComplete ||
+                            !isContestNameStandardizationComplete ||
+                            !isContestChoiceNameStandardizationComplete ||
                             !areChoiceNamesConsistentForAllContests
                           }
                           onClick={() => setIsConfirmDialogOpen(true)}

--- a/client/src/components/AuditAdmin/Setup/Review/StandardizeContestChoiceNamesDialog.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/StandardizeContestChoiceNamesDialog.tsx
@@ -1,0 +1,244 @@
+import {
+  Button,
+  Callout,
+  Classes,
+  Colors,
+  Dialog,
+  HTMLSelect,
+  HTMLTable,
+} from '@blueprintjs/core'
+import React, { useState } from 'react'
+import styled from 'styled-components'
+
+import FormButton from '../../../Atoms/Form/FormButton'
+import { IContest } from '../../../../types'
+import { IContestChoiceNameStandardizations } from '../../../useContestChoiceNameStandardizations'
+import { IJurisdiction } from '../../../useJurisdictions'
+
+export function isContestChoiceNameStandardizationComplete(
+  standardizations: IContestChoiceNameStandardizations
+): boolean {
+  for (const jurisdictionStandardizations of Object.values(standardizations)) {
+    for (const contestStandardizations of Object.values(
+      jurisdictionStandardizations
+    )) {
+      for (const standardizedChoiceName of Object.values(
+        contestStandardizations
+      )) {
+        if (standardizedChoiceName === null) {
+          return false
+        }
+      }
+    }
+  }
+  return true
+}
+
+const Table = styled(HTMLTable)`
+  background: ${Colors.WHITE};
+  border: 1px solid ${Colors.LIGHT_GRAY1};
+  width: 100%;
+
+  tr th,
+  tr td {
+    vertical-align: middle;
+    word-wrap: break-word;
+  }
+`
+
+interface IDialogProps {
+  contest: IContest
+  isOpen: boolean
+  jurisdictionsById: { [id: string]: IJurisdiction }
+  onClose: () => void
+  standardizations: IContestChoiceNameStandardizations
+  standardizedContestChoiceNames: string[]
+  updateStandardizations: (
+    newStandardizations: IContestChoiceNameStandardizations
+  ) => Promise<void>
+}
+
+/**
+ * A dialog for standardizing contest choice names
+ */
+export const StandardizeContestChoiceNamesDialog: React.FC<IDialogProps> = ({
+  isOpen,
+  onClose,
+  standardizations,
+  contest,
+  jurisdictionsById,
+  standardizedContestChoiceNames,
+  updateStandardizations,
+}) => {
+  const [formState, setFormState] = useState(standardizations)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const setStandardization = ({
+    jurisdictionId,
+    cvrChoiceName,
+    standardizedChoiceName,
+  }: {
+    jurisdictionId: string
+    cvrChoiceName: string
+    standardizedChoiceName: string | null
+  }) => {
+    setFormState({
+      ...formState,
+      [jurisdictionId]: {
+        ...formState[jurisdictionId],
+        [contest.id]: {
+          ...formState[jurisdictionId][contest.id],
+          [cvrChoiceName]: standardizedChoiceName,
+        },
+      },
+    })
+  }
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Standardize Contest Choice Names"
+      style={{ width: '600px' }}
+    >
+      <div className={Classes.DIALOG_BODY}>
+        <p>
+          For each contest choice below, select the standardized choice name
+          that matches the CVR choice name.
+        </p>
+        <Table striped bordered>
+          <thead>
+            <tr>
+              <th>Jurisdiction</th>
+              <th>CVR Choice</th>
+              <th>Standardized Choice</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(standardizations).map(
+              ([jurisdictionId, jurisdictionStandardizations]) =>
+                Object.keys(jurisdictionStandardizations[contest.id] ?? {}).map(
+                  cvrChoiceName => (
+                    <tr key={`${jurisdictionId}${cvrChoiceName}`}>
+                      <td>{jurisdictionsById[jurisdictionId].name}</td>
+                      <td>{cvrChoiceName}</td>
+                      <td>
+                        <HTMLSelect
+                          onChange={e =>
+                            setStandardization({
+                              jurisdictionId,
+                              cvrChoiceName,
+                              standardizedChoiceName: e.target.value || null,
+                            })
+                          }
+                          value={
+                            formState[jurisdictionId][contest.id][
+                              cvrChoiceName
+                            ] ?? ''
+                          }
+                        >
+                          <option key="" value="" />
+                          {standardizedContestChoiceNames.map(name => (
+                            <option value={name} key={name}>
+                              {name}
+                            </option>
+                          ))}
+                        </HTMLSelect>
+                      </td>
+                    </tr>
+                  )
+                )
+            )}
+          </tbody>
+        </Table>
+      </div>
+      <div className={Classes.DIALOG_FOOTER}>
+        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <Button onClick={onClose}>Cancel</Button>
+          <FormButton
+            intent="primary"
+            loading={isSubmitting}
+            onClick={async () => {
+              setIsSubmitting(true)
+              try {
+                await updateStandardizations(formState)
+                onClose()
+              } finally {
+                setIsSubmitting(false)
+              }
+            }}
+          >
+            Submit
+          </FormButton>
+        </div>
+      </div>
+    </Dialog>
+  )
+}
+
+const CalloutWithBottomMargin = styled(Callout)`
+  margin-bottom: 16px;
+`
+
+interface ICalloutProps {
+  contest: IContest
+  disabled: boolean
+  openDialog: () => void
+  standardizations: IContestChoiceNameStandardizations
+}
+
+/**
+ * A callout indicating the status of contest choice name standardization
+ */
+export const StandardizeContestChoiceNamesCallout: React.FC<ICalloutProps> = ({
+  contest,
+  disabled,
+  openDialog,
+  standardizations,
+}) => {
+  let isStandardizationNeeded = false
+  let isStandardizationNeededAndOutstanding = false
+  for (const jurisdictionStandardizations of Object.values(standardizations)) {
+    const contestStandardization = jurisdictionStandardizations[contest.id]
+    for (const standardizedChoiceName of Object.values(
+      contestStandardization
+    )) {
+      isStandardizationNeeded = true
+      if (standardizedChoiceName === null) {
+        isStandardizationNeededAndOutstanding = true
+        break
+      }
+    }
+  }
+
+  if (!isStandardizationNeeded) {
+    return null
+  }
+
+  if (isStandardizationNeededAndOutstanding) {
+    return (
+      <CalloutWithBottomMargin intent="warning">
+        <p>
+          Some {contest.name} choice names in the uploaded CVR files do not
+          match the standardized contest choice names.
+        </p>
+        <Button disabled={disabled} intent="primary" onClick={openDialog}>
+          Standardize Contest Choice Names
+        </Button>
+      </CalloutWithBottomMargin>
+    )
+  }
+
+  // Standardization is needed and has been completed
+  return (
+    <CalloutWithBottomMargin intent="success">
+      <p>
+        All {contest.name} choice names in the uploaded CVR files have been
+        standardized.
+      </p>
+      <Button disabled={disabled} intent="none" onClick={openDialog}>
+        Edit Standardized Contest Choice Names
+      </Button>
+    </CalloutWithBottomMargin>
+  )
+}

--- a/client/src/components/AuditAdmin/Setup/Review/StandardizeContestChoiceNamesDialog.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/StandardizeContestChoiceNamesDialog.tsx
@@ -87,7 +87,7 @@ export const StandardizeContestChoiceNamesDialog: React.FC<IDialogProps> = ({
       [jurisdictionId]: {
         ...formState[jurisdictionId],
         [contest.id]: {
-          ...formState[jurisdictionId][contest.id],
+          ...formState[jurisdictionId]?.[contest.id],
           [cvrChoiceName]: standardizedChoiceName,
         },
       },
@@ -132,7 +132,7 @@ export const StandardizeContestChoiceNamesDialog: React.FC<IDialogProps> = ({
                             })
                           }
                           value={
-                            formState[jurisdictionId][contest.id][
+                            formState[jurisdictionId]?.[contest.id]?.[
                               cvrChoiceName
                             ] ?? ''
                           }

--- a/client/src/components/AuditAdmin/Setup/Review/StandardizeContestNames.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/StandardizeContestNames.tsx
@@ -66,14 +66,14 @@ const StandardizeContestNamesDialog: React.FC<IStandardizeContestNamesDialogProp
           <div className={Classes.DIALOG_BODY}>
             <p>
               For each contest below, select the CVR contest name that matches
-              the standard target/opportunistic contest name.
+              the standardized contest name.
             </p>
             {
               <StandardizeContestsTable striped bordered>
                 <thead>
                   <tr>
                     <th>Jurisdiction</th>
-                    <th>Target/Opportunistic Contest</th>
+                    <th>Standardized Contest</th>
                     <th>CVR Contest</th>
                   </tr>
                 </thead>

--- a/client/src/components/AuditAdmin/Setup/Setup.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Setup.test.tsx
@@ -236,7 +236,9 @@ describe('Setup', () => {
       aaApiCalls.getJurisdictionFile,
       aaApiCalls.getSettings(auditSettingsMocks.blank),
       aaApiCalls.getJurisdictions,
+      aaApiCalls.getStandardizedContests([]),
       aaApiCalls.getContests(contestMocks.empty),
+      aaApiCalls.getContestChoiceNameStandardizations(),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderSetup()
@@ -256,7 +258,9 @@ describe('Setup', () => {
       aaApiCalls.getJurisdictionFile,
       aaApiCalls.getSettings(auditSettingsMocks.all),
       aaApiCalls.getJurisdictions,
+      aaApiCalls.getStandardizedContests([]),
       aaApiCalls.getContests(contestMocks.filledTargeted),
+      aaApiCalls.getContestChoiceNameStandardizations(),
       aaApiCalls.getSampleSizes(sampleSizeMock.ballotPolling),
     ]
     await withMockFetch(expectedCalls, async () => {

--- a/client/src/components/AuditAdmin/__snapshots__/AuditAdminView.test.tsx.snap
+++ b/client/src/components/AuditAdmin/__snapshots__/AuditAdminView.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
       class="sc-bwzfXH ijTqJq"
     >
       <div
-        class="sc-eHgmQL iOkYC"
+        class="sc-brqgnP lgMuXE"
       >
         <h2
           class="bp3-heading sc-bZQynM bTVHiW"

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -61,19 +61,19 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-fhYwyz icxIeN"
+          class="sc-rBLzX eWHGgB"
         >
           <div
-            class="sc-jzgbtB bSIaiB"
+            class="sc-bMvGRv grgVCw"
           >
             <div
-              class="sc-gJWqzi gEscEe"
+              class="sc-CtfFt dvyDeH"
             >
               <div
-                class="sc-CtfFt jjLuAa"
+                class="sc-fjmCvl dQoSDj"
               >
                 <button
-                  class="bp3-button bp3-minimal sc-bMvGRv lfkdzN"
+                  class="bp3-button bp3-minimal sc-hGoxap kMKOrL"
                   href="/election/1/audit-board/audit-board-1"
                   type="button"
                 >
@@ -103,56 +103,56 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                   </span>
                 </button>
                 <h3
-                  class="bp3-heading sc-gFaPwZ YcgUN"
+                  class="bp3-heading sc-gJWqzi ctPand"
                 >
                   Audit Ballot Selections
                 </h3>
               </div>
               <div
-                class="bp3-divider sc-cQFLBn rSWpj"
+                class="bp3-divider sc-bXGyLb dngKan"
               />
               <div
-                class="sc-eilVRo iliFTQ"
+                class="sc-cpmLhU fIoOY"
               >
                 <div>
                   <h5
-                    class="bp3-heading sc-dUjcNx cPXRfC"
+                    class="bp3-heading sc-eerKOB bXnzdc"
                   >
                     Tabulator
                   </h5>
                   <h4
-                    class="bp3-heading sc-eerKOB haOSjM"
+                    class="bp3-heading sc-dymIpo dQpQIm"
                   >
                     11
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-dUjcNx cPXRfC"
+                    class="bp3-heading sc-eerKOB bXnzdc"
                   >
                     Batch
                   </h5>
                   <h4
-                    class="bp3-heading sc-eerKOB haOSjM"
+                    class="bp3-heading sc-dymIpo dQpQIm"
                   >
                     0003-04-Precinct 19 (Jonesboro Fire Department)
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-dUjcNx cPXRfC"
+                    class="bp3-heading sc-eerKOB bXnzdc"
                   >
                     Ballot Number
                   </h5>
                   <h4
-                    class="bp3-heading sc-eerKOB haOSjM"
+                    class="bp3-heading sc-dymIpo dQpQIm"
                   >
                     2112
                   </h4>
                 </div>
                 <div>
                   <button
-                    class="bp3-button bp3-large bp3-intent-danger sc-emmjRN cjiaDr"
+                    class="bp3-button bp3-large bp3-intent-danger sc-bnXvFD ddUiNx"
                     type="button"
                   >
                     <span
@@ -164,36 +164,36 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 </div>
               </div>
               <div
-                class="bp3-divider sc-cQFLBn rSWpj"
+                class="bp3-divider sc-bXGyLb dngKan"
               />
               <div
-                class="sc-gojNiO kCQXPO"
+                class="sc-lkqHmb lkHHBM"
               >
                 <div
                   class="ballot-main"
                 >
                   <h5
-                    class="bp3-heading sc-dUjcNx cPXRfC"
+                    class="bp3-heading sc-eerKOB bXnzdc"
                   >
                     Ballot Contests
                   </h5>
                   <form>
                     <div
-                      class="sc-daURTG fcIHKg"
+                      class="sc-eLExRp eusgQt"
                     >
                       <div
-                        class="sc-krvtoX bAbmxr"
+                        class="sc-dUjcNx cLhvpD"
                       >
                         <div
-                          class="sc-fYiAbW hOwRmO"
+                          class="sc-gHboQg gRczol"
                         >
                           <h3
-                            class="bp3-heading sc-dymIpo fcXrwH"
+                            class="bp3-heading sc-fhYwyz bzGBvU"
                           >
                             Contest 1
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
+                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
                           >
                             <input
                               type="checkbox"
@@ -209,7 +209,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
+                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
                           >
                             <input
                               type="checkbox"
@@ -226,10 +226,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-fOKMvo jakMvu"
+                          class="sc-eilVRo eifIEB"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
+                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
                           >
                             <input
                               type="checkbox"
@@ -245,7 +245,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
+                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
                           >
                             <input
                               type="checkbox"
@@ -261,7 +261,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
+                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
                           >
                             <input
                               type="checkbox"
@@ -277,7 +277,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-cpmLhU exuBpI"
+                            class="bp3-input sc-gFaPwZ mBWlp"
                             name="comment-Contest 1"
                             placeholder="Add Note"
                           />
@@ -285,21 +285,21 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-daURTG fcIHKg"
+                      class="sc-eLExRp eusgQt"
                     >
                       <div
-                        class="sc-krvtoX bAbmxr"
+                        class="sc-dUjcNx cLhvpD"
                       >
                         <div
-                          class="sc-fYiAbW hOwRmO"
+                          class="sc-gHboQg gRczol"
                         >
                           <h3
-                            class="bp3-heading sc-dymIpo fcXrwH"
+                            class="bp3-heading sc-fhYwyz bzGBvU"
                           >
                             Contest 2
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
+                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
                           >
                             <input
                               type="checkbox"
@@ -315,7 +315,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
+                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
                           >
                             <input
                               type="checkbox"
@@ -332,10 +332,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-fOKMvo jakMvu"
+                          class="sc-eilVRo eifIEB"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
+                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
                           >
                             <input
                               type="checkbox"
@@ -351,7 +351,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
+                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
                           >
                             <input
                               type="checkbox"
@@ -367,7 +367,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gHboQg guiKIQ"
+                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
                           >
                             <input
                               type="checkbox"
@@ -383,7 +383,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-cpmLhU exuBpI"
+                            class="bp3-input sc-gFaPwZ mBWlp"
                             name="comment-Contest 2"
                             placeholder="Add Note"
                           />
@@ -391,10 +391,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-lkqHmb dSHWIf"
+                      class="sc-krvtoX hJaJdG"
                     >
                       <button
-                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-bnXvFD iGplTJ sc-dnqmqq iQfLYL"
+                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-jzgbtB kJLReP sc-dnqmqq iQfLYL"
                         disabled=""
                         tabindex="-1"
                         type="submit"
@@ -421,7 +421,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
               </div>
             </div>
             <div
-              class="sc-rBLzX hifYMt"
+              class="sc-laTMn cINNXD"
             >
               <h4
                 class="bp3-heading"
@@ -429,7 +429,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 Instructions
               </h4>
               <ol
-                class="bp3-list sc-laTMn dPpMdm"
+                class="bp3-list sc-TFwJa czXaOQ"
               >
                 <li>
                   Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -534,13 +534,13 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
       class="board-table-container"
     >
       <div
-        class="sc-hZSUBg blRWYv"
+        class="sc-esOvli gaxxTj"
       >
         <div
-          class="sc-bwzfXH sc-cMhqgX gksGAs"
+          class="sc-bwzfXH sc-cmthru MCtlb"
         >
           <div
-            class="sc-iQNlJl cdIcB"
+            class="sc-cMhqgX kfrMZZ"
           >
             <p>
               18
@@ -549,23 +549,23 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-hORach cZKLaE"
+              class="summary-label sc-iujRgT iRLgiW"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-bMVAic iQIqRK"
+              class="summary-label sc-GMQeP bCrbdD"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-bsbRJL dEwQsZ"
+            class="sc-iuJeZd dbfTuH"
           >
             <button
-              class="bp3-button bp3-intent-success sc-iujRgT kJAYyn"
+              class="bp3-button bp3-intent-success sc-cQFLBn eLlnEC"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -582,10 +582,10 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-iuJeZd jIISPh"
+          class="sc-hMFtBS bfsTnq"
         >
           <div
-            class="sc-esOvli yrFmX"
+            class="sc-cLQEGU huXbyu"
           >
             <h3
               class="bp3-heading"
@@ -594,7 +594,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Audit Board #1
             </h3>
             <div
-              class="sc-cmthru fxjRhw"
+              class="sc-gqPbQI bEnvAE"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -799,7 +799,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -809,7 +809,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -819,7 +819,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -829,7 +829,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -858,7 +858,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -877,7 +877,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -886,7 +886,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -895,7 +895,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -904,7 +904,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -913,7 +913,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -934,7 +934,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -944,7 +944,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -954,7 +954,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -964,7 +964,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -993,7 +993,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -1012,7 +1012,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1022,7 +1022,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1032,7 +1032,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1042,7 +1042,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1071,7 +1071,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -1090,7 +1090,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -1099,7 +1099,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1108,7 +1108,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -1117,7 +1117,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -1126,7 +1126,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -1147,7 +1147,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1157,7 +1157,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1167,7 +1167,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1177,7 +1177,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1206,7 +1206,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -1225,7 +1225,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1235,7 +1235,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1245,7 +1245,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1255,7 +1255,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1284,7 +1284,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -1303,7 +1303,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -1312,7 +1312,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1321,7 +1321,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -1330,7 +1330,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -1339,7 +1339,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -1360,7 +1360,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1370,7 +1370,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1380,7 +1380,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1390,7 +1390,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1419,7 +1419,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -1438,7 +1438,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1448,7 +1448,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1458,7 +1458,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1468,7 +1468,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1497,7 +1497,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -1516,7 +1516,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -1525,7 +1525,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1534,7 +1534,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -1543,7 +1543,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -1552,7 +1552,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -1573,7 +1573,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1583,7 +1583,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1593,7 +1593,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1603,7 +1603,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1632,7 +1632,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -1651,7 +1651,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1661,7 +1661,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1671,7 +1671,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1681,7 +1681,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1710,7 +1710,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -1729,7 +1729,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -1738,7 +1738,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1747,7 +1747,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -1756,7 +1756,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -1765,7 +1765,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -1786,7 +1786,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1796,7 +1796,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1806,7 +1806,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1816,7 +1816,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1845,7 +1845,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -1864,7 +1864,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1874,7 +1874,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1884,7 +1884,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1894,7 +1894,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1923,7 +1923,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -1942,7 +1942,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -1951,7 +1951,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1960,7 +1960,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -1969,7 +1969,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -1978,7 +1978,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -1999,7 +1999,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2009,7 +2009,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2019,7 +2019,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2029,7 +2029,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2058,7 +2058,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -2077,7 +2077,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2087,7 +2087,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2097,7 +2097,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2107,7 +2107,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2136,7 +2136,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -2155,7 +2155,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -2164,7 +2164,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2173,7 +2173,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -2182,7 +2182,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -2191,7 +2191,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -2212,7 +2212,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2222,7 +2222,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2232,7 +2232,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2242,7 +2242,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2271,7 +2271,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -2290,7 +2290,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2300,7 +2300,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2310,7 +2310,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2320,7 +2320,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2349,7 +2349,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -2368,7 +2368,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -2377,7 +2377,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2386,7 +2386,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -2395,7 +2395,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -2404,7 +2404,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -2425,7 +2425,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2435,7 +2435,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2445,7 +2445,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2455,7 +2455,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2484,7 +2484,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -2503,7 +2503,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2513,7 +2513,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2523,7 +2523,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2533,7 +2533,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2562,7 +2562,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -2581,7 +2581,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -2590,7 +2590,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2599,7 +2599,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -2608,7 +2608,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -2617,7 +2617,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -2638,7 +2638,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2648,7 +2648,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2658,7 +2658,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2668,7 +2668,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2697,7 +2697,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -2713,7 +2713,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-GMQeP dgoJfs"
+              class="bp3-button bp3-disabled bp3-large sc-gojNiO jBGhKr"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -2727,7 +2727,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
             </button>
           </div>
           <div
-            class="sc-hMFtBS eVxguM"
+            class="sc-hORach ZPclK"
           >
             <h4
               class="bp3-heading"
@@ -2735,7 +2735,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bAeIUo hsKqcp"
+              class="bp3-list sc-exAgwC dlOWaa"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -2815,13 +2815,13 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
       class="board-table-container"
     >
       <div
-        class="sc-hZSUBg blRWYv"
+        class="sc-esOvli gaxxTj"
       >
         <div
-          class="sc-bwzfXH sc-cMhqgX gksGAs"
+          class="sc-bwzfXH sc-cmthru MCtlb"
         >
           <div
-            class="sc-iQNlJl cdIcB"
+            class="sc-cMhqgX kfrMZZ"
           >
             <p>
               0
@@ -2830,23 +2830,23 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-hORach cZKLaE"
+              class="summary-label sc-iujRgT iRLgiW"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-bMVAic iQIqRK"
+              class="summary-label sc-GMQeP bCrbdD"
             >
               Not Audited: 
               27
             </span>
           </div>
           <div
-            class="sc-bsbRJL dEwQsZ"
+            class="sc-iuJeZd dbfTuH"
           >
             <button
-              class="bp3-button bp3-intent-success sc-iujRgT kJAYyn"
+              class="bp3-button bp3-intent-success sc-cQFLBn eLlnEC"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
               type="button"
             >
@@ -2863,10 +2863,10 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-iuJeZd jIISPh"
+          class="sc-hMFtBS bfsTnq"
         >
           <div
-            class="sc-esOvli yrFmX"
+            class="sc-cLQEGU huXbyu"
           >
             <h3
               class="bp3-heading"
@@ -2875,7 +2875,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Audit Board #1
             </h3>
             <div
-              class="sc-cmthru fxjRhw"
+              class="sc-gqPbQI bEnvAE"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -3080,7 +3080,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3089,7 +3089,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3098,7 +3098,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         313
                       </p>
@@ -3107,7 +3107,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3116,7 +3116,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -3137,7 +3137,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3146,7 +3146,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3155,7 +3155,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -3164,7 +3164,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3173,7 +3173,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -3194,7 +3194,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3203,7 +3203,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3212,7 +3212,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         1789
                       </p>
@@ -3221,7 +3221,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3230,7 +3230,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -3251,7 +3251,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3260,7 +3260,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3269,7 +3269,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         313
                       </p>
@@ -3278,7 +3278,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3287,7 +3287,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -3308,7 +3308,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3317,7 +3317,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3326,7 +3326,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -3335,7 +3335,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3344,7 +3344,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -3365,7 +3365,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3374,7 +3374,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3383,7 +3383,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         1789
                       </p>
@@ -3392,7 +3392,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3401,7 +3401,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -3422,7 +3422,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3431,7 +3431,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3440,7 +3440,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         313
                       </p>
@@ -3449,7 +3449,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3458,7 +3458,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -3479,7 +3479,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3488,7 +3488,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3497,7 +3497,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -3506,7 +3506,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3515,7 +3515,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -3536,7 +3536,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3545,7 +3545,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3554,7 +3554,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         1789
                       </p>
@@ -3563,7 +3563,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3572,7 +3572,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -3593,7 +3593,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3602,7 +3602,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3611,7 +3611,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         313
                       </p>
@@ -3620,7 +3620,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3629,7 +3629,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -3650,7 +3650,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3659,7 +3659,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3668,7 +3668,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -3677,7 +3677,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3686,7 +3686,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -3707,7 +3707,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3716,7 +3716,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3725,7 +3725,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         1789
                       </p>
@@ -3734,7 +3734,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3743,7 +3743,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -3764,7 +3764,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3773,7 +3773,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3782,7 +3782,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         313
                       </p>
@@ -3791,7 +3791,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3800,7 +3800,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -3821,7 +3821,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3830,7 +3830,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3839,7 +3839,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -3848,7 +3848,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3857,7 +3857,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -3878,7 +3878,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3887,7 +3887,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3896,7 +3896,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         1789
                       </p>
@@ -3905,7 +3905,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3914,7 +3914,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -3935,7 +3935,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -3944,7 +3944,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3953,7 +3953,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         313
                       </p>
@@ -3962,7 +3962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -3971,7 +3971,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -3992,7 +3992,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -4001,7 +4001,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4010,7 +4010,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -4019,7 +4019,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -4028,7 +4028,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -4049,7 +4049,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -4058,7 +4058,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4067,7 +4067,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         1789
                       </p>
@@ -4076,7 +4076,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -4085,7 +4085,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -4106,7 +4106,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -4115,7 +4115,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4124,7 +4124,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         313
                       </p>
@@ -4133,7 +4133,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -4142,7 +4142,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -4163,7 +4163,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -4172,7 +4172,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4181,7 +4181,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -4190,7 +4190,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -4199,7 +4199,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -4220,7 +4220,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -4229,7 +4229,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4238,7 +4238,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         1789
                       </p>
@@ -4247,7 +4247,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -4256,7 +4256,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -4277,7 +4277,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -4286,7 +4286,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4295,7 +4295,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         313
                       </p>
@@ -4304,7 +4304,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -4313,7 +4313,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -4334,7 +4334,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -4343,7 +4343,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4352,7 +4352,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -4361,7 +4361,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -4370,7 +4370,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -4391,7 +4391,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -4400,7 +4400,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4409,7 +4409,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         1789
                       </p>
@@ -4418,7 +4418,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -4427,7 +4427,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -4448,7 +4448,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -4457,7 +4457,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4466,7 +4466,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         313
                       </p>
@@ -4475,7 +4475,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -4484,7 +4484,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -4505,7 +4505,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -4514,7 +4514,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4523,7 +4523,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -4532,7 +4532,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -4541,7 +4541,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -4562,7 +4562,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -4571,7 +4571,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4580,7 +4580,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         1789
                       </p>
@@ -4589,7 +4589,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -4598,7 +4598,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -4616,7 +4616,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-GMQeP dgoJfs"
+              class="bp3-button bp3-disabled bp3-large sc-gojNiO jBGhKr"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -4630,7 +4630,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
             </button>
           </div>
           <div
-            class="sc-hMFtBS eVxguM"
+            class="sc-hORach ZPclK"
           >
             <h4
               class="bp3-heading"
@@ -4638,7 +4638,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bAeIUo hsKqcp"
+              class="bp3-list sc-exAgwC dlOWaa"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -4718,13 +4718,13 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
       class="board-table-container"
     >
       <div
-        class="sc-hZSUBg blRWYv"
+        class="sc-esOvli gaxxTj"
       >
         <div
-          class="sc-bwzfXH sc-cMhqgX gksGAs"
+          class="sc-bwzfXH sc-cmthru MCtlb"
         >
           <div
-            class="sc-iQNlJl cdIcB"
+            class="sc-cMhqgX kfrMZZ"
           >
             <p>
               0
@@ -4733,23 +4733,23 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-hORach cZKLaE"
+              class="summary-label sc-iujRgT iRLgiW"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-bMVAic iQIqRK"
+              class="summary-label sc-GMQeP bCrbdD"
             >
               Not Audited: 
               0
             </span>
           </div>
           <div
-            class="sc-bsbRJL dEwQsZ"
+            class="sc-iuJeZd dbfTuH"
           >
             <button
-              class="bp3-button bp3-intent-success sc-iujRgT kJAYyn"
+              class="bp3-button bp3-intent-success sc-cQFLBn eLlnEC"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4766,10 +4766,10 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-iuJeZd jIISPh"
+          class="sc-hMFtBS bfsTnq"
         >
           <div
-            class="sc-esOvli yrFmX"
+            class="sc-cLQEGU huXbyu"
           >
             <h3
               class="bp3-heading"
@@ -4778,7 +4778,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Audit Board #1
             </h3>
             <div
-              class="sc-cmthru fxjRhw"
+              class="sc-gqPbQI bEnvAE"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -4942,7 +4942,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               </table>
             </div>
             <button
-              class="bp3-button bp3-large bp3-intent-success sc-GMQeP dgoJfs"
+              class="bp3-button bp3-large bp3-intent-success sc-gojNiO jBGhKr"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4954,7 +4954,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
             </button>
           </div>
           <div
-            class="sc-hMFtBS eVxguM"
+            class="sc-hORach ZPclK"
           >
             <h4
               class="bp3-heading"
@@ -4962,7 +4962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bAeIUo hsKqcp"
+              class="bp3-list sc-exAgwC dlOWaa"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -5042,13 +5042,13 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
       class="board-table-container"
     >
       <div
-        class="sc-hZSUBg blRWYv"
+        class="sc-esOvli gaxxTj"
       >
         <div
-          class="sc-bwzfXH sc-cMhqgX gksGAs"
+          class="sc-bwzfXH sc-cmthru MCtlb"
         >
           <div
-            class="sc-iQNlJl cdIcB"
+            class="sc-cMhqgX kfrMZZ"
           >
             <p>
               18
@@ -5057,23 +5057,23 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-hORach cZKLaE"
+              class="summary-label sc-iujRgT iRLgiW"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-bMVAic iQIqRK"
+              class="summary-label sc-GMQeP bCrbdD"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-bsbRJL dEwQsZ"
+            class="sc-iuJeZd dbfTuH"
           >
             <button
-              class="bp3-button bp3-intent-success sc-iujRgT kJAYyn"
+              class="bp3-button bp3-intent-success sc-cQFLBn eLlnEC"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -5090,10 +5090,10 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-iuJeZd jIISPh"
+          class="sc-hMFtBS bfsTnq"
         >
           <div
-            class="sc-esOvli yrFmX"
+            class="sc-cLQEGU huXbyu"
           >
             <h3
               class="bp3-heading"
@@ -5102,7 +5102,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Audit Board #1
             </h3>
             <div
-              class="sc-cmthru fxjRhw"
+              class="sc-gqPbQI bEnvAE"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -5307,7 +5307,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5317,7 +5317,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5327,7 +5327,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5337,7 +5337,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5366,7 +5366,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -5385,7 +5385,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -5394,7 +5394,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5403,7 +5403,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -5412,7 +5412,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -5421,7 +5421,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -5442,7 +5442,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5452,7 +5452,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5462,7 +5462,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5472,7 +5472,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5501,7 +5501,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -5520,7 +5520,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5530,7 +5530,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5540,7 +5540,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5550,7 +5550,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5579,7 +5579,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -5598,7 +5598,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -5607,7 +5607,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5616,7 +5616,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -5625,7 +5625,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -5634,7 +5634,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -5655,7 +5655,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5665,7 +5665,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5675,7 +5675,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5685,7 +5685,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5714,7 +5714,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -5733,7 +5733,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5743,7 +5743,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5753,7 +5753,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5763,7 +5763,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5792,7 +5792,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -5811,7 +5811,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -5820,7 +5820,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5829,7 +5829,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -5838,7 +5838,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -5847,7 +5847,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -5868,7 +5868,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5878,7 +5878,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5888,7 +5888,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5898,7 +5898,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5927,7 +5927,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -5946,7 +5946,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5956,7 +5956,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5966,7 +5966,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5976,7 +5976,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6005,7 +6005,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -6024,7 +6024,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -6033,7 +6033,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6042,7 +6042,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -6051,7 +6051,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -6060,7 +6060,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -6081,7 +6081,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6091,7 +6091,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6101,7 +6101,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6111,7 +6111,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6140,7 +6140,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -6159,7 +6159,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6169,7 +6169,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6179,7 +6179,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6189,7 +6189,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6218,7 +6218,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -6237,7 +6237,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -6246,7 +6246,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6255,7 +6255,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -6264,7 +6264,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -6273,7 +6273,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -6294,7 +6294,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6304,7 +6304,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6314,7 +6314,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6324,7 +6324,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6353,7 +6353,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -6372,7 +6372,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6382,7 +6382,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6392,7 +6392,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6402,7 +6402,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6431,7 +6431,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -6450,7 +6450,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -6459,7 +6459,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6468,7 +6468,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -6477,7 +6477,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -6486,7 +6486,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -6507,7 +6507,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6517,7 +6517,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6527,7 +6527,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6537,7 +6537,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6566,7 +6566,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -6585,7 +6585,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6595,7 +6595,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6605,7 +6605,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6615,7 +6615,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6644,7 +6644,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -6663,7 +6663,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -6672,7 +6672,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6681,7 +6681,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -6690,7 +6690,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -6699,7 +6699,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -6720,7 +6720,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6730,7 +6730,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6740,7 +6740,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6750,7 +6750,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6779,7 +6779,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -6798,7 +6798,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6808,7 +6808,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6818,7 +6818,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6828,7 +6828,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6857,7 +6857,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -6876,7 +6876,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -6885,7 +6885,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6894,7 +6894,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -6903,7 +6903,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -6912,7 +6912,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -6933,7 +6933,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6943,7 +6943,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6953,7 +6953,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6963,7 +6963,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6992,7 +6992,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -7011,7 +7011,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7021,7 +7021,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -7031,7 +7031,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -7041,7 +7041,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7070,7 +7070,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -7089,7 +7089,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         11
                       </p>
@@ -7098,7 +7098,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -7107,7 +7107,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                       >
                         2112
                       </p>
@@ -7116,7 +7116,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-bMVAic iQIqRK"
+                        class="sc-GMQeP bCrbdD"
                       >
                         Not Audited
                       </span>
@@ -7125,7 +7125,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -7146,7 +7146,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7156,7 +7156,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -7166,7 +7166,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -7176,7 +7176,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-exAgwC ccEBA"
+                        class="sc-daURTG htjMod"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7205,7 +7205,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-cLQEGU itPCkU"
+                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -7221,7 +7221,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-GMQeP dgoJfs"
+              class="bp3-button bp3-disabled bp3-large sc-gojNiO jBGhKr"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -7235,7 +7235,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
             </button>
           </div>
           <div
-            class="sc-hMFtBS eVxguM"
+            class="sc-hORach ZPclK"
           >
             <h4
               class="bp3-heading"
@@ -7243,7 +7243,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bAeIUo hsKqcp"
+              class="bp3-list sc-exAgwC dlOWaa"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -25,6 +25,7 @@ import {
 } from './useJurisdictions'
 import { IStandardizedContest } from './useStandardizedContests'
 import { ISampleSizesResponse } from './AuditAdmin/Setup/Review/useSampleSizes'
+import { IContestChoiceNameStandardizationsResponse } from './useContestChoiceNameStandardizations'
 
 export const manifestFile = new File(
   ['fake manifest - contents dont matter'],
@@ -2017,6 +2018,14 @@ export const aaApiCalls = {
     options: { method: 'DELETE' },
     response: { status: 'ok' },
   },
+  getContestChoiceNameStandardizations: (
+    response: IContestChoiceNameStandardizationsResponse = {
+      standardizations: {},
+    }
+  ) => ({
+    url: '/api/election/1/contest/choice-name-standardizations',
+    response,
+  }),
 }
 
 export const supportApiCalls = {

--- a/client/src/components/useContestChoiceNameStandardizations.ts
+++ b/client/src/components/useContestChoiceNameStandardizations.ts
@@ -1,0 +1,70 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQuery,
+  useQueryClient,
+  UseQueryResult,
+} from 'react-query'
+
+import { ApiError, fetchApi } from '../utils/api'
+import { contestsQueryKey } from './useContests'
+
+export interface IContestChoiceNameStandardizations {
+  [jurisdictionId: string]: {
+    [contestId: string]: {
+      [cvrChoiceName: string]: string | null // Standardized choice name
+    }
+  }
+}
+
+export interface IContestChoiceNameStandardizationsResponse {
+  standardizations: IContestChoiceNameStandardizations
+}
+
+export const contestChoiceNameStandardizationsQueryKey = (
+  electionId: string
+): string[] => ['election', electionId, 'contestChoiceNameStandardizations']
+
+export const useContestChoiceNameStandardizations = (
+  electionId: string
+): UseQueryResult<IContestChoiceNameStandardizationsResponse, ApiError> =>
+  useQuery<IContestChoiceNameStandardizationsResponse, ApiError>(
+    contestChoiceNameStandardizationsQueryKey(electionId),
+    () => {
+      return fetchApi(
+        `/api/election/${electionId}/contest/choice-name-standardizations`
+      )
+    }
+  )
+
+export const useUpdateContestChoiceNameStandardizations = (
+  electionId: string
+): UseMutationResult<
+  IContestChoiceNameStandardizations,
+  ApiError,
+  IContestChoiceNameStandardizations
+> => {
+  const queryClient = useQueryClient()
+
+  const putStandardizations = (
+    newStandardizations: IContestChoiceNameStandardizations
+  ) => {
+    return fetchApi(
+      `/api/election/${electionId}/contest/choice-name-standardizations`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(newStandardizations),
+      }
+    )
+  }
+
+  return useMutation(putStandardizations, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(
+        contestChoiceNameStandardizationsQueryKey(electionId)
+      )
+      queryClient.invalidateQueries(contestsQueryKey(electionId))
+    },
+  })
+}

--- a/client/src/components/useContestNameStandardizations.ts
+++ b/client/src/components/useContestNameStandardizations.ts
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react'
+import { useQueryClient } from 'react-query'
 import { api } from './utilities'
 import { IAuditSettings } from './useAuditSettings'
+import { contestsQueryKey } from './useContests'
+import { contestChoiceNameStandardizationsQueryKey } from './useContestChoiceNameStandardizations'
 
 export interface IContestNameStandardizations {
   standardizations: {
@@ -31,6 +34,7 @@ const useContestNameStandardizations = (
     standardizations,
     setStandardizations,
   ] = useState<IContestNameStandardizations | null>(null)
+  const queryClient = useQueryClient()
 
   const updateStandardizations = async (
     newStandardizations: IContestNameStandardizations['standardizations']
@@ -45,7 +49,13 @@ const useContestNameStandardizations = (
         },
       }
     )
-    if (response) setStandardizations(await getStandardizations(electionId))
+    if (response) {
+      setStandardizations(await getStandardizations(electionId))
+    }
+    await queryClient.invalidateQueries(
+      contestChoiceNameStandardizationsQueryKey(electionId)
+    )
+    await queryClient.invalidateQueries(contestsQueryKey(electionId))
     return !!response
   }
 

--- a/client/src/components/useContests.ts
+++ b/client/src/components/useContests.ts
@@ -9,7 +9,7 @@ import { IContest } from '../types'
 import { IAuditSettings } from './useAuditSettings'
 import { ApiError, fetchApi } from '../utils/api'
 
-const contestsQueryKey = (electionId: string) => [
+export const contestsQueryKey = (electionId: string): string[] => [
   'elections',
   electionId,
   'contests',

--- a/client/src/components/useStandardizedContests.ts
+++ b/client/src/components/useStandardizedContests.ts
@@ -4,6 +4,7 @@ import { api } from './utilities'
 export interface IStandardizedContest {
   name: string
   jurisdictionIds: string[]
+  choiceNames?: string[]
 }
 
 const getStandardizedContests = async (

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -448,7 +448,7 @@ def get_contest_name_standardizations(election: Election):
     "/election/<election_id>/contest/choice-name-standardizations", methods=["PUT"],
 )
 @restrict_access([UserType.AUDIT_ADMIN])
-def put_contest_choice_name_standardizations(election: Election):
+def put_contest_choice_name_standardizations(election: Election):  # pragma: no cover
     if election.audit_type not in [AuditType.BALLOT_COMPARISON, AuditType.HYBRID]:
         raise Conflict("Cannot standardize contest choice names for this audit type.")
     if len(list(election.rounds)) > 0:
@@ -475,7 +475,7 @@ def put_contest_choice_name_standardizations(election: Election):
     "/election/<election_id>/contest/choice-name-standardizations", methods=["GET"],
 )
 @restrict_access([UserType.AUDIT_ADMIN])
-def get_contest_choice_name_standardizations(election: Election):
+def get_contest_choice_name_standardizations(election: Election):  # pragma: no cover
     def get_standardizations_for_jurisdiction_and_contest(jurisdiction, contest):
         # Get metadata with contest name standardizations applied but not contest choice name
         # standardizations applied

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -486,15 +486,17 @@ def get_contest_choice_name_standardizations(election: Election):  # pragma: no 
             (metadata or {}).get(contest.name, {}).get("choices", {}).keys()
         )
 
-        standardized_contest_choice_names = None
-        for standardized_contest in (
+        standardized_contests = (
             typing.cast(Optional[List[Dict]], election.standardized_contests) or []
-        ):
-            if standardized_contest["name"] == contest.name:
-                standardized_contest_choice_names = standardized_contest.get(
-                    "choiceNames", None
-                )
-                break
+        )
+        standardized_contest_choice_names = next(
+            (
+                standardized_contest.get("choiceNames", None)
+                for standardized_contest in standardized_contests
+                if standardized_contest["name"] == contest.name
+            ),
+            None,
+        )
 
         raw_standardizations = (
             typing.cast(

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -509,6 +509,9 @@ def get_contest_choice_name_standardizations(election: Election):  # pragma: no 
         standardizations = {
             cvr_choice_name: raw_standardizations.get(cvr_choice_name, None)
             for cvr_choice_name in cvr_choice_names
+            # Include as keys all CVR choice names requiring standardization and no other CVR
+            # choice names. The frontend uses the presence of keys to determine whether
+            # standardization is needed/outstanding.
             if standardized_contest_choice_names is not None
             and cvr_choice_name not in standardized_contest_choice_names
         }

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -5,6 +5,7 @@ import csv
 import itertools
 import os
 import shutil
+import typing
 from xml.etree import ElementTree as ET
 from typing import (
     IO,
@@ -121,12 +122,12 @@ def are_uploaded_cvrs_valid(contest: Contest):
         return False
 
 
-# Wraps Jurisdiction.cvr_contest_metadata, applying any contest name
-# standardizations in Jurisdiction.contest_name_standardizations. This wrapper
-# should always be used for reading the metadata, so that the contest names
-# from the CVR will match those selected by the AA.
+# Wraps Jurisdiction.cvr_contest_metadata, applying any contest and choice name
+# standardizations. This wrapper should always be used for reading the
+# metadata, so that contest and choice names from CVR files will match those
+# provided by the AA.
 def cvr_contests_metadata(
-    jurisdiction: Jurisdiction,
+    jurisdiction: Jurisdiction, should_standardize_contest_choice_names=True
 ) -> Optional[CVR_CONTESTS_METADATA]:
     metadata = typing_cast(
         Optional[CVR_CONTESTS_METADATA], jurisdiction.cvr_contests_metadata
@@ -134,19 +135,67 @@ def cvr_contests_metadata(
     if metadata is None:
         return None
 
-    standardizations = typing_cast(
-        Optional[Dict[str, str]], jurisdiction.contest_name_standardizations
+    contest_name_standardizations = (
+        typing_cast(
+            Optional[Dict[str, Optional[str]]],
+            jurisdiction.contest_name_standardizations,
+        )
+        or {}
     )
-    standardizations = {
+    cvr_contest_name_to_standardized_contest_name = {
         cvr_contest_name: contest_name
-        for contest_name, cvr_contest_name in (standardizations or {}).items()
+        for contest_name, cvr_contest_name in contest_name_standardizations.items()
         if cvr_contest_name
     }
 
-    return {
-        standardizations.get(cvr_contest_name, cvr_contest_name): contest_metadata
-        for cvr_contest_name, contest_metadata in metadata.items()
+    contest_choice_name_standardizations = (
+        typing_cast(
+            Optional[Dict[str, Dict[str, Optional[str]]]],
+            jurisdiction.contest_choice_name_standardizations,
+        )
+        or {}
+    )
+    cvr_choice_name_to_standardized_choice_name_by_contest_id = {
+        contest_id: {
+            cvr_choice_name: choice_name
+            for cvr_choice_name, choice_name in standardizations.items()
+            if choice_name
+        }
+        for contest_id, standardizations in contest_choice_name_standardizations.items()
     }
+
+    contest_name_to_id = {
+        contest.name: contest.id for contest in jurisdiction.election.contests
+    }
+
+    standardized_metadata = {}
+    for cvr_contest_name, contest_metadata in metadata.items():
+        standardized_contest_name = cvr_contest_name_to_standardized_contest_name.get(
+            cvr_contest_name, cvr_contest_name
+        )
+
+        contest_id = contest_name_to_id.get(standardized_contest_name, None)
+
+        standardized_metadata[standardized_contest_name] = (
+            typing.cast(
+                CvrContestMetadata,
+                {
+                    **contest_metadata,
+                    "choices": {
+                        cvr_choice_name_to_standardized_choice_name_by_contest_id.get(
+                            contest_id, {}
+                        ).get(cvr_choice_name, cvr_choice_name): choice_metadata
+                        for cvr_choice_name, choice_metadata in contest_metadata[
+                            "choices"
+                        ].items()
+                    },
+                },
+            )
+            if should_standardize_contest_choice_names and contest_id
+            else contest_metadata
+        )
+
+    return standardized_metadata
 
 
 def set_contest_metadata_from_cvrs(contest: Contest):

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -155,14 +155,6 @@ def cvr_contests_metadata(
         )
         or {}
     )
-    cvr_choice_name_to_standardized_choice_name_by_contest_id = {
-        contest_id: {
-            cvr_choice_name: choice_name
-            for cvr_choice_name, choice_name in standardizations.items()
-            if choice_name
-        }
-        for contest_id, standardizations in contest_choice_name_standardizations.items()
-    }
 
     contest_name_to_id = {
         contest.name: contest.id for contest in jurisdiction.election.contests
@@ -182,9 +174,13 @@ def cvr_contests_metadata(
                 {
                     **contest_metadata,
                     "choices": {
-                        cvr_choice_name_to_standardized_choice_name_by_contest_id.get(
-                            contest_id, {}
-                        ).get(cvr_choice_name, cvr_choice_name): choice_metadata
+                        contest_choice_name_standardizations.get(contest_id, {}).get(
+                            cvr_choice_name, None
+                        )
+                        # We need this "or" and can't just use cvr_choice_name as a fallback to the
+                        # .get because some keys exist in the standardizations but explicitly have
+                        # None as a value
+                        or cvr_choice_name: choice_metadata
                         for cvr_choice_name, choice_metadata in contest_metadata[
                             "choices"
                         ].items()

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -162,13 +162,13 @@ def cvr_contests_metadata(
 
     standardized_metadata = {}
     for cvr_contest_name, contest_metadata in metadata.items():
-        standardized_contest_name = cvr_contest_name_to_standardized_contest_name.get(
+        potentially_standardized_contest_name = cvr_contest_name_to_standardized_contest_name.get(
             cvr_contest_name, cvr_contest_name
         )
 
-        contest_id = contest_name_to_id.get(standardized_contest_name, None)
+        contest_id = contest_name_to_id.get(potentially_standardized_contest_name, None)
 
-        standardized_metadata[standardized_contest_name] = (
+        standardized_metadata[potentially_standardized_contest_name] = (
             typing.cast(
                 CvrContestMetadata,
                 {

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -95,7 +95,9 @@ def process_standardized_contests_file(election_id: str):
         # schema
         if CHOICE_NAMES in row:  # pragma: no cover
             choice_names = [
-                choice_name.strip() for choice_name in row[CHOICE_NAMES].split(";")
+                choice_name.strip()
+                for choice_name in row[CHOICE_NAMES].split(";")
+                if choice_name.strip() != ""
             ]
             parsed_row["choiceNames"] = choice_names
 

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -96,7 +96,7 @@ def process_standardized_contests_file(election_id: str):
 
         if file_has_choice_names_column:  # pragma: no cover
             choice_names = [
-                choice_name.strip() for choice_name in row[CHOICE_NAMES].split("/")
+                choice_name.strip() for choice_name in row[CHOICE_NAMES].split(";")
             ]
             parsed_row["choiceNames"] = choice_names
 

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -94,7 +94,7 @@ def process_standardized_contests_file(election_id: str):
             jurisdictionIds=[jurisdiction.id for jurisdiction in jurisdictions],
         )
 
-        if file_has_choice_names_column:
+        if file_has_choice_names_column:  # pragma: no cover
             choice_names = [
                 choice_name.strip() for choice_name in row[CHOICE_NAMES].split("/")
             ]

--- a/server/migrations/versions/8452f909a07e_jurisdiction_contest_choice_name_standardizations.py
+++ b/server/migrations/versions/8452f909a07e_jurisdiction_contest_choice_name_standardizations.py
@@ -1,0 +1,28 @@
+# pylint: disable=invalid-name
+"""Jurisdiction.contest_choice_name_standardizations
+
+Revision ID: 8452f909a07e
+Revises: cb8de251c1a5
+Create Date: 2024-06-19 20:40:42.730393+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8452f909a07e"
+down_revision = "cb8de251c1a5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "jurisdiction",
+        sa.Column("contest_choice_name_standardizations", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -292,11 +292,14 @@ class Jurisdiction(BaseModel):
     cvr_file_type = Column(Enum(CvrFileType))
     cvr_contests_metadata = Column(JSON)
 
-    # Sometimes contest names in a jurisdiction's CVR don't match the contest
-    # names selected by the AA. Here we store corrections made by the AA to
-    # apply to the cvr_contests_metadata.
+    # Contest and choice names in a jurisdiction's CVR files sometimes don't match the standardized
+    # contest and choice names provided by an AA. We store corrections made by the AA to apply to
+    # the cvr_contests_metadata in these values.
+    #
     # { contest_name: cvr_contest_name }
     contest_name_standardizations = Column(JSON)
+    # { contest_id: { cvr_choice_name: choice_name } }
+    contest_choice_name_standardizations = Column(JSON)
 
     finalized_full_hand_tally_results_at = Column(UTCDateTime)
 


### PR DESCRIPTION
# Overview

Issue link: https://github.com/votingworks/arlo/issues/1917

This PR implements a contest choice name standardization flow that mirrors our existing contest name standardization flow!

We long ago made the assumption that, though contest names can vary across jurisdictions, choice names would not. That assumption has since been proven wrong, notably in Nevada and Washington. The new flow allows you to add choice names to your standardized contests file and map CVR choice names to those standardized choice names.

The new "Choice Names" column in the standardized contests file isn't required. If you don't include it, we'll still try to detect and warn you when contest choice names are inconsistent across jurisdictions, per existing logic. Main change to that existing warning is that it'll now suggest adding choice names to your standardized contests file as a workaround. I didn't want to require the new column because it might actually be a hindrance for some users. I'm thinking of OC, who audits many contests and has only one jurisdiction.

Note that contest name standardization does affect contest choice name standardization. We don't explicitly block contest choice name standardization on contest name standardization. You can start standardizing choice names before you standardize contest names. It just may be that standardizing contest names surfaces more choice names to be standardized.

## Sample standardized contests file with choice names

We're using slashes as separators within the "Choice Names" field instead of commas since individual choice names may contain commas.

```
Contest Name,Jurisdictions,Choice Names
State Treasurer,all,"Conine, Zach/Elliott, Bryan/Fiore, Michele/Hendrickson, Margaret/None of These Candidates"
```

The template standardized contests file is unchanged and doesn't include the new column.

## Screencaptures and screenshots

End-to-end, before adding choice names to the standardized contests file, after adding choice names to the standardized contests file, and through contest choice name standardization

https://github.com/votingworks/arlo/assets/12616928/8bc014f8-121c-46a7-a53f-e26392c560c3

-----

Getting started on contest choice name standardization before contest name standardization, completing contest name standardization, and revisiting contest choice name standardization

https://github.com/votingworks/arlo/assets/12616928/0e20aea3-854f-44a6-bc57-76171d349bf5

-----

Completion of contest name standardization surfacing contest choice name standardization

https://github.com/votingworks/arlo/assets/12616928/dd3fd8bd-2191-4422-bf75-a592c67b2517

-----

Side-by-side of contest name and contest choice name standardization dialogs

<img alt="contest-names" src="https://github.com/votingworks/arlo/assets/12616928/041837b3-839f-407d-87f9-fce58ab6ef5c" width=375 /> <img alt="contest-choice-names" src="https://github.com/votingworks/arlo/assets/12616928/a192bde8-7fb2-413d-81f8-0922b873b3d2" width=375 />

# Testing

- [x] Updated existing tests
- [x] Manually tested e2e happy path
- [x] Manually tested interplay between contest name and contest choice name standardization
- [x] Manually tested switching back and forth between including choice names in standardized contests file and not

Punted on new tests in this PR as it's large enough as is, and I wanted to get this reviewed while I work on tests in a follow-up PR. Also wanted to get Jonah's eyes on this core logic today, whereas I can have someone else review tests tomorrow when he's out.