### PR TITLE
Update batch comparison audit reports to better handle extra batches

### DIFF
--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -981,7 +981,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
             pretty_choice_votes(total_audit_results_by_name),
             pretty_choice_votes(total_reported_results_by_name),
             "",  # change in results not calculated for totals
-            "",  # change in margin not calculcated for totals
+            "",  # change in margin not calculated for totals
         ]
     totals_row += ""  # last edited col
     rows.append(totals_row)

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -864,6 +864,13 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
     ]
     rows.append(column_headers)
 
+    total_reported_results: dict = {
+        contest.id: {choice.id: 0 for choice in contest.choices} for contest in contests
+    }
+    total_audit_results: dict = {
+        contest.id: {choice.id: 0 for choice in contest.choices} for contest in contests
+    }
+
     for batch in batches:
         row = [
             batch.jurisdiction.name,
@@ -890,6 +897,12 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
                 if contest.id in batch.jurisdiction.batch_tallies[batch.name]
                 else None
             )
+            if reported_results is not None:
+                for choice in contest.choices:
+                    total_reported_results[contest.id][choice.id] += reported_results[
+                        choice.id
+                    ]
+
             reported_results_by_name = reported_results and {
                 choice.name: reported_results[choice.id] for choice in contest.choices
             }
@@ -902,6 +915,11 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
                 if is_audited and reported_results
                 else None
             )
+            if audit_results is not None:
+                for choice in contest.choices:
+                    total_audit_results[contest.id][choice.id] += audit_results[
+                        choice.id
+                    ]
             audit_results_by_name = audit_results and {
                 choice.name: audit_results[choice.id] for choice in contest.choices
             }
@@ -947,6 +965,26 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
         row += [construct_batch_last_edited_by_string(batch)]
         rows.append(row)
 
+    totals_row = ["Totals", "", sum(batch.num_ballots for batch in batches)]
+    totals_row += ["" for _ in contests]  # Ticket number cols - not relevant to totals
+    totals_row += [""]  # Audited flag - not relevant to totals
+    for contest in contests:
+        total_reported_results_by_name = {
+            choice.name: total_reported_results[contest.id][choice.id]
+            for choice in contest.choices
+        }
+        total_audit_results_by_name = {
+            choice.name: total_audit_results[contest.id][choice.id]
+            for choice in contest.choices
+        }
+        totals_row += [
+            pretty_choice_votes(total_audit_results_by_name),
+            pretty_choice_votes(total_reported_results_by_name),
+            "",  # change in results not calculated for totals
+            "",  # change in margin not calculcated for totals
+        ]
+    totals_row += ""  # last edited col
+    rows.append(totals_row)
     return rows
 
 

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -453,6 +453,7 @@ def round_rows(election: Election):
                 .join(Jurisdiction)
                 .filter_by(election_id=election.id)
                 .filter(SampledBatchDraw.round_id == round.id)
+                .filter(SampledBatchDraw.ticket_number != EXTRA_TICKET_NUMBER)
                 .all()
             )
             num_distinct_batches = len(distinct_batches)

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -48,6 +48,7 @@ J1,Batch 3,500,Round 1: 0.753710009967479876,Yes,candidate 1: 500; candidate 2: 
 J1,Batch 6,100,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,100,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,jurisdiction.admin-UUID@example.com\r
 J2,Batch 3,500,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,jurisdiction.admin-UUID@example.com\r
+Totals,,1700,,,candidate 1: 1700; candidate 2: 850; candidate 3: 850,candidate 1: 1700; candidate 2: 850; candidate 3: 850,,\r
 """
 
 snapshots["test_batch_comparison_round_1 1"] = {
@@ -116,6 +117,7 @@ J1,Batch 8,100,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2:
 J2,Batch 3,500,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 100; candidate 2: 100; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +400; candidate 2: +150; candidate 3: +210,250,jurisdiction.admin-UUID@example.com\r
 J1,Batch 4,500,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
 J2,Batch 4,500,"Round 2: 0.608147659546583410, 0.868820918994249069",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
+Totals,,2700,,,candidate 1: 1100; candidate 2: 300; candidate 3: 200,candidate 1: 2700; candidate 2: 1350; candidate 3: 1350,,\r
 """
 
 snapshots[
@@ -127,6 +129,7 @@ J1,Batch 3,500,"Round 1: 0.753710009967479876, Round 2: 0.816608705419077476",Ye
 J1,Batch 6,100,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,100,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J1,Batch 4,500,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
+Totals,,1700,,,candidate 1: 1000; candidate 2: 200; candidate 3: 160,candidate 1: 1700; candidate 2: 850; candidate 3: 850,,\r
 """
 
 snapshots["test_batch_comparison_round_2 2"] = {

--- a/server/tests/batch_comparison/snapshots/snap_test_batches.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batches.py
@@ -37,6 +37,7 @@ J1,Batch 1 - 2,20,Round 1: 0.693314966899513707,No,,,,,\r
 J1,Batch 1 - 10,20,Round 1: 0.109576900310237874,No,,,,,\r
 J1,Batch 2,20,Round 1: 0.474971525750860236,No,,,,,\r
 J1,Batch 10,20,Round 1: 0.772049767819343419,No,,,,,\r
+Totals,,120,,,candidate 1: 0; candidate 2: 0; candidate 3: 0,candidate 1: 0; candidate 2: 0; candidate 3: 0,,\r
 """
 
 snapshots["test_record_batch_results 1"] = {

--- a/server/tests/batch_comparison/snapshots/snap_test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_multi_contest_batch_comparison.py
@@ -18,6 +18,7 @@ J1,Batch 5,100,"Round 1: 0.384177151866437890, 0.470460412141498108","Round 1: 0
 J1,Batch 6,100,"Round 1: 0.899217854763070950, 0.9233199163410086672",,Yes,Candidate 1: 49; Candidate 2: 1,Candidate 1: 50; Candidate 2: 0,Candidate 1: +1; Candidate 2: -1,2,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 7,100,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 49; Candidate 4: 1,Candidate 3: 50; Candidate 4: 0,Candidate 3: +1; Candidate 4: -1,2,jurisdiction.admin-UUID@example.com\r
 J1,Batch 9,100,,Round 1: 0.734926612730309894,Yes,Candidate 1: 52; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,Candidate 1: -2,-2,Candidate 3: 26; Candidate 4: 24,Candidate 3: 25; Candidate 4: 25,Candidate 3: -1; Candidate 4: +1,-2,jurisdiction.admin-UUID@example.com\r
+Totals,,700,,,,Candidate 1: 351; Candidate 2: 1,Candidate 1: 350; Candidate 2: 0,,,Candidate 3: 325; Candidate 4: 25,Candidate 3: 325; Candidate 4: 25,,\r
 """
 
 snapshots[
@@ -51,6 +52,7 @@ J1,Batch 7,100,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.8
 J1,Batch 9,100,,Round 1: 0.734926612730309894,Yes,Candidate 1: 52; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,Candidate 1: -2,-2,Candidate 3: 26; Candidate 4: 24,Candidate 3: 25; Candidate 4: 25,Candidate 3: -1; Candidate 4: +1,-2,jurisdiction.admin-UUID@example.com\r
 J2,Batch 1,100,"Round 1: 0.562697240648997100, 0.9008218268717084008",,No,,,,,,,,,\r
 J3,Batch 1,100,Round 1: 0.544165663445275136,,No,,,,,,,,,\r
+Totals,,900,,,,Candidate 1: 351; Candidate 2: 1,Candidate 1: 350; Candidate 2: 0,,,Candidate 3: 325; Candidate 4: 25,Candidate 3: 325; Candidate 4: 25,,\r
 """
 
 snapshots[
@@ -84,6 +86,7 @@ J1,Batch 7,100,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.8
 J1,Batch 9,100,,Round 1: 0.734926612730309894,Yes,Candidate 1: 52; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,Candidate 1: -2,-2,Candidate 3: 26; Candidate 4: 24,Candidate 3: 25; Candidate 4: 25,Candidate 3: -1; Candidate 4: +1,-2,jurisdiction.admin-UUID@example.com\r
 J2,Batch 1,100,"Round 1: 0.562697240648997100, 0.9008218268717084008",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
 J3,Batch 1,100,Round 1: 0.544165663445275136,,Yes,Candidate 1: 74; Candidate 2: 26,Candidate 1: 75; Candidate 2: 25,Candidate 1: +1; Candidate 2: -1,2,,,,,jurisdiction.admin-UUID@example.com\r
+Totals,,900,,,,Candidate 1: 500; Candidate 2: 52,Candidate 1: 500; Candidate 2: 50,,,Candidate 3: 325; Candidate 4: 25,Candidate 3: 325; Candidate 4: 25,,\r
 """
 
 snapshots[
@@ -117,6 +120,7 @@ J1,Batch 7,100,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.8
 J1,Batch 9,100,,Round 1: 0.734926612730309894,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 25; Candidate 4: 25,Candidate 3: 25; Candidate 4: 25,,,jurisdiction.admin-UUID@example.com\r
 J2,Batch 1,100,"Round 1: 0.562697240648997100, 0.9008218268717084008",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
 J3,Batch 1,100,Round 1: 0.544165663445275136,,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
+Totals,,900,,,,Candidate 1: 450; Candidate 2: 100,Candidate 1: 500; Candidate 2: 50,,,Candidate 3: 325; Candidate 4: 25,Candidate 3: 325; Candidate 4: 25,,\r
 """
 
 snapshots[
@@ -152,6 +156,7 @@ J1,Batch 9,100,,Round 1: 0.734926612730309894,Yes,Candidate 1: 50; Candidate 2: 
 J2,Batch 1,100,"Round 1: 0.562697240648997100, 0.9008218268717084008, Round 2: 0.9809620734120025512",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
 J3,Batch 1,100,"Round 1: 0.544165663445275136, Round 2: 0.651158228740912018",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,100,Round 2: 0.9723790677174592551,,No,,Candidate 1: 50; Candidate 2: 0,,,,Candidate 3: 50; Candidate 4: 0,,,\r
+Totals,,1000,,,,Candidate 1: 450; Candidate 2: 100,Candidate 1: 550; Candidate 2: 50,,,Candidate 3: 325; Candidate 4: 25,Candidate 3: 375; Candidate 4: 25,,\r
 """
 
 snapshots[
@@ -187,4 +192,5 @@ J1,Batch 9,100,,Round 1: 0.734926612730309894,Yes,Candidate 1: 50; Candidate 2: 
 J2,Batch 1,100,"Round 1: 0.562697240648997100, 0.9008218268717084008, Round 2: 0.9809620734120025512",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
 J3,Batch 1,100,"Round 1: 0.544165663445275136, Round 2: 0.651158228740912018",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,100,Round 2: 0.9723790677174592551,,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+Totals,,1000,,,,Candidate 1: 500; Candidate 2: 100,Candidate 1: 550; Candidate 2: 50,,,Candidate 3: 375; Candidate 4: 25,Candidate 3: 375; Candidate 4: 25,,\r
 """

--- a/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
@@ -34,4 +34,5 @@ J1,Batch 8,100,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2:
 J1,Batch 9,100,Round 1: EXTRA,Yes,candidate 1: 0; candidate 2: 0; candidate 3: 0,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: +100; candidate 2: +50; candidate 3: +50,50,jurisdiction.admin-UUID@example.com\r
 J2,Batch 3,500,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 100; candidate 2: 100; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +400; candidate 2: +150; candidate 3: +210,250,jurisdiction.admin-UUID@example.com\r
 J2,Batch 6,250,Round 1: EXTRA,Yes,candidate 1: 1; candidate 2: 200; candidate 3: 200,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: +99; candidate 2: -150; candidate 3: -150,249,jurisdiction.admin-UUID@example.com\r
+Totals,,2050,,,candidate 1: 1101; candidate 2: 500; candidate 3: 400,candidate 1: 1900; candidate 2: 950; candidate 3: 950,,\r
 """

--- a/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
@@ -23,7 +23,7 @@ Test Audit test_sample_extra_batches_by_counting_group[TEST-ORG/sample-extra-bat
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
-1,Contest 1,Targeted,7,No,0.1225641097,DATETIME,DATETIME,candidate 1: 1100; candidate 2: 300; candidate 3: 200,7,2050,candidate 1: 1900; candidate 2: 950; candidate 3: 950\r
+1,Contest 1,Targeted,7,No,0.1225641097,DATETIME,DATETIME,candidate 1: 1100; candidate 2: 300; candidate 3: 200,5,1700,candidate 1: 1700; candidate 2: 850; candidate 3: 850\r
 \r
 ######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By\r


### PR DESCRIPTION
Where there are "extra" batches included we want to ignore those in the summary round-level data. This change updates the logic introduced in https://github.com/votingworks/arlo/pull/1988 to filter out "extra" batches when computing those fields. 

It also adds a "totals" row to the end of the batches section to still capture the information with the extra batches included. This row just computes totals for number of ballots, audited results, and reported results. Note that if there are multiple rounds occurring in the audit the totals will the be total of the batches from all rounds combined. This can be seen in some of the snapshot test updates. 

