### PR TITLE
Only allow one background task per audit to run at a time

### DIFF
--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -103,6 +103,7 @@ def hybrid_jurisdiction_total_ballots(jurisdiction: Jurisdiction) -> HybridPair:
 
 @background_task
 def process_ballot_manifest_file(
+    election_id: str,
     jurisdiction_id: str,
     jurisdiction_admin_email: str,
     support_user_email: Optional[str],
@@ -189,10 +190,11 @@ def process_ballot_manifest_file(
         # batch names from the manifest
         if jurisdiction.cvr_file:
             cvrs.clear_cvr_contests_metadata(jurisdiction)
-            cvrs.clear_cvr_ballots(jurisdiction.id)
+            cvrs.clear_cvr_ballots(election_id, jurisdiction.id)
             jurisdiction.cvr_file.task = create_background_task(
                 cvrs.process_cvr_file,
                 dict(
+                    election_id=election_id,
                     jurisdiction_id=jurisdiction.id,
                     jurisdiction_admin_email=jurisdiction_admin_email,
                     support_user_email=support_user_email,
@@ -256,6 +258,7 @@ def save_ballot_manifest_file(
     jurisdiction.manifest_file.task = create_background_task(
         process_ballot_manifest_file,
         dict(
+            election_id=jurisdiction.election_id,
             jurisdiction_id=jurisdiction.id,
             jurisdiction_admin_email=get_loggedin_user(session)[1],
             support_user_email=get_support_user(session),

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -101,6 +101,7 @@ def items_list_to_dict(items):
 
 @background_task
 def process_batch_inventory_cvr_file(
+    election_id: str,  # pylint: disable=unused-argument
     jurisdiction_id: str,
     user: Tuple[UserType, str],
     support_user_email: Optional[str],
@@ -247,6 +248,7 @@ def process_batch_inventory_cvr_file(
             batch_inventory_data.tabulator_status_file.task = create_background_task(
                 process_batch_inventory_tabulator_status_file,
                 dict(
+                    election_id=jurisdiction.election_id,
                     jurisdiction_id=jurisdiction.id,
                     user=user,
                     support_user_email=support_user_email,
@@ -444,6 +446,7 @@ TABULATOR_STATUS_PARSE_ERROR = (
 
 @background_task
 def process_batch_inventory_tabulator_status_file(
+    election_id: str,  # pylint: disable=unused-argument
     jurisdiction_id: str,
     user: Tuple[UserType, str],
     support_user_email: Optional[str],
@@ -681,6 +684,7 @@ def complete_upload_for_batch_inventory_cvr(
     batch_inventory_data.cvr_file.task = create_background_task(
         process_batch_inventory_cvr_file,
         dict(
+            election_id=election.id,
             jurisdiction_id=jurisdiction.id,
             user=get_loggedin_user(session),
             support_user_email=get_support_user(session),
@@ -794,6 +798,7 @@ def complete_upload_for_batch_inventory_tabulator_status(
     batch_inventory_data.tabulator_status_file.task = create_background_task(
         process_batch_inventory_tabulator_status_file,
         dict(
+            election_id=election.id,
             jurisdiction_id=jurisdiction.id,
             user=get_loggedin_user(session),
             support_user_email=get_support_user(session),

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -67,6 +67,7 @@ def construct_contest_choice_csv_headers(
 
 @background_task
 def process_batch_tallies_file(
+    election_id: str,  # pylint: disable=unused-argument
     jurisdiction_id: str,
     user: Tuple[UserType, str],
     support_user_email: Optional[str],
@@ -213,6 +214,7 @@ def reprocess_batch_tallies_file_if_uploaded(
         jurisdiction.batch_tallies_file.task = create_background_task(
             process_batch_tallies_file,
             dict(
+                election_id=jurisdiction.election_id,
                 jurisdiction_id=jurisdiction.id,
                 user=user,
                 support_user_email=support_user_email,
@@ -268,6 +270,7 @@ def complete_upload_for_batch_tallies(
     jurisdiction.batch_tallies_file.task = create_background_task(
         process_batch_tallies_file,
         dict(
+            election_id=election.id,
             jurisdiction_id=jurisdiction.id,
             user=get_loggedin_user(session),
             support_user_email=get_support_user(session),

--- a/server/migrations/versions/4aec6c8a419f_backgroundtask_lock_key.py
+++ b/server/migrations/versions/4aec6c8a419f_backgroundtask_lock_key.py
@@ -1,0 +1,27 @@
+# pylint: disable=invalid-name
+"""BackgroundTask.lock_key
+
+Revision ID: 4aec6c8a419f
+Revises: 6c256e8152f8
+Create Date: 2024-10-28 23:56:45.256277+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "4aec6c8a419f"
+down_revision = "6c256e8152f8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "background_task", sa.Column("lock_key", sa.String(length=200), nullable=True)
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -1028,6 +1028,7 @@ class BackgroundTask(BaseModel):
     id = Column(String(200), primary_key=True)
     task_name = Column(String(200), nullable=False)
     payload = Column(JSON, nullable=False)
+    lock_key = Column(String(200))
 
     worker_id = Column(String(200))
     started_at = Column(UTCDateTime)


### PR DESCRIPTION
Task: #1934 

Many background tasks modify audit data in the database that is relied on by other background tasks. We don't want to allow background tasks that touch the same data to run concurrently, as this may result in inconsistent behavior due to race conditions.

The simplest guard to prevent that is to ensure that only one background task per audit runs at a time. Background tasks don't ever modify data across multiple audits, so this is a safe level of granularity. We'll still get the benefit of having multiple concurrent workers when there are multiple audits running at the same time.