### PR TITLE
Add dependencies that are required to build psycog2-binary on some VMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PATH := $(PATH):$(HOME)/.local/bin
 
 deps:
 	sudo apt update
-	sudo apt install -y python3.9 python3.9-venv libpython3.9-dev libpq-dev graphicsmagick
+	sudo apt install -y python3.9 python3.9-venv libpython3.9-dev libpq-dev graphicsmagick gcc python-dev
 	# Install node: https://github.com/nodesource/distributions/blob/master/README.md#deb		
 	curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 	sudo apt-get install -y nodejs


### PR DESCRIPTION
We've now seen multiple cases where installing `gcc` and `python-dev` allow for the `psycog2-binary` to properly build, so it seems worth adding to our `deps` command.

To test, I created a fresh VM and was able to run `make deps` successfully without any additional commands, while previously I would run into the `psycog2-binary` issue on each VM I created.

As a follow up task, I'm thinking the `Makefile` might benefit from a bit of a reorganization, but will limit this PR to this change since it is impeding some people's setup.