### PR TITLE
Improve batch computations

### DIFF
--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -150,6 +150,7 @@ def sample_size_options(election: Election) -> Dict[str, Dict[str, SampleSizeOpt
                 sampler_contest.from_db_contest(contest),
                 rounds.batch_tallies(contest),
                 rounds.sampled_batch_results(contest),
+                rounds.sampled_batches_by_ticket_number(contest),
             )
             return {"macro": {"key": "macro", "size": sample_size, "prob": None}}
 

--- a/server/audit_math/sampler.py
+++ b/server/audit_math/sampler.py
@@ -117,7 +117,7 @@ def draw_ppeb_sample(
     int_seed = int(consistent_sampler.sha256_hex(seed), 16)  # type: ignore
     generator = default_rng(int_seed)
 
-    U = macro.compute_U(batch_results, cast(Dict, {}), contest)
+    U = macro.compute_U(batch_results, contest)
 
     # Should only be possible if the specified contest isn't in any batches
     if U == 0:

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -39,7 +39,7 @@ Test Audit test_batch_comparison_batches_sampled_multiple_times,BATCH_COMPARISON
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
-1,Contest 1,Targeted,7,Yes,0.0825517715,DATETIME,DATETIME,candidate 1: 1700; candidate 2: 850; candidate 3: 850,5,1700,candidate 1: 1700; candidate 2: 850; candidate 3: 850\r
+1,Contest 1,Targeted,7,Yes,0.0544729376,DATETIME,DATETIME,candidate 1: 1700; candidate 2: 850; candidate 3: 850,5,1700,candidate 1: 1700; candidate 2: 850; candidate 3: 850\r
 \r
 ######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By\r
@@ -76,7 +76,7 @@ snapshots["test_batch_comparison_round_2 1"] = {
 }
 
 snapshots["test_batch_comparison_round_2 10"] = {
-    "numSamples": 2,
+    "numSamples": 1,
     "numSamplesAudited": 0,
     "numUnique": 1,
     "numUniqueAudited": 0,
@@ -106,17 +106,17 @@ Test Audit test_batch_comparison_round_2,BATCH_COMPARISON,MACRO,10%,1234567890,N
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
 1,Contest 1,Targeted,7,No,0.1225641097,DATETIME,DATETIME,candidate 1: 1100; candidate 2: 300; candidate 3: 200,5,1700,candidate 1: 1700; candidate 2: 850; candidate 3: 850\r
-2,Contest 1,Targeted,5,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0,3,1500,candidate 1: 1500; candidate 2: 750; candidate 3: 750\r
+2,Contest 1,Targeted,2,No,,DATETIME,,candidate 1: 0; candidate 2: 0; candidate 3: 0,2,1000,candidate 1: 1000; candidate 2: 500; candidate 3: 500\r
 \r
 ######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By\r
 J1,Batch 1,500,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
-J1,Batch 3,500,"Round 1: 0.753710009967479876, Round 2: 0.816608705419077476",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
+J1,Batch 3,500,Round 1: 0.753710009967479876,Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,100,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,100,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J2,Batch 3,500,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 100; candidate 2: 100; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +400; candidate 2: +150; candidate 3: +210,250,jurisdiction.admin-UUID@example.com\r
-J1,Batch 4,500,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
-J2,Batch 4,500,"Round 2: 0.608147659546583410, 0.868820918994249069",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
+J1,Batch 4,500,Round 2: 0.9553762217707628661,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
+J2,Batch 4,500,Round 2: 0.608147659546583410,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
 Totals,,2700,,,candidate 1: 1100; candidate 2: 300; candidate 3: 200,candidate 1: 2700; candidate 2: 1350; candidate 3: 1350,,\r
 """
 
@@ -125,10 +125,10 @@ snapshots[
 ] = """######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By\r
 J1,Batch 1,500,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
-J1,Batch 3,500,"Round 1: 0.753710009967479876, Round 2: 0.816608705419077476",Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
+J1,Batch 3,500,Round 1: 0.753710009967479876,Yes,candidate 1: 400; candidate 2: 50; candidate 3: 40,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: +100; candidate 2: +200; candidate 3: +210,-100,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,100,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,100,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 40,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 3: +10,-10,jurisdiction.admin-UUID@example.com\r
-J1,Batch 4,500,"Round 2: 0.9553762217707628661, 0.9782132493451071914",No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
+J1,Batch 4,500,Round 2: 0.9553762217707628661,No,,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,\r
 Totals,,1700,,,candidate 1: 1000; candidate 2: 200; candidate 3: 160,candidate 1: 1700; candidate 2: 850; candidate 3: 850,,\r
 """
 
@@ -189,11 +189,11 @@ snapshots["test_batch_comparison_round_2 8"] = {
 }
 
 snapshots["test_batch_comparison_round_2 9"] = {
-    "numSamples": 3,
-    "numSamplesAudited": 1,
-    "numUnique": 2,
-    "numUniqueAudited": 1,
-    "status": "IN_PROGRESS",
+    "numSamples": 1,
+    "numSamplesAudited": 0,
+    "numUnique": 1,
+    "numUniqueAudited": 0,
+    "status": "NOT_STARTED",
 }
 
 snapshots["test_batch_comparison_sample_preview 1"] = [

--- a/server/tests/batch_comparison/snapshots/snap_test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_multi_contest_batch_comparison.py
@@ -72,8 +72,8 @@ Test Audit test_multi_contest_batch_comparison_end_to_end,BATCH_COMPARISON,MACRO
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
-1,Contest 1,Targeted,10,Yes,0.0771277137,DATETIME,DATETIME,Candidate 1: 500; Candidate 2: 52,9,900,Candidate 1: 500; Candidate 2: 50\r
-1,Contest 2,Targeted,8,Yes,0.096146459,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25,9,900,Candidate 3: 325; Candidate 4: 25\r
+1,Contest 1,Targeted,10,Yes,0.0586274851,DATETIME,DATETIME,Candidate 1: 500; Candidate 2: 52,9,900,Candidate 1: 500; Candidate 2: 50\r
+1,Contest 2,Targeted,8,Yes,0.0696040967,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25,9,900,Candidate 3: 325; Candidate 4: 25\r
 \r
 ######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Ticket Numbers: Contest 2,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Results: Contest 2,Reported Results: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2,Last Edited By\r
@@ -106,8 +106,8 @@ Test Audit test_multi_contest_batch_comparison_round_2,BATCH_COMPARISON,MACRO,10
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
-1,Contest 1,Targeted,10,No,0.1689405441,DATETIME,DATETIME,Candidate 1: 450; Candidate 2: 100,9,900,Candidate 1: 500; Candidate 2: 50\r
-1,Contest 2,Targeted,8,Yes,0.0948645062,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25,9,900,Candidate 3: 325; Candidate 4: 25\r
+1,Contest 1,Targeted,10,No,0.3378810883,DATETIME,DATETIME,Candidate 1: 450; Candidate 2: 125,9,900,Candidate 1: 500; Candidate 2: 50\r
+1,Contest 2,Targeted,8,Yes,0.0677603615,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25,9,900,Candidate 3: 325; Candidate 4: 25\r
 \r
 ######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Ticket Numbers: Contest 2,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Results: Contest 2,Reported Results: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2,Last Edited By\r
@@ -116,11 +116,11 @@ J1,Batch 2,100,"Round 1: 0.474971525750860236, 0.555845039101209884",,Yes,Candid
 J1,Batch 3,100,,Round 1: 0.753710009967479876,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 5,100,"Round 1: 0.384177151866437890, 0.470460412141498108","Round 1: 0.384177151866437890, 0.470460412141498108",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,100,"Round 1: 0.899217854763070950, 0.9233199163410086672",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
-J1,Batch 7,100,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 0; Candidate 2: 50,Candidate 1: 50; Candidate 2: 0,Candidate 1: +50; Candidate 2: -50,100,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 7,100,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 0; Candidate 2: 75,Candidate 1: 50; Candidate 2: 0,Candidate 1: +50; Candidate 2: -75,125,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 9,100,,Round 1: 0.734926612730309894,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 25; Candidate 4: 25,Candidate 3: 25; Candidate 4: 25,,,jurisdiction.admin-UUID@example.com\r
 J2,Batch 1,100,"Round 1: 0.562697240648997100, 0.9008218268717084008",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
 J3,Batch 1,100,Round 1: 0.544165663445275136,,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
-Totals,,900,,,,Candidate 1: 450; Candidate 2: 100,Candidate 1: 500; Candidate 2: 50,,,Candidate 3: 325; Candidate 4: 25,Candidate 3: 325; Candidate 4: 25,,\r
+Totals,,900,,,,Candidate 1: 450; Candidate 2: 125,Candidate 1: 500; Candidate 2: 50,,,Candidate 3: 325; Candidate 4: 25,Candidate 3: 325; Candidate 4: 25,,\r
 """
 
 snapshots[
@@ -140,8 +140,8 @@ Test Audit test_multi_contest_batch_comparison_round_2,BATCH_COMPARISON,MACRO,10
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
-1,Contest 1,Targeted,10,No,0.1689405441,DATETIME,DATETIME,Candidate 1: 450; Candidate 2: 100,9,900,Candidate 1: 500; Candidate 2: 50\r
-1,Contest 2,Targeted,8,Yes,0.0948645062,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25,9,900,Candidate 3: 325; Candidate 4: 25\r
+1,Contest 1,Targeted,10,No,0.3378810883,DATETIME,DATETIME,Candidate 1: 450; Candidate 2: 125,9,900,Candidate 1: 500; Candidate 2: 50\r
+1,Contest 2,Targeted,8,Yes,0.0677603615,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25,9,900,Candidate 3: 325; Candidate 4: 25\r
 2,Contest 1,Targeted,6,No,,DATETIME,,Candidate 1: 0; Candidate 2: 0,6,600,Candidate 1: 350; Candidate 2: 50\r
 \r
 ######## SAMPLED BATCHES ########\r
@@ -151,12 +151,12 @@ J1,Batch 2,100,"Round 1: 0.474971525750860236, 0.555845039101209884",,Yes,Candid
 J1,Batch 3,100,Round 2: 0.753710009967479876,Round 1: 0.753710009967479876,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 5,100,"Round 1: 0.384177151866437890, 0.470460412141498108","Round 1: 0.384177151866437890, 0.470460412141498108",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,100,"Round 1: 0.899217854763070950, 0.9233199163410086672, Round 2: 0.9773691435537901980",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
-J1,Batch 7,100,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 0; Candidate 2: 50,Candidate 1: 50; Candidate 2: 0,Candidate 1: +50; Candidate 2: -50,100,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 7,100,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 0; Candidate 2: 75,Candidate 1: 50; Candidate 2: 0,Candidate 1: +50; Candidate 2: -75,125,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 9,100,,Round 1: 0.734926612730309894,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 25; Candidate 4: 25,Candidate 3: 25; Candidate 4: 25,,,jurisdiction.admin-UUID@example.com\r
 J2,Batch 1,100,"Round 1: 0.562697240648997100, 0.9008218268717084008, Round 2: 0.9809620734120025512",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
 J3,Batch 1,100,"Round 1: 0.544165663445275136, Round 2: 0.651158228740912018",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,100,Round 2: 0.9723790677174592551,,No,,Candidate 1: 50; Candidate 2: 0,,,,Candidate 3: 50; Candidate 4: 0,,,\r
-Totals,,1000,,,,Candidate 1: 450; Candidate 2: 100,Candidate 1: 550; Candidate 2: 50,,,Candidate 3: 325; Candidate 4: 25,Candidate 3: 375; Candidate 4: 25,,\r
+Totals,,1000,,,,Candidate 1: 450; Candidate 2: 125,Candidate 1: 550; Candidate 2: 50,,,Candidate 3: 325; Candidate 4: 25,Candidate 3: 375; Candidate 4: 25,,\r
 """
 
 snapshots[
@@ -176,9 +176,9 @@ Test Audit test_multi_contest_batch_comparison_round_2,BATCH_COMPARISON,MACRO,10
 \r
 ######## ROUNDS ########\r
 Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
-1,Contest 1,Targeted,10,No,0.1689405441,DATETIME,DATETIME,Candidate 1: 450; Candidate 2: 100,9,900,Candidate 1: 500; Candidate 2: 50\r
-1,Contest 2,Targeted,8,Yes,0.0948645062,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25,9,900,Candidate 3: 325; Candidate 4: 25\r
-2,Contest 1,Targeted,6,Yes,0.0750846863,DATETIME,DATETIME,Candidate 1: 350; Candidate 2: 50,6,600,Candidate 1: 350; Candidate 2: 50\r
+1,Contest 1,Targeted,10,No,0.3378810883,DATETIME,DATETIME,Candidate 1: 450; Candidate 2: 125,9,900,Candidate 1: 500; Candidate 2: 50\r
+1,Contest 2,Targeted,8,Yes,0.0677603615,DATETIME,DATETIME,Candidate 3: 325; Candidate 4: 25,9,900,Candidate 3: 325; Candidate 4: 25\r
+2,Contest 1,Targeted,6,Yes,0.0601355745,DATETIME,DATETIME,Candidate 1: 350; Candidate 2: 50,6,600,Candidate 1: 350; Candidate 2: 50\r
 \r
 ######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Ticket Numbers: Contest 2,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Audit Results: Contest 2,Reported Results: Contest 2,Change in Results: Contest 2,Change in Margin: Contest 2,Last Edited By\r
@@ -187,10 +187,10 @@ J1,Batch 2,100,"Round 1: 0.474971525750860236, 0.555845039101209884",,Yes,Candid
 J1,Batch 3,100,Round 2: 0.753710009967479876,Round 1: 0.753710009967479876,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 5,100,"Round 1: 0.384177151866437890, 0.470460412141498108","Round 1: 0.384177151866437890, 0.470460412141498108",Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 6,100,"Round 1: 0.899217854763070950, 0.9233199163410086672, Round 2: 0.9773691435537901980",,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
-J1,Batch 7,100,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 0; Candidate 2: 50,Candidate 1: 50; Candidate 2: 0,Candidate 1: +50; Candidate 2: -50,100,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 7,100,Round 1: 0.817464900879746084,"Round 1: 0.817464900879746084, 0.864505270651837742",Yes,Candidate 1: 0; Candidate 2: 75,Candidate 1: 50; Candidate 2: 0,Candidate 1: +50; Candidate 2: -75,125,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 9,100,,Round 1: 0.734926612730309894,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 25; Candidate 4: 25,Candidate 3: 25; Candidate 4: 25,,,jurisdiction.admin-UUID@example.com\r
 J2,Batch 1,100,"Round 1: 0.562697240648997100, 0.9008218268717084008, Round 2: 0.9809620734120025512",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
 J3,Batch 1,100,"Round 1: 0.544165663445275136, Round 2: 0.651158228740912018",,Yes,Candidate 1: 75; Candidate 2: 25,Candidate 1: 75; Candidate 2: 25,,,,,,,jurisdiction.admin-UUID@example.com\r
 J1,Batch 8,100,Round 2: 0.9723790677174592551,,Yes,Candidate 1: 50; Candidate 2: 0,Candidate 1: 50; Candidate 2: 0,,,Candidate 3: 50; Candidate 4: 0,Candidate 3: 50; Candidate 4: 0,,,jurisdiction.admin-UUID@example.com\r
-Totals,,1000,,,,Candidate 1: 500; Candidate 2: 100,Candidate 1: 550; Candidate 2: 50,,,Candidate 3: 375; Candidate 4: 25,Candidate 3: 375; Candidate 4: 25,,\r
+Totals,,1000,,,,Candidate 1: 500; Candidate 2: 125,Candidate 1: 550; Candidate 2: 50,,,Candidate 3: 375; Candidate 4: 25,Candidate 3: 375; Candidate 4: 25,,\r
 """

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -55,6 +55,7 @@ def test_batch_comparison_sample_size(
     rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     sample_size_options = json.loads(rv.data)["sampleSizes"]
+    print("SSO:", sample_size_options)
     assert len(sample_size_options) == 1
     snapshot.assert_match(sample_size_options[contest_id])
 
@@ -443,7 +444,7 @@ def test_batch_comparison_round_2(
 
     # Check that we automatically select the sample size
     batch_draws = SampledBatchDraw.query.filter_by(round_id=rounds[1]["id"]).all()
-    assert len(batch_draws) == 5
+    assert len(batch_draws) == 2
 
     # Check that we're sampling batches from the jurisdiction that uploaded manifests
     sampled_jurisdictions = {draw.batch.jurisdiction_id for draw in batch_draws}

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -55,7 +55,6 @@ def test_batch_comparison_sample_size(
     rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
     assert rv.status_code == 200
     sample_size_options = json.loads(rv.data)["sampleSizes"]
-    print("SSO:", sample_size_options)
     assert len(sample_size_options) == 1
     snapshot.assert_match(sample_size_options[contest_id])
 

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -952,7 +952,6 @@ def test_multi_contest_batch_comparison_round_2(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/batches"
     )
     jurisdiction_1_batches = json.loads(rv.data)["batches"]
-    # print ("J1:", [batch["name"] for batch in jurisdiction_1_batches])
     assert [batch["name"] for batch in jurisdiction_1_batches] == ["Batch 8"]
 
     set_logged_in_user(

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -814,7 +814,7 @@ def test_multi_contest_batch_comparison_round_2(
         jurisdiction_1_batches[5]["id"]: [
             {
                 contest_1_choice_ids[0]: 0,
-                contest_1_choice_ids[1]: 50,
+                contest_1_choice_ids[1]: 75,
                 contest_2_choice_ids[0]: 50,
                 contest_2_choice_ids[1]: 0,
             }
@@ -952,6 +952,7 @@ def test_multi_contest_batch_comparison_round_2(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_2_id}/batches"
     )
     jurisdiction_1_batches = json.loads(rv.data)["batches"]
+    # print ("J1:", [batch["name"] for batch in jurisdiction_1_batches])
     assert [batch["name"] for batch in jurisdiction_1_batches] == ["Batch 8"]
 
     set_logged_in_user(
@@ -986,6 +987,7 @@ def test_multi_contest_batch_comparison_round_2(
         # Batch 8 (with no discrepancies)
         jurisdiction_1_batches[0]["id"]: [reported_results_for_batches_1_through_8],
     }
+
     for batch_id, results in jurisdiction_1_batch_results.items():
         rv = put_batch_results(
             client, election_id, jurisdiction_ids[0], round_2_id, batch_id, results


### PR DESCRIPTION
Primarily this addresses #1857. Sample size calculations after round 1 should take the cumulative measured risk (p-value) into account; U does not change. 

Secondarily, compute_risk was set to terminate as soon as the risk limit was reached. That's valid, but tends to produce inflated p-values in many use cases. In discussion with @ginvdr we agreed that a good conservative approach is to use all the data from the RLA sample for the contest. (In principle it is legitimate to use the sequential minimum, which might be less if a batch late in the sample sequence has large discrepancies -- but that seems too clever.)