### PR TITLE
Bump cache-version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,11 +103,10 @@ jobs:
           docker_layer_caching: true
       - python/install-packages:
           pkg-manager: poetry
-          cache-version: v2
       - node/install-packages:
           pkg-manager: yarn
           app-dir: client
-          cache-version: v3
+          cache-version: v4
           # In order to cache the Cypress binary, we have to cache
           # ~/.cache/Cypress (alongside the default caching of ~/.cache/yarn).
           # So we just cache all of ~/.cache.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
           docker_layer_caching: true
       - python/install-packages:
           pkg-manager: poetry
+          cache-version: v2
       - node/install-packages:
           pkg-manager: yarn
           app-dir: client


### PR DESCRIPTION
Follow up to https://github.com/votingworks/arlo/pull/2002 which didn't fix the issue. Maybe since we are caching all of ~./cache, that is also caching the poetry deps even though that ideally should be separated out. 