### PR TITLE
ES&S CVR parsing: Protect against unknown columns in CVR file

### DIFF
--- a/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
+++ b/server/tests/ballot_comparison/snapshots/snap_test_cvrs.py
@@ -1238,6 +1238,127 @@ snapshots["test_ess_cvr_upload 8"] = {
     },
 }
 
+snapshots["test_ess_cvr_upload_cvr_file_with_tabulator_cvr_column 1"] = [
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0001000415",
+        "interpretations": "0,1,1,0,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0001000416",
+        "interpretations": "1,0,1,0,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0001000417",
+        "interpretations": "0,1,0,1,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH1",
+        "imprinted_id": "0001013415",
+        "interpretations": "0,1,1,0,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH1",
+        "imprinted_id": "0001013416",
+        "interpretations": "1,0,1,0,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH1",
+        "imprinted_id": "0001013417",
+        "interpretations": "u,u,1,0,0",
+        "tabulator": "0001",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0002000171",
+        "interpretations": "1,0,0,1,0",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0002000172",
+        "interpretations": "0,1,0,1,0",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0002000173",
+        "interpretations": "1,0,0,1,0",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 4,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0002000174",
+        "interpretations": "0,1,0,0,1",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 5,
+        "batch_name": "BATCH2",
+        "imprinted_id": "0002000175",
+        "interpretations": "1,0,0,0,1",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 1,
+        "batch_name": "BATCH1",
+        "imprinted_id": "0002003171",
+        "interpretations": "o,o,1,0,0",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 2,
+        "batch_name": "BATCH1",
+        "imprinted_id": "0002003172",
+        "interpretations": "0,1,1,0,0",
+        "tabulator": "0002",
+    },
+    {
+        "ballot_position": 3,
+        "batch_name": "BATCH1",
+        "imprinted_id": "0002003173",
+        "interpretations": "1,0,1,0,0",
+        "tabulator": "0002",
+    },
+]
+
+snapshots["test_ess_cvr_upload_cvr_file_with_tabulator_cvr_column 2"] = {
+    "Contest 1": {
+        "choices": {
+            "Choice 1-1": {"column": 0, "num_votes": 6},
+            "Choice 1-2": {"column": 1, "num_votes": 6},
+        },
+        "total_ballots_cast": 14,
+        "votes_allowed": 1,
+    },
+    "Contest 2": {
+        "choices": {
+            "Choice 2-1": {"column": 2, "num_votes": 8},
+            "Choice 2-2": {"column": 3, "num_votes": 4},
+            "Choice 2-3": {"column": 4, "num_votes": 2},
+        },
+        "total_ballots_cast": 14,
+        "votes_allowed": 1,
+    },
+}
+
 snapshots["test_hart_cvr_upload 1"] = [
     {
         "ballot_position": 1,


### PR DESCRIPTION
We added a hotfix in #1954 to allow different sets of metadata columsn in the CVR file. However, we still may see unknown columns we haven't seen before. Since there's no good way to differentiate those columsn from contest columns, our current approach may silently fail in that case. The consequence would be that metadata columns are treated as contests. This may or may not cause downstream issues.

To reduce the likelihood of that happening, we change our method of searching for the dividing line between metadata columns and contest columns to look for the _last_ known metadata header. That way, we'll get it right in every case except the case where the dividing line is a header we haven't seen before, which is much less likely to occur.