### PR TITLE
Server endpoint for surfacing discrepancies

### DIFF
--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -729,7 +729,7 @@ def get_discrepancy_counts_by_jurisdiction(election: Election):
     )
 
 
-DiscrepanciesByJurisdiction = Dict[str, Dict[str, Dict[str, Dict[str, int]]]]
+DiscrepanciesByJurisdiction = Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, int]]]]]
 # DiscrepanciesByJurisdiction = {
 #     jurisdictionID: {
 #         batchName: {
@@ -739,12 +739,6 @@ DiscrepanciesByJurisdiction = Dict[str, Dict[str, Dict[str, Dict[str, int]]]]
 #                 discrepancies:  {choiceID: int},
 #     }
 # }
-
-
-def create_nested_discrepancies_dict():
-    return defaultdict(
-        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
-    )
 
 
 @api.route("/election/<election_id>/discrepancy", methods=["GET"])
@@ -770,8 +764,10 @@ def get_discrepancies_by_jurisdiction(election: Election):
 
 def get_batch_comparison_audit_discrepancies_by_jurisdiction(
     election: Election, round_id: str
-):
-    discrepancies_by_jurisdiction = create_nested_discrepancies_dict()
+) -> DiscrepanciesByJurisdiction:
+    discrepancies_by_jurisdiction: DiscrepanciesByJurisdiction = defaultdict(
+        lambda: defaultdict(dict)
+    )
 
     # TODO: Add support for combined batches
     batch_keys_in_round = set(

--- a/server/tests/api/test_jurisdictions.py
+++ b/server/tests/api/test_jurisdictions.py
@@ -429,3 +429,38 @@ def test_discrepancy_counts_before_audit_launch(
             }
         ]
     }
+
+
+def test_discrepancy_before_audit_launch(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+):
+    rv = client.get(f"/api/election/{election_id}/discrepancy")
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Conflict",
+                "message": "Audit not started",
+            }
+        ]
+    }
+
+
+def test_discrepancy_non_batch_comparison_enabled(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+    round_1_id: str,  # pylint: disable=unused-argument
+):
+    rv = client.get(f"/api/election/{election_id}/discrepancy")
+    assert rv.status_code == 409
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Conflict",
+                "message": "Discrepancies are only implemented for batch comparison audits",
+            }
+        ]
+    }

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -692,6 +692,28 @@ def test_multi_contest_batch_comparison_end_to_end(
     assert discrepancy_counts[jurisdictions[1]["id"]] == 0
     assert discrepancy_counts[jurisdictions[2]["id"]] == 1
 
+    # Check discrepancies
+    rv = client.get(f"/api/election/{election_id}/discrepancy")
+    discrepancies = json.loads(rv.data)
+    assert (
+        discrepancies[jurisdictions[0]["id"]]["Batch 6"][contest_ids[0]][
+            "reportedVotes"
+        ][contest_1_choice_ids[0]]
+        == 50
+    )
+    assert (
+        discrepancies[jurisdictions[0]["id"]]["Batch 6"][contest_ids[0]][
+            "auditedVotes"
+        ][contest_1_choice_ids[0]]
+        == 49
+    )
+    assert (
+        discrepancies[jurisdictions[0]["id"]]["Batch 6"][contest_ids[0]][
+            "discrepancies"
+        ][contest_1_choice_ids[0]]
+        == 1
+    )
+
     #
     # Finish audit
     #
@@ -880,6 +902,31 @@ def test_multi_contest_batch_comparison_round_2(
     assert discrepancy_counts[jurisdiction_ids[1]] == 0
     assert discrepancy_counts[jurisdiction_ids[2]] == 0
 
+    # Check discrepancies
+    rv = client.get(f"/api/election/{election_id}/discrepancy")
+    discrepancies = json.loads(rv.data)
+
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Batch 7"][contest_ids[0]]["reportedVotes"][
+            contest_1_choice_ids[0]
+        ]
+        == 50
+    )
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Batch 7"][contest_ids[0]]["auditedVotes"][
+            contest_1_choice_ids[0]
+        ]
+        == 0
+    )
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Batch 7"][contest_ids[0]]["discrepancies"][
+            contest_1_choice_ids[0]
+        ]
+        == 50
+    )
+    assert jurisdiction_ids[1] not in discrepancies
+    assert jurisdiction_ids[2] not in discrepancies
+
     #
     # End round 1
     #
@@ -1011,6 +1058,14 @@ def test_multi_contest_batch_comparison_round_2(
     assert discrepancy_counts[jurisdiction_ids[0]] == 0
     assert discrepancy_counts[jurisdiction_ids[1]] == 0
     assert discrepancy_counts[jurisdiction_ids[2]] == 0
+
+    # Check discrepancies
+    rv = client.get(f"/api/election/{election_id}/discrepancy")
+    discrepancies = json.loads(rv.data)
+
+    assert jurisdiction_ids[0] not in discrepancies
+    assert jurisdiction_ids[1] not in discrepancies
+    assert jurisdiction_ids[2] not in discrepancies
 
     #
     # End round 2 / finish audit


### PR DESCRIPTION
This PR adds a server endpoint for getting discrepancies, and for now only adds the implementation for batch comparison audits.

Next, I plan to wire together the rest of the flow to the client, and then add implementation for ballot comparison audits. My plan is to build a bit more incrementally, so the PR doesn't become too much for me to reason about as I go.

For now, thought it might be helpful to agree upon the API and models I set up, of course subject to some minor changes if needed when the rest of the feature is built out.

Sample response received by the Client from this endpoint -
![Screenshot 2024-10-31 at 9 43 38 AM](https://github.com/user-attachments/assets/16e150ac-f96a-418f-a065-2c9fd69bfc82)

