### PR TITLE
Stream file downloaded from s3 to temporary file for processing

### DIFF
--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -41,7 +41,7 @@ from ..util.file import (
     get_file_upload_url,
     get_standard_file_upload_request_params,
     retrieve_file,
-    retrieve_file_streaming,
+    retrieve_file_to_buffer,
     serialize_file,
     serialize_file_processing,
     timestamp_filename,
@@ -120,7 +120,7 @@ def process_batch_inventory_cvr_file(
         jurisdiction_id
     )
     contests = list(jurisdiction.contests)
-    cvr_file = retrieve_file_streaming(
+    cvr_file = retrieve_file_to_buffer(
         batch_inventory_data.cvr_file.storage_path, working_directory
     )
 

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -41,6 +41,7 @@ from ..util.file import (
     get_file_upload_url,
     get_standard_file_upload_request_params,
     retrieve_file,
+    retrieve_file_streaming,
     serialize_file,
     serialize_file_processing,
     timestamp_filename,
@@ -119,7 +120,9 @@ def process_batch_inventory_cvr_file(
         jurisdiction_id
     )
     contests = list(jurisdiction.contests)
-    cvr_file = retrieve_file(batch_inventory_data.cvr_file.storage_path)
+    cvr_file = retrieve_file_streaming(
+        batch_inventory_data.cvr_file.storage_path, working_directory
+    )
 
     def process_dominion():
         cvrs = csv_reader_for_cvr(cvr_file)

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -47,7 +47,7 @@ from ..util.file import (
     get_file_upload_url,
     get_standard_file_upload_request_params,
     retrieve_file,
-    retrieve_file_streaming,
+    retrieve_file_to_buffer,
     serialize_file,
     serialize_file_processing,
     timestamp_filename,
@@ -317,7 +317,7 @@ def parse_clearballot_cvrs(
     jurisdiction: Jurisdiction,
     working_directory: str,
 ) -> Tuple[CVR_CONTESTS_METADATA, Iterable[CvrBallot]]:
-    cvr_file = retrieve_file_streaming(
+    cvr_file = retrieve_file_to_buffer(
         jurisdiction.cvr_file.storage_path, working_directory
     )
     cvrs = csv_reader_for_cvr(cvr_file)
@@ -418,7 +418,7 @@ def parse_dominion_cvrs(
     jurisdiction: Jurisdiction,
     working_directory: str,
 ) -> Tuple[CVR_CONTESTS_METADATA, Iterable[CvrBallot]]:
-    cvr_file = retrieve_file_streaming(
+    cvr_file = retrieve_file_to_buffer(
         jurisdiction.cvr_file.storage_path, working_directory
     )
     cvrs = csv_reader_for_cvr(cvr_file)
@@ -684,7 +684,7 @@ def parse_ess_cvrs(
     #   - Second, parse out the interpretations.
     # 5. Concatenate the parsed CVRBallot lists and join that to the parsed interpretation
 
-    zip_file = retrieve_file_streaming(
+    zip_file = retrieve_file_to_buffer(
         jurisdiction.cvr_file.storage_path, working_directory
     )
     file_names = unzip_files(zip_file, working_directory)
@@ -1036,7 +1036,7 @@ def parse_hart_cvrs(
        scheme for interpretations requires knowing all of the contest and choice names up front.
     6. Parse the interpretations.
     """
-    wrapper_zip_file = retrieve_file_streaming(
+    wrapper_zip_file = retrieve_file_to_buffer(
         jurisdiction.cvr_file.storage_path, working_directory
     )
     file_names = unzip_files(wrapper_zip_file, working_directory)
@@ -1060,8 +1060,6 @@ def parse_hart_cvrs(
 
     # If there are no zip files inside the "wrapper" we assume it was not a wrapper and there was only one cvr zip file uploaded, unwrapped.
     if len(cvr_zip_files) == 0 and len(scanned_ballot_information_files) == 0:
-        # We need to re open the file since it was closed after unzipping
-        # pylint: disable=consider-using-with
         wrapper_zip_file.seek(0)
         cvr_zip_files[jurisdiction.cvr_file.name] = wrapper_zip_file
     else:

--- a/server/tests/util/test_file_storage.py
+++ b/server/tests/util/test_file_storage.py
@@ -3,7 +3,7 @@ import os.path
 import shutil
 import tempfile
 import io
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from werkzeug.exceptions import BadRequest
 import pytest
 
@@ -92,24 +92,23 @@ def test_store_file_raises_with_s3_config(mock_boto_client):
     config.FILE_UPLOAD_STORAGE_PATH = original_file_upload_storage_path
 
 
-@patch("boto3.resource")
-def test_retrieve_file_streaming(mock_boto3_resource):
+@patch("boto3.client", autospec=True)
+def test_retrieve_file_streaming(mock_boto_client):
     config.AWS_ACCESS_KEY_ID = "test access key id"
     config.AWS_SECRET_ACCESS_KEY = "test secret access key"
     config.AWS_DEFAULT_REGION = "test region"
     original_file_upload_storage_path = config.FILE_UPLOAD_STORAGE_PATH
     config.FILE_UPLOAD_STORAGE_PATH = "s3://test_bucket"
-    mock_s3 = MagicMock()
-    mock_boto3_resource.return_value = mock_s3
-    mock_object = mock_s3.Object.return_value
-    mock_body = MagicMock()
-    mock_body.read.side_effect = [b"test data", b""]
-    mock_object.get.return_value = {"Body": mock_body}
+
+    file = io.BytesIO(b"test data")
+    mock_boto_client.return_value.download_fileobj.side_effect = (
+        lambda bucket, key, stream: stream.write(file.read())
+    )
 
     with tempfile.TemporaryDirectory() as working_dir:
-        temp_file_path = os.path.join(working_dir, "test_file.csv")
         file = retrieve_file_streaming("s3://test_bucket/test_file.csv", working_dir)
         assert file.read() == b"test data"
+        temp_file_path = os.path.join(working_dir, file.name)
 
         with open(temp_file_path, "rb") as temp_file:
             assert temp_file.read() == b"test data"

--- a/server/tests/util/test_file_storage.py
+++ b/server/tests/util/test_file_storage.py
@@ -10,7 +10,7 @@ import pytest
 from ...util.file import (
     delete_file,
     retrieve_file,
-    retrieve_file_streaming,
+    retrieve_file_to_buffer,
     store_file,
     get_file_upload_url,
     get_standard_file_upload_request_params,
@@ -106,7 +106,7 @@ def test_retrieve_file_streaming(mock_boto_client):
     )
 
     with tempfile.TemporaryDirectory() as working_dir:
-        file = retrieve_file_streaming("s3://test_bucket/test_file.csv", working_dir)
+        file = retrieve_file_to_buffer("s3://test_bucket/test_file.csv", working_dir)
         assert file.read() == b"test data"
         temp_file_path = os.path.join(working_dir, file.name)
 

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import pathlib
 import shutil
 import io
 import os
@@ -49,15 +48,6 @@ def s3():  # pylint: disable=invalid-name
     )
 
 
-def s3Resource():  # pylint: disable=invalid-name
-    return boto3.resource(
-        "s3",
-        aws_access_key_id=config.AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=config.AWS_SECRET_ACCESS_KEY,
-        region_name=config.AWS_DEFAULT_REGION,
-    )
-
-
 def store_file(file: IO[bytes], storage_path: str) -> str:
     assert not os.path.isabs(storage_path)
     full_path = get_full_storage_path(storage_path)
@@ -90,13 +80,12 @@ def retrieve_file_streaming(storage_path: str, working_directory: str) -> Binary
         parsed_path = urlparse(storage_path)
         bucket_name = parsed_path.netloc
         key = parsed_path.path[1:]
-        temp_file_path = os.path.join(working_directory, key)
-        # make sure the path exists
-        pathlib.Path(temp_file_path).parent.mkdir(parents=True, exist_ok=True)
-        obj = s3Resource().Object(bucket_name, key)
-        body = obj.get()["Body"]
-        with open(temp_file_path, "wb") as temp_file:
-            shutil.copyfileobj(body, temp_file)
+        with tempfile.NamedTemporaryFile(
+            dir=working_directory, delete=False
+        ) as temp_file:
+            s3().download_fileobj(bucket_name, key, temp_file)
+            temp_file_path = temp_file.name
+        # reopen the file to have a read only pointer
         return open(temp_file_path, "rb")
     else:
         return open(storage_path, "rb")

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -74,7 +74,10 @@ def retrieve_file(storage_path: str) -> BinaryIO:
         return open(storage_path, "rb")
 
 
-def retrieve_file_streaming(storage_path: str, working_directory: str) -> BinaryIO:
+# Similar functionality to retrieve_file expect when retrieving s3 files they are streamed
+# to a temporary file on disk to avoid loading the file in memory. Should be used for large file retrieval
+# The caller of this function is repsonsible for making sure that the working_directory is cleaned up and removed.
+def retrieve_file_to_buffer(storage_path: str, working_directory: str) -> BinaryIO:
     if config.FILE_UPLOAD_STORAGE_PATH.startswith("s3://"):
         assert storage_path.startswith(config.FILE_UPLOAD_STORAGE_PATH)
         parsed_path = urlparse(storage_path)


### PR DESCRIPTION
Instead of downloading the entire file into memory this change streams it to a file in the temp working directory (already cleaned up at the end of processing) for processing. There is more work to do to make sure we never load everything in memory but this is a good easy win and first step. 

Testing on a dominion CVR that is 1.6 GB is size on main I found that the python process for the worker grows to ~1.7gb in memory usage as the file is downloaded and remains at that level for the length of processing before dropping back to its stable state of 200-300mb. After this change the same file shows that process holding steady with about 300mb of memory usage throughout the length of processing. Verified the tmp file is cleaned up at the end. 

Testing on a hart cvr zip of 1.4gb in prod it had a quick spike of memory of 1.5gb then came back down to 500-700mb and stayed there throughout the rest of processing. On this branch memory grew after download to 400mb and grows to 700mb throughout processing, but does not have the initial spike to 1.4gb. 

ES&S has a known bottleneck later on in processing that still loads everything in memory, will tackle in future PR. 
