### PR TITLE
Support hart cvr files in batch inventory tool

### DIFF
--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -239,6 +239,7 @@ const SelectSystemStep: React.FC<{
             <option value={CvrFileType.DOMINION}>Dominion</option>
             {/* eslint-disable-next-line react/jsx-curly-brace-presence */}
             <option value={CvrFileType.ESS}>{'ES&S'}</option>
+            <option value={CvrFileType.HART}>Hart</option>
           </HTMLSelect>
         </Row>
       </StepPanel>
@@ -293,6 +294,17 @@ const UploadElectionResultsStep: React.FC<{
               title="Cast Vote Records (CVR)"
               {...cvrUpload}
               acceptFileTypes={['csv', 'zip']}
+            />
+          </StepPanelColumn>
+        </StepPanel>
+      )}
+      {systemType === CvrFileType.HART && (
+        <StepPanel>
+          <StepPanelColumn>
+            <FileUpload
+              title="Cast Vote Records (CVR)"
+              {...cvrUpload}
+              acceptFileTypes={['zip']}
             />
           </StepPanelColumn>
         </StepPanel>

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -287,11 +287,7 @@ def process_batch_inventory_cvr_file(
         if batch_inventory_data.cvr_file.storage_path.endswith(".zip"):
             entry_names = unzip_files(cvr_file, working_directory)
             file_names = [
-                entry_name
-                for entry_name in entry_names
-                if entry_name.endswith(".csv") and not entry_name.startswith(".")
-                # ZIP files created on Macs include a hidden __MACOSX folder
-                and not entry_name.startswith("__")
+                entry_name for entry_name in entry_names if entry_name.endswith(".csv")
             ]
             cvr_file.close()
 
@@ -424,9 +420,7 @@ def process_batch_inventory_cvr_file(
         cvr_file_names = [
             entry_name
             for entry_name in zip_entry_names
-            if entry_name.lower().endswith(".xml") and not entry_name.startswith(".")
-            # ZIP files created on Macs include a hidden __MACOSX folder
-            and not entry_name.startswith("__")
+            if entry_name.lower().endswith(".xml")
         ]
         cvr_file.close()
 

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
@@ -7,9 +7,7 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots[
-    "test_batch_inventory_excel_tabulator_status_file 1"
-] = """Batch Inventory Worksheet\r
+snapshots['test_batch_inventory_excel_tabulator_status_file 1'] = '''Batch Inventory Worksheet\r
 \r
 Section 1: Check Ballot Groups\r
 1. Compare the CVR Ballot Count for each ballot group to your voter check-in data.\r
@@ -29,11 +27,9 @@ Tabulator 1 - BATCH1,3,\r
 Tabulator 1 - BATCH2,3,\r
 Tabulator 2 - BATCH1,3,\r
 Tabulator 2 - BATCH2,6,\r
-"""
+'''
 
-snapshots[
-    "test_batch_inventory_happy_path 1"
-] = """Batch Inventory Worksheet\r
+snapshots['test_batch_inventory_happy_path 1'] = '''Batch Inventory Worksheet\r
 \r
 Section 1: Check Ballot Groups\r
 1. Compare the CVR Ballot Count for each ballot group to your voter check-in data.\r
@@ -53,29 +49,23 @@ Tabulator 1 - BATCH1,3,\r
 Tabulator 1 - BATCH2,3,\r
 Tabulator 2 - BATCH1,3,\r
 Tabulator 2 - BATCH2,6,\r
-"""
+'''
 
-snapshots[
-    "test_batch_inventory_happy_path 2"
-] = """Container,Batch Name,Number of Ballots\r
+snapshots['test_batch_inventory_happy_path 2'] = '''Container,Batch Name,Number of Ballots\r
 Election Day,Tabulator 1 - BATCH1,3\r
 Election Day,Tabulator 1 - BATCH2,3\r
 Mail,Tabulator 2 - BATCH1,3\r
 Election Day,Tabulator 2 - BATCH2,6\r
-"""
+'''
 
-snapshots[
-    "test_batch_inventory_happy_path 3"
-] = """Batch Name,Choice 1-1,Choice 1-2\r
-Tabulator 1 - BATCH1,1,2\r
-Tabulator 1 - BATCH2,2,1\r
-Tabulator 2 - BATCH1,2,1\r
-Tabulator 2 - BATCH2,2,0\r
-"""
+snapshots['test_batch_inventory_happy_path 3'] = '''Batch Name,Choice 1-1,Choice 1-2,Write-In\r
+Tabulator 1 - BATCH1,1,1,1\r
+Tabulator 1 - BATCH2,2,1,0\r
+Tabulator 2 - BATCH1,2,1,0\r
+Tabulator 2 - BATCH2,2,0,0\r
+'''
 
-snapshots[
-    "test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 1"
-] = """Batch Inventory Worksheet\r
+snapshots['test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 1'] = '''Batch Inventory Worksheet\r
 \r
 Section 1: Check Ballot Groups\r
 1. Compare the CVR Ballot Count for each ballot group to your voter check-in data.\r
@@ -95,29 +85,23 @@ Tabulator 1 - BATCH1,3,\r
 Tabulator 1 - BATCH2,3,\r
 Tabulator 2 - BATCH1,3,\r
 Tabulator 2 - BATCH2,6,\r
-"""
+'''
 
-snapshots[
-    "test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 2"
-] = """Container,Batch Name,Number of Ballots\r
+snapshots['test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 2'] = '''Container,Batch Name,Number of Ballots\r
 Election Day,Tabulator 1 - BATCH1,3\r
 Election Day,Tabulator 1 - BATCH2,3\r
 Mail,Tabulator 2 - BATCH1,3\r
 Election Day,Tabulator 2 - BATCH2,6\r
-"""
+'''
 
-snapshots[
-    "test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 3"
-] = """Batch Name,Choice 1-1,Choice 1-2\r
-Tabulator 1 - BATCH1,1,2\r
-Tabulator 1 - BATCH2,2,1\r
-Tabulator 2 - BATCH1,2,1\r
-Tabulator 2 - BATCH2,2,0\r
-"""
+snapshots['test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 3'] = '''Batch Name,Choice 1-1,Choice 1-2,Write-In\r
+Tabulator 1 - BATCH1,1,1,1\r
+Tabulator 1 - BATCH2,2,1,0\r
+Tabulator 2 - BATCH1,2,1,0\r
+Tabulator 2 - BATCH2,2,0,0\r
+'''
 
-snapshots[
-    "test_batch_inventory_happy_path_multi_contest_batch_comparison 1"
-] = """Batch Inventory Worksheet\r
+snapshots['test_batch_inventory_happy_path_multi_contest_batch_comparison 1'] = '''Batch Inventory Worksheet\r
 \r
 Section 1: Check Ballot Groups\r
 1. Compare the CVR Ballot Count for each ballot group to your voter check-in data.\r

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
@@ -156,3 +156,21 @@ Tabulator 1 - BATCH2,2,1,3,1,2\r
 Tabulator 2 - BATCH1,2,1,3,2,1\r
 Tabulator 2 - BATCH2,2,0,6,2,4\r
 """
+
+snapshots[
+    "test_batch_inventory_hart_cvr_upload 1"
+] = """Batch Name,Number of Ballots\r
+BATCH1,3\r
+BATCH2,3\r
+BATCH3,2\r
+BATCH4,1\r
+"""
+
+snapshots[
+    "test_batch_inventory_hart_cvr_upload 2"
+] = """Batch Name,Choice 1-1,Choice 1-2\r
+BATCH1,1,2\r
+BATCH2,2,1\r
+BATCH3,0,0\r
+BATCH4,0,0\r
+"""

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
@@ -7,7 +7,9 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_batch_inventory_excel_tabulator_status_file 1'] = '''Batch Inventory Worksheet\r
+snapshots[
+    "test_batch_inventory_excel_tabulator_status_file 1"
+] = """Batch Inventory Worksheet\r
 \r
 Section 1: Check Ballot Groups\r
 1. Compare the CVR Ballot Count for each ballot group to your voter check-in data.\r
@@ -27,9 +29,11 @@ Tabulator 1 - BATCH1,3,\r
 Tabulator 1 - BATCH2,3,\r
 Tabulator 2 - BATCH1,3,\r
 Tabulator 2 - BATCH2,6,\r
-'''
+"""
 
-snapshots['test_batch_inventory_happy_path 1'] = '''Batch Inventory Worksheet\r
+snapshots[
+    "test_batch_inventory_happy_path 1"
+] = """Batch Inventory Worksheet\r
 \r
 Section 1: Check Ballot Groups\r
 1. Compare the CVR Ballot Count for each ballot group to your voter check-in data.\r
@@ -49,23 +53,29 @@ Tabulator 1 - BATCH1,3,\r
 Tabulator 1 - BATCH2,3,\r
 Tabulator 2 - BATCH1,3,\r
 Tabulator 2 - BATCH2,6,\r
-'''
+"""
 
-snapshots['test_batch_inventory_happy_path 2'] = '''Container,Batch Name,Number of Ballots\r
+snapshots[
+    "test_batch_inventory_happy_path 2"
+] = """Container,Batch Name,Number of Ballots\r
 Election Day,Tabulator 1 - BATCH1,3\r
 Election Day,Tabulator 1 - BATCH2,3\r
 Mail,Tabulator 2 - BATCH1,3\r
 Election Day,Tabulator 2 - BATCH2,6\r
-'''
+"""
 
-snapshots['test_batch_inventory_happy_path 3'] = '''Batch Name,Choice 1-1,Choice 1-2,Write-In\r
+snapshots[
+    "test_batch_inventory_happy_path 3"
+] = """Batch Name,Choice 1-1,Choice 1-2,Write-In\r
 Tabulator 1 - BATCH1,1,1,1\r
 Tabulator 1 - BATCH2,2,1,0\r
 Tabulator 2 - BATCH1,2,1,0\r
 Tabulator 2 - BATCH2,2,0,0\r
-'''
+"""
 
-snapshots['test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 1'] = '''Batch Inventory Worksheet\r
+snapshots[
+    "test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 1"
+] = """Batch Inventory Worksheet\r
 \r
 Section 1: Check Ballot Groups\r
 1. Compare the CVR Ballot Count for each ballot group to your voter check-in data.\r
@@ -85,23 +95,29 @@ Tabulator 1 - BATCH1,3,\r
 Tabulator 1 - BATCH2,3,\r
 Tabulator 2 - BATCH1,3,\r
 Tabulator 2 - BATCH2,6,\r
-'''
+"""
 
-snapshots['test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 2'] = '''Container,Batch Name,Number of Ballots\r
+snapshots[
+    "test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 2"
+] = """Container,Batch Name,Number of Ballots\r
 Election Day,Tabulator 1 - BATCH1,3\r
 Election Day,Tabulator 1 - BATCH2,3\r
 Mail,Tabulator 2 - BATCH1,3\r
 Election Day,Tabulator 2 - BATCH2,6\r
-'''
+"""
 
-snapshots['test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 3'] = '''Batch Name,Choice 1-1,Choice 1-2,Write-In\r
+snapshots[
+    "test_batch_inventory_happy_path_cvrs_with_leading_equal_signs 3"
+] = """Batch Name,Choice 1-1,Choice 1-2,Write-In\r
 Tabulator 1 - BATCH1,1,1,1\r
 Tabulator 1 - BATCH2,2,1,0\r
 Tabulator 2 - BATCH1,2,1,0\r
 Tabulator 2 - BATCH2,2,0,0\r
-'''
+"""
 
-snapshots['test_batch_inventory_happy_path_multi_contest_batch_comparison 1'] = '''Batch Inventory Worksheet\r
+snapshots[
+    "test_batch_inventory_happy_path_multi_contest_batch_comparison 1"
+] = """Batch Inventory Worksheet\r
 \r
 Section 1: Check Ballot Groups\r
 1. Compare the CVR Ballot Count for each ballot group to your voter check-in data.\r
@@ -134,11 +150,11 @@ Election Day,Tabulator 2 - BATCH2,6\r
 
 snapshots[
     "test_batch_inventory_happy_path_multi_contest_batch_comparison 3"
-] = """Batch Name,Contest 1 - Choice 1-1,Contest 1 - Choice 1-2,Contest 2 - Choice 2-1,Contest 2 - Choice 2-2,Contest 2 - Choice 2-3\r
-Tabulator 1 - BATCH1,1,2,3,2,1\r
-Tabulator 1 - BATCH2,2,1,3,1,2\r
-Tabulator 2 - BATCH1,2,1,3,2,1\r
-Tabulator 2 - BATCH2,2,0,6,2,4\r
+] = """Batch Name,Contest 1 - Choice 1-1,Contest 1 - Choice 1-2,Contest 1 - Write-In,Contest 2 - Choice 2-1,Contest 2 - Choice 2-2,Contest 2 - Write-In\r
+Tabulator 1 - BATCH1,1,1,1,3,2,0\r
+Tabulator 1 - BATCH2,2,1,0,3,1,0\r
+Tabulator 2 - BATCH1,2,1,0,3,2,0\r
+Tabulator 2 - BATCH2,2,0,0,6,2,0\r
 """
 
 snapshots[
@@ -147,14 +163,14 @@ snapshots[
 BATCH1,3\r
 BATCH2,3\r
 BATCH3,2\r
-BATCH4,1\r
+BATCH4,2\r
 """
 
 snapshots[
     "test_batch_inventory_hart_cvr_upload 2"
-] = """Batch Name,Choice 1-1,Choice 1-2\r
-BATCH1,1,2\r
-BATCH2,2,1\r
-BATCH3,0,0\r
-BATCH4,0,0\r
+] = """Batch Name,Choice 1-1,Choice 1-2,Write-In\r
+BATCH1,1,2,0\r
+BATCH2,2,1,0\r
+BATCH4,1,0,1\r
+BATCH3,0,0,0\r
 """

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -4,48 +4,47 @@ from ..helpers import *  # pylint: disable=wildcard-import
 from ...models import BatchInventoryData
 from ..ballot_comparison.test_cvrs import build_hart_cvr
 
-# Overvote for contest Contest 1 in row 11
-TEST_CVR = """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
-,,,,,,,,Contest 1 (Vote For=1),Contest 1 (Vote For=1),Contest 2 (Vote For=2),Contest 2 (Vote For=2),Contest 2 (Vote For=2)
-,,,,,,,,Choice 1-1,Choice 1-2,Choice 2-1,Choice 2-2,Choice 2-3
+TEST_CVR = """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,,,,,,
+,,,,,,,,Contest 1 (Vote For=1),Contest 1 (Vote For=1),Contest 1 (Vote For=1),Contest 2 (Vote For=2),Contest 2 (Vote For=2),Contest 2 (Vote For=2),Contest 2 (Vote For=2)
+,,,,,,,,Choice 1-1,Choice 1-2,Write-In,Choice 2-1,Choice 2-2,Choice 2-3,Write-In
 CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM,LBR,IND,,
-1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1,1,1,0
-2,TABULATOR1,BATCH1,2,1-1-2,Election Day,12345,COUNTY,1,0,1,0,1
-3,TABULATOR1,BATCH1,3,1-1-3,Election Day,12345,COUNTY,0,1,1,1,0
-4,TABULATOR1,BATCH2,1,1-2-1,Election Day,12345,COUNTY,1,0,1,0,1
-5,TABULATOR1,BATCH2,2,1-2-2,Election Day,12345,COUNTY,0,1,1,1,0
-6,TABULATOR1,BATCH2,3,1-2-3,Election Day,12345,COUNTY,1,0,1,0,1
-7,TABULATOR2,BATCH1,1,2-1-1,Election Day,12345,COUNTY,0,1,1,1,0
-8,TABULATOR2,BATCH1,2,2-1-2,Mail,12345,COUNTY,1,0,1,0,1
-9,TABULATOR2,BATCH1,3,2-1-3,Mail,12345,COUNTY,1,0,1,1,0
-10,TABULATOR2,BATCH2,1,2-2-1,Election Day,12345,COUNTY,1,0,1,0,1
-11,TABULATOR2,BATCH2,2,2-2-2,Election Day,12345,COUNTY,1,1,1,1,0
-12,TABULATOR2,BATCH2,3,2-2-3,Election Day,12345,COUNTY,1,0,1,0,1
-13,TABULATOR2,BATCH2,4,2-2-4,Election Day,12345,CITY,,,1,0,1
-14,TABULATOR2,BATCH2,5,2-2-5,Election Day,12345,CITY,,,1,1,0
-15,TABULATOR2,BATCH2,6,2-2-6,Election Day,12345,CITY,,,1,0,1
+1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,0,1,1,1,0,0
+2,TABULATOR1,BATCH1,2,1-1-2,Election Day,12345,COUNTY,1,0,0,1,0,1,0
+3,TABULATOR1,BATCH1,3,1-1-3,Election Day,12345,COUNTY,0,1,0,1,1,0,0
+4,TABULATOR1,BATCH2,1,1-2-1,Election Day,12345,COUNTY,1,0,0,1,0,1,0
+5,TABULATOR1,BATCH2,2,1-2-2,Election Day,12345,COUNTY,0,1,0,1,1,0,0
+6,TABULATOR1,BATCH2,3,1-2-3,Election Day,12345,COUNTY,1,0,0,1,0,1,0
+7,TABULATOR2,BATCH1,1,2-1-1,Election Day,12345,COUNTY,0,1,0,1,1,0,0
+8,TABULATOR2,BATCH1,2,2-1-2,Mail,12345,COUNTY,1,0,0,1,0,1,0
+9,TABULATOR2,BATCH1,3,2-1-3,Mail,12345,COUNTY,1,0,0,1,1,0,0
+10,TABULATOR2,BATCH2,1,2-2-1,Election Day,12345,COUNTY,1,0,0,1,0,1,0
+11,TABULATOR2,BATCH2,2,2-2-2,Election Day,12345,COUNTY,1,1,0,1,1,0,0
+12,TABULATOR2,BATCH2,3,2-2-3,Election Day,12345,COUNTY,1,0,0,1,0,1,0
+13,TABULATOR2,BATCH2,4,2-2-4,Election Day,12345,CITY,,,,1,0,1,0
+14,TABULATOR2,BATCH2,5,2-2-5,Election Day,12345,CITY,,,,1,1,0,0
+15,TABULATOR2,BATCH2,6,2-2-6,Election Day,12345,CITY,,,,1,0,1,0
 """
 
 # Overvote for contest Contest 1 in row 11
-TEST_CVRS_WITH_LEADING_EQUAL_SIGNS = """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,
-,,,,,,,,Contest 1 (Vote For=1),Contest 1 (Vote For=1),Contest 2 (Vote For=2),Contest 2 (Vote For=2),Contest 2 (Vote For=2)
-,,,,,,,,Choice 1-1,Choice 1-2,Choice 2-1,Choice 2-2,Choice 2-3
+TEST_CVRS_WITH_LEADING_EQUAL_SIGNS = """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,,,,,,
+,,,,,,,,Contest 1 (Vote For=1),Contest 1 (Vote For=1),Contest 1 (Vote For=1),Contest 2 (Vote For=2),Contest 2 (Vote For=2),Contest 2 (Vote For=2),Contest 2 (Vote For=2)
+,,,,,,,,Choice 1-1,Choice 1-2,Write-In,Choice 2-1,Choice 2-2,Choice 2-3,Write-In
 CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM,LBR,IND,,
-="1",="TABULATOR1",="BATCH1",="1",="1-1-1",Election Day,12345,COUNTY,0,1,1,1,0
-="2",="TABULATOR1",="BATCH1",="2",="1-1-2",Election Day,12345,COUNTY,1,0,1,0,1
-="3",="TABULATOR1",="BATCH1",="3",="1-1-3",Election Day,12345,COUNTY,0,1,1,1,0
-="4",="TABULATOR1",="BATCH2",="1",="1-2-1",Election Day,12345,COUNTY,1,0,1,0,1
-="5",="TABULATOR1",="BATCH2",="2",="1-2-2",Election Day,12345,COUNTY,0,1,1,1,0
-="6",="TABULATOR1",="BATCH2",="3",="1-2-3",Election Day,12345,COUNTY,1,0,1,0,1
-="7",="TABULATOR2",="BATCH1",="1",="2-1-1",Election Day,12345,COUNTY,0,1,1,1,0
-="8",="TABULATOR2",="BATCH1",="2",="2-1-2",Mail,12345,COUNTY,1,0,1,0,1
-="9",="TABULATOR2",="BATCH1",="3",="2-1-3",Mail,12345,COUNTY,1,0,1,1,0
-="10",="TABULATOR2",="BATCH2",="1",="2-2-1",Election Day,12345,COUNTY,1,0,1,0,1
-="11",="TABULATOR2",="BATCH2",="2",="2-2-2",Election Day,12345,COUNTY,1,1,1,1,0
-="12",="TABULATOR2",="BATCH2",="3",="2-2-3",Election Day,12345,COUNTY,1,0,1,0,1
-="13",="TABULATOR2",="BATCH2",="4",="2-2-4",Election Day,12345,CITY,,,1,0,1
-="14",="TABULATOR2",="BATCH2",="5",="2-2-5",Election Day,12345,CITY,,,1,1,0
-="15",="TABULATOR2",="BATCH2",="6",="2-2-6",Election Day,12345,CITY,,,1,0,1
+="1",="TABULATOR1",="BATCH1",="1",="1-1-1",Election Day,12345,COUNTY,0,0,1,1,1,0,0
+="2",="TABULATOR1",="BATCH1",="2",="1-1-2",Election Day,12345,COUNTY,1,0,0,1,0,1,0
+="3",="TABULATOR1",="BATCH1",="3",="1-1-3",Election Day,12345,COUNTY,0,1,0,1,1,0,0
+="4",="TABULATOR1",="BATCH2",="1",="1-2-1",Election Day,12345,COUNTY,1,0,0,1,0,1,0
+="5",="TABULATOR1",="BATCH2",="2",="1-2-2",Election Day,12345,COUNTY,0,1,0,1,1,0,0
+="6",="TABULATOR1",="BATCH2",="3",="1-2-3",Election Day,12345,COUNTY,1,0,0,1,0,1,0
+="7",="TABULATOR2",="BATCH1",="1",="2-1-1",Election Day,12345,COUNTY,0,1,0,1,1,0,0
+="8",="TABULATOR2",="BATCH1",="2",="2-1-2",Mail,12345,COUNTY,1,0,0,1,0,1,0
+="9",="TABULATOR2",="BATCH1",="3",="2-1-3",Mail,12345,COUNTY,1,0,0,1,1,0,0
+="10",="TABULATOR2",="BATCH2",="1",="2-2-1",Election Day,12345,COUNTY,1,0,0,1,0,1,0
+="11",="TABULATOR2",="BATCH2",="2",="2-2-2",Election Day,12345,COUNTY,1,1,0,1,1,0,0
+="12",="TABULATOR2",="BATCH2",="3",="2-2-3",Election Day,12345,COUNTY,1,0,0,1,0,1,0
+="13",="TABULATOR2",="BATCH2",="4",="2-2-4",Election Day,12345,CITY,,,,1,0,1,0
+="14",="TABULATOR2",="BATCH2",="5",="2-2-5",Election Day,12345,CITY,,,,1,1,0,0
+="15",="TABULATOR2",="BATCH2",="6",="2-2-6",Election Day,12345,CITY,,,,1,0,1,0
 """
 
 TEST_TABULATOR_STATUS = """<?xml version="1.0" standalone="yes"?>
@@ -82,7 +81,8 @@ def contest_id(client: FlaskClient, election_id: str, jurisdiction_ids: List[str
         "choices": [
             # Double the actual number of votes in TEST_CVR to account for the two jurisdictions
             {"id": str(uuid.uuid4()), "name": "Choice 1-1", "numVotes": 14},
-            {"id": str(uuid.uuid4()), "name": "Choice 1-2", "numVotes": 8},
+            {"id": str(uuid.uuid4()), "name": "Choice 1-2", "numVotes": 6},
+            {"id": str(uuid.uuid4()), "name": "Write-In", "numVotes": 2},
         ],
         "numWinners": 1,
         "votesAllowed": 1,
@@ -103,7 +103,8 @@ def contest_ids(client: FlaskClient, election_id: str, jurisdiction_ids: List[st
         "choices": [
             # Double the actual number of votes in TEST_CVR to account for the two jurisdictions
             {"id": str(uuid.uuid4()), "name": "Choice 1-1", "numVotes": 14},
-            {"id": str(uuid.uuid4()), "name": "Choice 1-2", "numVotes": 8},
+            {"id": str(uuid.uuid4()), "name": "Choice 1-2", "numVotes": 6},
+            {"id": str(uuid.uuid4()), "name": "Write-In", "numVotes": 0},
         ],
         "numWinners": 1,
         "votesAllowed": 1,
@@ -117,7 +118,7 @@ def contest_ids(client: FlaskClient, election_id: str, jurisdiction_ids: List[st
             # Double the actual number of votes in TEST_CVR to account for the two jurisdictions
             {"id": str(uuid.uuid4()), "name": "Choice 2-1", "numVotes": 30},
             {"id": str(uuid.uuid4()), "name": "Choice 2-2", "numVotes": 14},
-            {"id": str(uuid.uuid4()), "name": "Choice 2-3", "numVotes": 16},
+            {"id": str(uuid.uuid4()), "name": "Write-In", "numVotes": 0},
         ],
         "numWinners": 1,
         "votesAllowed": 2,
@@ -893,12 +894,12 @@ def test_batch_inventory_invalid_file_uploads(
         client,
         io.BytesIO(
             TEST_CVR.replace(
-                """1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,1,1,1,0
-2,TABULATOR1,BATCH1,2,1-1-2,Election Day,12345,COUNTY,1,0,1,0,1
-3,TABULATOR1,BATCH1,3,1-1-3,Election Day,12345,COUNTY,0,1,1,1,0
-4,TABULATOR1,BATCH2,1,1-2-1,Election Day,12345,COUNTY,1,0,1,0,1
-5,TABULATOR1,BATCH2,2,1-2-2,Election Day,12345,COUNTY,0,1,1,1,0
-6,TABULATOR1,BATCH2,3,1-2-3,Election Day,12345,COUNTY,1,0,1,0,1
+                """1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,0,1,1,1,0,0
+2,TABULATOR1,BATCH1,2,1-1-2,Election Day,12345,COUNTY,1,0,0,1,0,1,0
+3,TABULATOR1,BATCH1,3,1-1-3,Election Day,12345,COUNTY,0,1,0,1,1,0,0
+4,TABULATOR1,BATCH2,1,1-2-1,Election Day,12345,COUNTY,1,0,0,1,0,1,0
+5,TABULATOR1,BATCH2,2,1-2-2,Election Day,12345,COUNTY,0,1,0,1,1,0,0
+6,TABULATOR1,BATCH2,3,1-2-3,Election Day,12345,COUNTY,1,0,0,1,0,1,0
 """,
                 "",
             ).encode()

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -1654,7 +1654,8 @@ def test_batch_inventory_hart_cvr_upload(
         build_hart_cvr("BATCH2", "3", "1-2-3", "1,0,0,0,1"),
         build_hart_cvr("BATCH3", "1", "1-3-1", ",,1,0,0"),
         build_hart_cvr("BATCH3", "2", "1-3-2", ",,1,0,0"),
-        build_hart_cvr("BATCH4", "1", "1-4-1", "1,1,0,0,1", add_write_in=True),
+        build_hart_cvr("BATCH4", "1", "1-4-1", "1,0,0,0,1"),
+        build_hart_cvr("BATCH4", "1", "1-4-1", "1,0,0,0,1", add_write_in=True),
     ]
     hart_zip = zip_hart_cvrs(hart_cvrs)
 

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -547,13 +547,17 @@ def upload_batch_inventory_cvr(
     file_content: io.BytesIO,
     election_id: str,
     jurisdiction_id: str,
+    file_type: str = "text/csv",
 ):
-    filename = timestamp_filename("batchInventoryCvr", "csv")
+    if file_type in ["application/zip", "application/x-zip-compressed"]:
+        filename = timestamp_filename("batchInventoryCvr", "zip")
+    else:
+        filename = timestamp_filename("batchInventoryCvr", "csv")
     return upload_file_helper(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-inventory/cvr",
         filename,
-        "text/csv",
+        file_type,
         file_content,
     )
 

--- a/server/tests/util/test_hart_parse.py
+++ b/server/tests/util/test_hart_parse.py
@@ -1,0 +1,63 @@
+from xml.etree.ElementTree import Element, ElementTree
+import pytest
+from ...util.hart_parse import (
+    find_text_xml,
+    find_xml,
+    findall_xml,
+    parse_contest_results,
+)
+
+
+@pytest.fixture
+def namespace():
+    return "http://tempuri.org/CVRDesign.xsd"
+
+
+def test_find_text_xml(namespace):
+    root = Element("Root")
+    child = Element(f"{{{namespace}}}Tag")
+    child.text = "Test"
+    root.append(child)
+    assert find_text_xml(ElementTree(root), "Tag") == "Test"
+    assert find_text_xml(None, "Tag") is None
+    assert find_text_xml(ElementTree(root), "NonExistentTag") is None
+
+
+def test_find_xml(namespace):
+    root = Element("Root")
+    child = Element(f"{{{namespace}}}Tag")
+    root.append(child)
+    assert find_xml(ElementTree(root), "Tag") is not None
+    assert find_xml(ElementTree(root), "NonExistentTag") is None
+
+
+def test_findall_xml(namespace):
+    root = Element("Root")
+    child1 = Element(f"{{{namespace}}}Tag")
+    child2 = Element(f"{{{namespace}}}Tag")
+    root.extend([child1, child2])
+    assert len(findall_xml(ElementTree(root), "Tag")) == 2
+    assert len(findall_xml(ElementTree(root), "NonExistentTag")) == 0
+
+
+def test_parse_contest_results(namespace):
+    cvr = Element(f"{{{namespace}}}CVR")
+    contests = Element(f"{{{namespace}}}Contests")
+    contest = Element(f"{{{namespace}}}Contest")
+    contest_name = Element(f"{{{namespace}}}Name")
+    contest_name.text = "Contest1"
+    options = Element(f"{{{namespace}}}Options")
+    option = Element(f"{{{namespace}}}Option")
+    option_name = Element(f"{{{namespace}}}Name")
+    option_name.text = "Choice1"
+    option.append(option_name)
+    options.append(option)
+    contest.append(contest_name)
+    contest.append(options)
+    contests.append(contest)
+    cvr.append(contests)
+    cvr_xml = ElementTree(cvr)
+
+    results = parse_contest_results(cvr_xml)
+    assert "Contest1" in results
+    assert "Choice1" in results["Contest1"]

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -100,7 +100,12 @@ def zip_files(files: Mapping[str, IO[bytes]]) -> IO[bytes]:
 def unzip_files(zip_file: BinaryIO, directory_to_extract_to: str) -> List[str]:
     with ZipFile(zip_file, "r") as zip_archive:
         zip_archive.extractall(directory_to_extract_to)
-        return zip_archive.namelist()
+        return [
+            entry_name
+            for entry_name in zip_archive.namelist()
+            # ZIP files created on Macs include a hidden __MACOSX folder
+            if not entry_name.startswith("__") and not entry_name.startswith(".")
+        ]
 
 
 def get_full_storage_path(file_path: str) -> str:

--- a/server/util/hart_parse.py
+++ b/server/util/hart_parse.py
@@ -9,7 +9,7 @@ def find_text_xml(xml: Optional[Union[ET.ElementTree, ET.Element]], tag: str):
     if xml is None:
         return None
     result = find_xml(xml, tag)
-    return None if result is None else result.text
+    return None if (result is None or result.text == "") else result.text
 
 
 def find_xml(xml: Union[ET.ElementTree, ET.Element], tag: str):

--- a/server/util/hart_parse.py
+++ b/server/util/hart_parse.py
@@ -1,0 +1,40 @@
+from typing import Union, Optional
+from collections import defaultdict
+from xml.etree import ElementTree as ET
+
+NAMESPACE = "http://tempuri.org/CVRDesign.xsd"
+
+
+def find_text_xml(xml: Optional[Union[ET.ElementTree, ET.Element]], tag: str):
+    if xml is None:
+        return None
+    result = find_xml(xml, tag)
+    return None if result is None else result.text
+
+
+def find_xml(xml: Union[ET.ElementTree, ET.Element], tag: str):
+    return xml.find(f"{{{NAMESPACE}}}{tag}")
+
+
+def findall_xml(xml: Union[ET.ElementTree, ET.Element], tag: str):
+    return xml.findall(f"{{{NAMESPACE}}}{tag}")
+
+
+def parse_contest_results(cvr_xml: ET.ElementTree):
+    # { contest_name: voted_for_choices }
+    results = defaultdict(set)
+    contests = findall_xml(find_xml(cvr_xml, "Contests"), "Contest")
+    for contest in contests:
+        contest_name = find_xml(contest, "Name").text
+        # From what we've seen so far with Hart CVRs, the only choices
+        # listed are the ones with votes (i.e. with "Value" = 1), so if we
+        # see a choice, we can count it as a vote.
+        choices = findall_xml(find_xml(contest, "Options"), "Option")
+        for choice in choices:
+            if find_xml(choice, "WriteInData"):
+                choice_name = "Write-In"
+            else:
+                choice_name = find_xml(choice, "Name").text
+            results[contest_name].add(choice_name)
+
+    return results


### PR DESCRIPTION
https://github.com/votingworks/arlo/issues/1865
Adds basic support for hart cvr uploads in the batch inventory tool. Extracts BatchNumber, when provided, from Hart CVRs to use to group batches, and falls back to the precinct (split) name. The hart documentation suggests that BatchNumber is only provided on central system drives, and in sample hart cvr files we have there are some without BatchNumbers. If the CVRs with a missing BatchNumber are precinct cvrs then grouping by precinct is a logical fallback. We may want to tweak this implementation as we have real use cases for it and understand the data better. 