### PR TITLE
ES&S CVR parsing: Allow "hinting" which file is the CVR file by changing the file name

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -607,13 +607,11 @@ def separate_ess_cvr_and_ballots_files(
         error = "Identified multiple CVR files - please upload only one CVR file containing the cast vote records for each ballot, and at least one ballots file containing the list of tabulated ballots and their corresponding CVR identifiers."
 
     if error is not None:
-        separator = " / "
-        error_components = [
-            error,
-            f"Identified CVR files: {', '.join(cvr_files.keys()) or 'None'}",
-            f"Identified ballots files: {', '.join(ballots_files.keys()) or 'None'}",
-        ]
-        raise UserError(separator.join(error_components))
+        identified_files = (
+            f"Identified CVR files: {', '.join(cvr_files.keys()) or 'None'}. "
+            f"Identified ballots files: {', '.join(ballots_files.keys()) or 'None'}."
+        )
+        raise UserError(f"{error} {identified_files}")
 
     [(cvr_file_name, cvr_file)] = cvr_files.items()
 

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1526,14 +1526,14 @@ def test_ess_cvr_upload_invalid(
     test_cases = [
         (
             [(io.BytesIO(ESS_CVR.encode()), "ess_cvr.csv")],
-            "Missing ballots files - at least one file should contain the list of tabulated ballots and their corresponding CVR identifiers. / Identified CVR files: ess_cvr.csv / Identified ballots files: None",
+            "Missing ballots files - at least one file should contain the list of tabulated ballots and their corresponding CVR identifiers. Identified CVR files: ess_cvr.csv. Identified ballots files: None.",
         ),
         (
             [
                 (io.BytesIO(ESS_BALLOTS_1.encode()), "ess_ballots_1.csv",),
                 (io.BytesIO(ESS_BALLOTS_2.encode()), "ess_ballots_2.csv",),
             ],
-            "Missing CVR file - one file should contain the cast vote records for each ballot. We attempt to auto-detect this file, but if we are failing to do so, you can rename the file cvr.csv to ensure that we treat it as the CVR file. / Identified CVR files: None / Identified ballots files: ess_ballots_1.csv, ess_ballots_2.csv",
+            "Missing CVR file - one file should contain the cast vote records for each ballot. We attempt to auto-detect this file, but if we are failing to do so, you can rename the file cvr.csv to ensure that we treat it as the CVR file. Identified CVR files: None. Identified ballots files: ess_ballots_1.csv, ess_ballots_2.csv.",
         ),
         (
             [
@@ -1542,7 +1542,7 @@ def test_ess_cvr_upload_invalid(
                 (io.BytesIO(ESS_CVR.encode()), "ess_cvr_1.csv",),
                 (io.BytesIO(ESS_CVR.encode()), "ess_cvr_2.csv",),
             ],
-            "Identified multiple CVR files - please upload only one CVR file containing the cast vote records for each ballot, and at least one ballots file containing the list of tabulated ballots and their corresponding CVR identifiers. / Identified CVR files: ess_cvr_1.csv, ess_cvr_2.csv / Identified ballots files: ess_ballots_1.csv, ess_ballots_2.csv",
+            "Identified multiple CVR files - please upload only one CVR file containing the cast vote records for each ballot, and at least one ballots file containing the list of tabulated ballots and their corresponding CVR identifiers. Identified CVR files: ess_cvr_1.csv, ess_cvr_2.csv. Identified ballots files: ess_ballots_1.csv, ess_ballots_2.csv.",
         ),
         (
             [
@@ -1770,8 +1770,8 @@ def test_ess_cvr_upload_cvr_file_with_tabulator_cvr_column(
             "processing": {
                 "completedAt": assert_is_date,
                 "error": "Missing CVR file - one file should contain the cast vote records for each ballot. "
-                "We attempt to auto-detect this file, but if we are failing to do so, you can rename the file cvr.csv to ensure that we treat it as the CVR file. / "
-                "Identified CVR files: None / Identified ballots files: ess_cvr.csv, ess_ballots_1.csv, ess_ballots_2.csv",
+                "We attempt to auto-detect this file, but if we are failing to do so, you can rename the file cvr.csv to ensure that we treat it as the CVR file. "
+                "Identified CVR files: None. Identified ballots files: ess_cvr.csv, ess_ballots_1.csv, ess_ballots_2.csv.",
                 "startedAt": assert_is_date,
                 "status": ProcessingStatus.ERRORED,
                 "workProgress": 0,


### PR DESCRIPTION
## Overview

ES&S CVRs consist of one CVR file and one or more ballots files. The CVR file contains the actual votes, and the ballots files contain additional useful identifiers.

We use some simple checks to distinguish the CVR file from the ballots files in the upload. But lately, one such check has been misidentifying some CVR files as ballots files. Specifically the check that - if a file has a "Tabulator CVR" column, it's a ballots file. Some jurisdiction's CVR files now include this "Tabulator CVR" column.

Long-term, this actually means that we may not need ballots files from some ES&S jurisdictions. Though even for these jurisdictions that have a "Tabulator CVR" column in their CVR files, we may still sometimes need ballots files. I won't get into the weeds of that right now, but a nice long-term flow that would work for everyone might look something like this:

1. We request your CVR file
2. If that file has everything we need, we move on
3. If that file doesn't have everything we need, we request your ballots files

I've seen the above proposed before, but it's a bigger change that requires more time and consideration.

Washington's current workaround is to open the CVR file and delete the "Tabulator CVR" column. But they understandably don't like having to open and edit the file exported by their system.

This PR allows "hinting" which file is the CVR file when Arlo incorrectly assumes that it's a ballots file by changing the file name to be a specific name (cvr.csv), with error messages that make this workaround clear. Not having to edit the file's contents should be a win for Washington.

<table>
<img width="1512" alt="error-message-2" src="https://github.com/user-attachments/assets/567ba142-b29f-4a39-9317-11e90adb5831">
</table>

https://github.com/user-attachments/assets/7d5639ac-aaf1-4ae1-ac48-e0852fd60f0d

## Testing

- [x] Tested manually
- [x] Updated automated tests

