### PR TITLE
Bump cache version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,10 +103,11 @@ jobs:
           docker_layer_caching: true
       - python/install-packages:
           pkg-manager: poetry
+          cache-version: v2
       - node/install-packages:
           pkg-manager: yarn
           app-dir: client
-          cache-version: v4
+          cache-version: v3
           # In order to cache the Cypress binary, we have to cache
           # ~/.cache/Cypress (alongside the default caching of ~/.cache/yarn).
           # So we just cache all of ~/.cache.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
           app-dir: client
-          cache-version: v3
+          cache-version: v4
           # In order to cache the Cypress binary, we have to cache
           # ~/.cache/Cypress (alongside the default caching of ~/.cache/yarn).
           # So we just cache all of ~/.cache.


### PR DESCRIPTION
Seeing issues with `main` branch failing after upgrading dependencies. Thinking that is a caching issue, so before downgrading `sentry-sdk` in [this PR ](https://github.com/votingworks/arlo/pull/2001), will attempt to fix it using this approach. 