### PR TITLE
Support large(r) file uploads by directly uploading to S3

### DIFF
--- a/client/src/components/Atoms/CSVForm.tsx
+++ b/client/src/components/Atoms/CSVForm.tsx
@@ -15,7 +15,6 @@ import { CvrFileType, IFileInfo, FileProcessingStatus } from '../useCSV'
 import FormWrapper from './Form/FormWrapper'
 import { FormSectionDescription } from './Form/FormSection'
 import { ErrorLabel, SuccessLabel } from './Form/_helpers'
-import { sum } from '../../utils/number'
 import FormButton from './Form/FormButton'
 import AsyncButton from './AsyncButton'
 
@@ -30,13 +29,13 @@ const schema = Yup.object().shape({
 })
 
 interface IValues {
-  csv: File[] | null
+  csv: File | null
   cvrFileType?: CvrFileType
 }
 
 interface IProps {
   csvFile: IFileInfo
-  uploadCSVFiles: (csvs: File[], cvrFileType?: CvrFileType) => Promise<boolean>
+  uploadCSVFile: (csv: File, cvrFileType?: CvrFileType) => Promise<boolean>
   deleteCSVFile?: () => Promise<boolean>
   title?: string
   description: string
@@ -47,7 +46,7 @@ interface IProps {
 
 const CSVFile: React.FC<IProps> = ({
   csvFile,
-  uploadCSVFiles,
+  uploadCSVFile,
   deleteCSVFile,
   title,
   description,
@@ -62,7 +61,7 @@ const CSVFile: React.FC<IProps> = ({
   return (
     <Formik
       initialValues={{
-        csv: isProcessing ? [new File([], file!.name)] : null,
+        csv: isProcessing ? new File([], file!.name) : null,
         cvrFileType: showCvrFileType
           ? file
             ? file.cvrFileType
@@ -74,7 +73,7 @@ const CSVFile: React.FC<IProps> = ({
       validateOnBlur={false}
       onSubmit={async (values: IValues) => {
         if (values.csv) {
-          await uploadCSVFiles(values.csv, values.cvrFileType)
+          await uploadCSVFile(values.csv, values.cvrFileType)
           setIsEditing(false)
         }
       }}
@@ -127,13 +126,12 @@ const CSVFile: React.FC<IProps> = ({
                           ? '.zip'
                           : '.csv',
                       name: 'csv',
-                      multiple: false,
                     }}
                     onInputChange={e => {
                       const { files } = e.currentTarget
                       setFieldValue(
                         'csv',
-                        files && files.length > 0 ? Array.from(files) : null
+                        files && files.length === 1 ? files[0] : null
                       )
                     }}
                     hasSelection={!!values.csv}
@@ -141,8 +139,7 @@ const CSVFile: React.FC<IProps> = ({
                       if (!values.csv) {
                         return 'Select a file...'
                       }
-                      if (values.csv.length === 1) return values.csv[0].name
-                      return `${values.csv.length} files selected`
+                      return values.csv.name
                     })()}
                     onBlur={handleBlur}
                     disabled={isSubmitting || isProcessing || !enabled}
@@ -178,7 +175,7 @@ const CSVFile: React.FC<IProps> = ({
                     {upload &&
                       // Only show upload progress for large sets of files (over 1 MB),
                       // otherwise it will just flash on the screen
-                      sum(upload.files.map(f => f.size)) >= 1000 * 1000 && (
+                      upload.file.size >= 1000 * 1000 && (
                         <>
                           <span style={{ marginRight: '5px' }}>
                             Uploading...

--- a/client/src/components/Atoms/CSVForm.tsx
+++ b/client/src/components/Atoms/CSVForm.tsx
@@ -117,16 +117,17 @@ const CSVFile: React.FC<IProps> = ({
                   <FileInput
                     inputProps={{
                       // While this component is named CSVFile, it can accept zip files in the case
-                      // of Hart CVRs
+                      // of Hart and ESS CVRs
                       // TODO: Consider renaming the component and its internals accordingly
                       accept:
-                        values.cvrFileType === CvrFileType.HART
-                          ? '.zip,.csv'
+                        values.cvrFileType &&
+                        [CvrFileType.HART, CvrFileType.ESS].includes(
+                          values.cvrFileType
+                        )
+                          ? '.zip'
                           : '.csv',
                       name: 'csv',
-                      multiple:
-                        values.cvrFileType === CvrFileType.ESS ||
-                        values.cvrFileType === CvrFileType.HART,
+                      multiple: false,
                     }}
                     onInputChange={e => {
                       const { files } = e.currentTarget
@@ -138,10 +139,7 @@ const CSVFile: React.FC<IProps> = ({
                     hasSelection={!!values.csv}
                     text={(() => {
                       if (!values.csv) {
-                        return values.cvrFileType === CvrFileType.ESS ||
-                          values.cvrFileType === CvrFileType.HART
-                          ? 'Select files...'
-                          : 'Select a file...'
+                        return 'Select a file...'
                       }
                       if (values.csv.length === 1) return values.csv[0].name
                       return `${values.csv.length} files selected`

--- a/client/src/components/Atoms/FileUpload.test.tsx
+++ b/client/src/components/Atoms/FileUpload.test.tsx
@@ -36,11 +36,7 @@ const TestFileUpload = ({
   const fileUpload: IFileUpload = {
     uploadedFile,
     uploadFiles: files => {
-      const formData = new FormData()
-      for (const file of files) {
-        formData.append('files', file, file.name)
-      }
-      return uploadFiles.mutateAsync(formData)
+      return uploadFiles.mutateAsync({ file: files[0] })
     },
     uploadProgress: uploadFiles.progress,
     deleteFile: () => deleteFile.mutateAsync(),

--- a/client/src/components/Atoms/FileUpload.test.tsx
+++ b/client/src/components/Atoms/FileUpload.test.tsx
@@ -68,10 +68,11 @@ uploadFormData.append('otherField', 'canBePassedThrough')
 uploadFormData.append('Content-Type', testFile.type)
 uploadFormData.append('file', testFile, testFile.name)
 
-const uploadCompleteFormData = new FormData()
-uploadCompleteFormData.append('fileName', testFile.name)
-uploadCompleteFormData.append('fileType', testFile.type)
-uploadCompleteFormData.append('storagePathKey', 'path/to/file/file.csv')
+const uploadCompleteJSONData = {
+  fileName: testFile.name,
+  fileType: testFile.type,
+  storagePathKey: 'path/to/file/file.csv',
+}
 
 const getUploadUrlMock = {
   url: '/test/file-upload',
@@ -100,7 +101,11 @@ describe('FileUpload + useFileUpload', () => {
       },
       {
         url: '/test/upload-complete',
-        options: { method: 'POST', body: uploadCompleteFormData },
+        options: {
+          method: 'POST',
+          body: (uploadCompleteJSONData as unknown) as BodyInit,
+          headers: { 'Content-Type': 'application/json' },
+        },
         response: { status: 'ok' },
       },
       { url: '/test', response: fileInfoMocks.processing },
@@ -177,7 +182,11 @@ describe('FileUpload + useFileUpload', () => {
       },
       {
         url: '/test/upload-complete',
-        options: { method: 'POST', body: uploadCompleteFormData },
+        options: {
+          method: 'POST',
+          body: (uploadCompleteJSONData as unknown) as BodyInit,
+          headers: { 'Content-Type': 'application/json' },
+        },
         response: { status: 'ok' },
       },
       { url: '/test', response: fileInfoMocks.errored },
@@ -227,7 +236,11 @@ describe('FileUpload + useFileUpload', () => {
       },
       {
         url: '/test/upload-complete',
-        options: { method: 'POST', body: uploadCompleteFormData },
+        options: {
+          method: 'POST',
+          body: (uploadCompleteJSONData as unknown) as BodyInit,
+          headers: { 'Content-Type': 'application/json' },
+        },
         response: { status: 'ok' },
       },
       { url: '/test', response: fileInfoMocks.processed },
@@ -363,7 +376,8 @@ describe('FileUpload + useFileUpload', () => {
         url: '/test/upload-complete',
         options: {
           method: 'POST',
-          body: uploadCompleteFormData,
+          body: (uploadCompleteJSONData as unknown) as BodyInit,
+          headers: { 'Content-Type': 'application/json' },
         },
       }),
     ]

--- a/client/src/components/AuditAdmin/AuditAdminView.test.tsx
+++ b/client/src/components/AuditAdmin/AuditAdminView.test.tsx
@@ -127,7 +127,9 @@ describe('AA setup flow', () => {
       aaApiCalls.getContests(contestMocks.filledTargeted),
       aaApiCalls.getSettings(auditSettingsMocks.all),
       aaApiCalls.getJurisdictionFileWithResponse(jurisdictionFileMocks.empty),
-      aaApiCalls.putJurisdictionFile,
+      aaApiCalls.uploadJurisdictionFileGetUrl,
+      aaApiCalls.uploadJurisdictionFilePostFile,
+      aaApiCalls.uploadJurisdictionFileUploadComplete,
       aaApiCalls.getJurisdictionFileWithResponse(
         jurisdictionFileMocks.processed
       ),
@@ -160,7 +162,9 @@ describe('AA setup flow', () => {
       aaApiCalls.getContests(contestMocks.filledTargeted),
       aaApiCalls.getSettings(auditSettingsMocks.all),
       aaApiCalls.getJurisdictionFileWithResponse(jurisdictionFileMocks.empty),
-      aaApiCalls.putJurisdictionErrorFile,
+      aaApiCalls.uploadJurisdictionFileGetUrl,
+      aaApiCalls.uploadJurisdictionFilePostFile,
+      aaApiCalls.uploadJurisdictionFileUploadCompleteError,
       aaApiCalls.getJurisdictionFileWithResponse(jurisdictionFileMocks.errored),
       aaApiCalls.getJurisdictions,
     ]
@@ -197,7 +201,9 @@ describe('AA setup flow', () => {
       aaApiCalls.getStandardizedContestsFileWithResponse(
         standardizedContestsFileMocks.empty
       ),
-      aaApiCalls.putStandardizedContestsFile,
+      aaApiCalls.uploadStandardizedContestsFileGetUrl,
+      aaApiCalls.uploadStandardizedContestsFilePostFile,
+      aaApiCalls.uploadStandardizedContestsFileUploadComplete,
       aaApiCalls.getStandardizedContestsFileWithResponse(
         standardizedContestsFileMocks.processed
       ),
@@ -320,7 +326,7 @@ describe('AA setup flow', () => {
       aaApiCalls.getSettings(auditSettingsMocks.all),
       aaApiCalls.getMapData,
       jaApiCalls.getBallotManifestFile(manifestMocks.empty),
-      jaApiCalls.putManifest,
+      ...jaApiCalls.uploadManifestCalls,
       jaApiCalls.getBallotManifestFile(manifestMocks.processed),
       {
         ...aaApiCalls.getJurisdictions,

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
@@ -165,10 +165,7 @@ const CvrsFileUpload = ({
         acceptFileTypes={
           selectedCvrFileType === CvrFileType.HART ? ['zip', 'csv'] : ['csv']
         }
-        allowMultipleFiles={
-          selectedCvrFileType === CvrFileType.ESS ||
-          selectedCvrFileType === CvrFileType.HART
-        }
+        allowMultipleFiles={false}
         uploadDisabled={uploadDisabled || (!cvrs.file && !selectedCvrFileType)}
         deleteDisabled={deleteDisabled}
         additionalFields={

--- a/client/src/components/AuditAdmin/Setup/Participants/Participants.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Participants/Participants.test.tsx
@@ -8,7 +8,7 @@ import { withMockFetch, createQueryClient } from '../../../testUtilities'
 import { IFileInfo, FileProcessingStatus } from '../../../useCSV'
 import {
   getMockFormDataForFileUpload,
-  getMockFormDataForUploadComplete,
+  getMockJsonDataForUploadComplete,
 } from '../../../_mocks'
 
 jest.mock('axios')
@@ -101,7 +101,8 @@ const apiCalls = {
         url: '/api/election/1/jurisdiction/file/upload-complete',
         options: {
           method: 'POST',
-          body: getMockFormDataForUploadComplete(file),
+          body: getMockJsonDataForUploadComplete(file),
+          headers: { 'Content-Type': 'application/json' },
         },
         response: { status: 'ok' },
       },
@@ -129,7 +130,8 @@ const apiCalls = {
         url: '/api/election/1/standardized-contests/file/upload-complete',
         options: {
           method: 'POST',
-          body: getMockFormDataForUploadComplete(file),
+          body: getMockJsonDataForUploadComplete(file),
+          headers: { 'Content-Type': 'application/json' },
         },
         response: { status: 'ok' },
       },

--- a/client/src/components/AuditAdmin/Setup/Participants/Participants.tsx
+++ b/client/src/components/AuditAdmin/Setup/Participants/Participants.tsx
@@ -47,8 +47,8 @@ const Participants: React.FC<IParticipantsProps> = ({
     >
       <CSVFile
         csvFile={jurisdictionsFileUpload.uploadedFile.data}
-        uploadCSVFiles={async files => {
-          await jurisdictionsFileUpload.uploadFiles(files)
+        uploadCSVFile={async file => {
+          await jurisdictionsFileUpload.uploadFiles([file])
           return true
         }}
         title={
@@ -64,8 +64,8 @@ const Participants: React.FC<IParticipantsProps> = ({
         <div style={{ marginTop: '30px' }}>
           <CSVFile
             csvFile={standardizedContestsFileUpload.uploadedFile.data!}
-            uploadCSVFiles={async files => {
-              await standardizedContestsFileUpload.uploadFiles(files)
+            uploadCSVFile={async file => {
+              await standardizedContestsFileUpload.uploadFiles([file])
               return true
             }}
             title="Standardized Contests"

--- a/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
@@ -13,7 +13,7 @@ import { CvrFileType, IFileInfo } from '../useCSV'
 import {
   fileInfoMocks,
   getMockFormDataForFileUpload,
-  getMockFormDataForUploadComplete,
+  getMockJsonDataForUploadComplete,
 } from '../_mocks'
 
 jest.mock('axios')
@@ -101,7 +101,8 @@ const apiCalls = {
         '/api/election/1/jurisdiction/jurisdiction-id-1/batch-inventory/cvr/upload-complete',
       options: {
         method: 'POST',
-        body: getMockFormDataForUploadComplete(testCvrFile),
+        body: getMockJsonDataForUploadComplete(testCvrFile),
+        headers: { 'Content-Type': 'application/json' },
       },
       response: { status: 'ok' },
     },
@@ -129,7 +130,8 @@ const apiCalls = {
         '/api/election/1/jurisdiction/jurisdiction-id-1/batch-inventory/tabulator-status/upload-complete',
       options: {
         method: 'POST',
-        body: getMockFormDataForUploadComplete(testTabulatorStatusFile),
+        body: getMockJsonDataForUploadComplete(testTabulatorStatusFile),
+        headers: { 'Content-Type': 'application/json' },
       },
       response: { status: 'ok' },
     },

--- a/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
@@ -10,7 +10,11 @@ import {
   createQueryClient,
 } from '../testUtilities'
 import { CvrFileType, IFileInfo } from '../useCSV'
-import { fileInfoMocks } from '../_mocks'
+import {
+  fileInfoMocks,
+  getMockFormDataForFileUpload,
+  getMockFormDataForUploadComplete,
+} from '../_mocks'
 
 jest.mock('axios')
 jest.mock('../useFeatureFlag', (): typeof import('../useFeatureFlag') => ({
@@ -21,8 +25,6 @@ jest.mock('../useFeatureFlag', (): typeof import('../useFeatureFlag') => ({
 const testCvrFile = new File([''], 'test-cvr.csv', {
   type: 'text/csv',
 })
-const cvrFormData = new FormData()
-cvrFormData.append('cvr', testCvrFile, testCvrFile.name)
 
 const testTabulatorStatusFile = new File([''], 'test-tabulator-status.xml', {
   type: 'application/xml',
@@ -76,23 +78,62 @@ const apiCalls = {
     },
     response: { status: 'ok' },
   }),
-  putCvr: {
-    url: '/api/election/1/jurisdiction/jurisdiction-id-1/batch-inventory/cvr',
-    options: {
-      method: 'PUT',
-      body: cvrFormData,
+  uploadCvrCalls: [
+    {
+      url:
+        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-inventory/cvr/upload-url',
+      options: {
+        method: 'GET',
+        params: { fileType: testCvrFile.type },
+      },
+      response: { url: '/api/upload', fields: { key: '/path/to/file' } },
     },
-    response: { status: 'ok' },
-  },
-  putTabulatorStatus: {
-    url:
-      '/api/election/1/jurisdiction/jurisdiction-id-1/batch-inventory/tabulator-status',
-    options: {
-      method: 'PUT',
-      body: tabulatorStatusFormData,
+    {
+      url: '/api/upload',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForFileUpload(testCvrFile),
+      },
+      response: { status: 'ok' },
     },
-    response: { status: 'ok' },
-  },
+    {
+      url:
+        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-inventory/cvr/upload-complete',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForUploadComplete(testCvrFile),
+      },
+      response: { status: 'ok' },
+    },
+  ],
+  uploadTabulatorStatusCalls: [
+    {
+      url:
+        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-inventory/tabulator-status/upload-url',
+      options: {
+        method: 'GET',
+        params: { fileType: testTabulatorStatusFile.type },
+      },
+      response: { url: '/api/upload', fields: { key: '/path/to/file' } },
+    },
+    {
+      url: '/api/upload',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForFileUpload(testTabulatorStatusFile),
+      },
+      response: { status: 'ok' },
+    },
+    {
+      url:
+        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-inventory/tabulator-status/upload-complete',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForUploadComplete(testTabulatorStatusFile),
+      },
+      response: { status: 'ok' },
+    },
+  ],
   postSignOff: {
     url:
       '/api/election/1/jurisdiction/jurisdiction-id-1/batch-inventory/sign-off',
@@ -138,12 +179,12 @@ describe('BatchInventory', () => {
       apiCalls.getCvr(fileInfoMocks.empty),
       apiCalls.getTabulatorStatus(fileInfoMocks.empty),
       apiCalls.getSignOff(null),
-      apiCalls.putCvr,
+      ...apiCalls.uploadCvrCalls,
       apiCalls.getCvr(cvrProcessed),
       apiCalls.getTabulatorStatus(fileInfoMocks.empty),
       apiCalls.getSignOff(null),
       apiCalls.getSignOff(null),
-      apiCalls.putTabulatorStatus,
+      ...apiCalls.uploadTabulatorStatusCalls,
       apiCalls.getTabulatorStatus(tabulatorStatusProcessed),
       apiCalls.getSignOff(null),
     ]

--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -147,9 +147,7 @@ const useBatchInventoryCVR = (
         ),
     }),
     uploadFiles: files => {
-      const formData = new FormData()
-      formData.append('cvr', files[0], files[0].name)
-      return uploadFiles.mutateAsync(formData)
+      return uploadFiles.mutateAsync({ file: files[0] })
     },
     uploadProgress: uploadFiles.progress,
     deleteFile: () => deleteFile.mutateAsync(),
@@ -175,9 +173,7 @@ const useBatchInventoryTabulatorStatus = (
         ),
     }),
     uploadFiles: files => {
-      const formData = new FormData()
-      formData.append('tabulatorStatus', files[0], files[0].name)
-      return uploadFiles.mutateAsync(formData)
+      return uploadFiles.mutateAsync({ file: files[0] })
     },
     uploadProgress: uploadFiles.progress,
     deleteFile: () => deleteFile.mutateAsync(),
@@ -237,7 +233,7 @@ const SelectSystemStep: React.FC<{
           <HTMLSelect
             large
             onChange={setSystemType}
-            value={systemType ?? undefined}
+            value={systemType || undefined}
           >
             {!systemType && <option value={undefined}></option>}
             <option value={CvrFileType.DOMINION}>Dominion</option>

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.tsx
@@ -131,7 +131,7 @@ const JurisdictionAdminView: React.FC = () => {
             <Card elevation={1}>
               <CSVFile
                 csvFile={ballotManifest}
-                uploadCSVFiles={uploadBallotManifest}
+                uploadCSVFile={uploadBallotManifest}
                 deleteCSVFile={deleteBallotManifest}
                 title={
                   isHybrid ? 'Ballot Manifest (All ballots)' : 'Ballot Manifest'
@@ -173,7 +173,7 @@ const JurisdictionAdminView: React.FC = () => {
                     ballotManifest.processing.status ===
                       FileProcessingStatus.PROCESSED
                   }
-                  uploadCSVFiles={uploadBatchTallies}
+                  uploadCSVFile={uploadBatchTallies}
                   deleteCSVFile={deleteBatchTallies}
                   title="Candidate Totals by Batch"
                   description='Click "Browse" to choose the appropriate Candidate
@@ -198,7 +198,7 @@ const JurisdictionAdminView: React.FC = () => {
                     ballotManifest.processing.status ===
                       FileProcessingStatus.PROCESSED
                   }
-                  uploadCSVFiles={uploadCVRS}
+                  uploadCSVFile={uploadCVRS}
                   deleteCSVFile={deleteCVRS}
                   title={
                     isHybrid

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -1464,34 +1464,32 @@ export const auditBoardMocks = mocksOfType<IAuditBoard[]>()({
   ],
 })
 
-const jurisdictionFormData: FormData = new FormData()
-jurisdictionFormData.append(
-  'jurisdictions',
-  jurisdictionFile,
-  jurisdictionFile.name
-)
-const jurisdictionErrorFormData: FormData = new FormData()
-jurisdictionErrorFormData.append(
-  'jurisdictions',
-  jurisdictionFile,
-  jurisdictionFile.name
-)
-const standardizedContestsFormData: FormData = new FormData()
-standardizedContestsFormData.append(
-  'standardized-contests',
-  standardizedContestsFile,
-  standardizedContestsFile.name
-)
+export const getMockFormDataForFileUpload = (file: File): FormData => {
+  const formData = new FormData()
+  formData.append('key', '/path/to/file')
+  formData.append('Content-Type', file.type)
+  formData.append('file', file, file.name)
+  return formData
+}
+export const getMockFormDataForUploadComplete = (
+  file: File,
+  cvrFileType?: CvrFileType
+): FormData => {
+  const formData = new FormData()
+  formData.append('fileName', file.name)
+  formData.append('fileType', file.type)
+  if (cvrFileType) {
+    formData.append('cvrFileType', cvrFileType)
+  }
+  formData.append('storagePathKey', '/path/to/file')
+  return formData
+}
 
-const manifestFormData: FormData = new FormData()
-manifestFormData.append('manifest', manifestFile, manifestFile.name)
-const talliesFormData: FormData = new FormData()
-talliesFormData.append('batchTallies', talliesFile, talliesFile.name)
-const cvrsFormData: FormData = new FormData()
 // Make the mock CVR file large enough to trigger an "Uploading..." progress bar
 Object.defineProperty(cvrsFile, 'size', { value: 1000 * 1000 })
-cvrsFormData.append('cvrs', cvrsFile, cvrsFile.name)
-cvrsFormData.append('cvrFileType', 'CLEARBALLOT')
+const cvrsZip = new File(['test cvr data'], 'cvrs.zip', {
+  type: 'application/zip',
+})
 
 export const apiCalls = {
   serverError: (
@@ -1637,30 +1635,122 @@ export const jaApiCalls = {
     url: '/api/election/1/jurisdiction/jurisdiction-id-1/settings',
     response,
   }),
-  putManifest: {
-    url: '/api/election/1/jurisdiction/jurisdiction-id-1/ballot-manifest',
-    options: {
-      method: 'PUT',
-      body: manifestFormData,
+  uploadManifestCalls: [
+    {
+      url:
+        '/api/election/1/jurisdiction/jurisdiction-id-1/ballot-manifest/upload-url',
+      options: {
+        method: 'GET',
+        params: { fileType: manifestFile.type },
+      },
+      response: { url: '/api/upload', fields: { key: '/path/to/file' } },
     },
-    response: { status: 'ok' },
-  },
-  putTallies: {
-    url: '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies',
-    options: {
-      method: 'PUT',
-      body: talliesFormData,
+    {
+      url: '/api/upload',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForFileUpload(manifestFile),
+      },
+      response: { status: 'ok' },
     },
-    response: { status: 'ok' },
-  },
-  putCVRs: {
-    url: '/api/election/1/jurisdiction/jurisdiction-id-1/cvrs',
-    options: {
-      method: 'PUT',
-      body: cvrsFormData,
+    {
+      url:
+        '/api/election/1/jurisdiction/jurisdiction-id-1/ballot-manifest/upload-complete',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForUploadComplete(manifestFile),
+      },
+      response: { status: 'ok' },
     },
-    response: { status: 'ok' },
-  },
+  ],
+  uploadTalliesCalls: [
+    {
+      url:
+        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies/upload-url',
+      options: {
+        method: 'GET',
+        params: { fileType: talliesFile.type },
+      },
+      response: { url: '/api/upload', fields: { key: '/path/to/file' } },
+    },
+    {
+      url: '/api/upload',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForFileUpload(talliesFile),
+      },
+      response: { status: 'ok' },
+    },
+    {
+      url:
+        '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies/upload-complete',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForUploadComplete(talliesFile),
+      },
+      response: { status: 'ok' },
+    },
+  ],
+  uploadCVRsCalls: [
+    {
+      url: '/api/election/1/jurisdiction/jurisdiction-id-1/cvrs/upload-url',
+      options: {
+        method: 'GET',
+        params: {
+          fileType: cvrsFile.type,
+          cvrFileType: CvrFileType.CLEARBALLOT,
+        },
+      },
+      response: { url: '/api/upload', fields: { key: '/path/to/file' } },
+    },
+    {
+      url: '/api/upload',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForFileUpload(cvrsFile),
+      },
+      response: { status: 'ok' },
+    },
+    {
+      url:
+        '/api/election/1/jurisdiction/jurisdiction-id-1/cvrs/upload-complete',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForUploadComplete(
+          cvrsFile,
+          CvrFileType.CLEARBALLOT
+        ),
+      },
+      response: { status: 'ok' },
+    },
+  ],
+  uploadCVRZipCalls: [
+    {
+      url: '/api/election/1/jurisdiction/jurisdiction-id-1/cvrs/upload-url',
+      options: {
+        method: 'GET',
+        params: { fileType: cvrsZip.type, cvrFileType: CvrFileType.HART },
+      },
+      response: { url: '/api/upload', fields: { key: '/path/to/file' } },
+    },
+    {
+      url: '/api/upload',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForFileUpload(cvrsZip),
+      },
+      response: { status: 'ok' },
+    },
+    {
+      url:
+        '/api/election/1/jurisdiction/jurisdiction-id-1/cvrs/upload-complete',
+      options: {
+        method: 'POST',
+        body: getMockFormDataForUploadComplete(cvrsZip, CvrFileType.HART),
+      },
+      response: { status: 'ok' },
+    },
+  ],
   deleteCVRs: {
     url: '/api/election/1/jurisdiction/jurisdiction-id-1/cvrs',
     options: { method: 'DELETE' },
@@ -1972,19 +2062,35 @@ export const aaApiCalls = {
     url: '/api/election/1/sample-sizes/1',
     response,
   }),
-  putJurisdictionFile: {
-    url: '/api/election/1/jurisdiction/file',
+  uploadJurisdictionFileGetUrl: {
+    url: '/api/election/1/jurisdiction/file/upload-url',
     options: {
-      method: 'PUT',
-      body: jurisdictionFormData,
+      method: 'GET',
+      params: { fileType: jurisdictionFile.type },
+    },
+    response: { url: '/api/upload', fields: { key: '/path/to/file' } },
+  },
+  uploadJurisdictionFilePostFile: {
+    url: '/api/upload',
+    options: {
+      method: 'POST',
+      body: getMockFormDataForFileUpload(jurisdictionFile),
     },
     response: { status: 'ok' },
   },
-  putJurisdictionErrorFile: {
-    url: '/api/election/1/jurisdiction/file',
+  uploadJurisdictionFileUploadComplete: {
+    url: '/api/election/1/jurisdiction/file/upload-complete',
     options: {
-      method: 'PUT',
-      body: jurisdictionErrorFormData,
+      method: 'POST',
+      body: getMockFormDataForUploadComplete(jurisdictionFile),
+    },
+    response: { status: 'ok' },
+  },
+  uploadJurisdictionFileUploadCompleteError: {
+    url: '/api/election/1/jurisdiction/file/upload-complete',
+    options: {
+      method: 'POST',
+      body: getMockFormDataForUploadComplete(jurisdictionFile),
     },
     response: { status: 'ok' },
   },
@@ -1992,11 +2098,27 @@ export const aaApiCalls = {
     url: '/api/election/1/jurisdiction/file',
     response,
   }),
-  putStandardizedContestsFile: {
-    url: '/api/election/1/standardized-contests/file',
+  uploadStandardizedContestsFileGetUrl: {
+    url: '/api/election/1/standardized-contests/file/upload-url',
     options: {
-      method: 'PUT',
-      body: standardizedContestsFormData,
+      method: 'GET',
+      params: { fileType: standardizedContestsFile.type },
+    },
+    response: { url: '/api/upload', fields: { key: '/path/to/file' } },
+  },
+  uploadStandardizedContestsFilePostFile: {
+    url: '/api/upload',
+    options: {
+      method: 'POST',
+      body: getMockFormDataForFileUpload(standardizedContestsFile),
+    },
+    response: { status: 'ok' },
+  },
+  uploadStandardizedContestsFileUploadComplete: {
+    url: '/api/election/1/standardized-contests/file/upload-complete',
+    options: {
+      method: 'POST',
+      body: getMockFormDataForUploadComplete(standardizedContestsFile),
     },
     response: { status: 'ok' },
   },

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -1471,18 +1471,17 @@ export const getMockFormDataForFileUpload = (file: File): FormData => {
   formData.append('file', file, file.name)
   return formData
 }
-export const getMockFormDataForUploadComplete = (
+
+export const getMockJsonDataForUploadComplete = (
   file: File,
   cvrFileType?: CvrFileType
-): FormData => {
-  const formData = new FormData()
-  formData.append('fileName', file.name)
-  formData.append('fileType', file.type)
-  if (cvrFileType) {
-    formData.append('cvrFileType', cvrFileType)
-  }
-  formData.append('storagePathKey', '/path/to/file')
-  return formData
+): BodyInit => {
+  return ({
+    fileName: file.name,
+    fileType: file.type,
+    ...(cvrFileType && { cvrFileType }),
+    storagePathKey: '/path/to/file',
+  } as unknown) as BodyInit
 }
 
 // Make the mock CVR file large enough to trigger an "Uploading..." progress bar
@@ -1658,7 +1657,8 @@ export const jaApiCalls = {
         '/api/election/1/jurisdiction/jurisdiction-id-1/ballot-manifest/upload-complete',
       options: {
         method: 'POST',
-        body: getMockFormDataForUploadComplete(manifestFile),
+        body: getMockJsonDataForUploadComplete(manifestFile),
+        headers: { 'Content-Type': 'application/json' },
       },
       response: { status: 'ok' },
     },
@@ -1686,7 +1686,8 @@ export const jaApiCalls = {
         '/api/election/1/jurisdiction/jurisdiction-id-1/batch-tallies/upload-complete',
       options: {
         method: 'POST',
-        body: getMockFormDataForUploadComplete(talliesFile),
+        body: getMockJsonDataForUploadComplete(talliesFile),
+        headers: { 'Content-Type': 'application/json' },
       },
       response: { status: 'ok' },
     },
@@ -1716,10 +1717,11 @@ export const jaApiCalls = {
         '/api/election/1/jurisdiction/jurisdiction-id-1/cvrs/upload-complete',
       options: {
         method: 'POST',
-        body: getMockFormDataForUploadComplete(
+        body: getMockJsonDataForUploadComplete(
           cvrsFile,
           CvrFileType.CLEARBALLOT
         ),
+        headers: { 'Content-Type': 'application/json' },
       },
       response: { status: 'ok' },
     },
@@ -1746,7 +1748,8 @@ export const jaApiCalls = {
         '/api/election/1/jurisdiction/jurisdiction-id-1/cvrs/upload-complete',
       options: {
         method: 'POST',
-        body: getMockFormDataForUploadComplete(cvrsZip, CvrFileType.HART),
+        body: getMockJsonDataForUploadComplete(cvrsZip, CvrFileType.HART),
+        headers: { 'Content-Type': 'application/json' },
       },
       response: { status: 'ok' },
     },
@@ -2082,7 +2085,8 @@ export const aaApiCalls = {
     url: '/api/election/1/jurisdiction/file/upload-complete',
     options: {
       method: 'POST',
-      body: getMockFormDataForUploadComplete(jurisdictionFile),
+      body: getMockJsonDataForUploadComplete(jurisdictionFile),
+      headers: { 'Content-Type': 'application/json' },
     },
     response: { status: 'ok' },
   },
@@ -2090,7 +2094,8 @@ export const aaApiCalls = {
     url: '/api/election/1/jurisdiction/file/upload-complete',
     options: {
       method: 'POST',
-      body: getMockFormDataForUploadComplete(jurisdictionFile),
+      body: getMockJsonDataForUploadComplete(jurisdictionFile),
+      headers: { 'Content-Type': 'application/json' },
     },
     response: { status: 'ok' },
   },
@@ -2118,7 +2123,8 @@ export const aaApiCalls = {
     url: '/api/election/1/standardized-contests/file/upload-complete',
     options: {
       method: 'POST',
-      body: getMockFormDataForUploadComplete(standardizedContestsFile),
+      body: getMockJsonDataForUploadComplete(standardizedContestsFile),
+      headers: { 'Content-Type': 'application/json' },
     },
     response: { status: 'ok' },
   },

--- a/client/src/components/testUtilities.tsx
+++ b/client/src/components/testUtilities.tsx
@@ -183,6 +183,10 @@ export const withMockFetch = async (
           }
           throw error
         }
+        return {
+          ...response,
+          data: await response.json(),
+        }
       }
     )
   }

--- a/client/src/components/useCSV.ts
+++ b/client/src/components/useCSV.ts
@@ -91,19 +91,21 @@ const putCSVFile = async (
     )
 
     // Tell the server that the upload has finished to save the file path reference and kick off processing
-    const finalizeUploadformData: FormData = new FormData()
-    finalizeUploadformData.append('fileName', file.name)
-    finalizeUploadformData.append('fileType', file.type)
-    if (cvrFileType) finalizeUploadformData.append('cvrFileType', cvrFileType)
-    finalizeUploadformData.append(
-      'storagePathKey',
-      getUploadResponse.data.fields.key
-    )
+    const jsonData = {
+      fileName: file.name,
+      fileType: file.type,
+      ...(cvrFileType && { cvrFileType }),
+      storagePathKey: getUploadResponse.data.fields.key,
+    }
+
     await axios(
       `/api${url}/upload-complete`,
       addCSRFToken({
         method: 'POST',
-        data: finalizeUploadformData,
+        data: jsonData,
+        headers: {
+          'Content-Type': 'application/json',
+        },
       }) as AxiosRequestConfig
     )
     return true

--- a/client/src/components/useCSV.ts
+++ b/client/src/components/useCSV.ts
@@ -37,7 +37,7 @@ export interface IFileInfo {
 }
 
 interface IUpload {
-  files: File[]
+  file: File
   progress: number
 }
 
@@ -47,15 +47,14 @@ export const isFileProcessed = (file: IFileInfo): boolean =>
 const loadCSVFile = async (url: string): Promise<IFileInfo | null> =>
   api<IFileInfo>(url)
 
-const putCSVFiles = async (
+const putCSVFile = async (
   url: string,
-  files: File[],
+  file: File,
   formKey: string,
   trackProgress: (progress: number) => void,
   cvrFileType?: CvrFileType
 ): Promise<boolean> => {
   try {
-    const file = files[0]
     // Get the signed s3 URL for the file upload
     const params = cvrFileType
       ? {
@@ -129,7 +128,7 @@ const useCSV = (
   dependencyFile?: IFileInfo | null
 ): [
   IFileInfo | null,
-  (csv: File[]) => Promise<boolean>,
+  (csv: File) => Promise<boolean>,
   () => Promise<boolean>
 ] => {
   const [csv, setCSV] = useState<IFileInfo | null>(null)
@@ -159,18 +158,18 @@ const useCSV = (
     dependencyNotProcessing,
   ])
 
-  const uploadCSVs = async (
-    files: File[],
+  const uploadCSV = async (
+    file: File,
     cvrFileType?: CvrFileType
   ): Promise<boolean> => {
     if (!shouldFetch) return false
-    setUpload({ files, progress: 0 })
+    setUpload({ file, progress: 0 })
     if (
-      await putCSVFiles(
+      await putCSVFile(
         url,
-        files,
+        file,
         formKey,
-        progress => setUpload({ files, progress }),
+        progress => setUpload({ file, progress }),
         cvrFileType
       )
     ) {
@@ -200,12 +199,12 @@ const useCSV = (
     shouldPoll ? 1000 : null
   )
 
-  return [csv && { ...csv, upload }, uploadCSVs, deleteCSV]
+  return [csv && { ...csv, upload }, uploadCSV, deleteCSV]
 }
 
 export const useJurisdictionsFile = (
   electionId: string
-): [IFileInfo | null, (csv: File[]) => Promise<boolean>] => {
+): [IFileInfo | null, (csv: File) => Promise<boolean>] => {
   const [csv, uploadCSV] = useCSV(
     `/election/${electionId}/jurisdiction/file`,
     'jurisdictions'
@@ -218,7 +217,7 @@ export const useStandardizedContestsFile = (
   electionId: string,
   auditType: IAuditSettings['auditType'],
   jurisdictionsFile?: IFileInfo | null
-): [IFileInfo | null, (csv: File[]) => Promise<boolean>] => {
+): [IFileInfo | null, (csv: File) => Promise<boolean>] => {
   const [csv, uploadCSV] = useCSV(
     `/election/${electionId}/standardized-contests/file`,
     'standardized-contests',
@@ -234,7 +233,7 @@ export const useBallotManifest = (
   jurisdictionId: string
 ): [
   IFileInfo | null,
-  (csv: File[]) => Promise<boolean>,
+  (csv: File) => Promise<boolean>,
   () => Promise<boolean>
 ] =>
   useCSV(
@@ -249,7 +248,7 @@ export const useBatchTallies = (
   ballotManifest: IFileInfo | null
 ): [
   IFileInfo | null,
-  (csv: File[]) => Promise<boolean>,
+  (csv: File) => Promise<boolean>,
   () => Promise<boolean>
 ] =>
   useCSV(
@@ -266,7 +265,7 @@ export const useCVRs = (
   ballotManifest: IFileInfo | null
 ): [
   IFileInfo | null,
-  (csv: File[]) => Promise<boolean>,
+  (csv: File) => Promise<boolean>,
   () => Promise<boolean>
 ] =>
   useCSV(

--- a/client/src/components/useFileUpload.ts
+++ b/client/src/components/useFileUpload.ts
@@ -57,21 +57,71 @@ export const useUploadedFile = (
   })
 }
 
+type CompleteFileUploadArgs = {
+  file: File
+  cvrFileType?: CvrFileType
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const useUploadFiles = (key: string[], url: string) => {
   const [progress, setProgress] = useState<number>()
 
-  const putFiles = async (formData: FormData) => {
+  const completeFileUpload = async ({
+    file,
+    cvrFileType,
+  }: CompleteFileUploadArgs): Promise<void> => {
     try {
-      await axios(
-        url,
+      // Get the signed s3 URL for the file upload
+      const params = cvrFileType
+        ? {
+            fileType: file.type,
+            cvrFileType,
+          }
+        : {
+            fileType: file.type,
+          }
+      const getUploadResponse = await axios(
+        `${url}/upload-url`,
         addCSRFToken({
-          method: 'PUT',
-          data: formData,
-          onUploadProgress: progressEvent =>
-            setProgress(progressEvent.loaded / progressEvent.total),
+          method: 'GET',
+          params,
         }) as AxiosRequestConfig
       )
+
+      // Upload the file to s3
+      const uploadFileFormData = new FormData()
+      Object.entries(getUploadResponse.data.fields).forEach(([k, v]) => {
+        uploadFileFormData.append(k, v as string)
+      })
+      uploadFileFormData.append('Content-Type', file.type)
+      uploadFileFormData.append('file', file, file.name)
+
+      await axios(
+        getUploadResponse.data.url,
+        addCSRFToken({
+          method: 'POST',
+          data: uploadFileFormData,
+          onUploadProgress: p => setProgress(p.loaded / p.total),
+        }) as AxiosRequestConfig
+      )
+
+      // Tell the server that the upload has finished to save the file path reference and kick off processing
+      const finalizeUploadformData: FormData = new FormData()
+      finalizeUploadformData.append('fileName', file.name)
+      finalizeUploadformData.append('fileType', file.type)
+      if (cvrFileType) finalizeUploadformData.append('cvrFileType', cvrFileType)
+      finalizeUploadformData.append(
+        'storagePathKey',
+        getUploadResponse.data.fields.key
+      )
+      await axios(
+        `${url}/upload-complete`,
+        addCSRFToken({
+          method: 'POST',
+          data: finalizeUploadformData,
+        }) as AxiosRequestConfig
+      )
+      return
     } catch (error) {
       const { errors } = error.response.data
       const message =
@@ -85,7 +135,7 @@ export const useUploadFiles = (key: string[], url: string) => {
   const queryClient = useQueryClient()
 
   return {
-    ...useMutation<void, ApiError, FormData>(putFiles, {
+    ...useMutation<void, ApiError, CompleteFileUploadArgs>(completeFileUpload, {
       onSuccess: () => queryClient.invalidateQueries(key),
     }),
     progress,
@@ -121,9 +171,7 @@ export const useJurisdictionsFile = (electionId: string): IFileUpload => {
       },
     }),
     uploadFiles: async (files: File[]) => {
-      const formData = new FormData()
-      formData.append('jurisdictions', files[0])
-      await uploadFiles.mutateAsync(formData)
+      await uploadFiles.mutateAsync({ file: files[0] })
     },
     uploadProgress: uploadFiles.progress,
     deleteFile: () => deleteFile.mutateAsync(),
@@ -151,9 +199,7 @@ export const useStandardizedContestsFile = (
       },
     }),
     uploadFiles: async (files: File[]) => {
-      const formData = new FormData()
-      formData.append('standardized-contests', files[0])
-      await uploadFiles.mutateAsync(formData)
+      await uploadFiles.mutateAsync({ file: files[0] })
     },
     uploadProgress: uploadFiles.progress,
     deleteFile: () => deleteFile.mutateAsync(),
@@ -189,9 +235,7 @@ export const useBallotManifest = (
       },
     }),
     uploadFiles: files => {
-      const formData = new FormData()
-      formData.append('manifest', files[0], files[0].name)
-      return uploadFiles.mutateAsync(formData)
+      return uploadFiles.mutateAsync({ file: files[0] })
     },
     uploadProgress: uploadFiles.progress,
     deleteFile: () => deleteFile.mutateAsync(),
@@ -222,9 +266,7 @@ export const useBatchTallies = (
       },
     }),
     uploadFiles: files => {
-      const formData = new FormData()
-      formData.append('batchTallies', files[0], files[0].name)
-      return uploadFiles.mutateAsync(formData)
+      return uploadFiles.mutateAsync({ file: files[0] })
     },
     uploadProgress: uploadFiles.progress,
     deleteFile: () => deleteFile.mutateAsync(),
@@ -259,12 +301,7 @@ export const useCVRs = (
       },
     }),
     uploadFiles: (files, cvrFileType) => {
-      const formData = new FormData()
-      for (const file of files) {
-        formData.append('cvrs', file, file.name)
-      }
-      formData.append('cvrFileType', cvrFileType)
-      return uploadFiles.mutateAsync(formData)
+      return uploadFiles.mutateAsync({ file: files[0], cvrFileType })
     },
     uploadProgress: uploadFiles.progress,
     deleteFile: () => deleteFile.mutateAsync(),

--- a/client/src/components/useFileUpload.ts
+++ b/client/src/components/useFileUpload.ts
@@ -105,20 +105,20 @@ export const useUploadFiles = (key: string[], url: string) => {
         }) as AxiosRequestConfig
       )
 
-      // Tell the server that the upload has finished to save the file path reference and kick off processing
-      const finalizeUploadformData: FormData = new FormData()
-      finalizeUploadformData.append('fileName', file.name)
-      finalizeUploadformData.append('fileType', file.type)
-      if (cvrFileType) finalizeUploadformData.append('cvrFileType', cvrFileType)
-      finalizeUploadformData.append(
-        'storagePathKey',
-        getUploadResponse.data.fields.key
-      )
+      const jsonData = {
+        fileName: file.name,
+        fileType: file.type,
+        ...(cvrFileType && { cvrFileType }),
+        storagePathKey: getUploadResponse.data.fields.key,
+      }
       await axios(
         `${url}/upload-complete`,
         addCSRFToken({
           method: 'POST',
-          data: finalizeUploadformData,
+          data: jsonData,
+          headers: {
+            'Content-Type': 'application/json',
+          },
         }) as AxiosRequestConfig
       )
       return

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -1032,7 +1032,7 @@ def parse_hart_cvrs(
 
     cvr_zip_files: Dict[str, BinaryIO] = {}  # { file_name: file }
     scanned_ballot_information_files: List[BinaryIO] = []
-    hasNonCsvZipFiles = []
+    nonCsvZipFiles = []
     for file_name in file_names:
         if file_name.lower().endswith(".zip"):
             # pylint: disable=consider-using-with
@@ -1045,7 +1045,7 @@ def parse_hart_cvrs(
                 open(os.path.join(working_directory, file_name), "rb")
             )
         else:
-            hasNonCsvZipFiles.append(file_name)
+            nonCsvZipFiles.append(file_name)
 
     # If there are no zip files inside the "wrapper" we assume it was not a wrapper and there was only one cvr zip file uploaded, unwrapped.
     if len(cvr_zip_files) == 0 and len(scanned_ballot_information_files) == 0:
@@ -1053,9 +1053,9 @@ def parse_hart_cvrs(
             jurisdiction.cvr_file.storage_path
         )
     # If the wrapper was a "wrapper" zip it should only contain csv and zip files
-    elif len(hasNonCsvZipFiles) > 0:
+    elif len(nonCsvZipFiles) > 0:
         raise UserError(
-            f"Unsupported file type. Expected either a ZIP file or a CSV file, but found {(','.join(hasNonCsvZipFiles))}."
+            f"Unsupported file type. Expected either a ZIP file or a CSV file, but found {(','.join(nonCsvZipFiles))}."
         )
 
     def parse_scanned_ballot_information_file(

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -1552,7 +1552,8 @@ def validate_cvr_upload(
     if not jurisdiction.manifest_file_id:
         raise Conflict("Must upload ballot manifest before uploading CVR file.")
 
-    cvr_file_type = request.form.get("cvrFileType")
+    data = request.get_json()
+    cvr_file_type = data.get("cvrFileType") if data else None
     if cvr_file_type is None:
         raise BadRequest("CVR file type is required")
 
@@ -1648,7 +1649,8 @@ def complete_upload_for_cvrs(
     (storage_path, filename, file_type) = get_standard_file_upload_request_params(
         request
     )
-    cvr_file_type = request.form.get("cvrFileType")
+    data = request.get_json()
+    cvr_file_type = data.get("cvrFileType") if data else None
     if cvr_file_type in [CvrFileType.ESS, CvrFileType.HART]:
         validate_zip_mimetype(file_type)
     else:

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -33,8 +33,6 @@ from werkzeug.exceptions import BadRequest, NotFound, Conflict
 from sqlalchemy import func, and_
 from sqlalchemy.orm import Session
 
-from server.util.isoformat import isoformat
-
 from . import api
 from ..database import db_session, engine as db_engine
 from ..models import *  # pylint: disable=wildcard-import
@@ -1626,10 +1624,7 @@ def start_upload_for_cvrs(election: Election, jurisdiction: Jurisdiction):
     if file_type is None:
         raise BadRequest("Missing expected query parameter: fileType")
 
-    storage_path_prefix = (
-        f"audits/{election.id}/jurisdictions/{jurisdiction.id}"
-        f"/cvrs_{isoformat(datetime.now(timezone.utc))}"
-    )
+    storage_path_prefix = f"audits/{election.id}/jurisdictions/{jurisdiction.id}"
 
     cvr_file_type = request.args.get("cvrFileType")
     if cvr_file_type in [CvrFileType.ESS, CvrFileType.HART]:

--- a/server/api/public.py
+++ b/server/api/public.py
@@ -6,7 +6,7 @@ from flask import jsonify, request
 
 
 from . import api
-from ..auth.auth_helpers import allow_public_access
+from ..auth.auth_helpers import allow_public_access, allow_any_logged_in_user_access
 from ..audit_math import bravo, sampler_contest, supersimple
 from ..util.jsonschema import validate
 from ..models import *  # pylint: disable=wildcard-import
@@ -158,7 +158,7 @@ def compute_batch_comparison_sample_size(
     "/file-upload",
     methods=["POST"],
 )
-@allow_public_access
+@allow_any_logged_in_user_access
 def upload_file_to_local_filesystem():
     file = request.files.get("file")
     storage_key = request.form.get("key")

--- a/server/api/public.py
+++ b/server/api/public.py
@@ -153,13 +153,14 @@ def compute_batch_comparison_sample_size(
     )
     return min(sample_size, contest.ballots)
 
+
 @api.route(
     "/file-upload",
     methods=["POST"],
 )
 @allow_public_access
 def upload_file_to_local_filesystem():
-    file = request.files["file"]
+    file = request.files.get("file")
     storage_key = request.form.get("key")
     if storage_key is None:
         raise BadRequest("Missing required form parameter 'key'")

--- a/server/api/public.py
+++ b/server/api/public.py
@@ -1,7 +1,7 @@
 import math
 from typing import Any
 
-from werkzeug.exceptions import Conflict
+from werkzeug.exceptions import Conflict, BadRequest
 from flask import jsonify, request
 
 
@@ -11,6 +11,7 @@ from ..audit_math import bravo, sampler_contest, supersimple
 from ..util.jsonschema import validate
 from ..models import *  # pylint: disable=wildcard-import
 from ..util.get_json import safe_get_json_dict
+from ..util.file import store_file
 
 
 # Leave enough buffer to support an election of galactic scale while making it hard for users to
@@ -151,3 +152,22 @@ def compute_batch_comparison_sample_size(
         + 2
     )
     return min(sample_size, contest.ballots)
+
+@api.route(
+    "/file-upload",
+    methods=["POST"],
+)
+@allow_public_access
+def upload_file_to_local_filesystem():
+    file = request.files["file"]
+    storage_key = request.form.get("key")
+    if storage_key is None:
+        raise BadRequest("Missing required form parameter 'key'")
+    if file is None:
+        raise BadRequest("Missing required form parameter 'file'")
+
+    store_file(
+        file.stream,
+        storage_key,
+    )
+    return jsonify(status="ok")

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -198,7 +198,7 @@ def save_standardized_contests_file(
 ):
     election.standardized_contests_file = File(
         id=str(uuid.uuid4()),
-        name=filename,  # type: ignore
+        name=filename,
         storage_path=storage_path,
         uploaded_at=datetime.now(timezone.utc),
     )
@@ -214,7 +214,7 @@ def save_standardized_contests_file(
 @restrict_access([UserType.AUDIT_ADMIN])
 def complete_upload_for_standardized_contests_file(election: Election):
     if election.audit_type not in [AuditType.BALLOT_COMPARISON, AuditType.HYBRID]:
-        raise Conflict("Can't upload CVR file for this audit type.")
+        raise Conflict("Can't upload standardized contests file for this audit type.")
 
     if len(list(election.jurisdictions)) == 0:
         raise Conflict(

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -4,7 +4,7 @@ import typing
 from datetime import datetime
 from typing import Dict, Optional
 from collections import defaultdict
-from flask import request, jsonify, Request
+from flask import request, jsonify
 from werkzeug.exceptions import BadRequest, Conflict
 
 from . import api
@@ -25,10 +25,11 @@ from ..util.csv_parse import (
 )
 from ..util.csv_download import csv_response
 from ..util.file import (
+    get_file_upload_url,
+    get_standard_file_upload_request_params,
     retrieve_file,
     serialize_file,
     serialize_file_processing,
-    store_file,
     timestamp_filename,
 )
 
@@ -177,7 +178,41 @@ def process_standardized_contests_file(election_id: str):
     set_contest_metadata(election)
 
 
-def validate_standardized_contests_upload(request: Request, election: Election):
+@api.route(
+    "/election/<election_id>/standardized-contests/file/upload-url", methods=["GET"]
+)
+@restrict_access([UserType.AUDIT_ADMIN])
+def start_upload_for_standardized_contests_file(election: Election):
+    file_type = request.args.get("fileType")
+    if file_type is None:
+        raise BadRequest("Missing expected query parameter: fileType")
+
+    storage_path_prefix = f"audits/{election.id}"
+    filename = timestamp_filename("standardized_contests", "csv")
+
+    return jsonify(get_file_upload_url(storage_path_prefix, filename, file_type))
+
+
+def save_standardized_contests_file(
+    election: Election, storage_path: str, filename: str
+):
+    election.standardized_contests_file = File(
+        id=str(uuid.uuid4()),
+        name=filename,  # type: ignore
+        storage_path=storage_path,
+        uploaded_at=datetime.now(timezone.utc),
+    )
+    election.standardized_contests_file.task = create_background_task(
+        process_standardized_contests_file, dict(election_id=election.id)
+    )
+
+
+@api.route(
+    "/election/<election_id>/standardized-contests/file/upload-complete",
+    methods=["POST"],
+)
+@restrict_access([UserType.AUDIT_ADMIN])
+def complete_upload_for_standardized_contests_file(election: Election):
     if election.audit_type not in [AuditType.BALLOT_COMPARISON, AuditType.HYBRID]:
         raise Conflict("Can't upload CVR file for this audit type.")
 
@@ -186,34 +221,14 @@ def validate_standardized_contests_upload(request: Request, election: Election):
             "Must upload jurisdictions file before uploading standardized contests file."
         )
 
-    if "standardized-contests" not in request.files:
-        raise BadRequest("Missing required file parameter 'standardized-contests'")
-
-    validate_csv_mimetype(request.files["standardized-contests"])
-
-
-@api.route("/election/<election_id>/standardized-contests/file", methods=["PUT"])
-@restrict_access([UserType.AUDIT_ADMIN])
-def upload_standardized_contests_file(election: Election):
-    validate_standardized_contests_upload(request, election)
+    (storage_path, filename, file_type) = get_standard_file_upload_request_params(
+        request
+    )
+    validate_csv_mimetype(file_type)
 
     election.standardized_contests = None
-    file = request.files["standardized-contests"]
-    storage_path = store_file(
-        file.stream,
-        f"audits/{election.id}/" + timestamp_filename("standardized_contests", "csv"),
-    )
-    election.standardized_contests_file = File(
-        id=str(uuid.uuid4()),
-        name=file.filename,  # type: ignore
-        storage_path=storage_path,
-        uploaded_at=datetime.now(timezone.utc),
-    )
-    election.standardized_contests_file.task = create_background_task(
-        process_standardized_contests_file, dict(election_id=election.id)
-    )
+    save_standardized_contests_file(election, storage_path, filename)
     db_session.commit()
-
     return jsonify(status="ok")
 
 

--- a/server/app.py
+++ b/server/app.py
@@ -37,6 +37,7 @@ Talisman(
         "default-src": "'self'",
         "script-src": "'self' 'unsafe-inline'",
         "style-src": "'self' 'unsafe-inline'",
+        "connect-src": "'self' https://*.s3.amazonaws.com",
     },
 )
 csrf = SeaSurf(app)

--- a/server/auth/auth_helpers.py
+++ b/server/auth/auth_helpers.py
@@ -260,3 +260,20 @@ def allow_public_access(route: Callable):
     wrapper.has_access_control = True  # type: ignore
 
     return wrapper
+
+
+def allow_any_logged_in_user_access(route: Callable):
+    """
+    Flask route decorator that allows public access to a route.
+    """
+
+    @functools.wraps(route)
+    def wrapper(*args, **kwargs):
+        _, user_key = get_loggedin_user(session)
+        if not user_key:
+            raise Unauthorized("Please log in to access Arlo")
+        return route(*args, **kwargs)
+
+    wrapper.has_access_control = True  # type: ignore
+
+    return wrapper

--- a/server/config.py
+++ b/server/config.py
@@ -142,10 +142,14 @@ FILE_UPLOAD_STORAGE_PATH = read_env_var(
     env_defaults=dict(development="/tmp/arlo", test="/tmp/arlo-test"),
 )
 # If using S3, AWS credentials are required as well
-AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY = (
-    (read_env_var("AWS_ACCESS_KEY_ID"), read_env_var("AWS_SECRET_ACCESS_KEY"))
+AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION = (
+    (
+        read_env_var("AWS_ACCESS_KEY_ID"),
+        read_env_var("AWS_SECRET_ACCESS_KEY"),
+        read_env_var("AWS_DEFAULT_REGION", default="us-west-1"),
+    )
     if FILE_UPLOAD_STORAGE_PATH.startswith("s3://")
-    else (None, None)
+    else (None, None, None)
 )
 
 # Configure round size growth from ARLO_MINERVA_MULTIPLE (a float) if given, otherwise 1.5

--- a/server/tests/api/test_activity.py
+++ b/server/tests/api/test_activity.py
@@ -318,12 +318,12 @@ def test_file_upload_errors(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client, io.BytesIO(b"invalid"), election_id, jurisdiction_ids[0]
     )
     assert_ok(rv)
 
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(b"Batch Name,Number of Ballots\n" b"A,1"),
         election_id,
@@ -335,7 +335,7 @@ def test_file_upload_errors(
     election.audit_type = AuditType.BATCH_COMPARISON
     db_session.commit()
 
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client, io.BytesIO(b"invalid"), election_id, jurisdiction_ids[0]
     )
     assert rv.status_code == 200
@@ -344,7 +344,7 @@ def test_file_upload_errors(
     election.audit_type = AuditType.BALLOT_COMPARISON
     db_session.commit()
 
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client, io.BytesIO(b""), election_id, jurisdiction_ids[0], "DOMINION"
     )
     assert_ok(rv)

--- a/server/tests/api/test_activity.py
+++ b/server/tests/api/test_activity.py
@@ -318,20 +318,16 @@ def test_file_upload_errors(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={"manifest": (io.BytesIO(b"invalid"), "manifest.csv")},
+    rv = setup_ballot_manifest_upload(
+        client, io.BytesIO(b"invalid"), election_id, jurisdiction_ids[0]
     )
     assert_ok(rv)
 
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(b"Batch Name,Number of Ballots\n" b"A,1"),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(b"Batch Name,Number of Ballots\n" b"A,1"),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -339,9 +335,8 @@ def test_file_upload_errors(
     election.audit_type = AuditType.BATCH_COMPARISON
     db_session.commit()
 
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
-        data={"batchTallies": (io.BytesIO(b"invalid"), "tallies.csv")},
+    rv = setup_batch_tallies_upload(
+        client, io.BytesIO(b"invalid"), election_id, jurisdiction_ids[0]
     )
     assert rv.status_code == 200
 
@@ -349,12 +344,8 @@ def test_file_upload_errors(
     election.audit_type = AuditType.BALLOT_COMPARISON
     db_session.commit()
 
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (io.BytesIO(b""), "cvrs.csv"),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client, io.BytesIO(b""), election_id, jurisdiction_ids[0], "DOMINION"
     )
     assert_ok(rv)
 

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -12,7 +12,7 @@ def test_ballot_manifest_upload(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n" b"12,100\n" b"6,0\n"),
         election_id,
@@ -57,7 +57,7 @@ def test_ballot_manifest_clear(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n"),
         election_id,
@@ -90,7 +90,7 @@ def test_ballot_manifest_replace_as_audit_admin(
 ):
     # Check that AA can also get/put/clear manifest
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n" b"12,100\n" b"6,0,,\n"),
         election_id,
@@ -100,7 +100,7 @@ def test_ballot_manifest_replace_as_audit_admin(
 
     file_id = Jurisdiction.query.get(jurisdiction_ids[0]).manifest_file_id
 
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n" b"12,6\n"),
         election_id,
@@ -201,7 +201,7 @@ def test_ballot_manifest_upload_missing_field(
         set_logged_in_user(
             client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
         )
-        rv = setup_ballot_manifest_upload(
+        rv = upload_ballot_manifest(
             client,
             io.BytesIO(header_row.encode() + b"\n1,2,3"),
             election_id,
@@ -236,7 +236,7 @@ def test_ballot_manifest_upload_invalid_num_ballots(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
 
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,not a number\n"),
         election_id,
@@ -270,7 +270,7 @@ def test_ballot_manifest_upload_duplicate_batch_name(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(b"Batch Name,Number of Ballots\n" b"12,23\n" b"12,100\n" b"6,0\n"),
         election_id,

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -12,16 +12,11 @@ def test_ballot_manifest_upload(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Batch Name,Number of Ballots\n" b"1,23\n" b"12,100\n" b"6,0\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n" b"12,100\n" b"6,0\n"),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -32,7 +27,7 @@ def test_ballot_manifest_upload(
         json.loads(rv.data),
         {
             "file": {
-                "name": "manifest.csv",
+                "name": asserts_startswith("manifest"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -62,14 +57,11 @@ def test_ballot_manifest_clear(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n"),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n"),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -98,29 +90,21 @@ def test_ballot_manifest_replace_as_audit_admin(
 ):
     # Check that AA can also get/put/clear manifest
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Batch Name,Number of Ballots\n" b"1,23\n" b"12,100\n" b"6,0,,\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n" b"12,100\n" b"6,0,,\n"),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
     file_id = Jurisdiction.query.get(jurisdiction_ids[0]).manifest_file_id
 
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n" b"12,6\n"),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n" b"12,6\n"),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -150,14 +134,14 @@ def test_ballot_manifest_replace_as_audit_admin(
     assert json.loads(rv.data) == {"file": None, "processing": None}
 
 
-def test_ballot_manifest_upload_missing_file(
+def test_ballot_manifest_upload_missing_file_path(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
+    rv = client.post(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest/upload-complete",
         data={},
     )
     assert rv.status_code == 400
@@ -165,7 +149,7 @@ def test_ballot_manifest_upload_missing_file(
         "errors": [
             {
                 "errorType": "Bad Request",
-                "message": "Missing required file parameter 'manifest'",
+                "message": "Missing required JSON parameter: storagePathKey",
             }
         ]
     }
@@ -177,9 +161,24 @@ def test_ballot_manifest_upload_bad_csv(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={"manifest": (io.BytesIO(b"not a CSV file"), "random.txt")},
+    rv = client.post(
+        "/api/file-upload",
+        data={
+            "file": (
+                io.BytesIO(b"not a CSV file"),
+                "random.txt",
+            ),
+            "key": "test_dir/random.txt",
+        },
+    )
+    assert_ok(rv)
+    rv = client.post(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest/upload-complete",
+        data={
+            "storagePathKey": "test_dir/random.txt",
+            "fileName": "random.txt",
+            "fileType": "text/plain",
+        },
     )
     assert rv.status_code == 400
     assert json.loads(rv.data) == {
@@ -202,14 +201,11 @@ def test_ballot_manifest_upload_missing_field(
         set_logged_in_user(
             client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
         )
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-            data={
-                "manifest": (
-                    io.BytesIO(header_row.encode() + b"\n1,2,3"),
-                    "manifest.csv",
-                )
-            },
+        rv = setup_ballot_manifest_upload(
+            client,
+            io.BytesIO(header_row.encode() + b"\n1,2,3"),
+            election_id,
+            jurisdiction_ids[0],
         )
         assert_ok(rv)
 
@@ -220,7 +216,7 @@ def test_ballot_manifest_upload_missing_field(
             json.loads(rv.data),
             {
                 "file": {
-                    "name": "manifest.csv",
+                    "name": asserts_startswith("manifest"),
                     "uploadedAt": assert_is_date,
                 },
                 "processing": {
@@ -239,14 +235,12 @@ def test_ballot_manifest_upload_invalid_num_ballots(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,not a number\n"),
-                "manifest.csv",
-            )
-        },
+
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,not a number\n"),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -257,7 +251,7 @@ def test_ballot_manifest_upload_invalid_num_ballots(
         json.loads(rv.data),
         {
             "file": {
-                "name": "manifest.csv",
+                "name": asserts_startswith("manifest"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -276,16 +270,11 @@ def test_ballot_manifest_upload_duplicate_batch_name(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Batch Name,Number of Ballots\n" b"12,23\n" b"12,100\n" b"6,0\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(b"Batch Name,Number of Ballots\n" b"12,23\n" b"12,100\n" b"6,0\n"),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -296,7 +285,7 @@ def test_ballot_manifest_upload_duplicate_batch_name(
         json.loads(rv.data),
         {
             "file": {
-                "name": "manifest.csv",
+                "name": asserts_startswith("manifest"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -142,7 +142,7 @@ def test_ballot_manifest_upload_missing_file_path(
     )
     rv = client.post(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest/upload-complete",
-        data={},
+        json={},
     )
     assert rv.status_code == 400
     assert json.loads(rv.data) == {
@@ -174,7 +174,7 @@ def test_ballot_manifest_upload_bad_csv(
     assert_ok(rv)
     rv = client.post(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest/upload-complete",
-        data={
+        json={
             "storagePathKey": "test_dir/random.txt",
             "fileName": "random.txt",
             "fileType": "text/plain",

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -307,3 +307,48 @@ def test_ballot_manifest_upload_duplicate_batch_name(
             },
         },
     )
+
+
+def test_ballot_manifest_get_upload_url_missing_file_type(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest/upload-url"
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Bad Request",
+                "message": "Missing expected query parameter: fileType",
+            }
+        ]
+    }
+
+
+def test_ballot_manifest_get_upload_url(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
+    allowed_users = [
+        (UserType.JURISDICTION_ADMIN, default_ja_email(election_id)),
+        (UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL),
+    ]
+    for user, email in allowed_users:
+        set_logged_in_user(client, user, email)
+        rv = client.get(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest/upload-url",
+            query_string={"fileType": "text/csv"},
+        )
+        assert rv.status_code == 200
+
+        response_data = json.loads(rv.data)
+        expected_url = "/api/file-upload"
+
+        assert response_data["url"] == expected_url
+        assert response_data["fields"]["key"].startswith(
+            f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/manifest_"
+        )
+        assert response_data["fields"]["key"].endswith(".csv")

--- a/server/tests/api/test_ballots.py
+++ b/server/tests/api/test_ballots.py
@@ -1248,19 +1248,16 @@ def test_ballots_human_sort_order(
         "Batch 2",
         "Batch 10",
     ]
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    (
-                        "Batch Name,Number of Ballots\n"
-                        + "\n".join(f"{batch},10" for batch in human_ordered_batches)
-                    ).encode()
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            (
+                "Batch Name,Number of Ballots\n"
+                + "\n".join(f"{batch},10" for batch in human_ordered_batches)
+            ).encode()
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 

--- a/server/tests/api/test_ballots.py
+++ b/server/tests/api/test_ballots.py
@@ -1248,7 +1248,7 @@ def test_ballots_human_sort_order(
         "Batch 2",
         "Batch 10",
     ]
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             (

--- a/server/tests/api/test_jurisdictions.py
+++ b/server/tests/api/test_jurisdictions.py
@@ -73,7 +73,7 @@ def test_jurisdictions_list_with_manifest(
     manifest = (
         b"Batch Name,Number of Ballots\n" b"1,23\n" b"2,101\n" b"3,122\n" b"4,400"
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(manifest),
         election_id,
@@ -154,7 +154,7 @@ def test_duplicate_batch_name(client, election_id, jurisdiction_ids):
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(b"Batch Name,Number of Ballots\n" b"1,23\n" b"1,101\n"),
         election_id,

--- a/server/tests/api/test_jurisdictions_file.py
+++ b/server/tests/api/test_jurisdictions_file.py
@@ -19,7 +19,7 @@ def test_missing_file(client: FlaskClient, election_id: str):
 
 
 def test_bad_csv_file(client: FlaskClient, election_id: str):
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(b"not a CSV file"),
         election_id,
@@ -44,7 +44,7 @@ def test_bad_csv_file(client: FlaskClient, election_id: str):
 
 
 def test_missing_one_csv_field(client, election_id):
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(b"Jurisdiction\nJurisdiction #1"),
         election_id,
@@ -74,7 +74,7 @@ def test_jurisdictions_file_metadata(client, election_id):
     assert json.loads(rv.data) == {"file": None, "processing": None}
 
     contents = "Jurisdiction,Admin Email\nJ1,ja@example.com"
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(contents.encode()),
         election_id,
@@ -105,7 +105,7 @@ def test_jurisdictions_file_metadata(client, election_id):
 
 def test_replace_jurisdictions_file(client, election_id):
     # Create the initial file.
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(
             b"Jurisdiction,Admin Email\n" b"J1,ja@example.com\n" b"J2,ja2@example.com"
@@ -126,7 +126,7 @@ def test_replace_jurisdictions_file(client, election_id):
     file_id = election.jurisdictions_file_id
 
     # Replace it with another file.
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(
             b"Jurisdiction,Admin Email\n" b"J2,ja2@example.com\n" b"J3,ja3@example.com"
@@ -155,7 +155,7 @@ def test_replace_jurisdictions_file(client, election_id):
 
 
 def test_no_jurisdiction(client, election_id):
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(b"Jurisdiction,Admin Email"),
         election_id,
@@ -167,7 +167,7 @@ def test_no_jurisdiction(client, election_id):
 
 
 def test_single_jurisdiction_single_admin(client, election_id):
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(b"Jurisdiction,Admin Email\nJ1,a1@example.com"),
         election_id,
@@ -184,7 +184,7 @@ def test_single_jurisdiction_single_admin(client, election_id):
 
 
 def test_single_jurisdiction_multiple_admins(client, election_id):
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(b"Jurisdiction,Admin Email\nJ1,a1@example.com\nJ1,a2@example.com"),
         election_id,
@@ -202,7 +202,7 @@ def test_single_jurisdiction_multiple_admins(client, election_id):
 
 
 def test_multiple_jurisdictions_single_admin(client, election_id):
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(b"Jurisdiction,Admin Email\nJ1,a1@example.com\nJ2,a1@example.com"),
         election_id,
@@ -224,7 +224,7 @@ def test_download_jurisdictions_file_not_found(client, election_id):
 
 
 def test_convert_emails_to_lowercase(client, election_id):
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(
             b"Jurisdiction,Admin Email\n"
@@ -247,7 +247,7 @@ def test_upload_jurisdictions_file_after_audit_starts(
     election_id: str,
     round_1_id: str,  # pylint: disable=unused-argument
 ):
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(b"Jurisdiction,Admin Email\n" b"J1,j1@example.com\n"),
         election_id,
@@ -267,7 +267,7 @@ def test_upload_jurisdictions_file_duplicate_row(
     client: FlaskClient,
     election_id: str,
 ):
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(
             b"Jurisdiction,Admin Email\n" b"J1,j1@example.com\n" b"J1,j1@example.com"
@@ -306,7 +306,7 @@ def test_jurisdictions_file_dont_clobber_other_elections(
     )
 
     # Add jurisdictions.
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(b"Jurisdiction,Admin Email\n" b"J1,j1@example.com\n"),
         election_id,
@@ -314,7 +314,7 @@ def test_jurisdictions_file_dont_clobber_other_elections(
     assert_ok(rv)
 
     # Add jurisdictions for other election
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(b"Jurisdiction,Admin Email\n" b"J2,j2@example.com\n"),
         other_election_id,
@@ -322,7 +322,7 @@ def test_jurisdictions_file_dont_clobber_other_elections(
     assert_ok(rv)
 
     # Now change them
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(b"Jurisdiction,Admin Email\n" b"J3,j3@example.com\n"),
         other_election_id,
@@ -341,7 +341,7 @@ def test_jurisdictions_file_dont_clobber_other_elections(
 
 
 def test_jurisdictions_file_expected_num_ballots(client: FlaskClient, election_id: str):
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(
             b"Jurisdiction,Admin Email,Expected Number of Ballots\n"

--- a/server/tests/api/test_jurisdictions_file.py
+++ b/server/tests/api/test_jurisdictions_file.py
@@ -6,7 +6,9 @@ from ..helpers import *  # pylint: disable=wildcard-import
 
 
 def test_missing_file(client: FlaskClient, election_id: str):
-    rv = client.post(f"/api/election/{election_id}/jurisdiction/file/upload-complete")
+    rv = client.post(
+        f"/api/election/{election_id}/jurisdiction/file/upload-complete", json={}
+    )
     assert rv.status_code == 400
     assert json.loads(rv.data) == {
         "errors": [
@@ -26,7 +28,7 @@ def test_bad_csv_file(client: FlaskClient, election_id: str):
     )
     rv = client.post(
         f"/api/election/{election_id}/jurisdiction/file/upload-complete",
-        data={
+        json={
             "storagePathKey": "test_dir/random.txt",
             "fileName": "random.txt",
             "fileType": "text/plain",

--- a/server/tests/api/test_public.py
+++ b/server/tests/api/test_public.py
@@ -1,7 +1,11 @@
 import json
+import io
+import tempfile
 from typing import Any, Dict, List, TypedDict
 
 from flask.testing import FlaskClient
+from ..helpers import *  # pylint: disable=wildcard-import
+from ... import config
 
 
 def copy_dict_and_remove_key(input: Dict, key: str):
@@ -548,3 +552,58 @@ def test_public_compute_sample_sizes(client: FlaskClient, snapshot):
         assert rv.status_code == 200
         response = json.loads(rv.data)
         snapshot.assert_match(response, test_case["description"])
+
+
+def test_public_file_upload(client: FlaskClient):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config.FILE_UPLOAD_STORAGE_PATH = temp_dir
+        rv = client.post(
+            "/api/file-upload",
+            data={
+                "file": (
+                    io.BytesIO(b"hello, I am a file"),
+                    "random.txt",
+                ),
+                "key": "test_dir/random.txt",
+            },
+        )
+        assert_ok(rv)
+        with open(f"{temp_dir}/test_dir/random.txt", "rb") as stored_file:
+            assert stored_file.read() == b"hello, I am a file"
+
+
+def test_public_file_upload_error(client: FlaskClient):
+    rv = client.post(
+        "/api/file-upload",
+        data={
+            "key": "test_dir/random.txt",
+        },
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Bad Request",
+                "message": "Missing required form parameter 'file'",
+            }
+        ]
+    }
+
+    rv = client.post(
+        "/api/file-upload",
+        data={
+            "file": (
+                io.BytesIO(b"hello, I am a file"),
+                "random.txt",
+            ),
+        },
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Bad Request",
+                "message": "Missing required form parameter 'key'",
+            }
+        ]
+    }

--- a/server/tests/ballot_comparison/conftest.py
+++ b/server/tests/ballot_comparison/conftest.py
@@ -87,7 +87,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Tabulator,Batch Name,Number of Ballots\n"
@@ -100,7 +100,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Tabulator,Batch Name,Number of Ballots\n"
@@ -121,7 +121,7 @@ def ess_manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[
         set_logged_in_user(
             client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
         )
-        rv = setup_ballot_manifest_upload(
+        rv = upload_ballot_manifest(
             client,
             io.BytesIO(
                 b"Tabulator,Batch Name,Number of Ballots\n"
@@ -142,7 +142,7 @@ def hart_manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List
         set_logged_in_user(
             client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
         )
-        rv = setup_ballot_manifest_upload(
+        rv = upload_ballot_manifest(
             client,
             io.BytesIO(
                 b"Tabulator,Batch Name,Number of Ballots\n"
@@ -167,7 +167,7 @@ def cvrs(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,
@@ -175,7 +175,7 @@ def cvrs(
         "DOMINION",
     )
     assert_ok(rv)
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,

--- a/server/tests/ballot_comparison/conftest.py
+++ b/server/tests/ballot_comparison/conftest.py
@@ -87,36 +87,30 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Tabulator,Batch Name,Number of Ballots\n"
-                    b"TABULATOR1,BATCH1,3\n"
-                    b"TABULATOR1,BATCH2,3\n"
-                    b"TABULATOR2,BATCH1,3\n"
-                    b"TABULATOR2,BATCH2,6"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Tabulator,Batch Name,Number of Ballots\n"
+            b"TABULATOR1,BATCH1,3\n"
+            b"TABULATOR1,BATCH2,3\n"
+            b"TABULATOR2,BATCH1,3\n"
+            b"TABULATOR2,BATCH2,6"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Tabulator,Batch Name,Number of Ballots\n"
-                    b"TABULATOR1,BATCH1,3\n"
-                    b"TABULATOR1,BATCH2,3\n"
-                    b"TABULATOR2,BATCH1,3\n"
-                    b"TABULATOR2,BATCH2,6"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Tabulator,Batch Name,Number of Ballots\n"
+            b"TABULATOR1,BATCH1,3\n"
+            b"TABULATOR1,BATCH2,3\n"
+            b"TABULATOR2,BATCH1,3\n"
+            b"TABULATOR2,BATCH2,6"
+        ),
+        election_id,
+        jurisdiction_ids[1],
     )
     assert_ok(rv)
 
@@ -127,20 +121,17 @@ def ess_manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[
         set_logged_in_user(
             client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
         )
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/ballot-manifest",
-            data={
-                "manifest": (
-                    io.BytesIO(
-                        b"Tabulator,Batch Name,Number of Ballots\n"
-                        b"0001,BATCH1,3\n"
-                        b"0001,BATCH2,3\n"
-                        b"0002,BATCH1,3\n"
-                        b"0002,BATCH2,6"
-                    ),
-                    "manifest.csv",
-                )
-            },
+        rv = setup_ballot_manifest_upload(
+            client,
+            io.BytesIO(
+                b"Tabulator,Batch Name,Number of Ballots\n"
+                b"0001,BATCH1,3\n"
+                b"0001,BATCH2,3\n"
+                b"0002,BATCH1,3\n"
+                b"0002,BATCH2,6"
+            ),
+            election_id,
+            jurisdiction_id,
         )
         assert_ok(rv)
 
@@ -151,20 +142,17 @@ def hart_manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List
         set_logged_in_user(
             client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
         )
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/ballot-manifest",
-            data={
-                "manifest": (
-                    io.BytesIO(
-                        b"Tabulator,Batch Name,Number of Ballots\n"
-                        b"TABULATOR1,BATCH1,3\n"
-                        b"TABULATOR1,BATCH2,3\n"
-                        b"TABULATOR2,BATCH3,3\n"
-                        b"TABULATOR2,BATCH4,6"
-                    ),
-                    "manifest.csv",
-                )
-            },
+        rv = setup_ballot_manifest_upload(
+            client,
+            io.BytesIO(
+                b"Tabulator,Batch Name,Number of Ballots\n"
+                b"TABULATOR1,BATCH1,3\n"
+                b"TABULATOR1,BATCH2,3\n"
+                b"TABULATOR2,BATCH3,3\n"
+                b"TABULATOR2,BATCH4,6"
+            ),
+            election_id,
+            jurisdiction_id,
         )
         assert_ok(rv)
 
@@ -179,25 +167,19 @@ def cvrs(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(TEST_CVRS.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(TEST_CVRS.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(TEST_CVRS.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(TEST_CVRS.encode()),
+        election_id,
+        jurisdiction_ids[1],
+        "DOMINION",
     )
     assert_ok(rv)

--- a/server/tests/ballot_comparison/test_ballot_comparison.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison.py
@@ -95,9 +95,7 @@ def test_set_contest_metadata_on_manifest_and_cvr_upload(
         b"TABULATOR2,BATCH1,3\n"
         b"TABULATOR2,BATCH2,6"
     )
-    rv = setup_ballot_manifest_upload(
-        client, file_content, election_id, jurisdiction_ids[0]
-    )
+    rv = upload_ballot_manifest(client, file_content, election_id, jurisdiction_ids[0])
     assert_ok(rv)
 
     # Contest total ballots isn't set when only some manifests uploaded
@@ -107,7 +105,7 @@ def test_set_contest_metadata_on_manifest_and_cvr_upload(
     assert contest["totalBallotsCast"] is None
     assert contest["votesAllowed"] is None
 
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Tabulator,Batch Name,Number of Ballots\n"
@@ -128,7 +126,7 @@ def test_set_contest_metadata_on_manifest_and_cvr_upload(
     assert contest["totalBallotsCast"] == 30
     assert contest["votesAllowed"] is None
 
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,
@@ -144,7 +142,7 @@ def test_set_contest_metadata_on_manifest_and_cvr_upload(
     assert contest["totalBallotsCast"] == 30
     assert contest["votesAllowed"] is None
 
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,
@@ -171,7 +169,7 @@ def test_set_contest_metadata_on_manifest_and_cvr_upload(
     # Contest metadata changes on new manifest/CVR upload
     #
 
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Tabulator,Batch Name,Number of Ballots\n"
@@ -185,7 +183,7 @@ def test_set_contest_metadata_on_manifest_and_cvr_upload(
     assert_ok(rv)
 
     new_cvr = "\n".join(TEST_CVRS.splitlines()[:10])
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(new_cvr.encode()),
         election_id,
@@ -235,7 +233,7 @@ def test_cvr_choice_name_validation(
     contest = json.loads(rv.data)["contests"][0]
     assert "cvrChoiceNameConsistencyError" not in contest
 
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,
@@ -248,7 +246,7 @@ def test_cvr_choice_name_validation(
     contest = json.loads(rv.data)["contests"][0]
     assert "cvrChoiceNameConsistencyError" not in contest
 
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,
@@ -262,7 +260,7 @@ def test_cvr_choice_name_validation(
     assert "cvrChoiceNameConsistencyError" not in contest
 
     modified_cvrs = TEST_CVRS.replace("Choice", "CHOICE")
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(modified_cvrs.encode()),
         election_id,
@@ -285,7 +283,7 @@ def test_cvr_choice_name_validation(
     }
 
     modified_cvrs = TEST_CVRS.replace("Choice 1-1", "CHOICE 1-1")
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(modified_cvrs.encode()),
         election_id,
@@ -308,7 +306,7 @@ def test_cvr_choice_name_validation(
     }
 
     modified_cvrs = TEST_CVRS_WITH_CHOICE_REMOVED
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(modified_cvrs.encode()),
         election_id,
@@ -322,7 +320,7 @@ def test_cvr_choice_name_validation(
     assert "cvrChoiceNameConsistencyError" not in contest
 
     modified_cvrs = TEST_CVRS_WITH_EXTRA_CHOICE
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(modified_cvrs.encode()),
         election_id,
@@ -369,7 +367,7 @@ def test_set_contest_metadata_on_jurisdiction_change(
 
     # Upload new jurisdictions, removing J1
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(
             (
@@ -692,7 +690,7 @@ def test_ballot_comparison_two_rounds(
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     # AA uploads standardized contests file
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(
             b"Contest Name,Jurisdictions\n"
@@ -1358,7 +1356,7 @@ def test_ballot_comparison_ess(
 13,p,bs,Choice 1-1,Choice 2-3
 15,p,bs,Choice 1-1,Choice 2-3
 """
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         zip_cvrs(
             [
@@ -1382,7 +1380,7 @@ def test_ballot_comparison_ess(
         "application/zip",
     )
     assert_ok(rv)
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         zip_cvrs(
             [

--- a/server/tests/ballot_comparison/test_ballot_comparison_manifests.py
+++ b/server/tests/ballot_comparison/test_ballot_comparison_manifests.py
@@ -19,7 +19,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    setup_ballot_manifest_upload(
+    upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Tabulator,Batch Name,Number of Ballots\n"
@@ -43,7 +43,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         election_id,
         jurisdiction_ids[0],
     )
-    setup_ballot_manifest_upload(
+    upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Tabulator,Batch Name,Number of Ballots\n"
@@ -81,7 +81,7 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,PrecinctPortion,BallotType,R
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    setup_cvrs_upload(
+    upload_cvrs(
         client,
         io.BytesIO(j1_cvr.encode()),
         election_id,
@@ -103,7 +103,7 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,PrecinctPortion,BallotType,R
         [f"{i},{line}" for i, line in enumerate(j2_cvr_lines)]
     )
 
-    setup_cvrs_upload(
+    upload_cvrs(
         client,
         io.BytesIO(j2_cvr.encode()),
         election_id,
@@ -282,7 +282,7 @@ def test_ballot_comparison_manifest_missing_tabulator(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Batch Name,Number of Ballots\n"
@@ -329,7 +329,7 @@ def test_ballot_comparison_manifest_unexpected_cvr_column(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Tabulator,Batch Name,Number of Ballots,CVR\n"

--- a/server/tests/ballot_comparison/test_contest_name_standardizations.py
+++ b/server/tests/ballot_comparison/test_contest_name_standardizations.py
@@ -237,15 +237,12 @@ def test_standardize_contest_names_cvr_change(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(TEST_CVRS.replace("Contest 1", "Contest A").encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(TEST_CVRS.replace("Contest 1", "Contest A").encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
 

--- a/server/tests/ballot_comparison/test_contest_name_standardizations.py
+++ b/server/tests/ballot_comparison/test_contest_name_standardizations.py
@@ -237,7 +237,7 @@ def test_standardize_contest_names_cvr_change(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.replace("Contest 1", "Contest A").encode()),
         election_id,

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -48,7 +48,6 @@ def test_dominion_cvr_upload(
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs"
     )
-    print(json.loads(rv.data))
     compare_json(
         json.loads(rv.data),
         {

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -498,7 +498,7 @@ def test_cvrs_upload_missing_file(
     )
     rv = client.post(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs/upload-complete",
-        data={},
+        json={},
     )
     assert rv.status_code == 400
     assert json.loads(rv.data) == {
@@ -522,7 +522,7 @@ def test_cvrs_upload_bad_csv(
     )
     rv = client.post(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs/upload-complete",
-        data={
+        json={
             "storagePathKey": "random.txt",
             "fileName": "random.txt",
             "fileType": "text/plain",

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -2918,3 +2918,63 @@ def test_cvr_invalid_file_type(
             }
         ]
     }
+
+
+def test_cvrs_get_upload_url_missing_file_type(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs/upload-url"
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Bad Request",
+                "message": "Missing expected query parameter: fileType",
+            }
+        ]
+    }
+
+
+def test_cvrs_get_upload_url(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
+    allowed_users = [
+        (UserType.JURISDICTION_ADMIN, default_ja_email(election_id)),
+        (UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL),
+    ]
+    for user, email in allowed_users:
+        set_logged_in_user(client, user, email)
+        rv = client.get(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs/upload-url",
+            query_string={"fileType": "text/csv", "cvrFileType": "DOMINION"},
+        )
+        assert rv.status_code == 200
+
+        response_data = json.loads(rv.data)
+        expected_url = "/api/file-upload"
+
+        assert response_data["url"] == expected_url
+        assert response_data["fields"]["key"].startswith(
+            f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/cvrs_"
+        )
+        assert response_data["fields"]["key"].endswith(".csv")
+
+        rv = client.get(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs/upload-url",
+            query_string={"fileType": "text/csv", "cvrFileType": "HART"},
+        )
+        assert rv.status_code == 200
+
+        response_data = json.loads(rv.data)
+        expected_url = "/api/file-upload"
+
+        assert response_data["url"] == expected_url
+        assert response_data["fields"]["key"].startswith(
+            f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/cvrs_"
+        )
+        assert response_data["fields"]["key"].endswith(".zip")

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -1,10 +1,9 @@
 import io, json
-from typing import BinaryIO, Dict, List, TypedDict, Tuple
+from typing import List, TypedDict, Tuple
 from flask.testing import FlaskClient
 
 from ...models import *  # pylint: disable=wildcard-import
 from ..helpers import *  # pylint: disable=wildcard-import
-from ...util.file import zip_files
 from .conftest import TEST_CVRS
 
 
@@ -34,15 +33,12 @@ def test_dominion_cvr_upload(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(TEST_CVRS.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(TEST_CVRS.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
 
@@ -52,11 +48,12 @@ def test_dominion_cvr_upload(
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs"
     )
+    print(json.loads(rv.data))
     compare_json(
         json.loads(rv.data),
         {
             "file": {
-                "name": "cvrs.csv",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
                 "cvrFileType": "DOMINION",
             },
@@ -103,7 +100,7 @@ def test_dominion_cvr_upload(
         jurisdictions[0]["cvrs"],
         {
             "file": {
-                "name": "cvrs.csv",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
                 "cvrFileType": "DOMINION",
             },
@@ -124,7 +121,7 @@ def test_dominion_cvr_upload(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs/csv"
     )
     assert rv.status_code == 200
-    assert rv.headers["Content-Disposition"] == 'attachment; filename="cvrs.csv"'
+    assert rv.headers["Content-Disposition"].startswith('attachment; filename="cvrs')
     assert rv.data == TEST_CVRS.encode()
 
 
@@ -160,15 +157,12 @@ def test_cvrs_counting_group(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(COUNTING_GROUP_CVR.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(COUNTING_GROUP_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
 
@@ -187,7 +181,7 @@ def test_cvrs_counting_group(
         json.loads(rv.data),
         {
             "file": {
-                "name": "cvrs.csv",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
                 "cvrFileType": "DOMINION",
             },
@@ -258,15 +252,12 @@ def test_dominion_cvr_unique_voting_identifier(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(DOMINION_UNIQUE_VOTING_IDENTIFIER_CVR.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(DOMINION_UNIQUE_VOTING_IDENTIFIER_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
 
@@ -285,7 +276,7 @@ def test_dominion_cvr_unique_voting_identifier(
         json.loads(rv.data),
         {
             "file": {
-                "name": "cvrs.csv",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
                 "cvrFileType": "DOMINION",
             },
@@ -354,15 +345,12 @@ def test_dominion_cvrs_with_leading_equal_signs(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(DOMINION_CVRS_WITH_LEADING_EQUAL_SIGNS.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(DOMINION_CVRS_WITH_LEADING_EQUAL_SIGNS.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
 
@@ -377,11 +365,12 @@ def test_dominion_cvrs_with_leading_equal_signs(
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs"
     )
+    print(json.loads(rv.data))
     compare_json(
         json.loads(rv.data),
         {
             "file": {
-                "name": "cvrs.csv",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
                 "cvrFileType": "DOMINION",
             },
@@ -406,15 +395,12 @@ def test_cvrs_clear(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(TEST_CVRS.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(TEST_CVRS.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
 
@@ -457,29 +443,23 @@ def test_cvrs_replace_as_audit_admin(
 ):
     # Check that AA can also get/put/clear batch tallies
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(TEST_CVRS.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(TEST_CVRS.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
 
     file_id = Jurisdiction.query.get(jurisdiction_ids[0]).cvr_file_id
 
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO("\n".join(TEST_CVRS.splitlines()[:-2]).encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO("\n".join(TEST_CVRS.splitlines()[:-2]).encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
 
@@ -517,8 +497,8 @@ def test_cvrs_upload_missing_file(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
+    rv = client.post(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs/upload-complete",
         data={},
     )
     assert rv.status_code == 400
@@ -526,7 +506,7 @@ def test_cvrs_upload_missing_file(
         "errors": [
             {
                 "errorType": "Bad Request",
-                "message": "Missing required file parameter 'cvrs'",
+                "message": "CVR file type is required",
             }
         ]
     }
@@ -541,10 +521,12 @@ def test_cvrs_upload_bad_csv(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
+    rv = client.post(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs/upload-complete",
         data={
-            "cvrs": (io.BytesIO(b"not a CSV file"), "random.txt"),
+            "storagePathKey": "random.txt",
+            "fileName": "random.txt",
+            "fileType": "text/plain",
             "cvrFileType": "DOMINION",
         },
     )
@@ -575,14 +557,12 @@ def test_cvrs_wrong_audit_type(
         set_logged_in_user(
             client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
         )
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-            data={
-                "cvrs": (
-                    io.BytesIO(TEST_CVRS.encode()),
-                    "cvrs.csv",
-                )
-            },
+        rv = setup_cvrs_upload(
+            client,
+            io.BytesIO(TEST_CVRS.encode()),
+            election_id,
+            jurisdiction_ids[0],
+            "DOMINION",
         )
         assert rv.status_code == 409
         assert json.loads(rv.data) == {
@@ -603,14 +583,12 @@ def test_cvrs_before_manifests(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(TEST_CVRS.encode()),
-                "cvrs.csv",
-            )
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(TEST_CVRS.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert rv.status_code == 409
     assert json.loads(rv.data) == {
@@ -657,15 +635,12 @@ def test_cvrs_newlines(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(NEWLINE_CVR.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(NEWLINE_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
 
@@ -684,7 +659,7 @@ def test_cvrs_newlines(
         json.loads(rv.data),
         {
             "file": {
-                "name": "cvrs.csv",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
                 "cvrFileType": "DOMINION",
             },
@@ -1006,15 +981,12 @@ BATCH1,1,1-1-1,p,bs,ps,TABULATOR1,s,r,0,1,1,1,0
     ]
 
     for invalid_cvr, expected_error, cvr_file_type in invalid_cvrs:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-            data={
-                "cvrs": (
-                    io.BytesIO(invalid_cvr.encode()),
-                    "cvrs.csv",
-                ),
-                "cvrFileType": cvr_file_type,
-            },
+        rv = setup_cvrs_upload(
+            client,
+            io.BytesIO(invalid_cvr.encode()),
+            election_id,
+            jurisdiction_ids[0],
+            cvr_file_type,
         )
         assert_ok(rv)
 
@@ -1025,7 +997,7 @@ BATCH1,1,1-1-1,p,bs,ps,TABULATOR1,s,r,0,1,1,1,0
             json.loads(rv.data),
             {
                 "file": {
-                    "name": "cvrs.csv",
+                    "name": asserts_startswith("cvrs"),
                     "uploadedAt": assert_is_date,
                     "cvrFileType": cvr_file_type,
                 },
@@ -1059,20 +1031,18 @@ def test_cvr_reprocess_after_manifest_reupload(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Tabulator,Batch Name,Number of Ballots\n"
-                    b"TABULATOR2,BATCH2,6\n"
-                    b"TABULATOR1,BATCH1,3\n"
-                    b"TABULATOR1,BATCH2,3"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Tabulator,Batch Name,Number of Ballots\n"
+            b"TABULATOR2,BATCH2,6\n"
+            b"TABULATOR1,BATCH1,3\n"
+            b"TABULATOR1,BATCH2,3"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
+
     assert_ok(rv)
 
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
@@ -1091,7 +1061,7 @@ def test_cvr_reprocess_after_manifest_reupload(
         json.loads(rv.data),
         {
             "file": {
-                "name": "cvrs.csv",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
                 "cvrFileType": "DOMINION",
             },
@@ -1115,20 +1085,17 @@ def test_cvr_reprocess_after_manifest_reupload(
     assert Jurisdiction.query.get(jurisdiction_ids[0]).cvr_contests_metadata is None
 
     # Fix the manifest
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Tabulator,Batch Name,Number of Ballots\n"
-                    b"TABULATOR1,BATCH1,3\n"
-                    b"TABULATOR1,BATCH2,3\n"
-                    b"TABULATOR2,BATCH1,3\n"
-                    b"TABULATOR2,BATCH2,6"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Tabulator,Batch Name,Number of Ballots\n"
+            b"TABULATOR1,BATCH1,3\n"
+            b"TABULATOR1,BATCH2,3\n"
+            b"TABULATOR2,BATCH1,3\n"
+            b"TABULATOR2,BATCH2,6"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -1148,7 +1115,7 @@ def test_cvr_reprocess_after_manifest_reupload(
         json.loads(rv.data),
         {
             "file": {
-                "name": "cvrs.csv",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
                 "cvrFileType": "DOMINION",
             },
@@ -1208,15 +1175,12 @@ def test_clearballot_cvr_upload(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(CLEARBALLOT_CVRS.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "CLEARBALLOT",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(CLEARBALLOT_CVRS.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "CLEARBALLOT",
     )
     assert_ok(rv)
 
@@ -1235,7 +1199,7 @@ def test_clearballot_cvr_upload(
         json.loads(rv.data),
         {
             "file": {
-                "name": "cvrs.csv",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
                 "cvrFileType": "CLEARBALLOT",
             },
@@ -1284,15 +1248,12 @@ def test_clearballot_cvr_upload_invalid(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(CLEARBALLOT_CVRS_INVALID.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "CLEARBALLOT",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(CLEARBALLOT_CVRS_INVALID.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "CLEARBALLOT",
     )
     assert_ok(rv)
 
@@ -1312,7 +1273,7 @@ def test_clearballot_cvr_upload_invalid(
         {
             "file": {
                 "cvrFileType": "CLEARBALLOT",
-                "name": "cvrs.csv",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -1495,9 +1456,13 @@ def test_ess_cvr_upload(
     )
 
     for cvrs in test_cases:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-            data={"cvrs": cvrs, "cvrFileType": "ESS"},
+        rv = setup_cvrs_upload(
+            client,
+            zip_cvrs(cvrs),
+            election_id,
+            jurisdiction_ids[0],
+            "ESS",
+            "application/zip",
         )
         assert_ok(rv)
 
@@ -1509,7 +1474,7 @@ def test_ess_cvr_upload(
             {
                 "file": {
                     "cvrFileType": "ESS",
-                    "name": "cvr-files.zip",
+                    "name": asserts_startswith("cvrs"),
                     "uploadedAt": assert_is_date,
                 },
                 "processing": {
@@ -1843,9 +1808,13 @@ def test_ess_cvr_upload_invalid(
     )
 
     for invalid_cvrs, expected_error in test_cases:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-            data={"cvrs": invalid_cvrs, "cvrFileType": "ESS"},
+        rv = setup_cvrs_upload(
+            client,
+            zip_cvrs(invalid_cvrs),
+            election_id,
+            jurisdiction_ids[0],
+            "ESS",
+            "application/zip",
         )
         assert_ok(rv)
 
@@ -1857,7 +1826,7 @@ def test_ess_cvr_upload_invalid(
             {
                 "file": {
                     "cvrFileType": "ESS",
-                    "name": "cvr-files.zip",
+                    "name": asserts_startswith("cvrs"),
                     "uploadedAt": assert_is_date,
                 },
                 "processing": {
@@ -1902,9 +1871,13 @@ def test_ess_cvr_upload_cvr_file_with_tabulator_cvr_column(
         (io.BytesIO(ESS_BALLOTS_2.encode()), "ess_ballots_2.csv"),
     ]
 
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={"cvrs": cvrs, "cvrFileType": "ESS"},
+    rv = setup_cvrs_upload(
+        client,
+        zip_cvrs(cvrs),
+        election_id,
+        jurisdiction_ids[0],
+        "ESS",
+        "application/zip",
     )
     assert_ok(rv)
 
@@ -1916,7 +1889,7 @@ def test_ess_cvr_upload_cvr_file_with_tabulator_cvr_column(
         {
             "file": {
                 "cvrFileType": "ESS",
-                "name": "cvr-files.zip",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -1932,9 +1905,13 @@ def test_ess_cvr_upload_cvr_file_with_tabulator_cvr_column(
         },
     )
 
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={"cvrs": cvrs_with_override_cvr_file_name, "cvrFileType": "ESS"},
+    rv = setup_cvrs_upload(
+        client,
+        zip_cvrs(cvrs_with_override_cvr_file_name),
+        election_id,
+        jurisdiction_ids[0],
+        "ESS",
+        "application/zip",
     )
     assert_ok(rv)
 
@@ -1946,7 +1923,7 @@ def test_ess_cvr_upload_cvr_file_with_tabulator_cvr_column(
         {
             "file": {
                 "cvrFileType": "ESS",
-                "name": "cvr-files.zip",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -2170,16 +2147,6 @@ HART_SCANNED_BALLOT_INFORMATION_CONFLICTING_WITH_MINIMAL = """#FormatVersion 1
 """
 
 
-def zip_hart_cvrs(cvrs: List[str]):
-    files: Dict[str, BinaryIO] = {
-        f"cvr-{i}.xml": io.BytesIO(cvr.encode()) for i, cvr in enumerate(cvrs)
-    }
-    # There's usually a WriteIns directory in the zip file - simulate that to
-    # make sure it gets skipped
-    files["WriteIns"] = io.BytesIO()
-    return io.BytesIO(zip_files(files).read())
-
-
 def test_hart_cvr_upload(
     client: FlaskClient,
     election_id: str,
@@ -2188,12 +2155,13 @@ def test_hart_cvr_upload(
     snapshot,
 ):
     # Upload CVRs
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": [(zip_hart_cvrs(HART_CVRS), "cvrs.zip")],
-            "cvrFileType": "HART",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        zip_hart_cvrs(HART_CVRS),
+        election_id,
+        jurisdiction_ids[0],
+        "HART",
+        "application/zip",
     )
     assert_ok(rv)
 
@@ -2212,7 +2180,7 @@ def test_hart_cvr_upload(
         json.loads(rv.data),
         {
             "file": {
-                "name": "cvr-files.zip",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
                 "cvrFileType": "HART",
             },
@@ -2366,21 +2334,25 @@ def test_hart_cvr_upload_with_scanned_ballot_information(
     ]
 
     for test_case in test_cases:
+        print("on test case ", test_case)
         scanned_ballot_information_files = [
             (string_to_bytes_io(file_contents), f"scanned-ballot-information-{i}.csv")
             for i, file_contents in enumerate(
                 test_case["scanned_ballot_information_file_contents"]
             )
         ]
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-            data={
-                "cvrs": [
+        rv = setup_cvrs_upload(
+            client,
+            zip_cvrs(
+                [
                     (zip_hart_cvrs(HART_CVRS), "cvrs.zip"),
                     *scanned_ballot_information_files,
-                ],
-                "cvrFileType": "HART",
-            },
+                ]
+            ),
+            election_id,
+            jurisdiction_ids[0],
+            "HART",
+            "application/zip",
         )
         assert_ok(rv)
 
@@ -2392,7 +2364,7 @@ def test_hart_cvr_upload_with_scanned_ballot_information(
             {
                 "file": {
                     "cvrFileType": "HART",
-                    "name": "cvr-files.zip",
+                    "name": asserts_startswith("cvrs"),
                     "uploadedAt": assert_is_date,
                 },
                 "processing": {
@@ -2453,7 +2425,7 @@ def test_hart_cvr_upload_with_duplicate_batch_names(
     )
 
     class TestCase(TypedDict):
-        files: List[Tuple[BinaryIO, str]]
+        files: List[Tuple[io.BytesIO, str]]
         expected_processing_status: ProcessingStatus
         expected_processing_error: Optional[str]
 
@@ -2540,12 +2512,13 @@ def test_hart_cvr_upload_with_duplicate_batch_names(
     ]
 
     for test_case in test_cases:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-            data={
-                "cvrs": test_case["files"],
-                "cvrFileType": "HART",
-            },
+        rv = setup_cvrs_upload(
+            client,
+            zip_cvrs(test_case["files"]),
+            election_id,
+            jurisdiction_ids[0],
+            "HART",
+            "application/zip",
         )
         assert_ok(rv)
 
@@ -2557,7 +2530,7 @@ def test_hart_cvr_upload_with_duplicate_batch_names(
             {
                 "file": {
                     "cvrFileType": "HART",
-                    "name": "cvr-files.zip",
+                    "name": asserts_startswith("cvrs"),
                     "uploadedAt": assert_is_date,
                 },
                 "processing": {
@@ -2623,12 +2596,14 @@ def test_hart_cvr_upload_no_batch_match(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for invalid_cvr, expected_error in invalid_cvrs:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-            data={
-                "cvrs": [(zip_hart_cvrs(invalid_cvr), "cvrs.zip")],
-                "cvrFileType": "HART",
-            },
+        rv = setup_cvrs_upload(
+            client,
+            zip_hart_cvrs(invalid_cvr),
+            election_id,
+            jurisdiction_ids[0],
+            "HART",
+            "application/zip",
+            "cvrs.zip",
         )
         assert_ok(rv)
 
@@ -2639,7 +2614,7 @@ def test_hart_cvr_upload_no_batch_match(
             json.loads(rv.data),
             {
                 "file": {
-                    "name": "cvr-files.zip",
+                    "name": asserts_startswith("cvrs"),
                     "uploadedAt": assert_is_date,
                     "cvrFileType": "HART",
                 },
@@ -2706,12 +2681,13 @@ def test_hart_cvr_upload_no_tabulator_plus_batch_match(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for cvr_upload, expected_error in cvr_uploads:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-            data={
-                "cvrs": cvr_upload,
-                "cvrFileType": "HART",
-            },
+        rv = setup_cvrs_upload(
+            client,
+            zip_cvrs(cvr_upload),
+            election_id,
+            jurisdiction_ids[0],
+            "HART",
+            "application/zip",
         )
         assert_ok(rv)
 
@@ -2722,7 +2698,7 @@ def test_hart_cvr_upload_no_tabulator_plus_batch_match(
             json.loads(rv.data),
             {
                 "file": {
-                    "name": "cvr-files.zip",
+                    "name": asserts_startswith("cvrs"),
                     "uploadedAt": assert_is_date,
                     "cvrFileType": "HART",
                 },
@@ -2749,80 +2725,122 @@ def test_hart_cvr_upload_basic_input_validation(
     )
 
     class TestCase(TypedDict):
-        cvrs: List
+        cvrs: io.BytesIO
+        file_type: str
         expected_status_code: int
         expected_response: Any
 
     test_cases: List[TestCase] = [
         {
-            "cvrs": [(zip_hart_cvrs(HART_CVRS), "cvrs.csv")],
+            "cvrs": zip_hart_cvrs(HART_CVRS),
+            "file_type": "text/csv",
             "expected_status_code": 400,
             "expected_response": {
                 "errors": [
                     {
                         "errorType": "Bad Request",
-                        "message": "Please submit at least one ZIP file.",
+                        "message": "Please submit a valid ZIP file.",
                     }
                 ]
             },
         },
         {
-            "cvrs": [
-                (zip_hart_cvrs(HART_CVRS), "cvrs.csv"),
-                (
-                    string_to_bytes_io(HART_SCANNED_BALLOT_INFORMATION),
-                    "scanned-ballot-information.csv",
-                ),
-            ],
-            "expected_status_code": 400,
-            "expected_response": {
-                "errors": [
-                    {
-                        "errorType": "Bad Request",
-                        "message": "Please submit at least one ZIP file.",
-                    }
-                ]
-            },
-        },
-        {
-            "cvrs": [
-                (zip_hart_cvrs(HART_CVRS), "cvrs.zip"),
-                (
-                    string_to_bytes_io(HART_SCANNED_BALLOT_INFORMATION),
-                    "scanned-ballot-information.jpg",
-                ),
-            ],
-            "expected_status_code": 400,
-            "expected_response": {
-                "errors": [
-                    {
-                        "errorType": "Bad Request",
-                        "message": "Please submit only ZIP files and CSVs.",
-                    }
-                ]
-            },
-        },
-        {
-            "cvrs": [
-                (
-                    zip_hart_cvrs(HART_CVRS),
-                    "cvrs.zip",
-                    # Verify that the Windows ZIP mimetype works
-                    "application/x-zip-compressed",
-                ),
-            ],
+            "cvrs": zip_hart_cvrs(HART_CVRS),
+            "file_type": "application/x-zip-compressed",  # Verify that the Windows ZIP mimetype works
             "expected_status_code": 200,
             "expected_response": {"status": "ok"},
         },
     ]
 
     for test_case in test_cases:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-            data={"cvrFileType": "HART", "cvrs": test_case["cvrs"]},
+        rv = setup_cvrs_upload(
+            client,
+            test_case["cvrs"],
+            election_id,
+            jurisdiction_ids[0],
+            "HART",
+            test_case["file_type"],
         )
         assert rv.status_code == test_case["expected_status_code"]
         assert json.loads(rv.data) == test_case["expected_response"]
+
+
+def test_hart_cvr_upload_processing_validation(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    hart_manifests,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    class TestCase(TypedDict):
+        cvrs: io.BytesIO
+        expected_status_code: int
+        expected_response: Any
+
+    test_cases: List[TestCase] = [
+        {
+            "cvrs": zip_cvrs(
+                [
+                    (zip_hart_cvrs(HART_CVRS), "cvrs.csv"),
+                    (
+                        string_to_bytes_io(HART_SCANNED_BALLOT_INFORMATION),
+                        "scanned-ballot-information.csv",
+                    ),
+                ]
+            ),
+            "expected_status_code": 400,
+            "expected_response": "Expected first line of scanned ballot information CSV to contain '#FormatVersion'.",
+        },
+        {
+            "cvrs": zip_cvrs(
+                [
+                    (zip_hart_cvrs(HART_CVRS), "cvrs.zip"),
+                    (
+                        string_to_bytes_io(HART_SCANNED_BALLOT_INFORMATION),
+                        "scanned-ballot-information.jpg",
+                    ),
+                ]
+            ),
+            "expected_status_code": 400,
+            "expected_response": "Unsupported file type. Expected either a ZIP file or a CSV file, but found scanned-ballot-information.jpg.",
+        },
+    ]
+
+    for test_case in test_cases:
+        rv = setup_cvrs_upload(
+            client,
+            test_case["cvrs"],
+            election_id,
+            jurisdiction_ids[0],
+            "HART",
+            "application/zip",
+        )
+        # these test cases will fail when being processed not uploaded
+        assert_ok(rv)
+        rv = client.get(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs"
+        )
+        compare_json(
+            json.loads(rv.data),
+            {
+                "file": {
+                    "name": asserts_startswith("cvrs"),
+                    "uploadedAt": assert_is_date,
+                    "cvrFileType": "HART",
+                },
+                "processing": {
+                    "status": ProcessingStatus.ERRORED,
+                    "startedAt": assert_is_date,
+                    "completedAt": assert_is_date,
+                    "error": test_case["expected_response"],
+                    "workProgress": 0,
+                    "workTotal": assert_is_int,
+                },
+            },
+        )
 
 
 def test_cvrs_unexpected_error(
@@ -2847,15 +2865,12 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortio
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(cvrs.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(cvrs.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
 
@@ -2866,7 +2881,7 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortio
         json.loads(rv.data),
         {
             "file": {
-                "name": "cvrs.csv",
+                "name": asserts_startswith("cvrs"),
                 "uploadedAt": assert_is_date,
                 "cvrFileType": "DOMINION",
             },
@@ -2899,15 +2914,12 @@ def test_cvr_invalid_file_type(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(TEST_CVRS.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "WRONG",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(TEST_CVRS.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "WRONG",
     )
     assert rv.status_code == 400
     assert json.loads(rv.data) == {

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -33,7 +33,7 @@ def test_dominion_cvr_upload(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,
@@ -156,7 +156,7 @@ def test_cvrs_counting_group(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(COUNTING_GROUP_CVR.encode()),
         election_id,
@@ -251,7 +251,7 @@ def test_dominion_cvr_unique_voting_identifier(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(DOMINION_UNIQUE_VOTING_IDENTIFIER_CVR.encode()),
         election_id,
@@ -344,7 +344,7 @@ def test_dominion_cvrs_with_leading_equal_signs(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(DOMINION_CVRS_WITH_LEADING_EQUAL_SIGNS.encode()),
         election_id,
@@ -394,7 +394,7 @@ def test_cvrs_clear(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,
@@ -442,7 +442,7 @@ def test_cvrs_replace_as_audit_admin(
 ):
     # Check that AA can also get/put/clear batch tallies
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,
@@ -453,7 +453,7 @@ def test_cvrs_replace_as_audit_admin(
 
     file_id = Jurisdiction.query.get(jurisdiction_ids[0]).cvr_file_id
 
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO("\n".join(TEST_CVRS.splitlines()[:-2]).encode()),
         election_id,
@@ -556,7 +556,7 @@ def test_cvrs_wrong_audit_type(
         set_logged_in_user(
             client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
         )
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             io.BytesIO(TEST_CVRS.encode()),
             election_id,
@@ -582,7 +582,7 @@ def test_cvrs_before_manifests(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,
@@ -634,7 +634,7 @@ def test_cvrs_newlines(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(NEWLINE_CVR.encode()),
         election_id,
@@ -980,7 +980,7 @@ BATCH1,1,1-1-1,p,bs,ps,TABULATOR1,s,r,0,1,1,1,0
     ]
 
     for invalid_cvr, expected_error, cvr_file_type in invalid_cvrs:
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             io.BytesIO(invalid_cvr.encode()),
             election_id,
@@ -1030,7 +1030,7 @@ def test_cvr_reprocess_after_manifest_reupload(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Tabulator,Batch Name,Number of Ballots\n"
@@ -1084,7 +1084,7 @@ def test_cvr_reprocess_after_manifest_reupload(
     assert Jurisdiction.query.get(jurisdiction_ids[0]).cvr_contests_metadata is None
 
     # Fix the manifest
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Tabulator,Batch Name,Number of Ballots\n"
@@ -1174,7 +1174,7 @@ def test_clearballot_cvr_upload(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(CLEARBALLOT_CVRS.encode()),
         election_id,
@@ -1247,7 +1247,7 @@ def test_clearballot_cvr_upload_invalid(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(CLEARBALLOT_CVRS_INVALID.encode()),
         election_id,
@@ -1455,7 +1455,7 @@ def test_ess_cvr_upload(
     )
 
     for cvrs in test_cases:
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             zip_cvrs(cvrs),
             election_id,
@@ -1807,7 +1807,7 @@ def test_ess_cvr_upload_invalid(
     )
 
     for invalid_cvrs, expected_error in test_cases:
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             zip_cvrs(invalid_cvrs),
             election_id,
@@ -1870,7 +1870,7 @@ def test_ess_cvr_upload_cvr_file_with_tabulator_cvr_column(
         (io.BytesIO(ESS_BALLOTS_2.encode()), "ess_ballots_2.csv"),
     ]
 
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         zip_cvrs(cvrs),
         election_id,
@@ -1904,7 +1904,7 @@ def test_ess_cvr_upload_cvr_file_with_tabulator_cvr_column(
         },
     )
 
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         zip_cvrs(cvrs_with_override_cvr_file_name),
         election_id,
@@ -2154,7 +2154,7 @@ def test_hart_cvr_upload(
     snapshot,
 ):
     # Upload CVRs
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         zip_hart_cvrs(HART_CVRS),
         election_id,
@@ -2340,7 +2340,7 @@ def test_hart_cvr_upload_with_scanned_ballot_information(
                 test_case["scanned_ballot_information_file_contents"]
             )
         ]
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             zip_cvrs(
                 [
@@ -2511,7 +2511,7 @@ def test_hart_cvr_upload_with_duplicate_batch_names(
     ]
 
     for test_case in test_cases:
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             zip_cvrs(test_case["files"]),
             election_id,
@@ -2595,7 +2595,7 @@ def test_hart_cvr_upload_no_batch_match(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for invalid_cvr, expected_error in invalid_cvrs:
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             zip_hart_cvrs(invalid_cvr),
             election_id,
@@ -2680,7 +2680,7 @@ def test_hart_cvr_upload_no_tabulator_plus_batch_match(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for cvr_upload, expected_error in cvr_uploads:
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             zip_cvrs(cvr_upload),
             election_id,
@@ -2752,7 +2752,7 @@ def test_hart_cvr_upload_basic_input_validation(
     ]
 
     for test_case in test_cases:
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             test_case["cvrs"],
             election_id,
@@ -2809,7 +2809,7 @@ def test_hart_cvr_upload_processing_validation(
     ]
 
     for test_case in test_cases:
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             test_case["cvrs"],
             election_id,
@@ -2864,7 +2864,7 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortio
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(cvrs.encode()),
         election_id,
@@ -2913,7 +2913,7 @@ def test_cvr_invalid_file_type(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -610,3 +610,47 @@ def test_reupload_standardized_contests_after_contests_selected(
             ]
         },
     )
+
+
+def test_standardized_contests_get_upload_url_missing_file_type(
+    client: FlaskClient, election_id: str
+):
+    set_logged_in_user(
+        client,
+        UserType.AUDIT_ADMIN,
+        DEFAULT_AA_EMAIL,
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/standardized-contests/file/upload-url"
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Bad Request",
+                "message": "Missing expected query parameter: fileType",
+            }
+        ]
+    }
+
+
+def test_standardized_contests_get_upload_url(client: FlaskClient, election_id: str):
+    set_logged_in_user(
+        client,
+        UserType.AUDIT_ADMIN,
+        DEFAULT_AA_EMAIL,
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/standardized-contests/file/upload-url",
+        query_string={"fileType": "text/csv"},
+    )
+    assert rv.status_code == 200
+
+    response_data = json.loads(rv.data)
+    expected_url = "/api/file-upload"
+
+    assert response_data["url"] == expected_url
+    assert response_data["fields"]["key"].startswith(
+        f"audits/{election_id}/standardized_contests_"
+    )
+    assert response_data["fields"]["key"].endswith(".csv")

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -178,7 +178,7 @@ def test_standardized_contests_missing_file(
 ):
     rv = client.post(
         f"/api/election/{election_id}/standardized-contests/file/upload-complete",
-        data={},
+        json={},
     )
     assert rv.status_code == 400
     assert json.loads(rv.data) == {
@@ -198,7 +198,7 @@ def test_standardized_contests_bad_csv(
 ):
     rv = client.post(
         f"/api/election/{election_id}/standardized-contests/file/upload-complete",
-        data={
+        json={
             "storagePathKey": "test_dir/random.txt",
             "fileName": "random.txt",
             "fileType": "text/plain",

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -237,7 +237,7 @@ def test_standardized_contests_wrong_audit_type(
             "errors": [
                 {
                     "errorType": "Conflict",
-                    "message": "Can't upload CVR file for this audit type.",
+                    "message": "Can't upload standardized contests file for this audit type.",
                 }
             ]
         }

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -15,7 +15,7 @@ def test_upload_standardized_contests(
         'Contest 2,"J1, J3"\n'
         "Contest 3,J2 \n"
     )
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(standardized_contests_file.encode()),
         election_id,
@@ -66,7 +66,7 @@ def test_download_standardized_contests_file_before_upload(
 def test_standardized_contests_replace(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(
             b"Contest Name,Jurisdictions\n"
@@ -82,7 +82,7 @@ def test_standardized_contests_replace(
     file_id = election.standardized_contests_file_id
     standardized_contests = election.standardized_contests
 
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 4,all\n"),
         election_id,
@@ -107,7 +107,7 @@ def test_standardized_contests_bad_jurisdiction(
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
 ):
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(
             b"Contest Name,Jurisdictions\n"
@@ -143,7 +143,7 @@ def test_standardized_contests_no_jurisdictions(
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
 ):
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 1,"),
         election_id,
@@ -227,7 +227,7 @@ def test_standardized_contests_wrong_audit_type(
         db_session.add(election)
         db_session.commit()
 
-        rv = setup_standardized_contests_upload(
+        rv = upload_standardized_contests(
             client,
             io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 1,all\n"),
             election_id,
@@ -246,7 +246,7 @@ def test_standardized_contests_wrong_audit_type(
 def test_standardized_contests_before_jurisdictions(
     client: FlaskClient, election_id: str
 ):
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 1,all\n"),
         election_id,
@@ -265,7 +265,7 @@ def test_standardized_contests_before_jurisdictions(
 def test_standardized_contests_newlines(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(
             b"Contest Name,Jurisdictions\n"
@@ -291,7 +291,7 @@ def test_standardized_contests_newlines(
 def test_standardized_contests_dominion_vote_for(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(
             b"Contest Name,Jurisdictions\n"
@@ -323,7 +323,7 @@ def test_standardized_contests_change_jurisdictions_file(
         'Contest 2,"J1, J3"\n'
         "Contest 3,all \n"
     )
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(standardized_contests_file.encode()),
         election_id,
@@ -346,7 +346,7 @@ def test_standardized_contests_change_jurisdictions_file(
     assert_ok(rv)
 
     # Remove a jurisdiction that isn't referenced directly in standardized contests
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(
             (
@@ -377,7 +377,7 @@ def test_standardized_contests_change_jurisdictions_file(
     ]
 
     # Now remove a jurisdiction that is referenced directly in standardized contests
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         io.BytesIO(
             (
@@ -417,7 +417,7 @@ def test_standardized_contests_parse_all(
     standardized_contests_file = (
         "Contest Name,Jurisdictions\n" + "Contest 1,All\n" + "Contest 2,  aLL \n"
     )
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(standardized_contests_file.encode()),
         election_id,
@@ -449,7 +449,7 @@ def test_reupload_standardized_contests_after_contests_selected(
         'Contest 2,"J1, J3"\n'
         "Contest 3,J2 \n"
     )
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(standardized_contests_file.encode()),
         election_id,
@@ -518,7 +518,7 @@ def test_reupload_standardized_contests_after_contests_selected(
     standardized_contests_file = (
         "Contest Name,Jurisdictions\n" + 'Contest 1,"J1,J2"\n' + "Contest 3,J2 \n"
     )
-    rv = setup_standardized_contests_upload(
+    rv = upload_standardized_contests(
         client,
         io.BytesIO(standardized_contests_file.encode()),
         election_id,

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -15,14 +15,10 @@ def test_upload_standardized_contests(
         'Contest 2,"J1, J3"\n'
         "Contest 3,J2 \n"
     )
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(standardized_contests_file.encode()),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(standardized_contests_file.encode()),
+        election_id,
     )
     assert_ok(rv)
 
@@ -31,7 +27,7 @@ def test_upload_standardized_contests(
         json.loads(rv.data),
         {
             "file": {
-                "name": "standardized-contests.csv",
+                "name": asserts_startswith("standardizedContests"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -54,9 +50,8 @@ def test_upload_standardized_contests(
     ]
 
     rv = client.get(f"/api/election/{election_id}/standardized-contests/file/csv")
-    assert (
-        rv.headers["Content-Disposition"]
-        == 'attachment; filename="standardized-contests.csv"'
+    assert rv.headers["Content-Disposition"].startswith(
+        'attachment; filename="standardizedContests'
     )
     assert rv.data.decode("utf-8") == standardized_contests_file
 
@@ -71,19 +66,15 @@ def test_download_standardized_contests_file_before_upload(
 def test_standardized_contests_replace(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(
-                    b"Contest Name,Jurisdictions\n"
-                    b"Contest 1,all\n"
-                    b'Contest 2,"J1, J3"\n'
-                    b"Contest 3,J2 \n"
-                ),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(
+            b"Contest Name,Jurisdictions\n"
+            b"Contest 1,all\n"
+            b'Contest 2,"J1, J3"\n'
+            b"Contest 3,J2 \n"
+        ),
+        election_id,
     )
     assert_ok(rv)
 
@@ -91,14 +82,10 @@ def test_standardized_contests_replace(
     file_id = election.standardized_contests_file_id
     standardized_contests = election.standardized_contests
 
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 4,all\n"),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 4,all\n"),
+        election_id,
     )
     assert_ok(rv)
 
@@ -120,17 +107,13 @@ def test_standardized_contests_bad_jurisdiction(
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
 ):
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(
-                    b"Contest Name,Jurisdictions\n"
-                    b'Contest 1,"J1,not a real jurisdiction,another bad one"\n"'
-                ),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(
+            b"Contest Name,Jurisdictions\n"
+            b'Contest 1,"J1,not a real jurisdiction,another bad one"\n"'
+        ),
+        election_id,
     )
     assert_ok(rv)
 
@@ -139,7 +122,7 @@ def test_standardized_contests_bad_jurisdiction(
         json.loads(rv.data),
         {
             "file": {
-                "name": "standardized-contests.csv",
+                "name": asserts_startswith("standardizedContests"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -160,14 +143,10 @@ def test_standardized_contests_no_jurisdictions(
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
 ):
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 1,"),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 1,"),
+        election_id,
     )
     assert_ok(rv)
 
@@ -176,7 +155,7 @@ def test_standardized_contests_no_jurisdictions(
         json.loads(rv.data),
         {
             "file": {
-                "name": "standardized-contests.csv",
+                "name": asserts_startswith("standardizedContests"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -197,8 +176,8 @@ def test_standardized_contests_missing_file(
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
 ):
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
+    rv = client.post(
+        f"/api/election/{election_id}/standardized-contests/file/upload-complete",
         data={},
     )
     assert rv.status_code == 400
@@ -206,7 +185,7 @@ def test_standardized_contests_missing_file(
         "errors": [
             {
                 "errorType": "Bad Request",
-                "message": "Missing required file parameter 'standardized-contests'",
+                "message": "Missing required JSON parameter: storagePathKey",
             }
         ]
     }
@@ -217,13 +196,12 @@ def test_standardized_contests_bad_csv(
     election_id: str,
     jurisdiction_ids: List[str],  # pylint: disable=unused-argument
 ):
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
+    rv = client.post(
+        f"/api/election/{election_id}/standardized-contests/file/upload-complete",
         data={
-            "standardized-contests": (
-                io.BytesIO(b"not a csv"),
-                "standardized-contests.txt",
-            )
+            "storagePathKey": "test_dir/random.txt",
+            "fileName": "random.txt",
+            "fileType": "text/plain",
         },
     )
     assert rv.status_code == 400
@@ -249,14 +227,10 @@ def test_standardized_contests_wrong_audit_type(
         db_session.add(election)
         db_session.commit()
 
-        rv = client.put(
-            f"/api/election/{election_id}/standardized-contests/file",
-            data={
-                "standardized-contests": (
-                    io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 1,all\n"),
-                    "standardized-contests.csv",
-                )
-            },
+        rv = setup_standardized_contests_upload(
+            client,
+            io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 1,all\n"),
+            election_id,
         )
         assert rv.status_code == 409
         assert json.loads(rv.data) == {
@@ -272,14 +246,10 @@ def test_standardized_contests_wrong_audit_type(
 def test_standardized_contests_before_jurisdictions(
     client: FlaskClient, election_id: str
 ):
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 1,all\n"),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(b"Contest Name,Jurisdictions\n" b"Contest 1,all\n"),
+        election_id,
     )
     assert rv.status_code == 409
     assert json.loads(rv.data) == {
@@ -295,19 +265,15 @@ def test_standardized_contests_before_jurisdictions(
 def test_standardized_contests_newlines(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(
-                    b"Contest Name,Jurisdictions\n"
-                    b'"Contest\r\n1",all\n'
-                    b'Contest 2,"J1, J3"\n'
-                    b"Contest 3,J2\n"
-                ),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(
+            b"Contest Name,Jurisdictions\n"
+            b'"Contest\r\n1",all\n'
+            b'Contest 2,"J1, J3"\n'
+            b"Contest 3,J2\n"
+        ),
+        election_id,
     )
     assert_ok(rv)
 
@@ -325,19 +291,15 @@ def test_standardized_contests_newlines(
 def test_standardized_contests_dominion_vote_for(
     client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
 ):
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(
-                    b"Contest Name,Jurisdictions\n"
-                    b'"Contest\r\n1 (Vote For=2)",all\n'
-                    b'Contest 2,"J1, J3"\n'
-                    b"Contest 3,J2\n"
-                ),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(
+            b"Contest Name,Jurisdictions\n"
+            b'"Contest\r\n1 (Vote For=2)",all\n'
+            b'Contest 2,"J1, J3"\n'
+            b"Contest 3,J2\n"
+        ),
+        election_id,
     )
     assert_ok(rv)
 
@@ -361,14 +323,10 @@ def test_standardized_contests_change_jurisdictions_file(
         'Contest 2,"J1, J3"\n'
         "Contest 3,all \n"
     )
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(standardized_contests_file.encode()),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(standardized_contests_file.encode()),
+        election_id,
     )
     assert_ok(rv)
 
@@ -388,20 +346,16 @@ def test_standardized_contests_change_jurisdictions_file(
     assert_ok(rv)
 
     # Remove a jurisdiction that isn't referenced directly in standardized contests
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/file",
-        data={
-            "jurisdictions": (
-                io.BytesIO(
-                    (
-                        "Jurisdiction,Admin Email\n"
-                        f"J3,j3-{election_id}@example.com\n"
-                        f"J1,{default_ja_email(election_id)}\n"
-                    ).encode()
-                ),
-                "jurisdictions.csv",
-            )
-        },
+    rv = setup_jurisdictions_upload(
+        client,
+        io.BytesIO(
+            (
+                "Jurisdiction,Admin Email\n"
+                f"J3,j3-{election_id}@example.com\n"
+                f"J1,{default_ja_email(election_id)}\n"
+            ).encode()
+        ),
+        election_id,
     )
     assert_ok(rv)
 
@@ -423,19 +377,14 @@ def test_standardized_contests_change_jurisdictions_file(
     ]
 
     # Now remove a jurisdiction that is referenced directly in standardized contests
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/file",
-        data={
-            "jurisdictions": (
-                io.BytesIO(
-                    (
-                        "Jurisdiction,Admin Email\n"
-                        f"J1,{default_ja_email(election_id)}\n"
-                    ).encode()
-                ),
-                "jurisdictions.csv",
-            )
-        },
+    rv = setup_jurisdictions_upload(
+        client,
+        io.BytesIO(
+            (
+                "Jurisdiction,Admin Email\n" f"J1,{default_ja_email(election_id)}\n"
+            ).encode()
+        ),
+        election_id,
     )
     assert_ok(rv)
 
@@ -449,7 +398,7 @@ def test_standardized_contests_change_jurisdictions_file(
         json.loads(rv.data),
         {
             "file": {
-                "name": "standardized-contests.csv",
+                "name": asserts_startswith("standardizedContests"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -468,14 +417,10 @@ def test_standardized_contests_parse_all(
     standardized_contests_file = (
         "Contest Name,Jurisdictions\n" + "Contest 1,All\n" + "Contest 2,  aLL \n"
     )
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(standardized_contests_file.encode()),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(standardized_contests_file.encode()),
+        election_id,
     )
     assert_ok(rv)
 
@@ -504,14 +449,10 @@ def test_reupload_standardized_contests_after_contests_selected(
         'Contest 2,"J1, J3"\n'
         "Contest 3,J2 \n"
     )
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(standardized_contests_file.encode()),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(standardized_contests_file.encode()),
+        election_id,
     )
     assert_ok(rv)
 
@@ -577,14 +518,10 @@ def test_reupload_standardized_contests_after_contests_selected(
     standardized_contests_file = (
         "Contest Name,Jurisdictions\n" + 'Contest 1,"J1,J2"\n' + "Contest 3,J2 \n"
     )
-    rv = client.put(
-        f"/api/election/{election_id}/standardized-contests/file",
-        data={
-            "standardized-contests": (
-                io.BytesIO(standardized_contests_file.encode()),
-                "standardized-contests.csv",
-            )
-        },
+    rv = setup_standardized_contests_upload(
+        client,
+        io.BytesIO(standardized_contests_file.encode()),
+        election_id,
     )
     assert_ok(rv)
 

--- a/server/tests/batch_comparison/conftest.py
+++ b/server/tests/batch_comparison/conftest.py
@@ -66,7 +66,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Batch Name,Number of Ballots\n"
@@ -84,7 +84,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Batch Name,Number of Ballots\n"
@@ -124,7 +124,7 @@ def batch_tallies(
         b"Batch 8,100,50,50\n"
         b"Batch 9,100,50,50\n"
     )
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(batch_tallies_file),
         election_id,
@@ -140,7 +140,7 @@ def batch_tallies(
         b"Batch 5,100,50,50\n"
         b"Batch 6,100,50,50\n"
     )
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(batch_tallies_file),
         election_id,

--- a/server/tests/batch_comparison/conftest.py
+++ b/server/tests/batch_comparison/conftest.py
@@ -66,43 +66,37 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Batch Name,Number of Ballots\n"
-                    b"Batch 1,500\n"
-                    b"Batch 2,500\n"
-                    b"Batch 3,500\n"
-                    b"Batch 4,500\n"
-                    b"Batch 5,100\n"
-                    b"Batch 6,100\n"
-                    b"Batch 7,100\n"
-                    b"Batch 8,100\n"
-                    b"Batch 9,100\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Batch Name,Number of Ballots\n"
+            b"Batch 1,500\n"
+            b"Batch 2,500\n"
+            b"Batch 3,500\n"
+            b"Batch 4,500\n"
+            b"Batch 5,100\n"
+            b"Batch 6,100\n"
+            b"Batch 7,100\n"
+            b"Batch 8,100\n"
+            b"Batch 9,100\n"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Batch Name,Number of Ballots\n"
-                    b"Batch 1,500\n"
-                    b"Batch 2,500\n"
-                    b"Batch 3,500\n"
-                    b"Batch 4,500\n"
-                    b"Batch 5,250\n"
-                    b"Batch 6,250\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Batch Name,Number of Ballots\n"
+            b"Batch 1,500\n"
+            b"Batch 2,500\n"
+            b"Batch 3,500\n"
+            b"Batch 4,500\n"
+            b"Batch 5,250\n"
+            b"Batch 6,250\n"
+        ),
+        election_id,
+        jurisdiction_ids[1],
     )
     assert_ok(rv)
 
@@ -130,15 +124,13 @@ def batch_tallies(
         b"Batch 8,100,50,50\n"
         b"Batch 9,100,50,50\n"
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
-        data={
-            "batchTallies": (
-                io.BytesIO(batch_tallies_file),
-                "batchTallies.csv",
-            )
-        },
+    rv = setup_batch_tallies_upload(
+        client,
+        io.BytesIO(batch_tallies_file),
+        election_id,
+        jurisdiction_ids[0],
     )
+    assert_ok(rv)
     batch_tallies_file = (
         b"Batch Name,candidate 1,candidate 2,candidate 3\n"
         b"Batch 1,500,250,250\n"
@@ -148,14 +140,11 @@ def batch_tallies(
         b"Batch 5,100,50,50\n"
         b"Batch 6,100,50,50\n"
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/batch-tallies",
-        data={
-            "batchTallies": (
-                io.BytesIO(batch_tallies_file),
-                "batchTallies.csv",
-            )
-        },
+    rv = setup_batch_tallies_upload(
+        client,
+        io.BytesIO(batch_tallies_file),
+        election_id,
+        jurisdiction_ids[1],
     )
     assert_ok(rv)
 

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -103,7 +103,7 @@ def test_batch_comparison_too_many_votes(
         b"Batch 5,100,50,50\n"
         b"Batch 6,100,50,50\n"
     )
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client, io.BytesIO(batch_tallies_file), election_id, jurisdiction_ids[1]
     )
     assert_ok(rv)

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -103,14 +103,8 @@ def test_batch_comparison_too_many_votes(
         b"Batch 5,100,50,50\n"
         b"Batch 6,100,50,50\n"
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/batch-tallies",
-        data={
-            "batchTallies": (
-                io.BytesIO(batch_tallies_file),
-                "batchTallies.csv",
-            )
-        },
+    rv = setup_batch_tallies_upload(
+        client, io.BytesIO(batch_tallies_file), election_id, jurisdiction_ids[1]
     )
     assert_ok(rv)
 

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -179,7 +179,7 @@ def test_batch_inventory_happy_path(
     compare_json(json.loads(rv.data), {"systemType": CvrFileType.DOMINION})
 
     # Upload CVR file
-    rv = setup_batch_inventory_cvr_upload(
+    rv = upload_batch_inventory_cvr(
         client,
         io.BytesIO(TEST_CVR.encode()),
         election_id,
@@ -207,7 +207,7 @@ def test_batch_inventory_happy_path(
     )
 
     # Upload tabulator status file
-    rv = setup_batch_inventory_tabulator_status_upload(
+    rv = upload_batch_inventory_tabulator_status(
         client,
         io.BytesIO(TEST_TABULATOR_STATUS.encode()),
         election_id,
@@ -271,7 +271,7 @@ def test_batch_inventory_happy_path(
     snapshot.assert_match(batch_tallies)
 
     # Upload manifest
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(ballot_manifest.encode()),
         election_id,
@@ -299,7 +299,7 @@ def test_batch_inventory_happy_path(
     )
 
     # Upload batch tallies
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(batch_tallies.encode()),
         election_id,
@@ -390,7 +390,7 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     compare_json(json.loads(rv.data), {"systemType": CvrFileType.DOMINION})
 
     # Upload CVR file
-    rv = setup_batch_inventory_cvr_upload(
+    rv = upload_batch_inventory_cvr(
         client,
         io.BytesIO(TEST_CVRS_WITH_LEADING_EQUAL_SIGNS.encode()),
         election_id,
@@ -418,7 +418,7 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     )
 
     # Upload tabulator status file
-    rv = setup_batch_inventory_tabulator_status_upload(
+    rv = upload_batch_inventory_tabulator_status(
         client,
         io.BytesIO(TEST_TABULATOR_STATUS.encode()),
         election_id,
@@ -482,7 +482,7 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     snapshot.assert_match(batch_tallies)
 
     # Upload manifest
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(ballot_manifest.encode()),
         election_id,
@@ -510,7 +510,7 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     )
 
     # Upload batch tallies
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(batch_tallies.encode()),
         election_id,
@@ -601,7 +601,7 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     compare_json(json.loads(rv.data), {"systemType": CvrFileType.DOMINION})
 
     # Upload CVR file
-    rv = setup_batch_inventory_cvr_upload(
+    rv = upload_batch_inventory_cvr(
         client,
         io.BytesIO(TEST_CVR.encode()),
         election_id,
@@ -629,7 +629,7 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     )
 
     # Upload tabulator status file
-    rv = setup_batch_inventory_tabulator_status_upload(
+    rv = upload_batch_inventory_tabulator_status(
         client,
         io.BytesIO(TEST_TABULATOR_STATUS.encode()),
         election_id,
@@ -693,7 +693,7 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     snapshot.assert_match(batch_tallies)
 
     # Upload manifest
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(ballot_manifest.encode()),
         election_id,
@@ -721,7 +721,7 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     )
 
     # Upload batch tallies
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(batch_tallies.encode()),
         election_id,
@@ -826,7 +826,7 @@ def test_batch_inventory_invalid_file_uploads(
         ),
     ]
     for invalid_cvr, expected_error in invalid_cvrs:
-        rv = setup_batch_inventory_cvr_upload(
+        rv = upload_batch_inventory_cvr(
             client,
             io.BytesIO(invalid_cvr.encode()),
             election_id,
@@ -847,7 +847,7 @@ def test_batch_inventory_invalid_file_uploads(
         assert_ok(rv)
 
     # Upload valid CVR file
-    rv = setup_batch_inventory_cvr_upload(
+    rv = upload_batch_inventory_cvr(
         client,
         io.BytesIO(TEST_CVR.encode()),
         election_id,
@@ -862,7 +862,7 @@ def test_batch_inventory_invalid_file_uploads(
     assert cvr["processing"]["status"] == ProcessingStatus.PROCESSED
 
     # Upload tabulator status file with missing tabulator
-    rv = setup_batch_inventory_tabulator_status_upload(
+    rv = upload_batch_inventory_tabulator_status(
         client,
         io.BytesIO(
             TEST_TABULATOR_STATUS.replace(
@@ -888,7 +888,7 @@ def test_batch_inventory_invalid_file_uploads(
     )
     assert_ok(rv)
 
-    rv = setup_batch_inventory_cvr_upload(
+    rv = upload_batch_inventory_cvr(
         client,
         io.BytesIO(
             TEST_CVR.replace(
@@ -955,7 +955,7 @@ def test_batch_inventory_missing_data_multi_contest_batch_comparison(
         ),
     ]
     for invalid_cvr, expected_error in invalid_cvrs:
-        rv = setup_batch_inventory_cvr_upload(
+        rv = upload_batch_inventory_cvr(
             client,
             io.BytesIO(invalid_cvr.encode()),
             election_id,
@@ -996,7 +996,7 @@ def test_batch_inventory_excel_tabulator_status_file(
     assert_ok(rv)
 
     # Upload CVR file
-    rv = setup_batch_inventory_cvr_upload(
+    rv = upload_batch_inventory_cvr(
         client,
         io.BytesIO(TEST_CVR.encode()),
         election_id,
@@ -1005,7 +1005,7 @@ def test_batch_inventory_excel_tabulator_status_file(
     assert_ok(rv)
 
     # Upload tabulator status "To Excel" version
-    rv = setup_batch_inventory_tabulator_status_upload(
+    rv = upload_batch_inventory_tabulator_status(
         client,
         io.BytesIO(
             b"""<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet" xmlns:html="http://www.w3.org/TR/REC-html40" xmlns:msxsl="urn:schemas-microsoft-com:xslt">
@@ -1177,7 +1177,7 @@ def test_batch_inventory_wrong_tabulator_status_file(
     assert_ok(rv)
 
     # Upload CVR file
-    rv = setup_batch_inventory_cvr_upload(
+    rv = upload_batch_inventory_cvr(
         client,
         io.BytesIO(TEST_CVR.encode()),
         election_id,
@@ -1186,7 +1186,7 @@ def test_batch_inventory_wrong_tabulator_status_file(
     assert_ok(rv)
 
     # Upload tabulator status HTML version
-    rv = setup_batch_inventory_tabulator_status_upload(
+    rv = upload_batch_inventory_tabulator_status(
         client,
         io.BytesIO(
             b"""<html xmlns:msxsl="urn:schemas-microsoft-com:xslt" xmlns:user="http://www.contoso.com">
@@ -1305,7 +1305,7 @@ def test_batch_inventory_undo_sign_off(
     assert_ok(rv)
 
     # Upload CVR file
-    rv = setup_batch_inventory_cvr_upload(
+    rv = upload_batch_inventory_cvr(
         client,
         io.BytesIO(TEST_CVR.encode()),
         election_id,
@@ -1314,7 +1314,7 @@ def test_batch_inventory_undo_sign_off(
     assert_ok(rv)
 
     # Upload tabulator status file
-    rv = setup_batch_inventory_tabulator_status_upload(
+    rv = upload_batch_inventory_tabulator_status(
         client,
         io.BytesIO(TEST_TABULATOR_STATUS.encode()),
         election_id,
@@ -1360,7 +1360,7 @@ def test_batch_inventory_delete_cvr_after_sign_off(
     assert_ok(rv)
 
     # Upload CVR file
-    rv = setup_batch_inventory_cvr_upload(
+    rv = upload_batch_inventory_cvr(
         client,
         io.BytesIO(TEST_CVR.encode()),
         election_id,
@@ -1369,7 +1369,7 @@ def test_batch_inventory_delete_cvr_after_sign_off(
     assert_ok(rv)
 
     # Upload tabulator status file
-    rv = setup_batch_inventory_tabulator_status_upload(
+    rv = upload_batch_inventory_tabulator_status(
         client,
         io.BytesIO(TEST_TABULATOR_STATUS.encode()),
         election_id,
@@ -1415,7 +1415,7 @@ def test_batch_inventory_delete_tabulator_status_after_sign_off(
     assert_ok(rv)
 
     # Upload CVR file
-    rv = setup_batch_inventory_cvr_upload(
+    rv = upload_batch_inventory_cvr(
         client,
         io.BytesIO(TEST_CVR.encode()),
         election_id,
@@ -1424,7 +1424,7 @@ def test_batch_inventory_delete_tabulator_status_after_sign_off(
     assert_ok(rv)
 
     # Upload tabulator status file
-    rv = setup_batch_inventory_tabulator_status_upload(
+    rv = upload_batch_inventory_tabulator_status(
         client,
         io.BytesIO(TEST_TABULATOR_STATUS.encode()),
         election_id,
@@ -1468,7 +1468,7 @@ def test_batch_inventory_upload_cvr_before_contests(
     )
     assert_ok(rv)
 
-    rv = setup_batch_inventory_cvr_upload(
+    rv = upload_batch_inventory_cvr(
         client,
         io.BytesIO(TEST_CVR.encode()),
         election_id,
@@ -1502,7 +1502,7 @@ def test_batch_inventory_upload_tabulator_status_before_cvr(
     )
     assert_ok(rv)
 
-    rv = setup_batch_inventory_tabulator_status_upload(
+    rv = upload_batch_inventory_tabulator_status(
         client,
         io.BytesIO(TEST_TABULATOR_STATUS.encode()),
         election_id,

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -179,14 +179,11 @@ def test_batch_inventory_happy_path(
     compare_json(json.loads(rv.data), {"systemType": CvrFileType.DOMINION})
 
     # Upload CVR file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={
-            "cvr": (
-                io.BytesIO(TEST_CVR.encode()),
-                "cvrs.csv",
-            ),
-        },
+    rv = setup_batch_inventory_cvr_upload(
+        client,
+        io.BytesIO(TEST_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -196,7 +193,10 @@ def test_batch_inventory_happy_path(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "cvrs.csv", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("batchInventoryCvr"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -207,14 +207,11 @@ def test_batch_inventory_happy_path(
     )
 
     # Upload tabulator status file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
-        data={
-            "tabulatorStatus": (
-                io.BytesIO(TEST_TABULATOR_STATUS.encode()),
-                "tabulator-status.xml",
-            ),
-        },
+    rv = setup_batch_inventory_tabulator_status_upload(
+        client,
+        io.BytesIO(TEST_TABULATOR_STATUS.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -224,7 +221,10 @@ def test_batch_inventory_happy_path(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "tabulator-status.xml", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("tabulator-status"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -271,14 +271,11 @@ def test_batch_inventory_happy_path(
     snapshot.assert_match(batch_tallies)
 
     # Upload manifest
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(ballot_manifest.encode()),
-                "ballot-manifest.csv",
-            ),
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(ballot_manifest.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -288,7 +285,10 @@ def test_batch_inventory_happy_path(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "ballot-manifest.csv", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("manifest"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -299,14 +299,11 @@ def test_batch_inventory_happy_path(
     )
 
     # Upload batch tallies
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
-        data={
-            "batchTallies": (
-                io.BytesIO(batch_tallies.encode()),
-                "batch-tallies.csv",
-            )
-        },
+    rv = setup_batch_tallies_upload(
+        client,
+        io.BytesIO(batch_tallies.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -316,7 +313,10 @@ def test_batch_inventory_happy_path(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "batch-tallies.csv", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("batchTallies"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -390,14 +390,11 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     compare_json(json.loads(rv.data), {"systemType": CvrFileType.DOMINION})
 
     # Upload CVR file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={
-            "cvr": (
-                io.BytesIO(TEST_CVRS_WITH_LEADING_EQUAL_SIGNS.encode()),
-                "cvrs.csv",
-            ),
-        },
+    rv = setup_batch_inventory_cvr_upload(
+        client,
+        io.BytesIO(TEST_CVRS_WITH_LEADING_EQUAL_SIGNS.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -407,7 +404,10 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "cvrs.csv", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("batchInventoryCvr"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -418,14 +418,11 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     )
 
     # Upload tabulator status file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
-        data={
-            "tabulatorStatus": (
-                io.BytesIO(TEST_TABULATOR_STATUS.encode()),
-                "tabulator-status.xml",
-            ),
-        },
+    rv = setup_batch_inventory_tabulator_status_upload(
+        client,
+        io.BytesIO(TEST_TABULATOR_STATUS.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -435,7 +432,10 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "tabulator-status.xml", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("tabulator-status"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -482,14 +482,11 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     snapshot.assert_match(batch_tallies)
 
     # Upload manifest
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(ballot_manifest.encode()),
-                "ballot-manifest.csv",
-            ),
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(ballot_manifest.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -499,7 +496,10 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "ballot-manifest.csv", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("manifest"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -510,14 +510,11 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     )
 
     # Upload batch tallies
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
-        data={
-            "batchTallies": (
-                io.BytesIO(batch_tallies.encode()),
-                "batch-tallies.csv",
-            )
-        },
+    rv = setup_batch_tallies_upload(
+        client,
+        io.BytesIO(batch_tallies.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -527,7 +524,10 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "batch-tallies.csv", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("batchTallies"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -601,14 +601,11 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     compare_json(json.loads(rv.data), {"systemType": CvrFileType.DOMINION})
 
     # Upload CVR file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={
-            "cvr": (
-                io.BytesIO(TEST_CVR.encode()),
-                "cvrs.csv",
-            ),
-        },
+    rv = setup_batch_inventory_cvr_upload(
+        client,
+        io.BytesIO(TEST_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -618,7 +615,10 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "cvrs.csv", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("batchInventoryCvr"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -629,14 +629,11 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     )
 
     # Upload tabulator status file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
-        data={
-            "tabulatorStatus": (
-                io.BytesIO(TEST_TABULATOR_STATUS.encode()),
-                "tabulator-status.xml",
-            ),
-        },
+    rv = setup_batch_inventory_tabulator_status_upload(
+        client,
+        io.BytesIO(TEST_TABULATOR_STATUS.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -646,7 +643,10 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "tabulator-status.xml", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("tabulator-status"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -693,14 +693,11 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     snapshot.assert_match(batch_tallies)
 
     # Upload manifest
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(ballot_manifest.encode()),
-                "ballot-manifest.csv",
-            ),
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(ballot_manifest.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -710,7 +707,10 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "ballot-manifest.csv", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("manifest"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -721,14 +721,11 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     )
 
     # Upload batch tallies
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
-        data={
-            "batchTallies": (
-                io.BytesIO(batch_tallies.encode()),
-                "batch-tallies.csv",
-            )
-        },
+    rv = setup_batch_tallies_upload(
+        client,
+        io.BytesIO(batch_tallies.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -738,7 +735,10 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "batch-tallies.csv", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("batchTallies"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -826,14 +826,11 @@ def test_batch_inventory_invalid_file_uploads(
         ),
     ]
     for invalid_cvr, expected_error in invalid_cvrs:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-            data={
-                "cvr": (
-                    io.BytesIO(invalid_cvr.encode()),
-                    "cvrs.csv",
-                )
-            },
+        rv = setup_batch_inventory_cvr_upload(
+            client,
+            io.BytesIO(invalid_cvr.encode()),
+            election_id,
+            jurisdiction_ids[0],
         )
         assert_ok(rv)
 
@@ -850,14 +847,11 @@ def test_batch_inventory_invalid_file_uploads(
         assert_ok(rv)
 
     # Upload valid CVR file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={
-            "cvr": (
-                io.BytesIO(TEST_CVR.encode()),
-                "cvrs.csv",
-            ),
-        },
+    rv = setup_batch_inventory_cvr_upload(
+        client,
+        io.BytesIO(TEST_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -868,18 +862,15 @@ def test_batch_inventory_invalid_file_uploads(
     assert cvr["processing"]["status"] == ProcessingStatus.PROCESSED
 
     # Upload tabulator status file with missing tabulator
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
-        data={
-            "tabulatorStatus": (
-                io.BytesIO(
-                    TEST_TABULATOR_STATUS.replace(
-                        '<tb id="1" tid="TABULATOR1" name="Tabulator 1" />', ""
-                    ).encode()
-                ),
-                "tabulator-status.xml",
-            ),
-        },
+    rv = setup_batch_inventory_tabulator_status_upload(
+        client,
+        io.BytesIO(
+            TEST_TABULATOR_STATUS.replace(
+                '<tb id="1" tid="TABULATOR1" name="Tabulator 1" />', ""
+            ).encode()
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     rv = client.get(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status"
@@ -897,25 +888,22 @@ def test_batch_inventory_invalid_file_uploads(
     )
     assert_ok(rv)
 
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={
-            "cvr": (
-                io.BytesIO(
-                    TEST_CVR.replace(
-                        """1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1,1,1,0
+    rv = setup_batch_inventory_cvr_upload(
+        client,
+        io.BytesIO(
+            TEST_CVR.replace(
+                """1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1,1,1,0
 2,TABULATOR1,BATCH1,2,1-1-2,Election Day,12345,COUNTY,1,0,1,0,1
 3,TABULATOR1,BATCH1,3,1-1-3,Election Day,12345,COUNTY,0,1,1,1,0
 4,TABULATOR1,BATCH2,1,1-2-1,Election Day,12345,COUNTY,1,0,1,0,1
 5,TABULATOR1,BATCH2,2,1-2-2,Election Day,12345,COUNTY,0,1,1,1,0
 6,TABULATOR1,BATCH2,3,1-2-3,Election Day,12345,COUNTY,1,0,1,0,1
 """,
-                        "",
-                    ).encode()
-                ),
-                "cvrs.csv",
-            ),
-        },
+                "",
+            ).encode()
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -967,14 +955,11 @@ def test_batch_inventory_missing_data_multi_contest_batch_comparison(
         ),
     ]
     for invalid_cvr, expected_error in invalid_cvrs:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-            data={
-                "cvr": (
-                    io.BytesIO(invalid_cvr.encode()),
-                    "cvrs.csv",
-                )
-            },
+        rv = setup_batch_inventory_cvr_upload(
+            client,
+            io.BytesIO(invalid_cvr.encode()),
+            election_id,
+            jurisdiction_ids[0],
         )
         assert_ok(rv)
 
@@ -1011,24 +996,19 @@ def test_batch_inventory_excel_tabulator_status_file(
     assert_ok(rv)
 
     # Upload CVR file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={
-            "cvr": (
-                io.BytesIO(TEST_CVR.encode()),
-                "cvrs.csv",
-            ),
-        },
+    rv = setup_batch_inventory_cvr_upload(
+        client,
+        io.BytesIO(TEST_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
     # Upload tabulator status "To Excel" version
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
-        data={
-            "tabulatorStatus": (
-                io.BytesIO(
-                    b"""<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet" xmlns:html="http://www.w3.org/TR/REC-html40" xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+    rv = setup_batch_inventory_tabulator_status_upload(
+        client,
+        io.BytesIO(
+            b"""<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet" xmlns:html="http://www.w3.org/TR/REC-html40" xmlns:msxsl="urn:schemas-microsoft-com:xslt">
 <Styles>
 <Style ss:ID="Number">
 <NumberFormat ss:Format="###,###,##0"/>
@@ -1147,10 +1127,9 @@ def test_batch_inventory_excel_tabulator_status_file(
 </Worksheet>
 </Workbook>
 """
-                ),
-                "tabulator-status.xml",
-            ),
-        },
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
 
     rv = client.get(
@@ -1207,12 +1186,10 @@ def test_batch_inventory_wrong_tabulator_status_file(
     assert_ok(rv)
 
     # Upload tabulator status HTML version
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
-        data={
-            "tabulatorStatus": (
-                io.BytesIO(
-                    b"""<html xmlns:msxsl="urn:schemas-microsoft-com:xslt" xmlns:user="http://www.contoso.com">
+    rv = setup_batch_inventory_tabulator_status_upload(
+        client,
+        io.BytesIO(
+            b"""<html xmlns:msxsl="urn:schemas-microsoft-com:xslt" xmlns:user="http://www.contoso.com">
   <head>
     <META http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Tabulator Status</title>
@@ -1293,10 +1270,9 @@ p { line-height=100%}
   </body>
 </html>
 """
-                ),
-                "tabulator-status.xml",
-            ),
-        },
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
 
     rv = client.get(
@@ -1329,26 +1305,20 @@ def test_batch_inventory_undo_sign_off(
     assert_ok(rv)
 
     # Upload CVR file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={
-            "cvr": (
-                io.BytesIO(TEST_CVR.encode()),
-                "cvrs.csv",
-            ),
-        },
+    rv = setup_batch_inventory_cvr_upload(
+        client,
+        io.BytesIO(TEST_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
     # Upload tabulator status file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
-        data={
-            "tabulatorStatus": (
-                io.BytesIO(TEST_TABULATOR_STATUS.encode()),
-                "tabulator-status.xml",
-            ),
-        },
+    rv = setup_batch_inventory_tabulator_status_upload(
+        client,
+        io.BytesIO(TEST_TABULATOR_STATUS.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
 
     # Sign off
@@ -1390,26 +1360,20 @@ def test_batch_inventory_delete_cvr_after_sign_off(
     assert_ok(rv)
 
     # Upload CVR file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={
-            "cvr": (
-                io.BytesIO(TEST_CVR.encode()),
-                "cvrs.csv",
-            ),
-        },
+    rv = setup_batch_inventory_cvr_upload(
+        client,
+        io.BytesIO(TEST_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
     # Upload tabulator status file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
-        data={
-            "tabulatorStatus": (
-                io.BytesIO(TEST_TABULATOR_STATUS.encode()),
-                "tabulator-status.xml",
-            ),
-        },
+    rv = setup_batch_inventory_tabulator_status_upload(
+        client,
+        io.BytesIO(TEST_TABULATOR_STATUS.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
 
     # Sign off
@@ -1451,26 +1415,20 @@ def test_batch_inventory_delete_tabulator_status_after_sign_off(
     assert_ok(rv)
 
     # Upload CVR file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={
-            "cvr": (
-                io.BytesIO(TEST_CVR.encode()),
-                "cvrs.csv",
-            ),
-        },
+    rv = setup_batch_inventory_cvr_upload(
+        client,
+        io.BytesIO(TEST_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
     # Upload tabulator status file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
-        data={
-            "tabulatorStatus": (
-                io.BytesIO(TEST_TABULATOR_STATUS.encode()),
-                "tabulator-status.xml",
-            ),
-        },
+    rv = setup_batch_inventory_tabulator_status_upload(
+        client,
+        io.BytesIO(TEST_TABULATOR_STATUS.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
 
     # Sign off
@@ -1510,14 +1468,11 @@ def test_batch_inventory_upload_cvr_before_contests(
     )
     assert_ok(rv)
 
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={
-            "cvr": (
-                io.BytesIO(TEST_CVR.encode()),
-                "cvrs.csv",
-            ),
-        },
+    rv = setup_batch_inventory_cvr_upload(
+        client,
+        io.BytesIO(TEST_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert json.loads(rv.data) == {
         "errors": [
@@ -1547,14 +1502,11 @@ def test_batch_inventory_upload_tabulator_status_before_cvr(
     )
     assert_ok(rv)
 
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status",
-        data={
-            "tabulatorStatus": (
-                io.BytesIO(TEST_TABULATOR_STATUS.encode()),
-                "tabulator-status.xml",
-            ),
-        },
+    rv = setup_batch_inventory_tabulator_status_upload(
+        client,
+        io.BytesIO(TEST_TABULATOR_STATUS.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert json.loads(rv.data) == {
         "errors": [

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -1138,7 +1138,10 @@ def test_batch_inventory_excel_tabulator_status_file(
     compare_json(
         json.loads(rv.data),
         {
-            "file": {"name": "tabulator-status.xml", "uploadedAt": assert_is_date},
+            "file": {
+                "name": asserts_startswith("tabulator-status"),
+                "uploadedAt": assert_is_date,
+            },
             "processing": {
                 "status": ProcessingStatus.PROCESSED,
                 "startedAt": assert_is_date,
@@ -1174,14 +1177,11 @@ def test_batch_inventory_wrong_tabulator_status_file(
     assert_ok(rv)
 
     # Upload CVR file
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr",
-        data={
-            "cvr": (
-                io.BytesIO(TEST_CVR.encode()),
-                "cvrs.csv",
-            ),
-        },
+    rv = setup_batch_inventory_cvr_upload(
+        client,
+        io.BytesIO(TEST_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -1564,3 +1564,87 @@ def test_batch_inventory_upload_tabulator_status_before_cvr(
             }
         ]
     }
+
+
+def test_batch_inventory_cvr_get_upload_url_missing_file_type(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr/upload-url"
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Bad Request",
+                "message": "Missing expected query parameter: fileType",
+            }
+        ]
+    }
+
+
+def test_batch_inventory_cvr_get_upload_url(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr/upload-url",
+        query_string={"fileType": "text/csv"},
+    )
+    assert rv.status_code == 200
+
+    response_data = json.loads(rv.data)
+    expected_url = "/api/file-upload"
+
+    assert response_data["url"] == expected_url
+    assert response_data["fields"]["key"].startswith(
+        f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/batch-inventory-cvrs_"
+    )
+    assert response_data["fields"]["key"].endswith(".csv")
+
+
+def test_batch_inventory_tabulator_status_get_upload_url_missing_file_type(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status/upload-url"
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Bad Request",
+                "message": "Missing expected query parameter: fileType",
+            }
+        ]
+    }
+
+
+def test_batch_inventory_tabulator_status_get_upload_url(
+    client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status/upload-url",
+        query_string={"fileType": "application/xml"},
+    )
+    assert rv.status_code == 200
+
+    response_data = json.loads(rv.data)
+    expected_url = "/api/file-upload"
+
+    assert response_data["url"] == expected_url
+    assert response_data["fields"]["key"].startswith(
+        f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/batch-inventory-tabulator-status_"
+    )
+    assert response_data["fields"]["key"].endswith(".xml")

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -277,7 +277,7 @@ def test_batch_tallies_upload_missing_file(
     )
     rv = client.post(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies/upload-complete",
-        data={},
+        json={},
     )
     assert rv.status_code == 400
     assert json.loads(rv.data) == {
@@ -313,7 +313,7 @@ def test_batch_tallies_upload_bad_csv(
     assert_ok(rv)
     rv = client.post(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies/upload-complete",
-        data={
+        json={
             "storagePathKey": "test_dir/random.txt",
             "fileName": "random.txt",
             "fileType": "text/plain",

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -12,7 +12,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Batch Name,Number of Ballots\n"
@@ -48,7 +48,7 @@ def test_batch_tallies_upload(
         b"Batch 1,1,10,100\n"
         b"Batch 2,2,20,200\n"
     )
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client, io.BytesIO(batch_tallies_file), election_id, jurisdiction_ids[0]
     )
     assert_ok(rv)
@@ -144,7 +144,7 @@ def test_batch_tallies_clear(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(
             b"Batch Name,candidate 1,candidate 2,candidate 3\n"
@@ -191,7 +191,7 @@ def test_batch_tallies_replace_as_audit_admin(
 ):
     # Check that AA can also get/put/clear batch tallies
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(
             b"Batch Name,candidate 1,candidate 2,candidate 3\n"
@@ -206,7 +206,7 @@ def test_batch_tallies_replace_as_audit_admin(
 
     file_id = Jurisdiction.query.get(jurisdiction_ids[0]).batch_tallies_file_id
 
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(
             b"Batch Name,candidate 1,candidate 2,candidate 3\n"
@@ -345,7 +345,7 @@ def test_batch_tallies_upload_missing_choice(
     for missing_field in headers:
         header_row = ",".join(h for h in headers if h != missing_field)
 
-        rv = setup_batch_tallies_upload(
+        rv = upload_batch_tallies(
             client,
             io.BytesIO(header_row.encode() + b"\n1,2,3"),
             election_id,
@@ -420,7 +420,7 @@ def test_batch_tallies_wrong_batch_names(
         ),
     ]
     for bad_file, expected_error in bad_files:
-        rv = setup_batch_tallies_upload(
+        rv = upload_batch_tallies(
             client, io.BytesIO(bad_file), election_id, jurisdiction_ids[0]
         )
         assert_ok(rv)
@@ -455,7 +455,7 @@ def test_batch_tallies_too_many_tallies(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(
             b"Batch Name,candidate 1,candidate 2,candidate 3\n"
@@ -504,7 +504,7 @@ def test_batch_tallies_ballot_polling(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(
             b"Batch Name,candidate 1,candidate 2,candidate 3\n"
@@ -536,7 +536,7 @@ def test_batch_tallies_bad_jurisdiction(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, f"j3-{election_id}@example.com"
     )
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(
             b"Batch Name,candidate 1,candidate 2,candidate 3\n"
@@ -567,7 +567,7 @@ def test_batch_tallies_before_manifests(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(
             b"Batch Name,candidate 1,candidate 2,candidate 3\n"
@@ -601,7 +601,7 @@ def test_batch_tallies_reprocess_after_manifest_reupload(
     )
 
     # Upload tallies
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(
             b"Batch Name,candidate 1,candidate 2,candidate 3\n"
@@ -615,7 +615,7 @@ def test_batch_tallies_reprocess_after_manifest_reupload(
     assert_ok(rv)
 
     # Reupload a manifest but remove a batch
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(b"Batch Name,Number of Ballots\n" b"Batch 1,200\n" b"Batch 2,300\n"),
         election_id,
@@ -646,7 +646,7 @@ def test_batch_tallies_reprocess_after_manifest_reupload(
     assert Jurisdiction.query.get(jurisdiction_ids[0]).batch_tallies is None
 
     # Fix the manifest
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Batch Name,Number of Ballots\n"

--- a/server/tests/batch_comparison/test_batches.py
+++ b/server/tests/batch_comparison/test_batches.py
@@ -915,21 +915,16 @@ def test_batches_human_sort_order(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for jurisdiction_id in jurisdiction_ids[:2]:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/ballot-manifest",
-            data={
-                "manifest": (
-                    io.BytesIO(
-                        (
-                            "Batch Name,Number of Ballots\n"
-                            + "\n".join(
-                                f"{batch},20" for batch in human_ordered_batches
-                            )
-                        ).encode()
-                    ),
-                    "manifest.csv",
-                )
-            },
+        rv = setup_ballot_manifest_upload(
+            client,
+            io.BytesIO(
+                (
+                    "Batch Name,Number of Ballots\n"
+                    + "\n".join(f"{batch},20" for batch in human_ordered_batches)
+                ).encode()
+            ),
+            election_id,
+            jurisdiction_id,
         )
         assert_ok(rv)
 
@@ -938,14 +933,11 @@ def test_batches_human_sort_order(
             "Batch Name,candidate 1,candidate 2,candidate 3\n"
             + "\n".join(f"{batch},10,5,5" for batch in human_ordered_batches)
         )
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-tallies",
-            data={
-                "batchTallies": (
-                    io.BytesIO(batch_tallies_file.encode()),
-                    "batchTallies.csv",
-                )
-            },
+        rv = setup_batch_tallies_upload(
+            client,
+            io.BytesIO(batch_tallies_file.encode()),
+            election_id,
+            jurisdiction_id,
         )
         assert_ok(rv)
         rv = client.get(

--- a/server/tests/batch_comparison/test_batches.py
+++ b/server/tests/batch_comparison/test_batches.py
@@ -915,7 +915,7 @@ def test_batches_human_sort_order(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for jurisdiction_id in jurisdiction_ids[:2]:
-        rv = setup_ballot_manifest_upload(
+        rv = upload_ballot_manifest(
             client,
             io.BytesIO(
                 (
@@ -933,7 +933,7 @@ def test_batches_human_sort_order(
             "Batch Name,candidate 1,candidate 2,candidate 3\n"
             + "\n".join(f"{batch},10,5,5" for batch in human_ordered_batches)
         )
-        rv = setup_batch_tallies_upload(
+        rv = upload_batch_tallies(
             client,
             io.BytesIO(batch_tallies_file.encode()),
             election_id,

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -73,9 +73,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         ),
     }
     for jurisdiction_id, manifest in manifests_by_jurisdiction.items():
-        rv = setup_ballot_manifest_upload(
-            client, manifest, election_id, jurisdiction_id
-        )
+        rv = upload_ballot_manifest(client, manifest, election_id, jurisdiction_id)
         assert_ok(rv)
 
 
@@ -125,7 +123,7 @@ def batch_tallies(
         jurisdiction_id,
         batch_tallies_file,
     ) in batch_tallies_by_jurisdiction.items():
-        rv = setup_batch_tallies_upload(
+        rv = upload_batch_tallies(
             client,
             batch_tallies_file,
             election_id,
@@ -251,7 +249,7 @@ def test_multi_contest_batch_comparison_jurisdiction_upload_validation(
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
 
     for jurisdiction_id, batch_tallies_file, expected_error in test_cases:
-        rv = setup_batch_tallies_upload(
+        rv = upload_batch_tallies(
             client, batch_tallies_file, election_id, jurisdiction_id
         )
         assert_ok(rv)

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -73,14 +73,8 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         ),
     }
     for jurisdiction_id, manifest in manifests_by_jurisdiction.items():
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/ballot-manifest",
-            data={
-                "manifest": (
-                    manifest,
-                    "manifest.csv",
-                )
-            },
+        rv = setup_ballot_manifest_upload(
+            client, manifest, election_id, jurisdiction_id
         )
         assert_ok(rv)
 
@@ -131,14 +125,11 @@ def batch_tallies(
         jurisdiction_id,
         batch_tallies_file,
     ) in batch_tallies_by_jurisdiction.items():
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-tallies",
-            data={
-                "batchTallies": (
-                    batch_tallies_file,
-                    "batchTallies.csv",
-                )
-            },
+        rv = setup_batch_tallies_upload(
+            client,
+            batch_tallies_file,
+            election_id,
+            jurisdiction_id,
         )
         assert_ok(rv)
 
@@ -260,14 +251,8 @@ def test_multi_contest_batch_comparison_jurisdiction_upload_validation(
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
 
     for jurisdiction_id, batch_tallies_file, expected_error in test_cases:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-tallies",
-            data={
-                "batchTallies": (
-                    batch_tallies_file,
-                    "batchTallies.csv",
-                )
-            },
+        rv = setup_batch_tallies_upload(
+            client, batch_tallies_file, election_id, jurisdiction_id
         )
         assert_ok(rv)
 

--- a/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
@@ -30,7 +30,7 @@ def manifests(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Batch Name,Number of Ballots\n"
@@ -48,7 +48,7 @@ def manifests(
         jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Batch Name,Number of Ballots\n"
@@ -88,7 +88,7 @@ def batch_tallies(
         b"Batch 8,100,50,50\n"
         b"Batch 9,100,50,50\n"
     )
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client, io.BytesIO(batch_tallies_file), election_id, jurisdiction_ids[0]
     )
     assert_ok(rv)
@@ -101,7 +101,7 @@ def batch_tallies(
         b"Batch 5,100,50,50\n"
         b"Batch 6,100,50,50\n"
     )
-    rv = setup_batch_tallies_upload(
+    rv = upload_batch_tallies(
         client,
         io.BytesIO(batch_tallies_file),
         election_id,
@@ -293,7 +293,7 @@ def test_sample_extra_batches_with_no_extra_batches_to_sample(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Batch Name,Number of Ballots\n"
@@ -311,7 +311,7 @@ def test_sample_extra_batches_with_no_extra_batches_to_sample(
         jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Batch Name,Number of Ballots\n"
@@ -389,7 +389,7 @@ def test_sample_extra_batches_min_percentage_of_jurisdiction_ballots_selected(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Batch Name,Number of Ballots\n"
@@ -462,7 +462,7 @@ def test_sample_extra_batches_hmpb_and_bmd_groups_selected(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Batch Name,Number of Ballots\n"
@@ -558,7 +558,7 @@ def test_sample_extra_batches_with_invalid_counting_group(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Batch Name,Number of Ballots\n"

--- a/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
@@ -30,45 +30,37 @@ def manifests(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                # Mostly HMPB counting groups
-                io.BytesIO(
-                    b"Container,Batch Name,Number of Ballots\n"
-                    b"Absentee by Mail,Batch 1,500\n"
-                    b"Absentee by Mail,Batch 2,500\n"
-                    b"Absentee by Mail,Batch 3,500\n"
-                    b"Absentee by Mail,Batch 4,500\n"
-                    b"Provisional,Batch 5,100\n"
-                    b"Provisional,Batch 6,100\n"
-                    b"Provisional,Batch 7,100\n"
-                    b"Provisional,Batch 8,100\n"
-                    b"Election Day,Batch 9,100\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Container,Batch Name,Number of Ballots\n"
+            b"Absentee by Mail,Batch 1,500\n"
+            b"Absentee by Mail,Batch 2,500\n"
+            b"Absentee by Mail,Batch 3,500\n"
+            b"Absentee by Mail,Batch 4,500\n"
+            b"Provisional,Batch 5,100\n"
+            b"Provisional,Batch 6,100\n"
+            b"Provisional,Batch 7,100\n"
+            b"Provisional,Batch 8,100\n"
+            b"Election Day,Batch 9,100\n"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/ballot-manifest",
-        data={
-            "manifest": (
-                # Mostly BMD counting groups
-                io.BytesIO(
-                    b"Container,Batch Name,Number of Ballots\n"
-                    b"Election Day,Batch 1,500\n"
-                    b"Elections Day,Batch 2,500\n"
-                    b"Advance Voting,Batch 3,500\n"
-                    b"Advanced Voting,Batch 4,500\n"
-                    b"Advanced Voting,Batch 5,250\n"
-                    b"Provisional,Batch 6,250\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Container,Batch Name,Number of Ballots\n"
+            b"Election Day,Batch 1,500\n"
+            b"Elections Day,Batch 2,500\n"
+            b"Advance Voting,Batch 3,500\n"
+            b"Advanced Voting,Batch 4,500\n"
+            b"Advanced Voting,Batch 5,250\n"
+            b"Provisional,Batch 6,250\n"
+        ),
+        election_id,
+        jurisdiction_ids[1],
     )
     assert_ok(rv)
 
@@ -96,15 +88,10 @@ def batch_tallies(
         b"Batch 8,100,50,50\n"
         b"Batch 9,100,50,50\n"
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies",
-        data={
-            "batchTallies": (
-                io.BytesIO(batch_tallies_file),
-                "batchTallies.csv",
-            )
-        },
+    rv = setup_batch_tallies_upload(
+        client, io.BytesIO(batch_tallies_file), election_id, jurisdiction_ids[0]
     )
+    assert_ok(rv)
     batch_tallies_file = (
         b"Batch Name,candidate 1,candidate 2,candidate 3\n"
         b"Batch 1,500,250,250\n"
@@ -114,14 +101,11 @@ def batch_tallies(
         b"Batch 5,100,50,50\n"
         b"Batch 6,100,50,50\n"
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/batch-tallies",
-        data={
-            "batchTallies": (
-                io.BytesIO(batch_tallies_file),
-                "batchTallies.csv",
-            )
-        },
+    rv = setup_batch_tallies_upload(
+        client,
+        io.BytesIO(batch_tallies_file),
+        election_id,
+        jurisdiction_ids[1],
     )
     assert_ok(rv)
 
@@ -309,45 +293,37 @@ def test_sample_extra_batches_with_no_extra_batches_to_sample(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                # Only HMPB counting groups
-                io.BytesIO(
-                    b"Container,Batch Name,Number of Ballots\n"
-                    b"Absentee by Mail,Batch 1,500\n"
-                    b"Absentee by Mail,Batch 2,500\n"
-                    b"Absentee by Mail,Batch 3,500\n"
-                    b"Absentee by Mail,Batch 4,500\n"
-                    b"Provisional,Batch 5,100\n"
-                    b"Provisional,Batch 6,100\n"
-                    b"Provisional,Batch 7,100\n"
-                    b"Provisional,Batch 8,100\n"
-                    b"Provisional,Batch 9,100\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Container,Batch Name,Number of Ballots\n"
+            b"Absentee by Mail,Batch 1,500\n"
+            b"Absentee by Mail,Batch 2,500\n"
+            b"Absentee by Mail,Batch 3,500\n"
+            b"Absentee by Mail,Batch 4,500\n"
+            b"Provisional,Batch 5,100\n"
+            b"Provisional,Batch 6,100\n"
+            b"Provisional,Batch 7,100\n"
+            b"Provisional,Batch 8,100\n"
+            b"Provisional,Batch 9,100\n"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/ballot-manifest",
-        data={
-            "manifest": (
-                # Only BMD counting groups
-                io.BytesIO(
-                    b"Container,Batch Name,Number of Ballots\n"
-                    b"Election Day,Batch 1,500\n"
-                    b"Election Day,Batch 2,500\n"
-                    b"Advanced Voting,Batch 3,500\n"
-                    b"Advanced Voting,Batch 4,500\n"
-                    b"Advanced Voting,Batch 5,250\n"
-                    b"Advanced Voting,Batch 6,250\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Container,Batch Name,Number of Ballots\n"
+            b"Election Day,Batch 1,500\n"
+            b"Election Day,Batch 2,500\n"
+            b"Advanced Voting,Batch 3,500\n"
+            b"Advanced Voting,Batch 4,500\n"
+            b"Advanced Voting,Batch 5,250\n"
+            b"Advanced Voting,Batch 6,250\n"
+        ),
+        election_id,
+        jurisdiction_ids[1],
     )
     assert_ok(rv)
 
@@ -413,25 +389,22 @@ def test_sample_extra_batches_min_percentage_of_jurisdiction_ballots_selected(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Container,Batch Name,Number of Ballots\n"
-                    b"Absentee by Mail,Batch 1,500\n"  # HMPB group
-                    b"Election Day,Batch 2,500\n"
-                    b"Election Day,Batch 3,500\n"
-                    b"Election Day,Batch 4,500\n"
-                    b"Election Day,Batch 5,100\n"
-                    b"Election Day,Batch 6,100\n"
-                    b"Election Day,Batch 7,100\n"
-                    b"Election Day,Batch 8,100\n"
-                    b"Election Day,Batch 9,1000000\n"  # Must be selected to hit the 2% selection threshold
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Container,Batch Name,Number of Ballots\n"
+            b"Absentee by Mail,Batch 1,500\n"  # HMPB group
+            b"Election Day,Batch 2,500\n"
+            b"Election Day,Batch 3,500\n"
+            b"Election Day,Batch 4,500\n"
+            b"Election Day,Batch 5,100\n"
+            b"Election Day,Batch 6,100\n"
+            b"Election Day,Batch 7,100\n"
+            b"Election Day,Batch 8,100\n"
+            b"Election Day,Batch 9,1000000\n"  # Must be selected to hit the 2% selection threshold
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -489,25 +462,22 @@ def test_sample_extra_batches_hmpb_and_bmd_groups_selected(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Container,Batch Name,Number of Ballots\n"
-                    b"Absentee by Mail,Batch 1,500\n"  # HMPB group
-                    b"Absentee by Mail,Batch 2,500\n"
-                    b"Election Day,Batch 3,500\n"  # BMD group
-                    b"Election Day,Batch 4,500\n"
-                    b"Election Day,Batch 5,100\n"
-                    b"Election Day,Batch 6,100\n"
-                    b"Election Day,Batch 7,100\n"
-                    b"Election Day,Batch 8,100\n"
-                    b"Election Day,Batch 9,100\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Container,Batch Name,Number of Ballots\n"
+            b"Absentee by Mail,Batch 1,500\n"  # HMPB group
+            b"Absentee by Mail,Batch 2,500\n"
+            b"Election Day,Batch 3,500\n"  # BMD group
+            b"Election Day,Batch 4,500\n"
+            b"Election Day,Batch 5,100\n"
+            b"Election Day,Batch 6,100\n"
+            b"Election Day,Batch 7,100\n"
+            b"Election Day,Batch 8,100\n"
+            b"Election Day,Batch 9,100\n"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -588,17 +558,14 @@ def test_sample_extra_batches_with_invalid_counting_group(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Container,Batch Name,Number of Ballots\n"
-                    b"Invalid Counting Group,Batch 1,500\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Container,Batch Name,Number of Ballots\n"
+            b"Invalid Counting Group,Batch 1,500\n"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -609,7 +576,7 @@ def test_sample_extra_batches_with_invalid_counting_group(
         json.loads(rv.data),
         {
             "file": {
-                "name": "manifest.csv",
+                "name": asserts_startswith("manifest"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -73,6 +73,8 @@ def election_id(client: FlaskClient, org_id: str, request) -> str:
 def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
     rv = setup_jurisdictions_upload(
         client,
+        # We expect the API to order the jurisdictions by name, so we
+        # upload them out of order.
         io.BytesIO(
             (
                 "Jurisdiction,Admin Email\n"

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -71,7 +71,7 @@ def election_id(client: FlaskClient, org_id: str, request) -> str:
 
 @pytest.fixture
 def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
-    rv = setup_jurisdictions_upload(
+    rv = upload_jurisdictions_file(
         client,
         # We expect the API to order the jurisdictions by name, so we
         # upload them out of order.
@@ -175,7 +175,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Batch Name,Number of Ballots\n" b"1,23\n" b"2,101\n" b"3,122\n" b"4,400"
@@ -184,7 +184,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Batch Name,Number of Ballots\n" b"1,20\n" b"2,10\n" b"3,220\n" b"4,40"

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -71,30 +71,28 @@ def election_id(client: FlaskClient, org_id: str, request) -> str:
 
 @pytest.fixture
 def jurisdiction_ids(client: FlaskClient, election_id: str) -> List[str]:
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/file",
-        data={
-            "jurisdictions": (
-                # We expect the API to order the jurisdictions by name, so we
-                # upload them out of order.
-                io.BytesIO(
-                    (
-                        "Jurisdiction,Admin Email\n"
-                        f"J2,{default_ja_email(election_id)}\n"
-                        f"J3,j3-{election_id}@example.com\n"
-                        f"J1,{default_ja_email(election_id)}\n"
-                    ).encode()
-                ),
-                "jurisdictions.csv",
-            )
-        },
+    rv = setup_jurisdictions_upload(
+        client,
+        io.BytesIO(
+            (
+                "Jurisdiction,Admin Email\n"
+                f"J2,{default_ja_email(election_id)}\n"
+                f"J3,j3-{election_id}@example.com\n"
+                f"J1,{default_ja_email(election_id)}\n"
+            ).encode()
+        ),
+        election_id,
     )
     assert_ok(rv)
+
     jurisdictions = (
         Jurisdiction.query.filter_by(election_id=election_id)
         .order_by(Jurisdiction.name)
         .all()
     )
+
+    # verify jurisdictions processed correctly
+    assert len(jurisdictions) == 3
     return [j.id for j in jurisdictions]
 
 
@@ -175,36 +173,22 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Batch Name,Number of Ballots\n"
-                    b"1,23\n"
-                    b"2,101\n"
-                    b"3,122\n"
-                    b"4,400"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Batch Name,Number of Ballots\n" b"1,23\n" b"2,101\n" b"3,122\n" b"4,400"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Batch Name,Number of Ballots\n"
-                    b"1,20\n"
-                    b"2,10\n"
-                    b"3,220\n"
-                    b"4,40"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Batch Name,Number of Ballots\n" b"1,20\n" b"2,10\n" b"3,220\n" b"4,40"
+        ),
+        election_id,
+        jurisdiction_ids[1],
     )
     assert_ok(rv)
 

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -443,7 +443,7 @@ def upload_file_helper(
 
     return client.post(
         f"{url}/upload-complete",
-        data={
+        json={
             "storagePathKey": f"test_dir/{filename}",
             "fileName": filename,
             "fileType": file_type,

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -452,7 +452,7 @@ def upload_file_helper(
     )
 
 
-def setup_ballot_manifest_upload(
+def upload_ballot_manifest(
     client: FlaskClient,
     file_content: io.BytesIO,
     election_id: str,
@@ -468,7 +468,7 @@ def setup_ballot_manifest_upload(
     )
 
 
-def setup_batch_tallies_upload(
+def upload_batch_tallies(
     client: FlaskClient,
     file_content: io.BytesIO,
     election_id: str,
@@ -484,7 +484,7 @@ def setup_batch_tallies_upload(
     )
 
 
-def setup_cvrs_upload(
+def upload_cvrs(
     client: FlaskClient,
     file_content: io.BytesIO,
     election_id: str,
@@ -512,7 +512,7 @@ def setup_cvrs_upload(
     )
 
 
-def setup_jurisdictions_upload(
+def upload_jurisdictions_file(
     client: FlaskClient,
     file_content: io.BytesIO,
     election_id: str,
@@ -527,7 +527,7 @@ def setup_jurisdictions_upload(
     )
 
 
-def setup_standardized_contests_upload(
+def upload_standardized_contests(
     client: FlaskClient,
     file_content: io.BytesIO,
     election_id: str,
@@ -542,7 +542,7 @@ def setup_standardized_contests_upload(
     )
 
 
-def setup_batch_inventory_cvr_upload(
+def upload_batch_inventory_cvr(
     client: FlaskClient,
     file_content: io.BytesIO,
     election_id: str,
@@ -558,7 +558,7 @@ def setup_batch_inventory_cvr_upload(
     )
 
 
-def setup_batch_inventory_tabulator_status_upload(
+def upload_batch_inventory_tabulator_status(
     client: FlaskClient,
     file_content: io.BytesIO,
     election_id: str,

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -1,12 +1,13 @@
 import io
 import uuid, json, re
 from datetime import datetime
-from typing import Any, List, Union, Tuple, Optional
+from typing import Any, List, Union, Tuple, Optional, Dict, BinaryIO
 import logging
 from flask.testing import FlaskClient
 from werkzeug.wrappers import Response
 from sqlalchemy.exc import IntegrityError
 
+from ..util.file import zip_files, timestamp_filename
 from ..auth.auth_helpers import UserType
 from ..auth import auth_helpers
 from ..database import db_session
@@ -311,6 +312,11 @@ def assert_is_string(value):
     assert isinstance(value, str)
 
 
+def assert_is_int(value):
+    __tracebackhide__ = True  # pylint: disable=unused-variable
+    assert isinstance(value, int)
+
+
 def assert_is_id(value):
     __tracebackhide__ = True  # pylint: disable=unused-variable
     assert isinstance(value, str)
@@ -413,3 +419,175 @@ def string_to_bytes_io(string: str) -> io.BytesIO:
     string_io = io.StringIO(string)
     bytes_io = io.BytesIO(string_io.read().encode("utf-8"))
     return bytes_io
+
+
+def upload_file_helper(
+    client: FlaskClient,
+    url: str,
+    filename: str,
+    file_type: str,
+    file_content: io.BytesIO,
+    cvr_file_type: Optional[str] = None,
+):
+    rv = client.post(
+        "/api/file-upload",
+        data={
+            "file": (
+                file_content,
+                filename,
+            ),
+            "key": f"test_dir/{filename}",
+        },
+    )
+    assert_ok(rv)
+
+    return client.post(
+        f"{url}/upload-complete",
+        data={
+            "storagePathKey": f"test_dir/{filename}",
+            "fileName": filename,
+            "fileType": file_type,
+            "cvrFileType": cvr_file_type,
+        },
+    )
+
+
+def setup_ballot_manifest_upload(
+    client: FlaskClient,
+    file_content: io.BytesIO,
+    election_id: str,
+    jurisdiction_id: str,
+):
+    filename = timestamp_filename("manifest", "csv")
+    return upload_file_helper(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/ballot-manifest",
+        filename,
+        "text/csv",
+        file_content,
+    )
+
+
+def setup_batch_tallies_upload(
+    client: FlaskClient,
+    file_content: io.BytesIO,
+    election_id: str,
+    jurisdiction_id: str,
+):
+    filename = timestamp_filename("batchTallies", "csv")
+    return upload_file_helper(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-tallies",
+        filename,
+        "text/csv",
+        file_content,
+    )
+
+
+def setup_cvrs_upload(
+    client: FlaskClient,
+    file_content: io.BytesIO,
+    election_id: str,
+    jurisdiction_id: str,
+    cvr_file_type: str,
+    file_type: Optional[str] = None,
+    filename: Optional[str] = None,
+):
+    if filename is None:
+        if file_type in ["application/zip", "application/x-zip-compressed"]:
+            filename = timestamp_filename("cvrs", "zip")
+        else:
+            filename = timestamp_filename("cvrs", "csv")
+
+    if file_type is None:
+        file_type = "text/csv"
+
+    return upload_file_helper(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/cvrs",
+        filename,
+        file_type,
+        file_content,
+        cvr_file_type,
+    )
+
+
+def setup_jurisdictions_upload(
+    client: FlaskClient,
+    file_content: io.BytesIO,
+    election_id: str,
+):
+    filename = timestamp_filename("jurisdictions", "csv")
+    return upload_file_helper(
+        client,
+        f"/api/election/{election_id}/jurisdiction/file",
+        filename,
+        "text/csv",
+        file_content,
+    )
+
+
+def setup_standardized_contests_upload(
+    client: FlaskClient,
+    file_content: io.BytesIO,
+    election_id: str,
+):
+    filename = timestamp_filename("standardizedContests", "csv")
+    return upload_file_helper(
+        client,
+        f"/api/election/{election_id}/standardized-contests/file",
+        filename,
+        "text/csv",
+        file_content,
+    )
+
+
+def setup_batch_inventory_cvr_upload(
+    client: FlaskClient,
+    file_content: io.BytesIO,
+    election_id: str,
+    jurisdiction_id: str,
+):
+    filename = timestamp_filename("batchInventoryCvr", "csv")
+    return upload_file_helper(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-inventory/cvr",
+        filename,
+        "text/csv",
+        file_content,
+    )
+
+
+def setup_batch_inventory_tabulator_status_upload(
+    client: FlaskClient,
+    file_content: io.BytesIO,
+    election_id: str,
+    jurisdiction_id: str,
+):
+    filename = timestamp_filename("tabulator-status", "xml")
+    return upload_file_helper(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-inventory/tabulator-status",
+        filename,
+        "text/xml",
+        file_content,
+    )
+
+
+def zip_cvrs(cvrs: List[Tuple[io.BytesIO, str]]) -> io.BytesIO:
+    if len(cvrs) == 1 and cvrs[0][1].endswith(".zip"):
+        return cvrs[0][0]
+    files: Dict[str, BinaryIO] = {}
+    for file_contents, file_name in cvrs:
+        files[file_name] = file_contents
+    return io.BytesIO(zip_files(files).read())
+
+
+def zip_hart_cvrs(cvrs: List[str]):
+    files: Dict[str, BinaryIO] = {
+        f"cvr-{i}.xml": io.BytesIO(cvr.encode()) for i, cvr in enumerate(cvrs)
+    }
+    # There's usually a WriteIns directory in the zip file - simulate that to
+    # make sure it gets skipped
+    files["WriteIns"] = io.BytesIO()
+    return io.BytesIO(zip_files(files).read())

--- a/server/tests/hybrid/conftest.py
+++ b/server/tests/hybrid/conftest.py
@@ -64,7 +64,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Tabulator,Batch Name,Number of Ballots,CVR\n"
@@ -78,7 +78,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Tabulator,Batch Name,Number of Ballots,CVR\n"
@@ -104,7 +104,7 @@ def cvrs(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,
@@ -112,7 +112,7 @@ def cvrs(
         "DOMINION",
     )
     assert_ok(rv)
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client,
         io.BytesIO(TEST_CVRS.encode()),
         election_id,

--- a/server/tests/hybrid/conftest.py
+++ b/server/tests/hybrid/conftest.py
@@ -64,38 +64,32 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Tabulator,Batch Name,Number of Ballots,CVR\n"
-                    b"TABULATOR1,BATCH1,3,Y\n"
-                    b"TABULATOR1,BATCH2,3,Y\n"
-                    b"TABULATOR2,BATCH1,3,Y\n"
-                    b"TABULATOR2,BATCH2,6,Y\n"
-                    b"TABULATOR3,BATCH1,10,N"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Tabulator,Batch Name,Number of Ballots,CVR\n"
+            b"TABULATOR1,BATCH1,3,Y\n"
+            b"TABULATOR1,BATCH2,3,Y\n"
+            b"TABULATOR2,BATCH1,3,Y\n"
+            b"TABULATOR2,BATCH2,6,Y\n"
+            b"TABULATOR3,BATCH1,10,N"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Tabulator,Batch Name,Number of Ballots,CVR\n"
-                    b"TABULATOR1,BATCH1,3,Y\n"
-                    b"TABULATOR1,BATCH2,3,Y\n"
-                    b"TABULATOR2,BATCH1,3,Y\n"
-                    b"TABULATOR2,BATCH2,6,Y\n"
-                    b"TABULATOR3,BATCH1,10,N"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Tabulator,Batch Name,Number of Ballots,CVR\n"
+            b"TABULATOR1,BATCH1,3,Y\n"
+            b"TABULATOR1,BATCH2,3,Y\n"
+            b"TABULATOR2,BATCH1,3,Y\n"
+            b"TABULATOR2,BATCH2,6,Y\n"
+            b"TABULATOR3,BATCH1,10,N"
+        ),
+        election_id,
+        jurisdiction_ids[1],
     )
     assert_ok(rv)
 
@@ -110,25 +104,19 @@ def cvrs(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(TEST_CVRS.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(TEST_CVRS.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "DOMINION",
     )
     assert_ok(rv)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(TEST_CVRS.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client,
+        io.BytesIO(TEST_CVRS.encode()),
+        election_id,
+        jurisdiction_ids[1],
+        "DOMINION",
     )
     assert_ok(rv)

--- a/server/tests/hybrid/test_hybrid.py
+++ b/server/tests/hybrid/test_hybrid.py
@@ -530,7 +530,7 @@ def test_hybrid_manifest_validation_too_many_votes(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for jurisdiction_id in jurisdiction_ids[:2]:
-        rv = setup_ballot_manifest_upload(
+        rv = upload_ballot_manifest(
             client,
             io.BytesIO(
                 b"Tabulator,Batch Name,Number of Ballots,CVR\n"
@@ -545,7 +545,7 @@ def test_hybrid_manifest_validation_too_many_votes(
         )
         assert_ok(rv)
 
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             io.BytesIO(TEST_CVRS.encode()),
             election_id,
@@ -618,7 +618,7 @@ def test_hybrid_manifest_validation_too_few_cvr_ballots(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for jurisdiction_id in jurisdiction_ids[:2]:
-        rv = setup_ballot_manifest_upload(
+        rv = upload_ballot_manifest(
             client,
             io.BytesIO(
                 b"Tabulator,Batch Name,Number of Ballots,CVR\n"
@@ -633,7 +633,7 @@ def test_hybrid_manifest_validation_too_few_cvr_ballots(
         )
         assert_ok(rv)
 
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             io.BytesIO(TEST_CVRS.encode()),
             election_id,
@@ -688,7 +688,7 @@ def test_hybrid_manifest_validation_few_non_cvr_ballots(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for jurisdiction_id in jurisdiction_ids[:2]:
-        rv = setup_ballot_manifest_upload(
+        rv = upload_ballot_manifest(
             client,
             io.BytesIO(
                 b"Tabulator,Batch Name,Number of Ballots,CVR\n"
@@ -703,7 +703,7 @@ def test_hybrid_manifest_validation_few_non_cvr_ballots(
         )
         assert_ok(rv)
 
-        rv = setup_cvrs_upload(
+        rv = upload_cvrs(
             client,
             io.BytesIO(TEST_CVRS.encode()),
             election_id,
@@ -804,7 +804,7 @@ def test_hybrid_filter_cvrs(
         "16,TABULATOR3,BATCH1,2,3-1-2,12345,COUNTY,0,1,1,1,0\n"
         "17,TABULATOR3,BATCH1,3,3-1-3,12345,COUNTY,0,1,1,1,0\n"
     )
-    rv = setup_cvrs_upload(
+    rv = upload_cvrs(
         client, io.BytesIO(cvr.encode()), election_id, jurisdiction_ids[0], "DOMINION"
     )
     assert_ok(rv)

--- a/server/tests/hybrid/test_hybrid.py
+++ b/server/tests/hybrid/test_hybrid.py
@@ -530,33 +530,27 @@ def test_hybrid_manifest_validation_too_many_votes(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for jurisdiction_id in jurisdiction_ids[:2]:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/ballot-manifest",
-            data={
-                "manifest": (
-                    io.BytesIO(
-                        b"Tabulator,Batch Name,Number of Ballots,CVR\n"
-                        b"TABULATOR1,BATCH1,3,Y\n"
-                        b"TABULATOR1,BATCH2,3,Y\n"
-                        b"TABULATOR2,BATCH1,3,Y\n"
-                        b"TABULATOR2,BATCH2,6,Y\n"
-                        b"TABULATOR3,BATCH1,10,N"
-                    ),
-                    "manifest.csv",
-                )
-            },
+        rv = setup_ballot_manifest_upload(
+            client,
+            io.BytesIO(
+                b"Tabulator,Batch Name,Number of Ballots,CVR\n"
+                b"TABULATOR1,BATCH1,3,Y\n"
+                b"TABULATOR1,BATCH2,3,Y\n"
+                b"TABULATOR2,BATCH1,3,Y\n"
+                b"TABULATOR2,BATCH2,6,Y\n"
+                b"TABULATOR3,BATCH1,10,N"
+            ),
+            election_id,
+            jurisdiction_id,
         )
         assert_ok(rv)
 
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/cvrs",
-            data={
-                "cvrs": (
-                    io.BytesIO(TEST_CVRS.encode()),
-                    "cvrs.csv",
-                ),
-                "cvrFileType": "DOMINION",
-            },
+        rv = setup_cvrs_upload(
+            client,
+            io.BytesIO(TEST_CVRS.encode()),
+            election_id,
+            jurisdiction_id,
+            "DOMINION",
         )
         assert_ok(rv)
 
@@ -624,33 +618,27 @@ def test_hybrid_manifest_validation_too_few_cvr_ballots(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for jurisdiction_id in jurisdiction_ids[:2]:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/ballot-manifest",
-            data={
-                "manifest": (
-                    io.BytesIO(
-                        b"Tabulator,Batch Name,Number of Ballots,CVR\n"
-                        b"TABULATOR1,BATCH1,3,Y\n"
-                        b"TABULATOR1,BATCH2,3,Y\n"
-                        b"TABULATOR2,BATCH1,3,Y\n"
-                        b"TABULATOR2,BATCH2,4,Y\n"
-                        b"TABULATOR3,BATCH1,12,N"
-                    ),
-                    "manifest.csv",
-                )
-            },
+        rv = setup_ballot_manifest_upload(
+            client,
+            io.BytesIO(
+                b"Tabulator,Batch Name,Number of Ballots,CVR\n"
+                b"TABULATOR1,BATCH1,3,Y\n"
+                b"TABULATOR1,BATCH2,3,Y\n"
+                b"TABULATOR2,BATCH1,3,Y\n"
+                b"TABULATOR2,BATCH2,4,Y\n"
+                b"TABULATOR3,BATCH1,12,N"
+            ),
+            election_id,
+            jurisdiction_id,
         )
         assert_ok(rv)
 
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/cvrs",
-            data={
-                "cvrs": (
-                    io.BytesIO(TEST_CVRS.encode()),
-                    "cvrs.csv",
-                ),
-                "cvrFileType": "DOMINION",
-            },
+        rv = setup_cvrs_upload(
+            client,
+            io.BytesIO(TEST_CVRS.encode()),
+            election_id,
+            jurisdiction_id,
+            "DOMINION",
         )
         assert_ok(rv)
 
@@ -700,33 +688,27 @@ def test_hybrid_manifest_validation_few_non_cvr_ballots(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
     for jurisdiction_id in jurisdiction_ids[:2]:
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/ballot-manifest",
-            data={
-                "manifest": (
-                    io.BytesIO(
-                        b"Tabulator,Batch Name,Number of Ballots,CVR\n"
-                        b"TABULATOR1,BATCH1,3,Y\n"
-                        b"TABULATOR1,BATCH2,3,Y\n"
-                        b"TABULATOR2,BATCH1,3,Y\n"
-                        b"TABULATOR2,BATCH2,6,Y\n"
-                        b"TABULATOR3,BATCH1,10,N"
-                    ),
-                    "manifest.csv",
-                )
-            },
+        rv = setup_ballot_manifest_upload(
+            client,
+            io.BytesIO(
+                b"Tabulator,Batch Name,Number of Ballots,CVR\n"
+                b"TABULATOR1,BATCH1,3,Y\n"
+                b"TABULATOR1,BATCH2,3,Y\n"
+                b"TABULATOR2,BATCH1,3,Y\n"
+                b"TABULATOR2,BATCH2,6,Y\n"
+                b"TABULATOR3,BATCH1,10,N"
+            ),
+            election_id,
+            jurisdiction_id,
         )
         assert_ok(rv)
 
-        rv = client.put(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/cvrs",
-            data={
-                "cvrs": (
-                    io.BytesIO(TEST_CVRS.encode()),
-                    "cvrs.csv",
-                ),
-                "cvrFileType": "DOMINION",
-            },
+        rv = setup_cvrs_upload(
+            client,
+            io.BytesIO(TEST_CVRS.encode()),
+            election_id,
+            jurisdiction_id,
+            "DOMINION",
         )
         assert_ok(rv)
 
@@ -822,15 +804,8 @@ def test_hybrid_filter_cvrs(
         "16,TABULATOR3,BATCH1,2,3-1-2,12345,COUNTY,0,1,1,1,0\n"
         "17,TABULATOR3,BATCH1,3,3-1-3,12345,COUNTY,0,1,1,1,0\n"
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs",
-        data={
-            "cvrs": (
-                io.BytesIO(cvr.encode()),
-                "cvrs.csv",
-            ),
-            "cvrFileType": "DOMINION",
-        },
+    rv = setup_cvrs_upload(
+        client, io.BytesIO(cvr.encode()), election_id, jurisdiction_ids[0], "DOMINION"
     )
     assert_ok(rv)
 

--- a/server/tests/hybrid/test_hybrid_manifests.py
+++ b/server/tests/hybrid/test_hybrid_manifests.py
@@ -19,7 +19,7 @@ def test_hybrid_manifest(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Tabulator,Batch Name,Number of Ballots,CVR\n"
@@ -71,7 +71,7 @@ def test_hybrid_manifest_missing_cvr_column(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Tabulator,Batch Name,Number of Ballots\n"
@@ -111,7 +111,7 @@ def test_hybrid_manifest_missing_cvr_column(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Container,Tabulator,Batch Name,Number of Ballots,CVR\n"

--- a/server/tests/hybrid/test_hybrid_manifests.py
+++ b/server/tests/hybrid/test_hybrid_manifests.py
@@ -19,32 +19,29 @@ def test_hybrid_manifest(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Container,Tabulator,Batch Name,Number of Ballots,CVR\n"
-                    b"CONTAINER1,TABULATOR1,BATCH1,50,Y\n"
-                    b"CONTAINER1,TABULATOR1,BATCH2,50,Y\n"
-                    b"CONTAINER1,TABULATOR2,BATCH1,50,Y\n"
-                    b"CONTAINER1,TABULATOR2,BATCH2,50,Y\n"
-                    b"CONTAINER2,TABULATOR1,BATCH3,50,Y\n"
-                    b"CONTAINER2,TABULATOR1,BATCH4,50,Y\n"
-                    b"CONTAINER2,TABULATOR2,BATCH3,50,Y\n"
-                    b"CONTAINER2,TABULATOR2,BATCH4,50,Y\n"
-                    b"CONTAINER3,TABULATOR1,BATCH5,50,N\n"
-                    b"CONTAINER3,TABULATOR1,BATCH6,50,N\n"
-                    b"CONTAINER3,TABULATOR2,BATCH5,50,N\n"
-                    b"CONTAINER3,TABULATOR2,BATCH6,50,N\n"
-                    b"CONTAINER4,TABULATOR1,BATCH7,50,N\n"
-                    b"CONTAINER4,TABULATOR1,BATCH8,50,N\n"
-                    b"CONTAINER4,TABULATOR2,BATCH7,50,N\n"
-                    b"CONTAINER4,TABULATOR2,BATCH8,50,N\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Container,Tabulator,Batch Name,Number of Ballots,CVR\n"
+            b"CONTAINER1,TABULATOR1,BATCH1,50,Y\n"
+            b"CONTAINER1,TABULATOR1,BATCH2,50,Y\n"
+            b"CONTAINER1,TABULATOR2,BATCH1,50,Y\n"
+            b"CONTAINER1,TABULATOR2,BATCH2,50,Y\n"
+            b"CONTAINER2,TABULATOR1,BATCH3,50,Y\n"
+            b"CONTAINER2,TABULATOR1,BATCH4,50,Y\n"
+            b"CONTAINER2,TABULATOR2,BATCH3,50,Y\n"
+            b"CONTAINER2,TABULATOR2,BATCH4,50,Y\n"
+            b"CONTAINER3,TABULATOR1,BATCH5,50,N\n"
+            b"CONTAINER3,TABULATOR1,BATCH6,50,N\n"
+            b"CONTAINER3,TABULATOR2,BATCH5,50,N\n"
+            b"CONTAINER3,TABULATOR2,BATCH6,50,N\n"
+            b"CONTAINER4,TABULATOR1,BATCH7,50,N\n"
+            b"CONTAINER4,TABULATOR1,BATCH8,50,N\n"
+            b"CONTAINER4,TABULATOR2,BATCH7,50,N\n"
+            b"CONTAINER4,TABULATOR2,BATCH8,50,N\n"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -74,17 +71,14 @@ def test_hybrid_manifest_missing_cvr_column(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Container,Tabulator,Batch Name,Number of Ballots\n"
-                    b"CONTAINER1,TABULATOR1,BATCH1,50\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Container,Tabulator,Batch Name,Number of Ballots\n"
+            b"CONTAINER1,TABULATOR1,BATCH1,50\n"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -95,7 +89,7 @@ def test_hybrid_manifest_missing_cvr_column(
         json.loads(rv.data),
         {
             "file": {
-                "name": "manifest.csv",
+                "name": asserts_startswith("manifest"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -117,17 +111,14 @@ def test_hybrid_manifest_missing_cvr_column(
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Container,Tabulator,Batch Name,Number of Ballots,CVR\n"
-                    b"CONTAINER1,TABULATOR1,BATCH1,50,yy\n"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Container,Tabulator,Batch Name,Number of Ballots,CVR\n"
+            b"CONTAINER1,TABULATOR1,BATCH1,50,yy\n"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
 
@@ -138,7 +129,7 @@ def test_hybrid_manifest_missing_cvr_column(
         json.loads(rv.data),
         {
             "file": {
-                "name": "manifest.csv",
+                "name": asserts_startswith("manifest"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {

--- a/server/tests/test_full_hand_tally.py
+++ b/server/tests/test_full_hand_tally.py
@@ -51,38 +51,32 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Batch Name,Number of Ballots\n"
-                    b"1,200000\n"
-                    b"2,200000\n"
-                    b"3,200000\n"
-                    b"4,200000\n"
-                    b"5,200000"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Batch Name,Number of Ballots\n"
+            b"1,200000\n"
+            b"2,200000\n"
+            b"3,200000\n"
+            b"4,200000\n"
+            b"5,200000"
+        ),
+        election_id,
+        jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = client.put(
-        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/ballot-manifest",
-        data={
-            "manifest": (
-                io.BytesIO(
-                    b"Batch Name,Number of Ballots\n"
-                    b"1,200000\n"
-                    b"2,200000\n"
-                    b"3,200000\n"
-                    b"4,200000\n"
-                    b"5,200000"
-                ),
-                "manifest.csv",
-            )
-        },
+    rv = setup_ballot_manifest_upload(
+        client,
+        io.BytesIO(
+            b"Batch Name,Number of Ballots\n"
+            b"1,200000\n"
+            b"2,200000\n"
+            b"3,200000\n"
+            b"4,200000\n"
+            b"5,200000"
+        ),
+        election_id,
+        jurisdiction_ids[1],
     )
     assert_ok(rv)
 

--- a/server/tests/test_full_hand_tally.py
+++ b/server/tests/test_full_hand_tally.py
@@ -51,7 +51,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
     )
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Batch Name,Number of Ballots\n"
@@ -65,7 +65,7 @@ def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: List[str]
         jurisdiction_ids[0],
     )
     assert_ok(rv)
-    rv = setup_ballot_manifest_upload(
+    rv = upload_ballot_manifest(
         client,
         io.BytesIO(
             b"Batch Name,Number of Ballots\n"

--- a/server/tests/util/test_file_storage.py
+++ b/server/tests/util/test_file_storage.py
@@ -3,27 +3,60 @@ import os.path
 import tempfile
 import io
 from unittest.mock import patch
+from werkzeug.exceptions import BadRequest
+import pytest
 
-from ...util.file import delete_file, retrieve_file, store_file
+from ...util.file import (
+    delete_file,
+    retrieve_file,
+    store_file,
+    get_file_upload_url,
+    get_standard_file_upload_request_params,
+    validate_zip_mimetype,
+    validate_csv_or_zip_mimetype,
+    validate_xml_mimetype,
+    get_full_storage_path,
+)
 from ... import config
 
 
 @patch("boto3.client", autospec=True)
-def test_file_storage_s3(mock_boto_client):
+def test_store_file_raises_with_s3_config(mock_boto_client):
     config.AWS_ACCESS_KEY_ID = "test access key id"
     config.AWS_SECRET_ACCESS_KEY = "test secret access key"
+    config.AWS_DEFAULT_REGION = "test region"
     original_file_upload_storage_path = config.FILE_UPLOAD_STORAGE_PATH
     config.FILE_UPLOAD_STORAGE_PATH = "s3://test_bucket"
 
     file = io.BytesIO(b"test file contents")
-    store_file(file, "test_dir/test_file.csv")
+
+    # store file should raise an exception as we do not allow passthrough uploads to s3
+    with pytest.raises(
+        Exception, match=r"This method should only be used for local file storage."
+    ):
+        store_file(file, "test_dir/test_file.csv")
+
+    path = "/fake/path/to/file"
+    filename = "test_file.csv"
+    full_path = f"{path}/{filename}"
+    # test create presigned url
+    get_file_upload_url(path, filename, "text/csv")
+
     mock_boto_client.assert_called_once_with(
         "s3",
         aws_access_key_id="test access key id",
         aws_secret_access_key="test secret access key",
+        region_name="test region",
     )
-    mock_boto_client.return_value.upload_fileobj.assert_called_once_with(
-        file, "test_bucket", "test_dir/test_file.csv"
+    mock_boto_client.return_value.generate_presigned_post.assert_called_once_with(
+        "test_bucket",
+        full_path,
+        Conditions=[
+            {"bucket": "test_bucket"},
+            {"Content-Type": "text/csv"},
+            {"key": full_path},
+        ],
+        ExpiresIn=600,
     )
 
     mock_boto_client.return_value.download_fileobj.side_effect = (
@@ -39,6 +72,9 @@ def test_file_storage_s3(mock_boto_client):
         == "test_dir/test_file.csv"
     )
     assert retrieved_file.read() == b"test file contents"
+
+    with pytest.raises(Exception, match=r"Invalid file storage path"):
+        retrieve_file("invalid/path/to/file")
 
     delete_file("s3://test_bucket/test_dir/test_file.csv")
     mock_boto_client.return_value.delete_object.assert_called_once()
@@ -60,16 +96,127 @@ def test_file_storage_local_file():
         config.FILE_UPLOAD_STORAGE_PATH = temp_dir
 
         file = io.BytesIO(b"test file contents")
-        path = f"test_dir/{datetime.now(timezone.utc).timestamp()}/test_file.csv"
-        storage_path = store_file(file, path)
+        path = f"test_dir/{datetime.now(timezone.utc).timestamp()}"
+        filename = "test_file.csv"
+        full_path = f"{path}/{filename}"
 
-        with open(f"{config.FILE_UPLOAD_STORAGE_PATH}/{path}", "rb") as stored_file:
+        upload_url = get_file_upload_url(path, filename, "text/csv")
+        assert upload_url == {"url": "/api/file-upload", "fields": {"key": full_path}}
+
+        storage_path = store_file(file, full_path)
+
+        with open(
+            f"{config.FILE_UPLOAD_STORAGE_PATH}/{full_path}", "rb"
+        ) as stored_file:
             assert stored_file.read() == b"test file contents"
 
         retrieved_file = retrieve_file(storage_path)
         assert retrieved_file.read() == b"test file contents"
 
         delete_file(storage_path)
-        assert not os.path.exists(f"{config.FILE_UPLOAD_STORAGE_PATH}/{path}")
+        assert not os.path.exists(f"{config.FILE_UPLOAD_STORAGE_PATH}/{full_path}")
 
         config.FILE_UPLOAD_STORAGE_PATH = original_file_upload_storage_path
+
+
+## Tests for general file type utils
+
+
+@patch("flask.Request", autospec=True)
+def test_get_standard_file_upload_request_params(mock_request):
+    mock_request.form = {
+        "storagePathKey": "test_dir/test_file.csv",
+        "fileName": "test_file.csv",
+        "fileType": "text/csv",
+    }
+    (storage_path, filename, file_type) = get_standard_file_upload_request_params(
+        mock_request
+    )
+    assert storage_path == f"{config.FILE_UPLOAD_STORAGE_PATH}/test_dir/test_file.csv"
+    assert filename == "test_file.csv"
+    assert file_type == "text/csv"
+
+    with pytest.raises(
+        BadRequest, match="Missing required JSON parameter: storagePathKey"
+    ):
+        mock_request.form = {
+            "fileName": "test_file.csv",
+            "fileType": "text/csv",
+        }
+        get_standard_file_upload_request_params(mock_request)
+
+    with pytest.raises(BadRequest, match="Missing required JSON parameter: fileName"):
+        mock_request.form = {
+            "storagePathKey": "test_dir/test_file.csv",
+            "fileType": "text/csv",
+        }
+        get_standard_file_upload_request_params(mock_request)
+
+    with pytest.raises(BadRequest, match="Missing required JSON parameter: fileType"):
+        mock_request.form = {
+            "storagePathKey": "test_dir/test_file.csv",
+            "fileName": "test_file.csv",
+        }
+        get_standard_file_upload_request_params(mock_request)
+
+
+def test_validate_zip_mimetype():
+    validate_zip_mimetype("application/zip")
+    validate_zip_mimetype("application/x-zip-compressed")
+
+    for invalid_mimetype in [
+        "text/csv",
+        "application/pdf",
+        "text/plain",
+    ]:
+        with pytest.raises(
+            BadRequest, match="400 Bad Request: Please submit a valid ZIP file."
+        ):
+            validate_zip_mimetype(invalid_mimetype)
+
+
+def test_validate_xml_mimetype():
+    validate_xml_mimetype("text/xml")
+
+    for invalid_mimetype in [
+        "text/csv",
+        "application/pdf",
+        "text/plain",
+        "application/zip",
+    ]:
+        with pytest.raises(
+            BadRequest, match="400 Bad Request: Please submit a valid XML file."
+        ):
+            validate_xml_mimetype(invalid_mimetype)
+
+
+def test_validate_csv_or_zip_mimetype():
+    validate_csv_or_zip_mimetype("text/csv")
+    validate_csv_or_zip_mimetype("application/vnd.ms-excel")
+    validate_csv_or_zip_mimetype("application/zip")
+    validate_csv_or_zip_mimetype("application/x-zip-compressed")
+
+    for invalid_mimetype in [
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/pdf",
+        "text/plain",
+        "text/xml",
+    ]:
+        with pytest.raises(
+            BadRequest, match="400 Bad Request: Please submit a valid CSV or ZIP file."
+        ):
+            validate_csv_or_zip_mimetype(invalid_mimetype)
+
+
+def test_get_full_storage_path():
+    config.FILE_UPLOAD_STORAGE_PATH = "/test/storage/path"
+    assert (
+        get_full_storage_path("test_dir/test_file.csv")
+        == "/test/storage/path/test_dir/test_file.csv"
+    )
+
+    config.FILE_UPLOAD_STORAGE_PATH = "s3://test_bucket"
+    assert (
+        get_full_storage_path("test_dir/test_file.csv")
+        == "s3://test_bucket/test_dir/test_file.csv"
+    )

--- a/server/tests/util/test_file_storage.py
+++ b/server/tests/util/test_file_storage.py
@@ -124,7 +124,7 @@ def test_file_storage_local_file():
 
 @patch("flask.Request", autospec=True)
 def test_get_standard_file_upload_request_params(mock_request):
-    mock_request.form = {
+    mock_request.get_json.return_value = {
         "storagePathKey": "test_dir/test_file.csv",
         "fileName": "test_file.csv",
         "fileType": "text/csv",
@@ -139,24 +139,28 @@ def test_get_standard_file_upload_request_params(mock_request):
     with pytest.raises(
         BadRequest, match="Missing required JSON parameter: storagePathKey"
     ):
-        mock_request.form = {
+        mock_request.get_json.return_value = {
             "fileName": "test_file.csv",
             "fileType": "text/csv",
         }
         get_standard_file_upload_request_params(mock_request)
 
     with pytest.raises(BadRequest, match="Missing required JSON parameter: fileName"):
-        mock_request.form = {
+        mock_request.get_json.return_value = {
             "storagePathKey": "test_dir/test_file.csv",
             "fileType": "text/csv",
         }
         get_standard_file_upload_request_params(mock_request)
 
     with pytest.raises(BadRequest, match="Missing required JSON parameter: fileType"):
-        mock_request.form = {
+        mock_request.get_json.return_value = {
             "storagePathKey": "test_dir/test_file.csv",
             "fileName": "test_file.csv",
         }
+        get_standard_file_upload_request_params(mock_request)
+
+    with pytest.raises(BadRequest, match="Missing JSON request body"):
+        mock_request.get_json.return_value = None
         get_standard_file_upload_request_params(mock_request)
 
 

--- a/server/tests/util/test_file_storage.py
+++ b/server/tests/util/test_file_storage.py
@@ -73,7 +73,7 @@ def test_store_file_raises_with_s3_config(mock_boto_client):
     )
     assert retrieved_file.read() == b"test file contents"
 
-    with pytest.raises(Exception, match=r"Invalid file storage path"):
+    with pytest.raises(AssertionError):
         retrieve_file("invalid/path/to/file")
 
     delete_file("s3://test_bucket/test_dir/test_file.csv")

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -16,7 +16,6 @@ from typing import (
 import csv as py_csv
 import io, re, locale, chardet
 from werkzeug.exceptions import BadRequest
-from werkzeug.datastructures import FileStorage
 
 from .jsonschema import EMAIL_REGEX
 from .collections import find_first_duplicate
@@ -82,17 +81,12 @@ def parse_csv(file: BinaryIO, columns: List[CSVColumnType]) -> CSVDictIterator:
     return dict_csv
 
 
-def does_file_have_csv_mimetype(file: FileStorage) -> bool:
-    # In Windows, CSVs have mimetype application/vnd.ms-excel
-    return file.mimetype in ["text/csv", "application/vnd.ms-excel"]
+def is_filetype_csv_mimetype(file_type: str) -> bool:
+    return file_type in ["text/csv", "application/vnd.ms-excel"]
 
 
-def does_file_have_zip_mimetype(file: FileStorage) -> bool:
-    return file.mimetype in ["application/zip", "application/x-zip-compressed"]
-
-
-def validate_csv_mimetype(file: FileStorage) -> None:
-    if not does_file_have_csv_mimetype(file):
+def validate_csv_mimetype(file_type: str) -> None:
+    if not is_filetype_csv_mimetype(file_type):
         raise BadRequest(INVALID_CSV_ERROR)
 
 

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -3,16 +3,19 @@ import shutil
 import io
 import os
 import tempfile
-from typing import BinaryIO, IO, List, Mapping, Optional
+from typing import BinaryIO, IO, List, Mapping, Optional, Dict, Any, Tuple
 from urllib.parse import urlparse
 from zipfile import ZipFile
+from werkzeug.exceptions import BadRequest
 import boto3
+from flask import Request
 
 from .. import config
 from ..models import *  # pylint: disable=wildcard-import
 from ..worker.tasks import serialize_background_task
 from ..util.isoformat import isoformat
 from ..util.jsonschema import JSONDict
+from ..util.csv_parse import is_filetype_csv_mimetype
 
 
 def serialize_file(file: Optional[File]) -> Optional[JSONDict]:
@@ -41,6 +44,7 @@ def s3():  # pylint: disable=invalid-name
         "s3",
         aws_access_key_id=config.AWS_ACCESS_KEY_ID,
         aws_secret_access_key=config.AWS_SECRET_ACCESS_KEY,
+        region_name=config.AWS_DEFAULT_REGION,
     )
 
 
@@ -48,8 +52,7 @@ def store_file(file: IO[bytes], storage_path: str) -> str:
     assert not os.path.isabs(storage_path)
     full_path = os.path.join(config.FILE_UPLOAD_STORAGE_PATH, storage_path)
     if config.FILE_UPLOAD_STORAGE_PATH.startswith("s3://"):
-        bucket_name = urlparse(config.FILE_UPLOAD_STORAGE_PATH).netloc
-        s3().upload_fileobj(file, bucket_name, storage_path)
+        raise Exception("This method should only be used for local file storage.")
     else:
         os.makedirs(os.path.dirname(full_path), exist_ok=True)
         with open(full_path, "wb") as system_file:
@@ -59,7 +62,8 @@ def store_file(file: IO[bytes], storage_path: str) -> str:
 
 def retrieve_file(storage_path: str) -> BinaryIO:
     if config.FILE_UPLOAD_STORAGE_PATH.startswith("s3://"):
-        assert storage_path.startswith("s3://")
+        if not storage_path.startswith(config.FILE_UPLOAD_STORAGE_PATH):
+            raise Exception("Invalid file storage path")
         parsed_path = urlparse(storage_path)
         bucket_name = parsed_path.netloc
         key = parsed_path.path[1:]
@@ -98,3 +102,76 @@ def unzip_files(zip_file: BinaryIO, directory_to_extract_to: str) -> List[str]:
     with ZipFile(zip_file, "r") as zip_archive:
         zip_archive.extractall(directory_to_extract_to)
         return zip_archive.namelist()
+
+
+def get_full_storage_path(file_path: str) -> str:
+    if config.FILE_UPLOAD_STORAGE_PATH.startswith("s3://"):
+        bucket_name = urlparse(config.FILE_UPLOAD_STORAGE_PATH).netloc
+        return f"s3://{bucket_name}/{file_path}"
+    else:
+        return os.path.join(config.FILE_UPLOAD_STORAGE_PATH, file_path)
+
+
+def get_file_upload_url(
+    storage_prefix: str, file_name: str, file_type: str
+) -> Optional[Dict[str, Any]]:
+    if config.FILE_UPLOAD_STORAGE_PATH.startswith("s3://"):
+        bucket_name = urlparse(config.FILE_UPLOAD_STORAGE_PATH).netloc
+        response: Dict[str, Any] = s3().generate_presigned_post(
+            bucket_name,
+            f"{storage_prefix}/{file_name}",
+            # More documentation on diffrent options to specify here:
+            # https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
+            Conditions=[
+                {"bucket": bucket_name},
+                {"Content-Type": file_type},
+                {"key": f"{storage_prefix}/{file_name}"},
+            ],
+            ExpiresIn=60 * 10,  # 10 minutes
+        )
+        return response
+    else:
+        return {
+            "url": "/api/file-upload",
+            "fields": {
+                "key": f"{storage_prefix}/{file_name}",
+            },
+        }
+
+
+def get_standard_file_upload_request_params(request: Request) -> Tuple[str, str, str]:
+    storage_path = request.form.get("storagePathKey")
+    filename = request.form.get("fileName")
+    file_type = request.form.get("fileType")
+    if not storage_path:
+        raise BadRequest("Missing required JSON parameter: storagePathKey")
+    if not filename:
+        raise BadRequest("Missing required JSON parameter: fileName")
+    if not file_type:
+        raise BadRequest("Missing required JSON parameter: fileType")
+    return (get_full_storage_path(storage_path), filename, file_type)
+
+
+def is_filetype_zip_mimetype(file_type: str) -> bool:
+    return file_type in ["application/zip", "application/x-zip-compressed"]
+
+
+def is_filetype_xml_mimetype(file_type: str) -> bool:
+    return file_type in ["text/xml"]
+
+
+def validate_csv_or_zip_mimetype(file_type: str) -> None:
+    if not is_filetype_zip_mimetype(file_type) and not is_filetype_csv_mimetype(
+        file_type
+    ):
+        raise BadRequest("Please submit a valid CSV or ZIP file.")
+
+
+def validate_zip_mimetype(file_type: str) -> None:
+    if not is_filetype_zip_mimetype(file_type):
+        raise BadRequest("Please submit a valid ZIP file.")
+
+
+def validate_xml_mimetype(file_type: str) -> None:
+    if not is_filetype_xml_mimetype(file_type):
+        raise BadRequest("Please submit a valid XML file.")

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -50,7 +50,7 @@ def s3():  # pylint: disable=invalid-name
 
 def store_file(file: IO[bytes], storage_path: str) -> str:
     assert not os.path.isabs(storage_path)
-    full_path = os.path.join(config.FILE_UPLOAD_STORAGE_PATH, storage_path)
+    full_path = get_full_storage_path(storage_path)
     if config.FILE_UPLOAD_STORAGE_PATH.startswith("s3://"):
         raise Exception("This method should only be used for local file storage.")
     else:
@@ -62,8 +62,7 @@ def store_file(file: IO[bytes], storage_path: str) -> str:
 
 def retrieve_file(storage_path: str) -> BinaryIO:
     if config.FILE_UPLOAD_STORAGE_PATH.startswith("s3://"):
-        if not storage_path.startswith(config.FILE_UPLOAD_STORAGE_PATH):
-            raise Exception("Invalid file storage path")
+        assert storage_path.startswith(config.FILE_UPLOAD_STORAGE_PATH)
         parsed_path = urlparse(storage_path)
         bucket_name = parsed_path.netloc
         key = parsed_path.path[1:]
@@ -120,7 +119,7 @@ def get_file_upload_url(
         response: Dict[str, Any] = s3().generate_presigned_post(
             bucket_name,
             f"{storage_prefix}/{file_name}",
-            # More documentation on diffrent options to specify here:
+            # More documentation on different options to specify here:
             # https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
             Conditions=[
                 {"bucket": bucket_name},

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -139,9 +139,12 @@ def get_file_upload_url(
 
 
 def get_standard_file_upload_request_params(request: Request) -> Tuple[str, str, str]:
-    storage_path = request.form.get("storagePathKey")
-    filename = request.form.get("fileName")
-    file_type = request.form.get("fileType")
+    data = request.get_json()
+    if data is None:
+        raise BadRequest("Missing JSON request body")
+    storage_path = data.get("storagePathKey")
+    filename = data.get("fileName")
+    file_type = data.get("fileType")
     if not storage_path:
         raise BadRequest("Missing required JSON parameter: storagePathKey")
     if not filename:


### PR DESCRIPTION
https://github.com/votingworks/arlo/issues/1674

## Suppor large(r) file uploads by directly uploading to S3 

In order to enable larger file uploads in arlo directly upload from the client to s3 rather then doing "passthrough" file uploads through our server. This is the heroku recommended approach and generally recommended by most other heroku/s3 users. There will still be a 5GB max limit above which we need to chunk the transfer to s3. The process involves
1. Making a GET to <url>/upload-url to get the url to POST the file to for the actual upload. If configured to save files to the local file system this url will be a local server endpoint, otherwise it will be a presigned AWS url. 
2. Make a POST to the url returned in step 1 with the file attached. Again this will either be a server endpoint (/file) or a AWS endpoint. 
3. Make a POST to <url>/upload-complete to mark the file as uploaded and do any post-upload steps like updating DB elements and kicking off background jobs. 

I landed on keeping the upload-url endpoint for step 1 rather then the other suggested approaches as different files have different authentication which directly relates to the file path that that endpoint needs to construct (it needs to know about the election_id and in some cases jurisdiction_id) so it seemed simplest to leave it like this. 

This PR also changes CVR uploads to be 1 file and always be the "wrapper" zip we previously created for Hart/ESS. In the case of HART we now check if there were not any zip files inside of the top-level zip after unzipping to handle the situation where someone just uploads the zip of cvrs and does not "wrap" it in anything. There was some validation logic for hart around not having images or other file types in the zip that is now moves to happen in the processing step. 

I recommend reviewing by commit, I tried to isolate the bigger test refactors but let me know if you want me to break up any commits further. 

 If we wanted to support multiple file uploads in the future to not change this I think we would need to:
- Upload all selected files to the s3 bucket (this part is easy enough we can even call the presigned POST url multiple times )
- Change the way it references a single CVR file in the DB to either reference a path to the s3 bucket containing all the files, or allow a list of cvr files 
- Change the hart/ess background tasks to fetch all the files in that bucket instead of fetching the zip and unzipping. 
