### PR TITLE
Review screen: Show only one modal for choice name standardization

### DIFF
--- a/client/src/components/AuditAdmin/Setup/Review/Review.tsx
+++ b/client/src/components/AuditAdmin/Setup/Review/Review.tsx
@@ -131,9 +131,9 @@ const Review: React.FC<IProps> = ({
     electionId
   )
   const [
-    isContestChoiceNameStandardizationDialogOpen,
-    setIsContestChoiceNameStandardizationDialogOpen,
-  ] = useState(false)
+    contestIdForChoiceNameStandardizationDialog,
+    setContestIdForChoiceNameStandardizationDialog,
+  ] = useState<IContest['id'] | null>(null)
 
   const setupComplete =
     jurisdictionsQuery.isSuccess &&
@@ -360,16 +360,18 @@ const Review: React.FC<IProps> = ({
               contest={contest}
               disabled={locked}
               openDialog={() =>
-                setIsContestChoiceNameStandardizationDialogOpen(true)
+                setContestIdForChoiceNameStandardizationDialog(contest.id)
               }
               standardizations={contestChoiceNameStandardizations}
             />
             <StandardizeContestChoiceNamesDialog
               contest={contest}
-              isOpen={isContestChoiceNameStandardizationDialogOpen}
+              isOpen={
+                contestIdForChoiceNameStandardizationDialog === contest.id
+              }
               jurisdictionsById={jurisdictionsById}
               onClose={() =>
-                setIsContestChoiceNameStandardizationDialogOpen(false)
+                setContestIdForChoiceNameStandardizationDialog(null)
               }
               standardizations={contestChoiceNameStandardizations}
               standardizedContestChoiceNames={
@@ -384,7 +386,7 @@ const Review: React.FC<IProps> = ({
                 )
               }}
               // Reset the form state within the dialog component any time the dialog is opened
-              key={isContestChoiceNameStandardizationDialogOpen.toString()}
+              key={contestIdForChoiceNameStandardizationDialog || 'closed'}
             />
             <div style={{ display: 'flex' }}>
               {!cvrsUploaded ? (


### PR DESCRIPTION
We currently render a modal for each contest that may require choice name standardization. These modals are all controlled by a single boolean flag. That means that showing any one modal will show all of them, which is not what we want to happen.

To fix this, I replaced the boolean flag with a contest ID for the modal to show.

Manually tested that this fixes the issue, and also confirmed that form state resets when closing/reopening the modal.