### PR TITLE
Filter out empty rows and protect against missing values in ES&S CVR parsing

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -639,7 +639,11 @@ def read_ess_ballots_file(
     else:
         headers = first_row
 
-    rows = (row for row in ballots_csv if not row[0].startswith("Total"))
+    rows = (
+        row
+        for row in ballots_csv
+        if not row[0].startswith("Total") and not all(not cell for cell in row)
+    )
 
     return (headers, rows)
 

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -697,8 +697,19 @@ def parse_ess_cvrs(
         # The rows may not be in order, but we need them sorted in order to
         # concatenate and merge the files. For now, sort them in memory, though
         # we may need to change this if it becomes a memory bottleneck.
-        sorted_ballot_rows = sorted(
-            rows, key=lambda row: int(row[header_indices["Cast Vote Record"]])
+        sorted_ballot_rows = (
+            row
+            for _, row in sorted(
+                enumerate(rows),
+                key=lambda index_and_row: int(
+                    column_value(
+                        index_and_row[1],
+                        "Cast Vote Record",
+                        index_and_row[0] + 1,
+                        header_indices,
+                    )
+                ),
+            )
         )
 
         ten_digit_tabulator_cvr_regex = re.compile(r"^(\d{4})(\d{6})$")

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1666,6 +1666,22 @@ def test_ess_cvr_upload_invalid(
         ),
         (
             [
+                (
+                    io.BytesIO(
+                        (
+                            ESS_BALLOTS_1
+                            + ",BATCH1,Not Reviewed,,,,N,Election Day,0002003172,p"
+                        ).encode()
+                    ),
+                    "ess_ballots_1.csv",
+                ),
+                (io.BytesIO(ESS_CVR.encode()), "ess_cvr.csv",),
+                (io.BytesIO(ESS_BALLOTS_2.encode()), "ess_ballots_2.csv",),
+            ],
+            "ess_ballots_1.csv: Missing required column Cast Vote Record in row 8.",
+        ),
+        (
+            [
                 (io.BytesIO(ESS_BALLOTS_1.encode()), "ess_ballots_1.csv",),
                 (
                     io.BytesIO(

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1319,6 +1319,7 @@ Cast Vote Record,Batch,Ballot Status,Original Ballot Exception,Remaining Ballot 
 3,BATCH1,Not Reviewed,Undervote,,,N,Election Day,0001013417,p
 4,BATCH1,Not Reviewed,Overvote,,,N,Election Day,0002003171,p
 Total : 7,,,,,,,,,
+,,,,,,,,,
 """
 
 ESS_BALLOTS_2 = """Ballots,,,,,,,,,


### PR DESCRIPTION
We saw a ballots file uploaded with empty rows at the end, which caused an error when trying to access the "Cast Vote Record" column to sort on. Since empty rows are easy to filter out, I added logic to do that. I also changed the sorting code to use `column_value`, which checks for missing values and raises a user-facing error if missing as a backup.