### PR TITLE
Concurrent background workers

### DIFF
--- a/server/migrations/versions/6c256e8152f8_backgroundtask_worker_id.py
+++ b/server/migrations/versions/6c256e8152f8_backgroundtask_worker_id.py
@@ -2,7 +2,7 @@
 """BackgroundTask.worker_id
 
 Revision ID: 6c256e8152f8
-Revises: 8452f909a07e
+Revises: 34824a2d1ba8
 Create Date: 2024-10-23 23:34:52.713596+00:00
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "6c256e8152f8"
-down_revision = "8452f909a07e"
+down_revision = "34824a2d1ba8"
 branch_labels = None
 depends_on = None
 

--- a/server/migrations/versions/6c256e8152f8_backgroundtask_worker_id.py
+++ b/server/migrations/versions/6c256e8152f8_backgroundtask_worker_id.py
@@ -1,0 +1,27 @@
+# pylint: disable=invalid-name
+"""BackgroundTask.worker_id
+
+Revision ID: 6c256e8152f8
+Revises: 8452f909a07e
+Create Date: 2024-10-23 23:34:52.713596+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "6c256e8152f8"
+down_revision = "8452f909a07e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "background_task", sa.Column("worker_id", sa.String(length=200), nullable=True)
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -1029,6 +1029,7 @@ class BackgroundTask(BaseModel):
     task_name = Column(String(200), nullable=False)
     payload = Column(JSON, nullable=False)
 
+    worker_id = Column(String(200))
     started_at = Column(UTCDateTime)
     completed_at = Column(UTCDateTime)
     error = Column(Text)

--- a/server/tests/test_websessions.py
+++ b/server/tests/test_websessions.py
@@ -58,7 +58,7 @@ def test_websession_create():
     db_session.commit()
 
     # cleanup shouldn't remove the session because 1s hasn't yet elapsed
-    cleanup_sessions()
+    cleanup_sessions(db_session)
     session_2 = asi.open_session(app, req)
     assert session_2.sid == session.sid
     assert session_2["foo"] == "bar"
@@ -66,7 +66,7 @@ def test_websession_create():
     time.sleep(1)
 
     # now cleanup should remove the session because 1s has elapsed
-    cleanup_sessions()
+    cleanup_sessions(db_session)
     session_3 = asi.open_session(app, req)
     assert session_3.sid != session.sid
     assert "foo" not in session_3

--- a/server/websession.py
+++ b/server/websession.py
@@ -87,12 +87,12 @@ class ArloSessionInterface(SessionInterface):
         )
 
 
-def cleanup_sessions():
+def cleanup_sessions(db_session):
     """
     Because we keep session freshness information in fields embedded inside the data column,
     the only marker in the database that we can safely and cleanly use to clean up a session is the updated_at field.
     """
-    query = WebSession.query.filter(
+    query = db_session.query(WebSession).filter(
         WebSession.updated_at
         < datetime.now(timezone.utc) - config.SESSION_INACTIVITY_TIMEOUT
     )

--- a/server/worker/worker.py
+++ b/server/worker/worker.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import sys
 import time
@@ -16,7 +17,7 @@ from server.websession import cleanup_sessions
 from server import api  # pylint: disable=unused-import
 
 
-def run_worker():
+def run_worker(worker_id: str):
     task = None
 
     # Heroku dynos are sent one or more SIGTERM signals when they are shut down,
@@ -35,7 +36,7 @@ def run_worker():
     signal.signal(signal.SIGINT, interrupt_handler)
 
     while True:
-        task = claim_next_task()
+        task = claim_next_task(worker_id)
         if task:
             run_task(task)
             # Ensure we don't reset the task on interrupt once it completes
@@ -54,5 +55,6 @@ def run_worker():
 
 
 if __name__ == "__main__":
+    worker_id = os.environ.get("HEROKU_DYNO_ID", str(os.getpid()))
     configure_sentry()
-    run_worker()
+    run_worker(worker_id)

--- a/server/worker/worker.py
+++ b/server/worker/worker.py
@@ -1,7 +1,13 @@
+import signal
+import sys
 import time
 
 from server.database import db_session
-from server.worker.tasks import run_new_tasks
+from server.worker.tasks import (
+    claim_next_task,
+    reset_task,
+    run_task,
+)
 from server.sentry import configure_sentry
 from server.websession import cleanup_sessions
 
@@ -9,13 +15,44 @@ from server.websession import cleanup_sessions
 # handlers get registered as background_tasks.
 from server import api  # pylint: disable=unused-import
 
-if __name__ == "__main__":
-    configure_sentry()
+
+def run_worker():
+    task = None
+
+    # Heroku dynos are sent one or more SIGTERM signals when they are shut down,
+    # then a SIGKILL if they don't exit after 30 seconds. If we're interrupted
+    # in the middle of a task, reset it before exiting so it can be picked up by
+    # another worker.
+    def interrupt_handler(*_args):
+        nonlocal task
+        if task:
+            reset_task(task)
+            task = None
+        sys.exit(1)
+
+    signal.signal(signal.SIGTERM, interrupt_handler)
+    # Also handle SIGINT for local development
+    signal.signal(signal.SIGINT, interrupt_handler)
+
     while True:
-        run_new_tasks()
-        cleanup_sessions()
+        task = claim_next_task()
+        if task:
+            run_task(task)
+            # Ensure we don't reset the task on interrupt once it completes
+            # successfully
+            task = None
+
+        # Unrelated, we use the same worker process to clean up expired web
+        # sessions, since it's a convenient place to essentially run a cron job.
+        cleanup_sessions(db_session)
+
         # Before sleeping, we need to commit the current transaction, otherwise
         # we will have "idle in transaction" queries that will lock the
         # database, which gets in the way of migrations.
         db_session.commit()
         time.sleep(2)
+
+
+if __name__ == "__main__":
+    configure_sentry()
+    run_worker()


### PR DESCRIPTION
Task: #1934 

Updates the background worker so that multiple workers can safely run concurrently. Attempts to ensure that:
- Every job is run exactly once
- If a worker is available, it will immediately start on the next job in the queue
- If a worker is terminated (e.g. by a [Heroku dyno shutdown](https://devcenter.heroku.com/articles/dyno-shutdown-behavior)), any in-progress job will be re-enqueued

Note that there is no logical locking of jobs to prevent conflicts when trying to access the same resources, but we'll need to add that as an additional layer on top of this (since it will require domain-specific logic). Will tackle this in a follow up PR.

For testing, I added some automated testing to simulate multiple concurrent workers competing for jobs. I also created a Heroku review app and tested out running multiple workers simultaneously and restarting workers in the middle of jobs.
