### PR TITLE
Presentation mode for random seed input

### DIFF
--- a/client/cypress/end-to-end/ballot-comparison.cy.js
+++ b/client/cypress/end-to-end/ballot-comparison.cy.js
@@ -112,9 +112,7 @@ describe('Ballot Comparison Test Cases', () => {
     cy.findByRole('combobox', {
       name: /Set the risk limit for the audit/,
     }).select('10')
-    cy.findByLabelText(
-      'Enter the random characters to seed the pseudo-random number generator.'
-    ).type('543210')
+    cy.findByLabelText(/Enter a series of random numbers/).type('543210')
     cy.findByText('Save & Next').click()
     cy.findByRole('heading', { name: 'Review & Launch' })
     cy.logout(auditAdmin)

--- a/client/cypress/end-to-end/ballot-polling.cy.js
+++ b/client/cypress/end-to-end/ballot-polling.cy.js
@@ -145,9 +145,7 @@ describe('Ballot Polling', () => {
     cy.findByRole('combobox', {
       name: /Set the risk limit for the audit/,
     }).select('10')
-    cy.findByLabelText(
-      'Enter the random characters to seed the pseudo-random number generator.'
-    ).type('543210')
+    cy.findByLabelText(/Enter a series of random numbers/).type('543210')
     cy.findByText('Save & Next').click()
     cy.findAllByText('Review & Launch').should('have.length', 2)
     cy.logout(auditAdmin)


### PR DESCRIPTION
Closes #1777 

Adds a presentation mode for inputting the random seed. To begin an audit, state officials often have a ceremony where they publicly roll dice to generate the random seed and then type it into Arlo. They like to project Arlo onto a screen during this ceremony. This PR adds a presentation mode for the random seed input to be used during this ceremony.

https://github.com/user-attachments/assets/635e0c5a-0384-4737-b7a3-89cdf3cc50e4

