### PR TITLE
Set worker logger level to info explicitly

### DIFF
--- a/server/worker/tasks.py
+++ b/server/worker/tasks.py
@@ -13,10 +13,11 @@ from ..util.isoformat import isoformat
 from ..util.jsonschema import JSONDict
 from .. import config
 
-# Something in the imports above is setting the root logging level to WARNING in
-# production, so we need to explicitly set it back to INFO.
-logging.basicConfig(level=logging.INFO, force=True)
 logger = logging.getLogger("arlo.worker")
+# Something is setting the root logging level to WARNING in production, so we
+# need to set this logger's level to INFO to ensure our info logs below are
+# emitted.
+logger.setLevel(logging.INFO)
 
 
 class UserError(Exception):


### PR DESCRIPTION
The previous approach (#1958) of modifying the root logger level only worked temporarily. It still got changed back. I don't understand why, but setting the log level on the logger itself is a more resilient fix, since it doesn't need to inherit the root logger level anymore.