### PR TITLE
CircleCI: Cache Cypress separately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,15 +103,19 @@ jobs:
           docker_layer_caching: true
       - python/install-packages:
           pkg-manager: poetry
-          cache-version: v2
+          cache-version: v5
       - node/install-packages:
           pkg-manager: yarn
           app-dir: client
-          cache-version: v4
-          # In order to cache the Cypress binary, we have to cache
-          # ~/.cache/Cypress (alongside the default caching of ~/.cache/yarn).
-          # So we just cache all of ~/.cache.
-          cache-path: ~/.cache
+          cache-version: v5
+      - restore_cache:
+          name: "Restoring Cypress cache"
+          key: v1-cypress-cache-{{ checksum "client/yarn.lock" }}
+      - save_cache:
+          name: "Saving Cypress cache"
+          key: v1-cypress-cache-{{ checksum "client/yarn.lock" }}
+          paths:
+            - ~/.cache/Cypress
       - browser-tools/install-chrome
       - create-data-model
       - run:


### PR DESCRIPTION
Previously, we were caching Cypress by including all of `~/.cache` in the node cache, which only updates when `client/yarn.lock` changes. We hypothesize that since `~/.cache` also included cached Python dependencies, changes to the Python dependencies would be overriden by this cache. To fix this, we cache Cypress separately and restore the original behavior of the node cache (only caching node deps).

To be safe, I updated the cache version for all the existing caches.