### PR TITLE
Hotfix: Expect more possible metadata columns when parsing ES&S CVRs

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -796,9 +796,23 @@ def parse_ess_cvrs(
 
     def parse_contest_metadata(cvr_csv: CSVIterator) -> CVR_CONTESTS_METADATA:
         headers = next(cvr_csv)
-        # Based on files we've seen, the first 3 columns are Cast Vote Record,
-        # Precinct, Ballot Style and the rest are contest names
-        first_contest_column = 3
+        # Based on files we've seen, the first few columns are metadata, and the
+        # rest are contest names
+        known_metadata_headers = [
+            "Election ID",
+            "Audit Number",
+            "Tabulator CVR",
+            "Cast Vote Record",
+            "Batch",
+            "Ballot Status",
+            "Precinct",
+            "Ballot Style",
+        ]
+        first_contest_column = next(
+            index
+            for index, header in enumerate(headers)
+            if header not in known_metadata_headers
+        )
         contest_names = headers[first_contest_column:]
         # { contest_name: choice_names }
         contest_choices = defaultdict(set)


### PR DESCRIPTION
Previously, we expected exactly 3 metadata columns. When given a file with more metadata columns, they were treated like contest columns. This caused a bloating of the contest metadata and major performance slowdown.

Manually tested this hotfix, will add regression test separately.