### PR TITLE
Combine commingled batches during audit

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -6,12 +6,14 @@ module.exports = {
   ],
   coverageReporters: ['text', 'text-summary', 'html'],
   coverageThreshold: {
-    // We only set a threshold for branches, since that's the strictest form of
-    // coverage. This number represents the absolute number of branches allowed
-    // to be uncovered. Ideally, we can get this to 0 eventually, but this
+    // These numbers represent the absolute number of lines and branches allowed
+    // to be uncovered. Ideally, we can get them to 0 eventually, but this
     // accounts for legacy uncovered code. All new code should be covered (so
     // this number should only be getting closer to 0).
-    global: { branches: -193 },
+    global: {
+      lines: -161,
+      branches: -194,
+    },
   },
   moduleFileExtensions: [
     'web.js',

--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@babel/core": "7.8.4",
     "@blueprintjs/core": "^3.20.0",
+    "@blueprintjs/select": "^3.19.1",
     "@hookform/error-message": "^2.0.0",
     "@sentry/react": "^5.27.3",
     "@sentry/tracing": "^5.27.3",

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
@@ -7,15 +7,15 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
     style="width: 100%;"
   >
     <div
-      class="sc-hSdWYo hzbdZY"
+      class="sc-eHgmQL dVdNaN"
     >
       <h2
-        class="bp3-heading sc-iAyFgw iTWqlu"
+        class="bp3-heading sc-hSdWYo hYxqFn"
       >
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-gxMtzJ dzikUU"
+        class="bp3-card bp3-elevation-0 sc-dfVpRl dcBoUA"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -122,18 +122,18 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-bYSBpT dWeuEb"
+            class="sc-elJkPf coSrCL"
           >
             <div
-              class="sc-elJkPf jTzEQh"
+              class="sc-jtRfpW fBMFJb"
             >
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -148,12 +148,12 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -169,15 +169,15 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <div
-              class="sc-elJkPf jTzEQh"
+              class="sc-jtRfpW fBMFJb"
             >
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -192,12 +192,12 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -213,7 +213,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <p
-              class="sc-dqBHgY goZYTp"
+              class="sc-gxMtzJ gHoIvt"
             >
               Add a new candidate/choice
             </p>
@@ -324,7 +324,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
       </div>
     </div>
     <div
-      class="sc-lhVmIH hRaoXy"
+      class="sc-bYSBpT jGvioy"
       style="margin-top: 15px;"
     >
       <button
@@ -397,15 +397,15 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
     style="width: 100%;"
   >
     <div
-      class="sc-hSdWYo hzbdZY"
+      class="sc-eHgmQL dVdNaN"
     >
       <h2
-        class="bp3-heading sc-iAyFgw iTWqlu"
+        class="bp3-heading sc-hSdWYo hYxqFn"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-gxMtzJ dzikUU"
+        class="bp3-card bp3-elevation-0 sc-dfVpRl dcBoUA"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -512,18 +512,18 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-bYSBpT dWeuEb"
+            class="sc-elJkPf coSrCL"
           >
             <div
-              class="sc-elJkPf jTzEQh"
+              class="sc-jtRfpW fBMFJb"
             >
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -538,12 +538,12 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -559,15 +559,15 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-elJkPf jTzEQh"
+              class="sc-jtRfpW fBMFJb"
             >
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -582,12 +582,12 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -603,7 +603,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-dqBHgY goZYTp"
+              class="sc-gxMtzJ gHoIvt"
             >
               Add a new candidate/choice
             </p>
@@ -714,7 +714,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-lhVmIH hRaoXy"
+      class="sc-bYSBpT jGvioy"
       style="margin-top: 15px;"
     >
       <button
@@ -787,15 +787,15 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
     style="width: 100%;"
   >
     <div
-      class="sc-hSdWYo hzbdZY"
+      class="sc-eHgmQL dVdNaN"
     >
       <h2
-        class="bp3-heading sc-iAyFgw iTWqlu"
+        class="bp3-heading sc-hSdWYo hYxqFn"
       >
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-gxMtzJ dzikUU"
+        class="bp3-card bp3-elevation-0 sc-dfVpRl dcBoUA"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -902,18 +902,18 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-bYSBpT dWeuEb"
+            class="sc-elJkPf coSrCL"
           >
             <div
-              class="sc-elJkPf jTzEQh"
+              class="sc-jtRfpW fBMFJb"
             >
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -928,12 +928,12 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -949,15 +949,15 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <div
-              class="sc-elJkPf jTzEQh"
+              class="sc-jtRfpW fBMFJb"
             >
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -972,12 +972,12 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -993,7 +993,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <p
-              class="sc-dqBHgY goZYTp"
+              class="sc-gxMtzJ gHoIvt"
             >
               Add a new candidate/choice
             </p>
@@ -1104,7 +1104,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
       </div>
     </div>
     <div
-      class="sc-lhVmIH hRaoXy"
+      class="sc-bYSBpT jGvioy"
       style="margin-top: 15px;"
     >
       <button
@@ -1177,15 +1177,15 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
     style="width: 100%;"
   >
     <div
-      class="sc-hSdWYo hzbdZY"
+      class="sc-eHgmQL dVdNaN"
     >
       <h2
-        class="bp3-heading sc-iAyFgw iTWqlu"
+        class="bp3-heading sc-hSdWYo hYxqFn"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-gxMtzJ dzikUU"
+        class="bp3-card bp3-elevation-0 sc-dfVpRl dcBoUA"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -1292,18 +1292,18 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-bYSBpT dWeuEb"
+            class="sc-elJkPf coSrCL"
           >
             <div
-              class="sc-elJkPf jTzEQh"
+              class="sc-jtRfpW fBMFJb"
             >
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1318,12 +1318,12 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1339,15 +1339,15 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-elJkPf jTzEQh"
+              class="sc-jtRfpW fBMFJb"
             >
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1362,12 +1362,12 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1383,7 +1383,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-dqBHgY goZYTp"
+              class="sc-gxMtzJ gHoIvt"
             >
               Add a new candidate/choice
             </p>
@@ -1494,7 +1494,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-lhVmIH hRaoXy"
+      class="sc-bYSBpT jGvioy"
       style="margin-top: 15px;"
     >
       <button

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
@@ -7,15 +7,15 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
     style="width: 100%;"
   >
     <div
-      class="sc-hSdWYo hzbdZY"
+      class="sc-eHgmQL dVdNaN"
     >
       <h2
-        class="bp3-heading sc-iAyFgw iTWqlu"
+        class="bp3-heading sc-hSdWYo hYxqFn"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-gxMtzJ dzikUU"
+        class="bp3-card bp3-elevation-0 sc-dfVpRl dcBoUA"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -42,7 +42,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                Name
               <br />
               <div
-                class="bp3-html-select sc-gzOgki hzfmIs"
+                class="bp3-html-select sc-iyvyFf hVQKkz"
               >
                 <select
                   field="[object Object]"
@@ -158,18 +158,18 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-bYSBpT dWeuEb"
+            class="sc-elJkPf coSrCL"
           >
             <div
-              class="sc-elJkPf jTzEQh"
+              class="sc-jtRfpW fBMFJb"
             >
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -184,12 +184,12 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -205,15 +205,15 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <div
-              class="sc-elJkPf jTzEQh"
+              class="sc-jtRfpW fBMFJb"
             >
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -228,12 +228,12 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-kTUwUJ fEUeVD"
+                class="bp3-label sc-dqBHgY kfBGWI"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-jtRfpW vAitH sc-gqjmRU egaEhI"
+                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -249,7 +249,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <p
-              class="sc-dqBHgY goZYTp"
+              class="sc-gxMtzJ gHoIvt"
             >
               Add a new candidate/choice
             </p>
@@ -291,7 +291,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
       </div>
     </div>
     <div
-      class="sc-lhVmIH hRaoXy"
+      class="sc-bYSBpT jGvioy"
       style="margin-top: 15px;"
     >
       <button

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -61,19 +61,19 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-rBLzX eWHGgB"
+          class="sc-bMvGRv eoqrva"
         >
           <div
-            class="sc-bMvGRv grgVCw"
+            class="sc-CtfFt droipi"
           >
             <div
-              class="sc-CtfFt dvyDeH"
+              class="sc-laTMn cFaJqX"
             >
               <div
-                class="sc-fjmCvl dQoSDj"
+                class="sc-TFwJa kEXxgL"
               >
                 <button
-                  class="bp3-button bp3-minimal sc-hGoxap kMKOrL"
+                  class="bp3-button bp3-minimal sc-fjmCvl dTaAoV"
                   href="/election/1/audit-board/audit-board-1"
                   type="button"
                 >
@@ -103,56 +103,56 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                   </span>
                 </button>
                 <h3
-                  class="bp3-heading sc-gJWqzi ctPand"
+                  class="bp3-heading sc-rBLzX gNxfKc"
                 >
                   Audit Ballot Selections
                 </h3>
               </div>
               <div
-                class="bp3-divider sc-bXGyLb dngKan"
+                class="bp3-divider sc-lkqHmb TcpPN"
               />
               <div
-                class="sc-cpmLhU fIoOY"
+                class="sc-dymIpo fRJiSg"
               >
                 <div>
                   <h5
-                    class="bp3-heading sc-eerKOB bXnzdc"
+                    class="bp3-heading sc-emmjRN DUKSN"
                   >
                     Tabulator
                   </h5>
                   <h4
-                    class="bp3-heading sc-dymIpo dQpQIm"
+                    class="bp3-heading sc-bnXvFD gRXvw"
                   >
                     11
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-eerKOB bXnzdc"
+                    class="bp3-heading sc-emmjRN DUKSN"
                   >
                     Batch
                   </h5>
                   <h4
-                    class="bp3-heading sc-dymIpo dQpQIm"
+                    class="bp3-heading sc-bnXvFD gRXvw"
                   >
                     0003-04-Precinct 19 (Jonesboro Fire Department)
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-eerKOB bXnzdc"
+                    class="bp3-heading sc-emmjRN DUKSN"
                   >
                     Ballot Number
                   </h5>
                   <h4
-                    class="bp3-heading sc-dymIpo dQpQIm"
+                    class="bp3-heading sc-bnXvFD gRXvw"
                   >
                     2112
                   </h4>
                 </div>
                 <div>
                   <button
-                    class="bp3-button bp3-large bp3-intent-danger sc-bnXvFD ddUiNx"
+                    class="bp3-button bp3-large bp3-intent-danger sc-gFaPwZ hjBLLy"
                     type="button"
                   >
                     <span
@@ -164,36 +164,36 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 </div>
               </div>
               <div
-                class="bp3-divider sc-bXGyLb dngKan"
+                class="bp3-divider sc-lkqHmb TcpPN"
               />
               <div
-                class="sc-lkqHmb lkHHBM"
+                class="sc-eLExRp hPtYdv"
               >
                 <div
                   class="ballot-main"
                 >
                   <h5
-                    class="bp3-heading sc-eerKOB bXnzdc"
+                    class="bp3-heading sc-emmjRN DUKSN"
                   >
                     Ballot Contests
                   </h5>
                   <form>
                     <div
-                      class="sc-eLExRp eusgQt"
+                      class="sc-cbkKFq kZkYDv"
                     >
                       <div
-                        class="sc-dUjcNx cLhvpD"
+                        class="sc-gHboQg bVcsNq"
                       >
                         <div
-                          class="sc-gHboQg gRczol"
+                          class="sc-eilVRo kYUzWb"
                         >
                           <h3
-                            class="bp3-heading sc-fhYwyz bzGBvU"
+                            class="bp3-heading sc-jzgbtB kYoHmT"
                           >
                             Contest 1
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
+                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
                           >
                             <input
                               type="checkbox"
@@ -209,7 +209,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
+                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
                           >
                             <input
                               type="checkbox"
@@ -226,10 +226,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-eilVRo eifIEB"
+                          class="sc-eerKOB dBoKjH"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
+                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
                           >
                             <input
                               type="checkbox"
@@ -245,7 +245,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
+                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
                           >
                             <input
                               type="checkbox"
@@ -261,7 +261,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
+                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
                           >
                             <input
                               type="checkbox"
@@ -277,7 +277,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-gFaPwZ mBWlp"
+                            class="bp3-input sc-fhYwyz dUZAsj"
                             name="comment-Contest 1"
                             placeholder="Add Note"
                           />
@@ -285,21 +285,21 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-eLExRp eusgQt"
+                      class="sc-cbkKFq kZkYDv"
                     >
                       <div
-                        class="sc-dUjcNx cLhvpD"
+                        class="sc-gHboQg bVcsNq"
                       >
                         <div
-                          class="sc-gHboQg gRczol"
+                          class="sc-eilVRo kYUzWb"
                         >
                           <h3
-                            class="bp3-heading sc-fhYwyz bzGBvU"
+                            class="bp3-heading sc-jzgbtB kYoHmT"
                           >
                             Contest 2
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
+                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
                           >
                             <input
                               type="checkbox"
@@ -315,7 +315,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
+                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
                           >
                             <input
                               type="checkbox"
@@ -332,10 +332,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-eilVRo eifIEB"
+                          class="sc-eerKOB dBoKjH"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
+                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
                           >
                             <input
                               type="checkbox"
@@ -351,7 +351,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
+                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
                           >
                             <input
                               type="checkbox"
@@ -367,7 +367,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-emmjRN hrwfRU"
+                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
                           >
                             <input
                               type="checkbox"
@@ -383,7 +383,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-gFaPwZ mBWlp"
+                            class="bp3-input sc-fhYwyz dUZAsj"
                             name="comment-Contest 2"
                             placeholder="Add Note"
                           />
@@ -391,10 +391,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-krvtoX hJaJdG"
+                      class="sc-fYiAbW faWdJk"
                     >
                       <button
-                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-jzgbtB kJLReP sc-dnqmqq iQfLYL"
+                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-gJWqzi bdivNA sc-dnqmqq iQfLYL"
                         disabled=""
                         tabindex="-1"
                         type="submit"
@@ -421,7 +421,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
               </div>
             </div>
             <div
-              class="sc-laTMn cINNXD"
+              class="sc-hGoxap bBkpGZ"
             >
               <h4
                 class="bp3-heading"
@@ -429,7 +429,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 Instructions
               </h4>
               <ol
-                class="bp3-list sc-TFwJa czXaOQ"
+                class="bp3-list sc-bHwgHz cFhicz"
               >
                 <li>
                   Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -534,13 +534,13 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
       class="board-table-container"
     >
       <div
-        class="sc-esOvli gaxxTj"
+        class="sc-cmthru eJJcgP"
       >
         <div
-          class="sc-bwzfXH sc-cmthru MCtlb"
+          class="sc-bwzfXH sc-hMFtBS gFeFHl"
         >
           <div
-            class="sc-cMhqgX kfrMZZ"
+            class="sc-iuJeZd gmlHVf"
           >
             <p>
               18
@@ -549,23 +549,23 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-iujRgT iRLgiW"
+              class="summary-label sc-GMQeP dcYvRA"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-GMQeP bCrbdD"
+              class="summary-label sc-exAgwC liBTBs"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-iuJeZd dbfTuH"
+            class="sc-esOvli jVpAYR"
           >
             <button
-              class="bp3-button bp3-intent-success sc-cQFLBn eLlnEC"
+              class="bp3-button bp3-intent-success sc-gojNiO hoVeOI"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -582,10 +582,10 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-hMFtBS bfsTnq"
+          class="sc-cLQEGU mBqav"
         >
           <div
-            class="sc-cLQEGU huXbyu"
+            class="sc-gqPbQI iqcfVi"
           >
             <h3
               class="bp3-heading"
@@ -594,7 +594,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Audit Board #1
             </h3>
             <div
-              class="sc-gqPbQI bEnvAE"
+              class="sc-hORach iKVYhX"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -799,7 +799,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -809,7 +809,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -819,7 +819,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -829,7 +829,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -858,7 +858,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -877,7 +877,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -886,7 +886,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -895,7 +895,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -904,7 +904,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -913,7 +913,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -934,7 +934,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -944,7 +944,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -954,7 +954,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -964,7 +964,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -993,7 +993,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -1012,7 +1012,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1022,7 +1022,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1032,7 +1032,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1042,7 +1042,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1071,7 +1071,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -1090,7 +1090,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -1099,7 +1099,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1108,7 +1108,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -1117,7 +1117,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -1126,7 +1126,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -1147,7 +1147,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1157,7 +1157,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1167,7 +1167,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1177,7 +1177,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1206,7 +1206,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -1225,7 +1225,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1235,7 +1235,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1245,7 +1245,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1255,7 +1255,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1284,7 +1284,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -1303,7 +1303,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -1312,7 +1312,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1321,7 +1321,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -1330,7 +1330,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -1339,7 +1339,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -1360,7 +1360,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1370,7 +1370,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1380,7 +1380,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1390,7 +1390,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1419,7 +1419,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -1438,7 +1438,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1448,7 +1448,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1458,7 +1458,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1468,7 +1468,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1497,7 +1497,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -1516,7 +1516,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -1525,7 +1525,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1534,7 +1534,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -1543,7 +1543,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -1552,7 +1552,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -1573,7 +1573,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1583,7 +1583,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1593,7 +1593,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1603,7 +1603,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1632,7 +1632,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -1651,7 +1651,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1661,7 +1661,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1671,7 +1671,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1681,7 +1681,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1710,7 +1710,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -1729,7 +1729,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -1738,7 +1738,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1747,7 +1747,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -1756,7 +1756,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -1765,7 +1765,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -1786,7 +1786,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1796,7 +1796,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1806,7 +1806,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1816,7 +1816,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1845,7 +1845,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -1864,7 +1864,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1874,7 +1874,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1884,7 +1884,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1894,7 +1894,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1923,7 +1923,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -1942,7 +1942,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -1951,7 +1951,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1960,7 +1960,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -1969,7 +1969,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -1978,7 +1978,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -1999,7 +1999,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2009,7 +2009,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2019,7 +2019,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2029,7 +2029,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2058,7 +2058,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -2077,7 +2077,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2087,7 +2087,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2097,7 +2097,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2107,7 +2107,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2136,7 +2136,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -2155,7 +2155,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -2164,7 +2164,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2173,7 +2173,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -2182,7 +2182,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -2191,7 +2191,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -2212,7 +2212,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2222,7 +2222,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2232,7 +2232,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2242,7 +2242,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2271,7 +2271,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -2290,7 +2290,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2300,7 +2300,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2310,7 +2310,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2320,7 +2320,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2349,7 +2349,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -2368,7 +2368,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -2377,7 +2377,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2386,7 +2386,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -2395,7 +2395,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -2404,7 +2404,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -2425,7 +2425,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2435,7 +2435,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2445,7 +2445,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2455,7 +2455,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2484,7 +2484,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -2503,7 +2503,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2513,7 +2513,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2523,7 +2523,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2533,7 +2533,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2562,7 +2562,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -2581,7 +2581,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -2590,7 +2590,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2599,7 +2599,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -2608,7 +2608,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -2617,7 +2617,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -2638,7 +2638,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2648,7 +2648,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2658,7 +2658,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2668,7 +2668,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2697,7 +2697,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -2713,7 +2713,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-gojNiO jBGhKr"
+              class="bp3-button bp3-disabled bp3-large sc-daURTG dAYiqU"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -2727,7 +2727,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
             </button>
           </div>
           <div
-            class="sc-hORach ZPclK"
+            class="sc-bMVAic gnoFyt"
           >
             <h4
               class="bp3-heading"
@@ -2735,7 +2735,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-exAgwC dlOWaa"
+              class="bp3-list sc-cQFLBn bcegBR"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -2815,13 +2815,13 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
       class="board-table-container"
     >
       <div
-        class="sc-esOvli gaxxTj"
+        class="sc-cmthru eJJcgP"
       >
         <div
-          class="sc-bwzfXH sc-cmthru MCtlb"
+          class="sc-bwzfXH sc-hMFtBS gFeFHl"
         >
           <div
-            class="sc-cMhqgX kfrMZZ"
+            class="sc-iuJeZd gmlHVf"
           >
             <p>
               0
@@ -2830,23 +2830,23 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-iujRgT iRLgiW"
+              class="summary-label sc-GMQeP dcYvRA"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-GMQeP bCrbdD"
+              class="summary-label sc-exAgwC liBTBs"
             >
               Not Audited: 
               27
             </span>
           </div>
           <div
-            class="sc-iuJeZd dbfTuH"
+            class="sc-esOvli jVpAYR"
           >
             <button
-              class="bp3-button bp3-intent-success sc-cQFLBn eLlnEC"
+              class="bp3-button bp3-intent-success sc-gojNiO hoVeOI"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
               type="button"
             >
@@ -2863,10 +2863,10 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-hMFtBS bfsTnq"
+          class="sc-cLQEGU mBqav"
         >
           <div
-            class="sc-cLQEGU huXbyu"
+            class="sc-gqPbQI iqcfVi"
           >
             <h3
               class="bp3-heading"
@@ -2875,7 +2875,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Audit Board #1
             </h3>
             <div
-              class="sc-gqPbQI bEnvAE"
+              class="sc-hORach iKVYhX"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -3080,7 +3080,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3089,7 +3089,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3098,7 +3098,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         313
                       </p>
@@ -3107,7 +3107,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3116,7 +3116,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -3137,7 +3137,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3146,7 +3146,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3155,7 +3155,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -3164,7 +3164,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3173,7 +3173,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -3194,7 +3194,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3203,7 +3203,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3212,7 +3212,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         1789
                       </p>
@@ -3221,7 +3221,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3230,7 +3230,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -3251,7 +3251,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3260,7 +3260,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3269,7 +3269,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         313
                       </p>
@@ -3278,7 +3278,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3287,7 +3287,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -3308,7 +3308,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3317,7 +3317,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3326,7 +3326,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -3335,7 +3335,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3344,7 +3344,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -3365,7 +3365,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3374,7 +3374,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3383,7 +3383,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         1789
                       </p>
@@ -3392,7 +3392,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3401,7 +3401,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -3422,7 +3422,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3431,7 +3431,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3440,7 +3440,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         313
                       </p>
@@ -3449,7 +3449,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3458,7 +3458,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -3479,7 +3479,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3488,7 +3488,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3497,7 +3497,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -3506,7 +3506,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3515,7 +3515,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -3536,7 +3536,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3545,7 +3545,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3554,7 +3554,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         1789
                       </p>
@@ -3563,7 +3563,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3572,7 +3572,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -3593,7 +3593,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3602,7 +3602,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3611,7 +3611,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         313
                       </p>
@@ -3620,7 +3620,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3629,7 +3629,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -3650,7 +3650,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3659,7 +3659,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3668,7 +3668,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -3677,7 +3677,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3686,7 +3686,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -3707,7 +3707,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3716,7 +3716,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3725,7 +3725,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         1789
                       </p>
@@ -3734,7 +3734,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3743,7 +3743,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -3764,7 +3764,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3773,7 +3773,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3782,7 +3782,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         313
                       </p>
@@ -3791,7 +3791,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3800,7 +3800,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -3821,7 +3821,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3830,7 +3830,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3839,7 +3839,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -3848,7 +3848,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3857,7 +3857,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -3878,7 +3878,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3887,7 +3887,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3896,7 +3896,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         1789
                       </p>
@@ -3905,7 +3905,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3914,7 +3914,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -3935,7 +3935,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -3944,7 +3944,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3953,7 +3953,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         313
                       </p>
@@ -3962,7 +3962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -3971,7 +3971,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -3992,7 +3992,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -4001,7 +4001,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4010,7 +4010,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -4019,7 +4019,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -4028,7 +4028,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -4049,7 +4049,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -4058,7 +4058,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4067,7 +4067,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         1789
                       </p>
@@ -4076,7 +4076,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -4085,7 +4085,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -4106,7 +4106,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -4115,7 +4115,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4124,7 +4124,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         313
                       </p>
@@ -4133,7 +4133,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -4142,7 +4142,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -4163,7 +4163,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -4172,7 +4172,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4181,7 +4181,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -4190,7 +4190,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -4199,7 +4199,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -4220,7 +4220,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -4229,7 +4229,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4238,7 +4238,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         1789
                       </p>
@@ -4247,7 +4247,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -4256,7 +4256,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -4277,7 +4277,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -4286,7 +4286,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4295,7 +4295,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         313
                       </p>
@@ -4304,7 +4304,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -4313,7 +4313,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -4334,7 +4334,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -4343,7 +4343,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4352,7 +4352,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -4361,7 +4361,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -4370,7 +4370,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -4391,7 +4391,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -4400,7 +4400,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4409,7 +4409,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         1789
                       </p>
@@ -4418,7 +4418,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -4427,7 +4427,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -4448,7 +4448,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -4457,7 +4457,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4466,7 +4466,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         313
                       </p>
@@ -4475,7 +4475,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -4484,7 +4484,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -4505,7 +4505,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -4514,7 +4514,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4523,7 +4523,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -4532,7 +4532,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -4541,7 +4541,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -4562,7 +4562,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -4571,7 +4571,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4580,7 +4580,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         1789
                       </p>
@@ -4589,7 +4589,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -4598,7 +4598,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -4616,7 +4616,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-gojNiO jBGhKr"
+              class="bp3-button bp3-disabled bp3-large sc-daURTG dAYiqU"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -4630,7 +4630,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
             </button>
           </div>
           <div
-            class="sc-hORach ZPclK"
+            class="sc-bMVAic gnoFyt"
           >
             <h4
               class="bp3-heading"
@@ -4638,7 +4638,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-exAgwC dlOWaa"
+              class="bp3-list sc-cQFLBn bcegBR"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -4718,13 +4718,13 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
       class="board-table-container"
     >
       <div
-        class="sc-esOvli gaxxTj"
+        class="sc-cmthru eJJcgP"
       >
         <div
-          class="sc-bwzfXH sc-cmthru MCtlb"
+          class="sc-bwzfXH sc-hMFtBS gFeFHl"
         >
           <div
-            class="sc-cMhqgX kfrMZZ"
+            class="sc-iuJeZd gmlHVf"
           >
             <p>
               0
@@ -4733,23 +4733,23 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-iujRgT iRLgiW"
+              class="summary-label sc-GMQeP dcYvRA"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-GMQeP bCrbdD"
+              class="summary-label sc-exAgwC liBTBs"
             >
               Not Audited: 
               0
             </span>
           </div>
           <div
-            class="sc-iuJeZd dbfTuH"
+            class="sc-esOvli jVpAYR"
           >
             <button
-              class="bp3-button bp3-intent-success sc-cQFLBn eLlnEC"
+              class="bp3-button bp3-intent-success sc-gojNiO hoVeOI"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4766,10 +4766,10 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-hMFtBS bfsTnq"
+          class="sc-cLQEGU mBqav"
         >
           <div
-            class="sc-cLQEGU huXbyu"
+            class="sc-gqPbQI iqcfVi"
           >
             <h3
               class="bp3-heading"
@@ -4778,7 +4778,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Audit Board #1
             </h3>
             <div
-              class="sc-gqPbQI bEnvAE"
+              class="sc-hORach iKVYhX"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -4942,7 +4942,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               </table>
             </div>
             <button
-              class="bp3-button bp3-large bp3-intent-success sc-gojNiO jBGhKr"
+              class="bp3-button bp3-large bp3-intent-success sc-daURTG dAYiqU"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4954,7 +4954,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
             </button>
           </div>
           <div
-            class="sc-hORach ZPclK"
+            class="sc-bMVAic gnoFyt"
           >
             <h4
               class="bp3-heading"
@@ -4962,7 +4962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-exAgwC dlOWaa"
+              class="bp3-list sc-cQFLBn bcegBR"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -5042,13 +5042,13 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
       class="board-table-container"
     >
       <div
-        class="sc-esOvli gaxxTj"
+        class="sc-cmthru eJJcgP"
       >
         <div
-          class="sc-bwzfXH sc-cmthru MCtlb"
+          class="sc-bwzfXH sc-hMFtBS gFeFHl"
         >
           <div
-            class="sc-cMhqgX kfrMZZ"
+            class="sc-iuJeZd gmlHVf"
           >
             <p>
               18
@@ -5057,23 +5057,23 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-iujRgT iRLgiW"
+              class="summary-label sc-GMQeP dcYvRA"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-GMQeP bCrbdD"
+              class="summary-label sc-exAgwC liBTBs"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-iuJeZd dbfTuH"
+            class="sc-esOvli jVpAYR"
           >
             <button
-              class="bp3-button bp3-intent-success sc-cQFLBn eLlnEC"
+              class="bp3-button bp3-intent-success sc-gojNiO hoVeOI"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -5090,10 +5090,10 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-hMFtBS bfsTnq"
+          class="sc-cLQEGU mBqav"
         >
           <div
-            class="sc-cLQEGU huXbyu"
+            class="sc-gqPbQI iqcfVi"
           >
             <h3
               class="bp3-heading"
@@ -5102,7 +5102,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Audit Board #1
             </h3>
             <div
-              class="sc-gqPbQI bEnvAE"
+              class="sc-hORach iKVYhX"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -5307,7 +5307,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5317,7 +5317,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5327,7 +5327,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5337,7 +5337,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5366,7 +5366,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -5385,7 +5385,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -5394,7 +5394,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5403,7 +5403,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -5412,7 +5412,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -5421,7 +5421,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -5442,7 +5442,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5452,7 +5452,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5462,7 +5462,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5472,7 +5472,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5501,7 +5501,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -5520,7 +5520,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5530,7 +5530,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5540,7 +5540,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5550,7 +5550,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5579,7 +5579,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -5598,7 +5598,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -5607,7 +5607,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5616,7 +5616,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -5625,7 +5625,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -5634,7 +5634,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -5655,7 +5655,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5665,7 +5665,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5675,7 +5675,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5685,7 +5685,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5714,7 +5714,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -5733,7 +5733,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5743,7 +5743,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5753,7 +5753,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5763,7 +5763,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5792,7 +5792,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -5811,7 +5811,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -5820,7 +5820,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5829,7 +5829,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -5838,7 +5838,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -5847,7 +5847,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -5868,7 +5868,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5878,7 +5878,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5888,7 +5888,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5898,7 +5898,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5927,7 +5927,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -5946,7 +5946,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5956,7 +5956,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5966,7 +5966,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5976,7 +5976,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6005,7 +6005,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -6024,7 +6024,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -6033,7 +6033,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6042,7 +6042,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -6051,7 +6051,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -6060,7 +6060,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -6081,7 +6081,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6091,7 +6091,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6101,7 +6101,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6111,7 +6111,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6140,7 +6140,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -6159,7 +6159,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6169,7 +6169,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6179,7 +6179,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6189,7 +6189,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6218,7 +6218,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -6237,7 +6237,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -6246,7 +6246,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6255,7 +6255,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -6264,7 +6264,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -6273,7 +6273,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -6294,7 +6294,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6304,7 +6304,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6314,7 +6314,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6324,7 +6324,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6353,7 +6353,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -6372,7 +6372,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6382,7 +6382,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6392,7 +6392,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6402,7 +6402,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6431,7 +6431,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -6450,7 +6450,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -6459,7 +6459,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6468,7 +6468,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -6477,7 +6477,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -6486,7 +6486,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -6507,7 +6507,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6517,7 +6517,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6527,7 +6527,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6537,7 +6537,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6566,7 +6566,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -6585,7 +6585,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6595,7 +6595,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6605,7 +6605,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6615,7 +6615,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6644,7 +6644,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -6663,7 +6663,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -6672,7 +6672,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6681,7 +6681,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -6690,7 +6690,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -6699,7 +6699,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -6720,7 +6720,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6730,7 +6730,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6740,7 +6740,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6750,7 +6750,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6779,7 +6779,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -6798,7 +6798,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6808,7 +6808,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6818,7 +6818,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6828,7 +6828,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6857,7 +6857,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -6876,7 +6876,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -6885,7 +6885,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6894,7 +6894,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -6903,7 +6903,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -6912,7 +6912,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -6933,7 +6933,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6943,7 +6943,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6953,7 +6953,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6963,7 +6963,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6992,7 +6992,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -7011,7 +7011,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7021,7 +7021,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -7031,7 +7031,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -7041,7 +7041,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7070,7 +7070,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -7089,7 +7089,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         11
                       </p>
@@ -7098,7 +7098,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -7107,7 +7107,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                       >
                         2112
                       </p>
@@ -7116,7 +7116,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-GMQeP bCrbdD"
+                        class="sc-exAgwC liBTBs"
                       >
                         Not Audited
                       </span>
@@ -7125,7 +7125,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -7146,7 +7146,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7156,7 +7156,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -7166,7 +7166,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -7176,7 +7176,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-daURTG htjMod"
+                        class="sc-bXGyLb jLiywa"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7205,7 +7205,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bMVAic cfVyBv"
+                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -7221,7 +7221,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-gojNiO jBGhKr"
+              class="bp3-button bp3-disabled bp3-large sc-daURTG dAYiqU"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -7235,7 +7235,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
             </button>
           </div>
           <div
-            class="sc-hORach ZPclK"
+            class="sc-bMVAic gnoFyt"
           >
             <h4
               class="bp3-heading"
@@ -7243,7 +7243,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-exAgwC dlOWaa"
+              class="bp3-list sc-cQFLBn bcegBR"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.

--- a/client/src/components/JurisdictionAdmin/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
+++ b/client/src/components/JurisdictionAdmin/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`full hand tally data entry deletes full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-jlyJG hHBFug"
+    class="sc-gipzik hvuvct"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -159,7 +159,7 @@ exports[`full hand tally data entry deletes full hand tally batch result 1`] = `
 exports[`full hand tally data entry edits full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-jlyJG hHBFug"
+    class="sc-gipzik hvuvct"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -360,7 +360,7 @@ exports[`full hand tally data entry edits full hand tally batch result 1`] = `
 exports[`full hand tally data entry finalizes full hand tally results 1`] = `
 <div>
   <form
-    class="sc-jlyJG hHBFug"
+    class="sc-gipzik hvuvct"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -593,7 +593,7 @@ exports[`full hand tally data entry finalizes full hand tally results 1`] = `
 exports[`full hand tally data entry renders 1`] = `
 <div>
   <form
-    class="sc-jlyJG hHBFug"
+    class="sc-gipzik hvuvct"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -749,7 +749,7 @@ exports[`full hand tally data entry renders 1`] = `
 exports[`full hand tally data entry renders with full hand tally results 1`] = `
 <div>
   <form
-    class="sc-jlyJG hHBFug"
+    class="sc-gipzik hvuvct"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -950,7 +950,7 @@ exports[`full hand tally data entry renders with full hand tally results 1`] = `
 exports[`full hand tally data entry renders with proper totals 1`] = `
 <div>
   <form
-    class="sc-jlyJG hHBFug"
+    class="sc-gipzik hvuvct"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -1203,7 +1203,7 @@ exports[`full hand tally data entry renders with proper totals 1`] = `
 exports[`full hand tally data entry submits full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-jlyJG hHBFug"
+    class="sc-gipzik hvuvct"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -1404,7 +1404,7 @@ exports[`full hand tally data entry submits full hand tally batch result 1`] = `
 exports[`full hand tally data entry validation error for blank submission 1`] = `
 <div>
   <form
-    class="sc-jlyJG hHBFug"
+    class="sc-gipzik hvuvct"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1102,6 +1102,13 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@blueprintjs/colors@^4.0.0-alpha.3":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/colors/-/colors-4.2.1.tgz#603b2512caee84feddcb3dbd536534c140b9a1f3"
+  integrity sha512-Cx7J2YnUuxn+fi+y5XtXnBB7+cFHN4xBrRkaAetp78i3VTCXjUk+d1omrOr8TqbRucUXTdrhbZOUHpzRLFcJpQ==
+  dependencies:
+    tslib "~2.5.0"
+
 "@blueprintjs/core@^3.20.0":
   version "3.20.0"
   resolved "https://registry.yarnpkg.com/@blueprintjs/core/-/core-3.20.0.tgz#2c3fd713ac2dc47df7acec03bb88e53fb335715d"
@@ -1119,6 +1126,24 @@
     resize-observer-polyfill "^1.5.1"
     tslib "~1.9.0"
 
+"@blueprintjs/core@^3.54.0":
+  version "3.54.0"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/core/-/core-3.54.0.tgz#7269f34eccdf0d2874377c5ad973ca2a31562221"
+  integrity sha512-u2c1s6MNn0ocxhnC6CuiG5g3KV6b4cKUvSobznepA9SC3/AL1s3XOvT7DLWoHRv2B/vBOHFYEDzLw2/vlcGGZg==
+  dependencies:
+    "@blueprintjs/colors" "^4.0.0-alpha.3"
+    "@blueprintjs/icons" "^3.33.0"
+    "@juggle/resize-observer" "^3.3.1"
+    "@types/dom4" "^2.0.1"
+    classnames "^2.2"
+    dom4 "^2.1.5"
+    normalize.css "^8.0.1"
+    popper.js "^1.16.1"
+    react-lifecycles-compat "^3.0.4"
+    react-popper "^1.3.7"
+    react-transition-group "^2.9.0"
+    tslib "~2.3.1"
+
 "@blueprintjs/icons@^3.12.0":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@blueprintjs/icons/-/icons-3.12.0.tgz#cea6a6434d9d469e26d87b055e6b6aa5768135b3"
@@ -1126,6 +1151,23 @@
   dependencies:
     classnames "^2.2"
     tslib "~1.9.0"
+
+"@blueprintjs/icons@^3.33.0":
+  version "3.33.0"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/icons/-/icons-3.33.0.tgz#4dacdb7731abdf08d1ab240f3a23a185df60918b"
+  integrity sha512-Q6qoSDIm0kRYQZISm59UUcDCpV3oeHulkLuh3bSlw0HhcSjvEQh2PSYbtaifM60Q4aK4PCd6bwJHg7lvF1x5fQ==
+  dependencies:
+    classnames "^2.2"
+    tslib "~2.3.1"
+
+"@blueprintjs/select@^3.19.1":
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/select/-/select-3.19.1.tgz#b5e8baa6f182a0647651a57fde8d1d97eaa1e997"
+  integrity sha512-8UJIZMaWXRMQHr14wbmzJc/CklcSKxOU5JUux0xXKQz/hDW/g1a650tlwJmnxufvRdShbGinlVfHupCs0EL6sw==
+  dependencies:
+    "@blueprintjs/core" "^3.54.0"
+    classnames "^2.2"
+    tslib "~2.3.1"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
@@ -1203,6 +1245,14 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@hookform/error-message/-/error-message-2.0.0.tgz#9b1b037fd816ea9b1531c06aa7fab5f5154aa740"
   integrity sha512-Y90nHzjgL2MP7GFy75kscdvxrCTjtyxGmOLLxX14nd08OXRIh9lMH/y9Kpdo0p1IPowJBiZMHyueg7p+yrqynQ==
+
+"@hypnosphi/create-react-context@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz#f8bfebdc7665f5d426cba3753e0e9c7d3154d7c6"
+  integrity sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==
+  dependencies:
+    gud "^1.0.0"
+    warning "^4.0.3"
 
 "@jest/console@^24.7.1":
   version "24.7.1"
@@ -1428,6 +1478,11 @@
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@juggle/resize-observer@^3.3.1":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
+  integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -4164,6 +4219,18 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
+deep-equal@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.2.tgz#78a561b7830eef3134c7f6f3a3d6af272a678761"
+  integrity sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==
+  dependencies:
+    is-arguments "^1.1.1"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.5.1"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -4179,7 +4246,7 @@ deepmerge@^2.1.1:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
   integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
-define-data-property@^1.1.4:
+define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
   integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
@@ -4200,6 +4267,15 @@ define-properties@^1.1.4:
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
   integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
   dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
+
+define-properties@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
+  integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
+  dependencies:
+    define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
@@ -5491,7 +5567,7 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-functions-have-names@^1.2.2:
+functions-have-names@^1.2.2, functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
@@ -6265,6 +6341,14 @@ is-alphanumerical@^1.0.0:
     is-alphabetical "^1.0.0"
     is-decimal "^1.0.0"
 
+is-arguments@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -6358,6 +6442,13 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
   integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+
+is-date-object@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
+  integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-decimal@^1.0.0:
   version "1.0.3"
@@ -8298,6 +8389,14 @@ object-inspect@^1.13.1:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.2.tgz#dea0088467fb991e67af4058147a24824a3043ff"
   integrity sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==
 
+object-is@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.6.tgz#1a6a53aed2dd8f7e6775ff870bea58545956ab07"
+  integrity sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -8755,6 +8854,11 @@ popper.js@^1.14.4, popper.js@^1.15.0:
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
   integrity sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==
 
+popper.js@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -9175,6 +9279,19 @@ react-popper@^1.3.3:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
+react-popper@^1.3.7:
+  version "1.3.11"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.11.tgz#a2cc3f0a67b75b66cfa62d2c409f9dd1fcc71ffd"
+  integrity sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    "@hypnosphi/create-react-context" "^0.3.1"
+    deep-equal "^1.1.1"
+    popper.js "^1.14.4"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.7"
+    warning "^4.0.2"
+
 react-query@^3.39.0:
   version "3.39.0"
   resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.0.tgz#0caca7b0da98e65008bbcd4df0d25618c2100050"
@@ -9374,6 +9491,16 @@ regexp.prototype.flags@^1.4.1, regexp.prototype.flags@^1.4.3:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     functions-have-names "^1.2.2"
+
+regexp.prototype.flags@^1.5.1:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz#b3ae40b1d2499b8350ab2c3fe6ef3845d3a96f42"
+  integrity sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-errors "^1.3.0"
+    set-function-name "^2.0.2"
 
 regexpp@^2.0.1:
   version "2.0.1"
@@ -9839,6 +9966,16 @@ set-function-length@^1.2.1:
     function-bind "^1.1.2"
     get-intrinsic "^1.2.4"
     gopd "^1.0.1"
+    has-property-descriptors "^1.0.2"
+
+set-function-name@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.2.tgz#16a705c5a0dc2f5e638ca96d8a8cd4e1c2b90985"
+  integrity sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.2"
 
 set-value@^2.0.0, set-value@^2.0.1:
@@ -10843,6 +10980,16 @@ tslib@~1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslib@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@~2.5.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
+  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
 
 tsutils@^3.17.1:
   version "3.17.1"

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -7,7 +7,6 @@ from werkzeug.exceptions import BadRequest, Conflict
 from sqlalchemy.orm import Query, joinedload
 from sqlalchemy import func
 
-
 from . import api
 from ..auth import get_loggedin_user, get_support_user, restrict_access, UserType
 from ..database import db_session

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -7,11 +7,12 @@ from werkzeug.exceptions import BadRequest, Conflict
 from sqlalchemy.orm import Query, joinedload
 from sqlalchemy import func
 
+
 from . import api
 from ..auth import get_loggedin_user, get_support_user, restrict_access, UserType
 from ..database import db_session
 from ..models import *  # pylint: disable=wildcard-import
-from .shared import get_current_round
+from .shared import get_current_round, group_combined_batches
 from ..util.csv_download import csv_response, jurisdiction_timestamp_name
 from ..util.jsonschema import JSONDict, validate
 from ..util.isoformat import isoformat
@@ -22,6 +23,27 @@ from ..activity_log.activity_log import (
     record_activity,
 )
 from ..util.get_json import safe_get_json_list
+
+
+def replace_combined_batches_with_representative_batches(
+    batches: List[Batch],
+) -> List[Batch]:
+    regular_batches = []
+    all_sub_batches = []
+    for batch in batches:
+        if batch.combined_batch_name is None:
+            regular_batches.append(batch)
+        else:
+            all_sub_batches.append(batch)
+
+    combined_batches = group_combined_batches(all_sub_batches)
+    representative_batches = [
+        combined_batch["representative_batch"] for combined_batch in combined_batches
+    ]
+    for representative_batch in representative_batches:
+        representative_batch.name = representative_batch.combined_batch_name  # type: ignore
+
+    return regular_batches + representative_batches
 
 
 def already_audited_batches(jurisdiction: Jurisdiction, round: Round) -> Query:
@@ -134,9 +156,15 @@ def list_batches_for_jurisdiction(
     results_finalized = BatchResultsFinalized.query.filter_by(
         jurisdiction_id=jurisdiction.id, round_id=round.id
     ).one_or_none()
+
     return jsonify(
         {
-            "batches": [serialize_batch(batch) for batch in batches],
+            "batches": [
+                serialize_batch(batch)
+                for batch in replace_combined_batches_with_representative_batches(
+                    batches
+                )
+            ],
             "resultsFinalizedAt": isoformat(
                 results_finalized and results_finalized.created_at
             ),
@@ -205,12 +233,26 @@ def validate_batch_results(
         )
 
     for contest in contests:
-        total_votes = 0
-        for tally_sheet in batch_results:
-            for choice in contest.choices:
-                total_votes += tally_sheet["results"][choice.id]
+        total_votes = sum(
+            tally_sheet["results"][choice.id]
+            for tally_sheet in batch_results
+            for choice in contest.choices
+        )
+
+        # Special case: if the batch is a combined batch, we need to sum the
+        # number of ballots in all sub-batches its been combined with.
+        if batch.combined_batch_name is not None:
+            sub_batches = Batch.query.filter_by(
+                combined_batch_name=batch.combined_batch_name,
+                jurisdiction_id=jurisdiction.id,
+            )
+            num_ballots = sum(sub_batch.num_ballots for sub_batch in sub_batches)
+        else:
+            num_ballots = batch.num_ballots
+
         assert contest.votes_allowed is not None
-        allowed_votes = batch.num_ballots * contest.votes_allowed
+        allowed_votes = num_ballots * contest.votes_allowed
+
         if total_votes > allowed_votes:
             raise BadRequest(
                 f"Total votes for batch {batch.name} contest {contest.name} should not exceed "

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -246,8 +246,10 @@ def validate_batch_results(
                 combined_batch_name=batch.combined_batch_name,
                 jurisdiction_id=jurisdiction.id,
             )
+            batch_name = batch.combined_batch_name
             num_ballots = sum(sub_batch.num_ballots for sub_batch in sub_batches)
         else:
+            batch_name = batch.name
             num_ballots = batch.num_ballots
 
         assert contest.votes_allowed is not None
@@ -255,8 +257,8 @@ def validate_batch_results(
 
         if total_votes > allowed_votes:
             raise BadRequest(
-                f"Total votes for batch {batch.name} contest {contest.name} should not exceed "
-                f"{allowed_votes} - the number of ballots in the batch ({batch.num_ballots}) "
+                f"Total votes for batch {batch_name} contest {contest.name} should not exceed "
+                f"{allowed_votes} - the number of ballots in the batch ({num_ballots}) "
                 f"times the number of votes allowed ({contest.votes_allowed})."
             )
 

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -1082,7 +1082,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction = None):
 
             combined_batch_row += [
                 construct_batch_last_edited_by_string(representative_batch),
-                f"Combines {', '.join(sub_batch.name for sub_batch in sub_batches)}",
+                f"Combines {', '.join(sub_batch.name for sub_batch in sorted(sub_batches, key=lambda batch: batch.name))}",
             ]
             rows.append(combined_batch_row)
 

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -19,6 +19,7 @@ from .shared import (
     SampleSize,
     active_targeted_contests,
     batch_tallies,
+    combined_batch_keys,
     compute_sample_ballots,
     compute_sample_batches,
     contest_results_by_round,
@@ -303,6 +304,7 @@ def calculate_risk_measurements(election: Election, round: Round):
                 batch_tallies(contest),
                 sampled_batch_results(contest),
                 sampled_batches_by_ticket_number(contest),
+                combined_batch_keys(election.id),
             )
         elif election.audit_type == AuditType.BALLOT_COMPARISON:
             p_value, is_complete = supersimple.compute_risk(

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -8,7 +8,7 @@ from werkzeug.exceptions import BadRequest
 from . import api
 from ..models import *  # pylint: disable=wildcard-import
 from ..database import db_session
-from .shared import BatchTallies
+from .shared import BatchTallies, combined_batch_keys
 from ..auth import restrict_access, UserType
 from ..audit_math import (
     ballot_polling,
@@ -151,6 +151,7 @@ def sample_size_options(election: Election) -> Dict[str, Dict[str, SampleSizeOpt
                 rounds.batch_tallies(contest),
                 rounds.sampled_batch_results(contest),
                 rounds.sampled_batches_by_ticket_number(contest),
+                combined_batch_keys(election.id),
             )
             return {"macro": {"key": "macro", "size": sample_size, "prob": None}}
 

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -622,6 +622,8 @@ def create_combined_batch(jurisdiction_id: str):
         raise Conflict(
             "One or more of these batches are already part of a combined batch"
         )
+    if all(len(batch.draws) == 0 for batch in batches):
+        raise Conflict("At least one batch must be part of the sample")
 
     representative_batch = combined_batch_representative(batches)
     support_user_email = get_support_user(session)

--- a/server/migrations/versions/34824a2d1ba8_batch_combined_batch_name.py
+++ b/server/migrations/versions/34824a2d1ba8_batch_combined_batch_name.py
@@ -1,0 +1,27 @@
+# pylint: disable=invalid-name
+"""Batch.combined_batch_name
+
+Revision ID: 34824a2d1ba8
+Revises: 8452f909a07e
+Create Date: 2024-10-21 19:04:17.936262+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "34824a2d1ba8"
+down_revision = "8452f909a07e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "batch", sa.Column("combined_batch_name", sa.String(length=200), nullable=True)
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -423,6 +423,11 @@ class Batch(BaseModel):
     # ballot polling math).
     has_cvrs = Column(Boolean)
 
+    # For batch comparison audits, if auditors discover after sampling that some
+    # batches' ballots were commingled and can't be separated, allow auditing
+    # those batches together by labeling them with a combined batch name.
+    combined_batch_name = Column(String(200))
+
     draws = relationship(
         "SampledBatchDraw",
         uselist=True,

--- a/server/tests/audit_math/test_macro.py
+++ b/server/tests/audit_math/test_macro.py
@@ -177,7 +177,7 @@ def test_get_sizes_extra_contests(contests, batches) -> None:
     sample_ticket_numbers: Dict = {}
     for contest in contests:
         computed = macro.get_sample_sizes(
-            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers
+            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers, []
         )
 
         assert (
@@ -198,7 +198,7 @@ def test_get_sample_sizes(contests, batches) -> None:
     sample_ticket_numbers: Dict = {}
     for contest in contests:
         computed = macro.get_sample_sizes(
-            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers
+            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers, []
         )
 
         assert (
@@ -233,7 +233,7 @@ def test_get_sample_sizes(contests, batches) -> None:
 
     for contest in contests:
         computed = macro.get_sample_sizes(
-            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers
+            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers, []
         )
 
         assert (
@@ -266,7 +266,7 @@ def test_get_sample_sizes(contests, batches) -> None:
 
     for contest in contests:
         computed = macro.get_sample_sizes(
-            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers
+            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers, []
         )
 
         assert (
@@ -285,7 +285,7 @@ def test_get_sample_sizes(contests, batches) -> None:
     }
     sample_ticket_numbers["9"] = "Batch 9"
     computed = macro.get_sample_sizes(
-        RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers
+        RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers, []
     )
 
     assert computed == 0, "Fourth round sample expected 0, got {}".format(computed)
@@ -299,11 +299,16 @@ def test_full_recount(contests, batches) -> None:
 
         with pytest.raises(ValueError, match=r"All ballots have already been counted!"):
             macro.get_sample_sizes(
-                RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers
+                RISK_LIMIT,
+                contests[contest],
+                batches,
+                sample,
+                sample_ticket_numbers,
+                [],
             )
 
         computed_p, result = macro.compute_risk(
-            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers
+            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers, []
         )
 
         assert computed_p == 0.0, "Incorrect p-value: Got {}, expected {}".format(
@@ -324,11 +329,16 @@ def test_full_recount_with_replacement(contests, batches) -> None:
 
         with pytest.raises(ValueError, match=r"All ballots have already been counted!"):
             macro.get_sample_sizes(
-                RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers
+                RISK_LIMIT,
+                contests[contest],
+                batches,
+                sample,
+                sample_ticket_numbers,
+                [],
             )
 
         computed_p, result = macro.compute_risk(
-            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers
+            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers, []
         )
 
         assert computed_p == 0.0, "Incorrect p-value: Got {}, expected {}".format(
@@ -357,7 +367,7 @@ def test_almost_done() -> None:
 
     with pytest.raises(ValueError, match=r"All ballots have already been counted!"):
         macro.get_sample_sizes(
-            RISK_LIMIT, contest, batches, sample, sample_ticket_numbers
+            RISK_LIMIT, contest, batches, sample, sample_ticket_numbers, []
         )
 
 
@@ -386,7 +396,7 @@ def test_worst_case() -> None:
     sample_ticket_numbers = {"1": "Batch 1"}
 
     assert macro.compute_risk(
-        RISK_LIMIT, contest, batches, sample, sample_ticket_numbers
+        RISK_LIMIT, contest, batches, sample, sample_ticket_numbers, []
     ) == (
         Decimal(1.0),
         False,
@@ -448,7 +458,7 @@ def test_compute_risk(contests, batches) -> None:
 
     for contest in contests:
         computed_p, result = macro.compute_risk(
-            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers
+            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers, []
         )
 
         expected_p = expected_ps[contest]
@@ -484,7 +494,7 @@ def test_compute_risk(contests, batches) -> None:
 
     for contest in contests:
         computed_p, result = macro.compute_risk(
-            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers
+            RISK_LIMIT, contests[contest], batches, sample, sample_ticket_numbers, []
         )
 
         expected_p = expected_ps[contest]
@@ -499,7 +509,6 @@ def test_compute_risk(contests, batches) -> None:
 
 
 def test_tied_contest() -> None:
-
     contest_data = {
         "winner": 50000,
         "loser": 50000,
@@ -525,7 +534,7 @@ def test_tied_contest() -> None:
     sample_ticket_numbers: Dict = {}
 
     sample_size = macro.get_sample_sizes(
-        RISK_LIMIT, contest, batches, sample_results, sample_ticket_numbers
+        RISK_LIMIT, contest, batches, sample_results, sample_ticket_numbers, []
     )
 
     assert sample_size == len(batches)
@@ -543,7 +552,7 @@ def test_tied_contest() -> None:
     sample_ticket_numbers = {"1": "0"}
 
     computed_p, res = macro.compute_risk(
-        RISK_LIMIT, contest, batches, sample_results, sample_ticket_numbers
+        RISK_LIMIT, contest, batches, sample_results, sample_ticket_numbers, []
     )
 
     assert computed_p > ALPHA
@@ -552,7 +561,7 @@ def test_tied_contest() -> None:
     # Now do a full hand recount
     sample_ticket_numbers = {str(i): batch for i, batch in enumerate(batches.keys())}
     computed_p, res = macro.compute_risk(
-        RISK_LIMIT, contest, batches, batches, sample_ticket_numbers
+        RISK_LIMIT, contest, batches, batches, sample_ticket_numbers, []
     )
 
     assert not computed_p
@@ -608,7 +617,7 @@ def test_close_contest() -> None:
     sample_ticket_numbers: Dict = {}
 
     sample_size = macro.get_sample_sizes(
-        RISK_LIMIT, contest, batches, sample_results, sample_ticket_numbers
+        RISK_LIMIT, contest, batches, sample_results, sample_ticket_numbers, []
     )
 
     assert sample_size == len(batches)
@@ -626,7 +635,7 @@ def test_close_contest() -> None:
     sample_ticket_numbers = {"1": "1"}
 
     computed_p, res = macro.compute_risk(
-        RISK_LIMIT, contest, batches, sample_results, sample_ticket_numbers
+        RISK_LIMIT, contest, batches, sample_results, sample_ticket_numbers, []
     )
 
     assert computed_p > ALPHA
@@ -635,8 +644,278 @@ def test_close_contest() -> None:
     # Now do a full hand recount
     sample_ticket_numbers = {str(i): batch for i, batch in enumerate(batches.keys())}
     computed_p, res = macro.compute_risk(
-        RISK_LIMIT, contest, batches, batches, sample_ticket_numbers
+        RISK_LIMIT, contest, batches, batches, sample_ticket_numbers, []
     )
 
     assert not computed_p
     assert res
+
+
+def test_combined_batches_no_discrepancies():
+    contest_data = {
+        "winner": 110,
+        "loser": 90,
+        "ballots": 200,
+        "numWinners": 1,
+        "votesAllowed": 1,
+    }
+    contest = Contest("Combined Batches Contest", contest_data)
+
+    batches = {}
+    batches["Batch 1"] = {
+        contest.name: {
+            "winner": 30,
+            "loser": 20,
+            "ballots": 50,
+        }
+    }
+    batches["Batch 2"] = {
+        contest.name: {
+            "winner": 10,
+            "loser": 40,
+            "ballots": 50,
+        }
+    }
+    batches["Batch 3"] = {
+        contest.name: {
+            "winner": 40,
+            "loser": 0,
+            "ballots": 40,
+        }
+    }
+    batches["Batch 4"] = {
+        contest.name: {
+            "winner": 30,
+            "loser": 30,
+            "ballots": 60,
+        }
+    }
+
+    sample_size = macro.get_sample_sizes(RISK_LIMIT, contest, batches, {}, {}, [])
+    assert sample_size == len(batches)
+
+    combined_batch_1_and_2_results = {
+        contest.name: {
+            "winner": batches["Batch 1"][contest.name]["winner"]
+            + batches["Batch 2"][contest.name]["winner"],
+            "loser": batches["Batch 1"][contest.name]["loser"]
+            + batches["Batch 2"][contest.name]["loser"],
+        }
+    }
+    sample_results = {
+        "Batch 1": combined_batch_1_and_2_results,
+        "Batch 2": combined_batch_1_and_2_results,
+        "Batch 3": batches["Batch 3"],
+    }
+    sample_ticket_numbers = {
+        "1": "Batch 1",
+        "2": "Batch 2",
+        "3": "Batch 3",
+    }
+    combined_batches = [{"Batch 1", "Batch 2"}]
+
+    computed_p, res = macro.compute_risk(
+        RISK_LIMIT,
+        contest,
+        batches,
+        sample_results,
+        sample_ticket_numbers,
+        combined_batches,
+    )
+    U = macro.compute_U(batches, contest)
+    expected_taint = 0
+    expected_p = ((1 - 1 / U) / (1 - expected_taint)) ** len(sample_results)
+    assert computed_p == float(expected_p)
+    assert res is (expected_p < ALPHA)
+
+
+def test_combined_batches_one_discrepancy():
+    contest_data = {
+        "winner": 110,
+        "loser": 90,
+        "ballots": 200,
+        "numWinners": 1,
+        "votesAllowed": 1,
+    }
+    contest = Contest("Combined Batches Contest", contest_data)
+
+    batches = {}
+    batches["Batch 1"] = {
+        contest.name: {
+            "winner": 30,
+            "loser": 20,
+            "ballots": 50,
+        }
+    }
+    batches["Batch 2"] = {
+        contest.name: {
+            "winner": 10,
+            "loser": 40,
+            "ballots": 50,
+        }
+    }
+    batches["Batch 3"] = {
+        contest.name: {
+            "winner": 40,
+            "loser": 0,
+            "ballots": 40,
+        }
+    }
+    batches["Batch 4"] = {
+        contest.name: {
+            "winner": 30,
+            "loser": 30,
+            "ballots": 60,
+        }
+    }
+
+    sample_size = macro.get_sample_sizes(RISK_LIMIT, contest, batches, {}, {}, [])
+    assert sample_size == len(batches)
+
+    discrepancy_votes = 2
+    combined_batch_1_and_2_results = {
+        contest.name: {
+            "winner": batches["Batch 1"][contest.name]["winner"]
+            + batches["Batch 2"][contest.name]["winner"],
+            "loser": batches["Batch 1"][contest.name]["loser"]
+            + batches["Batch 2"][contest.name]["loser"]
+            + discrepancy_votes,
+        }
+    }
+    sample_results = {
+        "Batch 1": combined_batch_1_and_2_results,
+        "Batch 2": combined_batch_1_and_2_results,
+        "Batch 3": batches["Batch 3"],
+    }
+    sample_ticket_numbers = {
+        "1": "Batch 1",
+        "2": "Batch 2",
+        "3": "Batch 3",
+    }
+    combined_batches = [{"Batch 1", "Batch 2"}]
+
+    computed_p, res = macro.compute_risk(
+        RISK_LIMIT,
+        contest,
+        batches,
+        sample_results,
+        sample_ticket_numbers,
+        combined_batches,
+    )
+    U = macro.compute_U(batches, contest)
+    max_error_batch_1 = (
+        batches["Batch 1"][contest.name]["winner"]
+        - batches["Batch 1"][contest.name]["loser"]
+        + batches["Batch 1"][contest.name]["ballots"]
+    )
+    max_error_batch_2 = (
+        batches["Batch 2"][contest.name]["winner"]
+        - batches["Batch 2"][contest.name]["loser"]
+        + batches["Batch 2"][contest.name]["ballots"]
+    )
+    expected_taint_batch_1 = discrepancy_votes / max_error_batch_1
+    expected_taint_batch_2 = discrepancy_votes / max_error_batch_2
+    numerator = 1 - 1 / U
+    expected_p = (
+        (numerator / (1 - Decimal(expected_taint_batch_1)))
+        * (numerator / (1 - Decimal(expected_taint_batch_2)))
+        * ((numerator / 1) ** (len(sample_results) - 2))
+    )
+    assert computed_p == float(expected_p)
+    assert res is (expected_p < ALPHA)
+
+
+def test_combined_batches_sampled_and_unsampled():
+    contest_data = {
+        "winner": 120,
+        "loser": 80,
+        "third": 50,
+        "ballots": 250,
+        "numWinners": 1,
+        "votesAllowed": 1,
+    }
+    contest = Contest("Combined Batches Contest", contest_data)
+
+    batches = {}
+    batches["Batch 1"] = {
+        contest.name: {
+            "winner": 30,
+            "loser": 20,
+            "third": 0,
+            "ballots": 50,
+        }
+    }
+    batches["Batch 2"] = {
+        contest.name: {
+            "winner": 0,
+            "loser": 40,
+            "third": 10,
+            "ballots": 50,
+        }
+    }
+    batches["Batch 3"] = {
+        contest.name: {
+            "winner": 60,
+            "loser": 10,
+            "third": 30,
+            "ballots": 100,
+        }
+    }
+    batches["Batch 4"] = {
+        contest.name: {
+            "winner": 30,
+            "loser": 10,
+            "third": 10,
+            "ballots": 50,
+        }
+    }
+
+    sample_size = macro.get_sample_sizes(RISK_LIMIT, contest, batches, {}, {}, [])
+    assert sample_size == len(batches)
+
+    discrepancy_votes = 3
+    combined_batch_1_and_4_results = {
+        contest.name: {
+            "winner": batches["Batch 1"][contest.name]["winner"]
+            + batches["Batch 4"][contest.name]["winner"],
+            "loser": batches["Batch 1"][contest.name]["loser"]
+            + batches["Batch 4"][contest.name]["loser"]
+            + discrepancy_votes,
+            "third": batches["Batch 1"][contest.name]["third"]
+            + batches["Batch 4"][contest.name]["third"],
+        }
+    }
+
+    sample_results = {
+        "Batch 1": combined_batch_1_and_4_results,
+        "Batch 2": batches["Batch 2"],
+        "Batch 3": batches["Batch 3"],
+    }
+    sample_ticket_numbers = {
+        "1": "Batch 1",
+        "2": "Batch 2",
+        "3": "Batch 3",
+    }
+    combined_batches = [{"Batch 1", "Batch 4"}]
+
+    computed_p, res = macro.compute_risk(
+        RISK_LIMIT,
+        contest,
+        batches,
+        sample_results,
+        sample_ticket_numbers,
+        combined_batches,
+    )
+    U = macro.compute_U(batches, contest)
+    max_error_batch_1 = (
+        batches["Batch 1"][contest.name]["winner"]
+        - batches["Batch 1"][contest.name]["loser"]
+        + batches["Batch 1"][contest.name]["ballots"]
+    )
+    expected_taint_batch_1 = discrepancy_votes / max_error_batch_1
+    numerator = 1 - 1 / U
+    expected_p = (numerator / (1 - Decimal(expected_taint_batch_1))) * (
+        (numerator / 1) ** (len(sample_results) - 1)
+    )
+    assert computed_p == float(expected_p)
+    assert res is (expected_p < ALPHA)

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -51,6 +51,35 @@ J2,Batch 3,500,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candida
 Totals,,1700,,,candidate 1: 1700; candidate 2: 850; candidate 3: 850,candidate 1: 1700; candidate 2: 850; candidate 3: 850,,\r
 """
 
+snapshots[
+    "test_batch_comparison_combined_batches 1"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+Test Org test_batch_comparison_combined_batches,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
+Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_batch_comparison_combined_batches,BATCH_COMPARISON,MACRO,10%,1234567890,No\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
+1,Contest 1,Targeted,7,Yes,0.0842250678,DATETIME,DATETIME,candidate 1: 2200; candidate 2: 1095; candidate 3: 1105,3,2200,candidate 1: 2200; candidate 2: 1100; candidate 3: 1100\r
+\r
+######## SAMPLED BATCHES ########\r
+Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By,Combined Batch\r
+J1,Batch 1,500,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,Combined Batch\r
+J1,Batch 3,500,Round 1: 0.753710009967479876,Yes,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,Combined Batch\r
+J1,Batch 6,100,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,\r
+J1,Batch 8,100,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,\r
+J2,Batch 3,500,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,\r
+J1,Combined Batch,1500,,Yes,candidate 1: 1500; candidate 2: 745; candidate 3: 755,candidate 1: 1500; candidate 2: 750; candidate 3: 750,candidate 2: +5; candidate 3: -5,5,support@example.org,"Combines Batch 1, Batch 2, Batch 3"\r
+Totals,,1700,,,candidate 1: 2200; candidate 2: 1095; candidate 3: 1105,candidate 1: 2200; candidate 2: 1100; candidate 3: 1100,,\r
+"""
+
 snapshots["test_batch_comparison_round_1 1"] = {
     "numSamples": 9,
     "numSamplesAudited": 0,

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -67,7 +67,7 @@ Test Audit test_batch_comparison_combined_batches,BATCH_COMPARISON,MACRO,10%,123
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
-1,Contest 1,Targeted,7,Yes,0.0842250678,DATETIME,DATETIME,candidate 1: 2200; candidate 2: 1095; candidate 3: 1105,3,2200,candidate 1: 2200; candidate 2: 1100; candidate 3: 1100\r
+1,Contest 1,Targeted,7,Yes,0.0555770855,DATETIME,DATETIME,candidate 1: 2200; candidate 2: 1095; candidate 3: 1105,3,2200,candidate 1: 2200; candidate 2: 1100; candidate 3: 1100\r
 \r
 ######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By,Combined Batch\r

--- a/server/tests/batch_comparison/test_support_batch_comparison.py
+++ b/server/tests/batch_comparison/test_support_batch_comparison.py
@@ -33,3 +33,231 @@ def test_support_get_jurisdiction_batch_comparison(
             "recordedResultsAt": None,
         },
     )
+
+
+def test_support_combined_batches(
+    client: FlaskClient,
+    election_id: str,  # pylint: disable=unused-argument
+    jurisdiction_ids: List[str],
+    round_1_id: str,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/contest"
+    )
+    contest = json.loads(rv.data)["contests"][0]
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches"
+    )
+    sampled_batches = json.loads(rv.data)["batches"]
+    all_batches = Batch.query.filter_by(jurisdiction_id=jurisdiction_ids[0]).all()
+
+    # Initially, no combined batches
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+    rv = client.get(f"/api/support/jurisdictions/{jurisdiction_ids[0]}/batches")
+    response = json.loads(rv.data)
+    assert response["batches"] == [
+        dict(
+            id=batch.id,
+            name=batch.name,
+        )
+        for batch in all_batches
+    ]
+    assert response["combinedBatches"] == []
+
+    # Create a combined batch
+    assert sampled_batches[0]["id"] != all_batches[1].id
+    rv = post_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/combined-batches",
+        dict(
+            name="Combined Batch 1",
+            subBatchIds=[sampled_batches[0]["id"], all_batches[1].id],
+        ),
+    )
+    assert_ok(rv)
+
+    # Check that the combined batch is there
+    rv = client.get(f"/api/support/jurisdictions/{jurisdiction_ids[0]}/batches")
+    response = json.loads(rv.data)
+    assert response["combinedBatches"] == [
+        dict(
+            name="Combined Batch 1",
+            subBatches=[
+                dict(
+                    id=sampled_batches[0]["id"],
+                    name=sampled_batches[0]["name"],
+                ),
+                dict(
+                    id=all_batches[1].id,
+                    name=all_batches[1].name,
+                ),
+            ],
+        )
+    ]
+
+    # Record some audit results for the combined batch
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches"
+    )
+    combined_sampled_batches = json.loads(rv.data)["batches"]
+    combined_batch = next(
+        batch
+        for batch in combined_sampled_batches
+        if batch["name"] == "Combined Batch 1"
+    )
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches/{combined_batch['id']}/results",
+        [
+            {
+                "name": "Tally Sheet #1",
+                "results": {choice["id"]: 1 for choice in contest["choices"]},
+            }
+        ],
+    )
+    assert_ok(rv)
+
+    # Create another combined batch
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+    assert sampled_batches[2]["id"] != all_batches[3].id
+    assert sampled_batches[2]["id"] != all_batches[1].id
+    rv = post_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/combined-batches",
+        dict(
+            name="Combined Batch 2",
+            subBatchIds=[sampled_batches[2]["id"], all_batches[3].id],
+        ),
+    )
+
+    # Delete the first combined batch
+    rv = client.delete(
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/combined-batches/{response['combinedBatches'][0]['name']}"
+    )
+    assert_ok(rv)
+
+    # Check that the combined batch is gone
+    rv = client.get(f"/api/support/jurisdictions/{jurisdiction_ids[0]}/batches")
+    response = json.loads(rv.data)
+    assert response["combinedBatches"] == [
+        dict(
+            name="Combined Batch 2",
+            subBatches=[
+                dict(
+                    id=all_batches[3].id,
+                    name=all_batches[3].name,
+                ),
+                dict(
+                    id=sampled_batches[2]["id"],
+                    name=sampled_batches[2]["name"],
+                ),
+            ],
+        )
+    ]
+
+    # The sub batches should have their tallies cleared
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches"
+    )
+    batches = json.loads(rv.data)["batches"]
+    for batch in batches:
+        if batch["id"] in [sampled_batches[0]["id"], all_batches[1].id]:
+            assert batch["resultTallySheets"] == []
+
+
+def test_support_invalid_combined_batches(
+    client: FlaskClient,
+    election_id: str,  # pylint: disable=unused-argument
+    jurisdiction_ids: List[str],
+    round_1_id: str,  # pylint: disable=unused-argument
+):
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+
+    jurisdiction_1_batches = Batch.query.filter_by(
+        jurisdiction_id=jurisdiction_ids[0]
+    ).all()
+    jurisdiction_2_batches = Batch.query.filter_by(
+        jurisdiction_id=jurisdiction_ids[1]
+    ).all()
+
+    # Invalid jurisdiction
+    rv = post_json(
+        client,
+        "/api/support/jurisdictions/not-a-real-jurisdiction/combined-batches",
+    )
+    assert rv.status_code == 404
+
+    # Invalid JSON
+    for invalid_json in [
+        dict(),
+        dict(subBatchIds=[jurisdiction_1_batches[0].id, jurisdiction_1_batches[1].id]),
+        dict(name="Combined Batch 1"),
+        dict(name="Combined Batch 1", subBatchIds=[]),
+        dict(name="Combined Batch 1", subBatchIds=[jurisdiction_1_batches[0].id]),
+        dict(
+            name="",
+            subBatchIds=[jurisdiction_1_batches[0].id, jurisdiction_1_batches[1].id],
+        ),
+    ]:
+        rv = post_json(
+            client,
+            f"/api/support/jurisdictions/{jurisdiction_ids[0]}/combined-batches",
+            invalid_json,
+        )
+        assert rv.status_code == 400
+
+    # Invalid subBatchIds
+    rv = post_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/combined-batches",
+        dict(
+            name="Combined Batch 1",
+            subBatchIds=[jurisdiction_1_batches[0].id, jurisdiction_2_batches[0].id],
+        ),
+    )
+    assert rv.status_code == 400
+
+    # Create one valid combined batch
+    rv = post_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/combined-batches",
+        dict(
+            name="Combined Batch 1",
+            subBatchIds=[jurisdiction_1_batches[0].id, jurisdiction_1_batches[1].id],
+        ),
+    )
+    assert_ok(rv)
+
+    # Can't reuse the same name
+    rv = post_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/combined-batches",
+        dict(
+            name="Combined Batch 1",
+            subBatchIds=[jurisdiction_1_batches[2].id, jurisdiction_1_batches[3].id],
+        ),
+    )
+    assert rv.status_code == 409
+
+    # Can't reuse any of the subBatchIds
+    rv = post_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/combined-batches",
+        dict(
+            name="Combined Batch 2",
+            subBatchIds=[jurisdiction_1_batches[0].id, jurisdiction_1_batches[2].id],
+        ),
+    )
+    assert rv.status_code == 409
+
+    # Can't delete a non-existent combined batch
+    rv = client.delete(
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/combined-batches/non-existent"
+    )
+    assert rv.status_code == 404

--- a/server/tests/batch_comparison/test_support_batch_comparison.py
+++ b/server/tests/batch_comparison/test_support_batch_comparison.py
@@ -182,6 +182,9 @@ def test_support_invalid_combined_batches(
     jurisdiction_1_batches = Batch.query.filter_by(
         jurisdiction_id=jurisdiction_ids[0]
     ).all()
+    unsampled_j1_batches = [
+        batch for batch in jurisdiction_1_batches if len(batch.draws) == 0
+    ]
     jurisdiction_2_batches = Batch.query.filter_by(
         jurisdiction_id=jurisdiction_ids[1]
     ).all()
@@ -222,6 +225,17 @@ def test_support_invalid_combined_batches(
         ),
     )
     assert rv.status_code == 400
+
+    # No sampled batches
+    rv = post_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/combined-batches",
+        dict(
+            name="Combined Batch 1",
+            subBatchIds=[batch.id for batch in unsampled_j1_batches],
+        ),
+    )
+    assert rv.status_code == 409
 
     # Create one valid combined batch
     rv = post_json(


### PR DESCRIPTION
Closes: https://github.com/votingworks/arlo/issues/1932

In batch comparison audits, sometimes auditors discover after launching the audit the some of the sampled batches have been physically commingled such that it's impossible to know which ballots belonged to which batch. This PR adds the ability for Support Users to combine batches after the audit has started to mitigate this issue. A combined batch may consist of both sampled and unsampled batches.

Combined batches will then appear to auditors like any other batch, and the original batches that were combined will be hidden. The audit math is updated to conservatively incorporate these combined batches into the risk measurement calculation. Finally, the discrepancy report and audit reports are updated to include the combined batch (while also showing which original batches were combined to make it).

On the technical side, since this is an edge case, I wanted to implement it in a lightweight way that didn't fundamentally alter the data model and require widespread changes. While it's important to get the math and main flows right, if there are certain places in Arlo that don't take into account combined batches, it's ok.

Thus, I came up with the following approach:
- Tag batches that are combined with a common `combined_batch_name` field
- Pick one representative sampled batch for each combined batch. This batch will be used to store the combined batch audit results. The rest of the batches in the combined batch are given tallies with 0 votes for each candidate. (This means we don't need to create some new entity to represent the "combined batch")

Support Tools interface

https://github.com/user-attachments/assets/23a63617-a2e0-4fad-aec2-88b1e1b35dc2

Jurisdiction auditing interface (unchanged, just shows combined batch)
<img width="1424" alt="Screenshot 2024-10-23 at 11 14 04 AM" src="https://github.com/user-attachments/assets/6fe30dc3-4830-41eb-8afe-eb6444a142bd">
