### PR TITLE
Make extra batch sampling deterministic by using sortable batch keys

### DIFF
--- a/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
@@ -436,7 +436,9 @@ def test_sample_extra_batches_min_percentage_of_jurisdiction_ballots_selected(
     assert rv.status_code == 200
     j1_batches = json.loads(rv.data)["batches"]
     j1_batch_names = {batch["name"] for batch in j1_batches}
-    assert len(j1_batch_names) >= 2
+    # This is a magic number, but we want to make sure the sampling logic is
+    # deterministic, so we enshrine it in the tests
+    assert len(j1_batch_names) == 8
     assert "Batch 1" in j1_batch_names  # HMPB group
     assert (
         "Batch 9" in j1_batch_names


### PR DESCRIPTION
Previously, we were choosing extra batches from a nondeterministically ordered set of batch ids. Instead, we use batch keys (instead of db ids, which are random) and sort them before choosing batches.