### PR TITLE
Ensure logger in worker uses info level

### DIFF
--- a/server/worker/tasks.py
+++ b/server/worker/tasks.py
@@ -13,6 +13,9 @@ from ..util.isoformat import isoformat
 from ..util.jsonschema import JSONDict
 from .. import config
 
+# Something in the imports above is setting the root logging level to WARNING in
+# production, so we need to explicitly set it back to INFO.
+logging.basicConfig(level=logging.INFO, force=True)
 logger = logging.getLogger("arlo.worker")
 
 


### PR DESCRIPTION
In production (but not dev), it looks like the root log level gets changed somewhere before the worker logger is created, so worker logs were not showing up in Heroku. We explicitly force the log level back to info to fix it.