### PR TITLE
Batch comparison discrepancies in UI batch comparison

### DIFF
--- a/client/src/components/AuditAdmin/Progress/JurisdictionDiscrepancies.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDiscrepancies.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { Classes, Colors, Dialog, H6, HTMLTable } from '@blueprintjs/core'
+import styled from 'styled-components'
+import {
+  IJurisdiction,
+  useDiscrepanciesByJurisdiction,
+} from '../../useJurisdictions'
+import useContestsJurisdictionAdmin from '../../JurisdictionAdmin/useContestsJurisdictionAdmin'
+import { IContest } from '../../../types'
+
+const ContestDiscrepanciesTable = styled(HTMLTable).attrs({
+  bordered: true,
+  striped: true,
+})`
+  &.${Classes.HTML_TABLE} {
+    background: #ffffff;
+    border: 1px solid ${Colors.LIGHT_GRAY1};
+    margin-bottom: 32px;
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  &.${Classes.HTML_TABLE} td {
+    vertical-align: middle;
+  }
+`
+
+/* istanbul ignore next */
+function getContestName(contests: IContest[], contestId: string) {
+  const contest = contests.find(c => c.id === contestId)
+  return contest ? contest.name : 'Contest not found'
+}
+
+/* istanbul ignore next */
+function getChoiceName(
+  contests: IContest[],
+  contestId: string,
+  choiceId: string
+) {
+  const contest = contests.find(c => c.id === contestId)
+  if (!contest) return 'Choice not found'
+  const choice = contest.choices.find(c => c.id === choiceId)
+  return choice ? choice.name : 'Choice not found'
+}
+
+export interface IJurisdictionDiscrepanciesProps {
+  electionId: string
+  handleClose: () => void
+  jurisdiction: IJurisdiction
+}
+
+const JurisdictionDiscrepancies: React.FC<IJurisdictionDiscrepanciesProps> = ({
+  handleClose,
+  jurisdiction,
+  electionId,
+}) => {
+  const discrepancyQuery = useDiscrepanciesByJurisdiction(electionId, {})
+  const contestsQuery = useContestsJurisdictionAdmin(
+    electionId,
+    jurisdiction.id
+  )
+
+  if (!discrepancyQuery.isSuccess || !contestsQuery.isSuccess) {
+    return null
+  }
+
+  const discrepanciesByBatch = discrepancyQuery.data[jurisdiction.id]
+  const contests = contestsQuery.data
+
+  return (
+    <Dialog
+      isOpen
+      onClose={handleClose}
+      style={{ width: '600px' }}
+      title={`${jurisdiction.name} Discrepancies`}
+    >
+      <div className={Classes.DIALOG_BODY} style={{ marginBottom: 0 }}>
+        {Object.entries(discrepanciesByBatch).map(
+          ([batchName, discrepanciesByContest]) => {
+            return Object.entries(discrepanciesByContest).map(
+              ([contestId, contestDiscrepancies], idx) => (
+                <div key={contestId}>
+                  <H6 style={idx === 0 ? { marginTop: '8px' } : {}}>
+                    {batchName} - {getContestName(contests, contestId)}
+                  </H6>
+                  <ContestDiscrepanciesTable>
+                    <thead>
+                      <tr>
+                        <th>Choice</th>
+                        <th>Reported Votes</th>
+                        <th>Audited Votes</th>
+                        <th>Discrepancy</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {Object.keys(contestDiscrepancies.discrepancies).map(
+                        choiceId => (
+                          <tr key={choiceId}>
+                            <td>
+                              {getChoiceName(contests, contestId, choiceId)}
+                            </td>
+                            <td>
+                              {contestDiscrepancies.reportedVotes[choiceId]}
+                            </td>
+                            <td>
+                              {contestDiscrepancies.auditedVotes[choiceId]}
+                            </td>
+                            <td>
+                              {contestDiscrepancies.discrepancies[choiceId]}
+                            </td>
+                          </tr>
+                        )
+                      )}
+                    </tbody>
+                  </ContestDiscrepanciesTable>
+                </div>
+              )
+            )
+          }
+        )}
+      </div>
+    </Dialog>
+  )
+}
+
+export { JurisdictionDiscrepancies }

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDiscrepancies.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDiscrepancies.tsx
@@ -7,20 +7,19 @@ import {
 } from '../../useJurisdictions'
 import useContestsJurisdictionAdmin from '../../JurisdictionAdmin/useContestsJurisdictionAdmin'
 import { IContest } from '../../../types'
+import { assert } from '../../utilities'
 
 const ContestDiscrepanciesTable = styled(HTMLTable).attrs({
   bordered: true,
   striped: true,
 })`
-  &.${Classes.HTML_TABLE} {
-    background: #ffffff;
-    border: 1px solid ${Colors.LIGHT_GRAY1};
-    margin-bottom: 32px;
-    table-layout: fixed;
-    width: 100%;
-  }
+  background: #ffffff;
+  border: 1px solid ${Colors.LIGHT_GRAY1};
+  margin-bottom: 32px;
+  table-layout: fixed;
+  width: 100%;
 
-  &.${Classes.HTML_TABLE} td {
+  td {
     vertical-align: middle;
   }
 `
@@ -31,22 +30,22 @@ const TableHeader = styled(H6)`
   }
 `
 
-/* istanbul ignore next */
 function getContestName(contests: IContest[], contestId: string) {
   const contest = contests.find(c => c.id === contestId)
-  return contest ? contest.name : `Contest Unknown: ID ${contestId}`
+  assert(contest !== undefined)
+  return contest.name
 }
 
-/* istanbul ignore next */
 function getChoiceName(
   contests: IContest[],
   contestId: string,
   choiceId: string
 ) {
   const contest = contests.find(c => c.id === contestId)
-  if (!contest) return `Contest Unknown: ID ${choiceId}`
+  assert(contest !== undefined)
   const choice = contest.choices.find(c => c.id === choiceId)
-  return choice ? choice.name : `Choice Unknown: ID ${choiceId}`
+  assert(choice !== undefined)
+  return choice.name
 }
 
 export interface IJurisdictionDiscrepanciesProps {

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDiscrepancies.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDiscrepancies.tsx
@@ -25,10 +25,16 @@ const ContestDiscrepanciesTable = styled(HTMLTable).attrs({
   }
 `
 
+const TableHeader = styled(H6)`
+  &:first-child {
+    margin-top: 8px;
+  }
+`
+
 /* istanbul ignore next */
 function getContestName(contests: IContest[], contestId: string) {
   const contest = contests.find(c => c.id === contestId)
-  return contest ? contest.name : 'Contest not found'
+  return contest ? contest.name : `Contest Unknown: ID ${contestId}`
 }
 
 /* istanbul ignore next */
@@ -38,9 +44,9 @@ function getChoiceName(
   choiceId: string
 ) {
   const contest = contests.find(c => c.id === contestId)
-  if (!contest) return 'Choice not found'
+  if (!contest) return `Contest Unknown: ID ${choiceId}`
   const choice = contest.choices.find(c => c.id === choiceId)
-  return choice ? choice.name : 'Choice not found'
+  return choice ? choice.name : `Choice Unknown: ID ${choiceId}`
 }
 
 export interface IJurisdictionDiscrepanciesProps {
@@ -78,11 +84,11 @@ const JurisdictionDiscrepancies: React.FC<IJurisdictionDiscrepanciesProps> = ({
         {Object.entries(discrepanciesByBatch).map(
           ([batchName, discrepanciesByContest]) => {
             return Object.entries(discrepanciesByContest).map(
-              ([contestId, contestDiscrepancies], idx) => (
+              ([contestId, contestDiscrepancies]) => (
                 <div key={contestId}>
-                  <H6 style={idx === 0 ? { marginTop: '8px' } : {}}>
+                  <TableHeader>
                     {batchName} - {getContestName(contests, contestId)}
-                  </H6>
+                  </TableHeader>
                   <ContestDiscrepanciesTable>
                     <thead>
                       <tr>

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -35,6 +35,7 @@ import { sum } from '../../../utils/number'
 import { apiDownload, assert } from '../../utilities'
 import AsyncButton from '../../Atoms/AsyncButton'
 import useSearchParams from '../../useSearchParams'
+import { JurisdictionDiscrepancies } from './JurisdictionDiscrepancies'
 
 const Wrapper = styled.div`
   flex-grow: 1;
@@ -75,6 +76,8 @@ const Progress: React.FC<IProgressProps> = ({
   const showDiscrepancies =
     Boolean(round) &&
     (auditType === 'BALLOT_COMPARISON' || auditType === 'BATCH_COMPARISON')
+  const showDiscrepanciesReview =
+    Boolean(round) && auditType === 'BATCH_COMPARISON'
   const discrepancyCountsQuery = useDiscrepancyCountsByJurisdiction(
     electionId,
     { enabled: showDiscrepancies }
@@ -90,12 +93,16 @@ const Progress: React.FC<IProgressProps> = ({
   const [jurisdictionDetailId, setJurisdictionDetailId] = useState<
     string | null
   >(null)
+  const [
+    jurisdictionDiscrepanciesId,
+    setJurisdictionDiscrepanciesId,
+  ] = useState<string | null>(null)
 
   const ballotsOrBatches =
     auditType === 'BATCH_COMPARISON' ? 'Batches' : 'Ballots'
 
   const someJurisdictionHasDiscrepancies = Object.values(
-    discrepancyCountsQuery.data ?? {}
+    discrepancyCountsQuery.data ? discrepancyCountsQuery.data : {}
   ).some(count => count > 0)
 
   const columns: Column<IJurisdiction>[] = [
@@ -315,7 +322,10 @@ const Progress: React.FC<IProgressProps> = ({
           s &&
           s.status === JurisdictionRoundStatus.COMPLETE &&
           discrepancyCountsQuery.data?.[id],
-        Cell: ({ value }: { value: number | null }) => {
+        Cell: ({
+          value,
+          row: { original: jurisdiction },
+        }: Cell<IJurisdiction>) => {
           if (discrepancyCountsQuery.isLoading) {
             return (
               <div style={{ display: 'flex', justifyContent: 'start' }}>
@@ -324,10 +334,23 @@ const Progress: React.FC<IProgressProps> = ({
             )
           }
           if (!value) return null
+          if (!showDiscrepanciesReview)
+            return (
+              <>
+                <Icon icon="flag" intent="danger" /> {value.toLocaleString()}
+              </>
+            )
           return (
-            <>
-              <Icon icon="flag" intent="danger" /> {value.toLocaleString()}
-            </>
+            <Button
+              onClick={() => setJurisdictionDiscrepanciesId(jurisdiction.id)}
+            >
+              <Icon
+                icon="flag"
+                intent="danger"
+                style={{ marginRight: '4px' }}
+              />
+              Review {value.toLocaleString()}
+            </Button>
           )
         },
         Footer: discrepancyCountsQuery.isLoading
@@ -499,6 +522,17 @@ const Progress: React.FC<IProgressProps> = ({
           round={round}
           handleClose={() => setJurisdictionDetailId(null)}
           auditSettings={auditSettings}
+        />
+      )}
+      {jurisdictionDiscrepanciesId && round && (
+        <JurisdictionDiscrepancies
+          jurisdiction={
+            jurisdictions.find(
+              jurisdiction => jurisdiction.id === jurisdictionDiscrepanciesId
+            )!
+          }
+          electionId={electionId}
+          handleClose={() => setJurisdictionDiscrepanciesId(null)}
         />
       )}
     </Wrapper>

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -101,10 +101,6 @@ const Progress: React.FC<IProgressProps> = ({
   const ballotsOrBatches =
     auditType === 'BATCH_COMPARISON' ? 'Batches' : 'Ballots'
 
-  const someJurisdictionHasDiscrepancies = Object.values(
-    discrepancyCountsQuery.data ? discrepancyCountsQuery.data : {}
-  ).some(count => count > 0)
-
   const columns: Column<IJurisdiction>[] = [
     {
       Header: 'Jurisdiction',
@@ -442,12 +438,6 @@ const Progress: React.FC<IProgressProps> = ({
         <AsyncButton
           onClick={() =>
             apiDownload(`/election/${electionId}/discrepancy-report`)
-          }
-          icon={
-            <Icon
-              icon="flag"
-              intent={someJurisdictionHasDiscrepancies ? 'danger' : 'none'}
-            />
           }
         >
           Download Discrepancy Report

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -524,7 +524,7 @@ const Progress: React.FC<IProgressProps> = ({
           auditSettings={auditSettings}
         />
       )}
-      {jurisdictionDiscrepanciesId && round && (
+      {jurisdictionDiscrepanciesId && (
         <JurisdictionDiscrepancies
           jurisdiction={
             jurisdictions.find(

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -61,19 +61,19 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-bMvGRv eoqrva"
+          class="sc-laTMn hAAKnY"
         >
           <div
-            class="sc-CtfFt droipi"
+            class="sc-hGoxap caLCHz"
           >
             <div
-              class="sc-laTMn cFaJqX"
+              class="sc-fjmCvl kMxBci"
             >
               <div
-                class="sc-TFwJa kEXxgL"
+                class="sc-krDsej ehqnVq"
               >
                 <button
-                  class="bp3-button bp3-minimal sc-fjmCvl dTaAoV"
+                  class="bp3-button bp3-minimal sc-bHwgHz bMElXT"
                   href="/election/1/audit-board/audit-board-1"
                   type="button"
                 >
@@ -103,56 +103,56 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                   </span>
                 </button>
                 <h3
-                  class="bp3-heading sc-rBLzX gNxfKc"
+                  class="bp3-heading sc-CtfFt kZgVRS"
                 >
                   Audit Ballot Selections
                 </h3>
               </div>
               <div
-                class="bp3-divider sc-lkqHmb TcpPN"
+                class="bp3-divider sc-cbkKFq ODwFP"
               />
               <div
-                class="sc-dymIpo fRJiSg"
+                class="sc-gFaPwZ cHJJmb"
               >
                 <div>
                   <h5
-                    class="bp3-heading sc-emmjRN DUKSN"
+                    class="bp3-heading sc-dymIpo biKLRv"
                   >
                     Tabulator
                   </h5>
                   <h4
-                    class="bp3-heading sc-bnXvFD gRXvw"
+                    class="bp3-heading sc-fhYwyz FZsZD"
                   >
                     11
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-emmjRN DUKSN"
+                    class="bp3-heading sc-dymIpo biKLRv"
                   >
                     Batch
                   </h5>
                   <h4
-                    class="bp3-heading sc-bnXvFD gRXvw"
+                    class="bp3-heading sc-fhYwyz FZsZD"
                   >
                     0003-04-Precinct 19 (Jonesboro Fire Department)
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-emmjRN DUKSN"
+                    class="bp3-heading sc-dymIpo biKLRv"
                   >
                     Ballot Number
                   </h5>
                   <h4
-                    class="bp3-heading sc-bnXvFD gRXvw"
+                    class="bp3-heading sc-fhYwyz FZsZD"
                   >
                     2112
                   </h4>
                 </div>
                 <div>
                   <button
-                    class="bp3-button bp3-large bp3-intent-danger sc-gFaPwZ hjBLLy"
+                    class="bp3-button bp3-large bp3-intent-danger sc-jzgbtB eofazy"
                     type="button"
                   >
                     <span
@@ -164,36 +164,36 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 </div>
               </div>
               <div
-                class="bp3-divider sc-lkqHmb TcpPN"
+                class="bp3-divider sc-cbkKFq ODwFP"
               />
               <div
-                class="sc-eLExRp hPtYdv"
+                class="sc-krvtoX NyKrz"
               >
                 <div
                   class="ballot-main"
                 >
                   <h5
-                    class="bp3-heading sc-emmjRN DUKSN"
+                    class="bp3-heading sc-dymIpo biKLRv"
                   >
                     Ballot Contests
                   </h5>
                   <form>
                     <div
-                      class="sc-cbkKFq kZkYDv"
+                      class="sc-fYiAbW bbEbqb"
                     >
                       <div
-                        class="sc-gHboQg bVcsNq"
+                        class="sc-eerKOB ggGbtG"
                       >
                         <div
-                          class="sc-eilVRo kYUzWb"
+                          class="sc-emmjRN dZjvLQ"
                         >
                           <h3
-                            class="bp3-heading sc-jzgbtB kYoHmT"
+                            class="bp3-heading sc-rBLzX cWmzGW"
                           >
                             Contest 1
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
+                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
                           >
                             <input
                               type="checkbox"
@@ -209,7 +209,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
+                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
                           >
                             <input
                               type="checkbox"
@@ -226,10 +226,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-eerKOB dBoKjH"
+                          class="sc-cpmLhU hTfvkj"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
+                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
                           >
                             <input
                               type="checkbox"
@@ -245,7 +245,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
+                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
                           >
                             <input
                               type="checkbox"
@@ -261,7 +261,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
+                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
                           >
                             <input
                               type="checkbox"
@@ -277,7 +277,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-fhYwyz dUZAsj"
+                            class="bp3-input sc-gJWqzi GKtRR"
                             name="comment-Contest 1"
                             placeholder="Add Note"
                           />
@@ -285,21 +285,21 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-cbkKFq kZkYDv"
+                      class="sc-fYiAbW bbEbqb"
                     >
                       <div
-                        class="sc-gHboQg bVcsNq"
+                        class="sc-eerKOB ggGbtG"
                       >
                         <div
-                          class="sc-eilVRo kYUzWb"
+                          class="sc-emmjRN dZjvLQ"
                         >
                           <h3
-                            class="bp3-heading sc-jzgbtB kYoHmT"
+                            class="bp3-heading sc-rBLzX cWmzGW"
                           >
                             Contest 2
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
+                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
                           >
                             <input
                               type="checkbox"
@@ -315,7 +315,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
+                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
                           >
                             <input
                               type="checkbox"
@@ -332,10 +332,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-eerKOB dBoKjH"
+                          class="sc-cpmLhU hTfvkj"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
+                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
                           >
                             <input
                               type="checkbox"
@@ -351,7 +351,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
+                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
                           >
                             <input
                               type="checkbox"
@@ -367,7 +367,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-cpmLhU hjQGAc"
+                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
                           >
                             <input
                               type="checkbox"
@@ -383,7 +383,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-fhYwyz dUZAsj"
+                            class="bp3-input sc-gJWqzi GKtRR"
                             name="comment-Contest 2"
                             placeholder="Add Note"
                           />
@@ -391,10 +391,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-fYiAbW faWdJk"
+                      class="sc-dUjcNx dkzrkJ"
                     >
                       <button
-                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-gJWqzi bdivNA sc-dnqmqq iQfLYL"
+                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-bMvGRv linPlW sc-dnqmqq iQfLYL"
                         disabled=""
                         tabindex="-1"
                         type="submit"
@@ -421,7 +421,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
               </div>
             </div>
             <div
-              class="sc-hGoxap bBkpGZ"
+              class="sc-TFwJa bLnEQX"
             >
               <h4
                 class="bp3-heading"
@@ -429,7 +429,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 Instructions
               </h4>
               <ol
-                class="bp3-list sc-bHwgHz cFhicz"
+                class="bp3-list sc-dTdPqK bFxpEO"
               >
                 <li>
                   Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -534,13 +534,13 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
       class="board-table-container"
     >
       <div
-        class="sc-cmthru eJJcgP"
+        class="sc-cLQEGU hwGJZf"
       >
         <div
-          class="sc-bwzfXH sc-hMFtBS gFeFHl"
+          class="sc-bwzfXH sc-gqPbQI eVSFPs"
         >
           <div
-            class="sc-iuJeZd gmlHVf"
+            class="sc-cmthru gDBFlp"
           >
             <p>
               18
@@ -549,23 +549,23 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-GMQeP dcYvRA"
+              class="summary-label sc-cQFLBn fSoOLv"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-exAgwC liBTBs"
+              class="summary-label sc-gojNiO fJlUdq"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-esOvli jVpAYR"
+            class="sc-hMFtBS hkaYVQ"
           >
             <button
-              class="bp3-button bp3-intent-success sc-gojNiO hoVeOI"
+              class="bp3-button bp3-intent-success sc-bXGyLb doTSjZ"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -582,10 +582,10 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-cLQEGU mBqav"
+          class="sc-hORach bqIkDb"
         >
           <div
-            class="sc-gqPbQI iqcfVi"
+            class="sc-bMVAic kClWEP"
           >
             <h3
               class="bp3-heading"
@@ -594,7 +594,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Audit Board #1
             </h3>
             <div
-              class="sc-hORach iKVYhX"
+              class="sc-bAeIUo jWgAMa"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -799,7 +799,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -809,7 +809,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -819,7 +819,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -829,7 +829,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -858,7 +858,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -877,7 +877,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -886,7 +886,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -895,7 +895,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -904,7 +904,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -913,7 +913,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -934,7 +934,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -944,7 +944,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -954,7 +954,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -964,7 +964,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -993,7 +993,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -1012,7 +1012,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1022,7 +1022,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1032,7 +1032,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1042,7 +1042,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1071,7 +1071,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -1090,7 +1090,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -1099,7 +1099,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1108,7 +1108,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -1117,7 +1117,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -1126,7 +1126,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -1147,7 +1147,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1157,7 +1157,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1167,7 +1167,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1177,7 +1177,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1206,7 +1206,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -1225,7 +1225,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1235,7 +1235,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1245,7 +1245,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1255,7 +1255,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1284,7 +1284,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -1303,7 +1303,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -1312,7 +1312,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1321,7 +1321,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -1330,7 +1330,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -1339,7 +1339,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -1360,7 +1360,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1370,7 +1370,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1380,7 +1380,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1390,7 +1390,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1419,7 +1419,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -1438,7 +1438,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1448,7 +1448,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1458,7 +1458,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1468,7 +1468,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1497,7 +1497,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -1516,7 +1516,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -1525,7 +1525,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1534,7 +1534,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -1543,7 +1543,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -1552,7 +1552,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -1573,7 +1573,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1583,7 +1583,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1593,7 +1593,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1603,7 +1603,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1632,7 +1632,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -1651,7 +1651,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1661,7 +1661,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1671,7 +1671,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1681,7 +1681,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1710,7 +1710,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -1729,7 +1729,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -1738,7 +1738,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1747,7 +1747,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -1756,7 +1756,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -1765,7 +1765,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -1786,7 +1786,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1796,7 +1796,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1806,7 +1806,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1816,7 +1816,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1845,7 +1845,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -1864,7 +1864,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1874,7 +1874,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1884,7 +1884,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1894,7 +1894,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1923,7 +1923,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -1942,7 +1942,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -1951,7 +1951,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1960,7 +1960,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -1969,7 +1969,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -1978,7 +1978,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -1999,7 +1999,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2009,7 +2009,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2019,7 +2019,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2029,7 +2029,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2058,7 +2058,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -2077,7 +2077,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2087,7 +2087,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2097,7 +2097,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2107,7 +2107,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2136,7 +2136,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -2155,7 +2155,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -2164,7 +2164,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2173,7 +2173,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -2182,7 +2182,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -2191,7 +2191,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -2212,7 +2212,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2222,7 +2222,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2232,7 +2232,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2242,7 +2242,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2271,7 +2271,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -2290,7 +2290,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2300,7 +2300,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2310,7 +2310,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2320,7 +2320,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2349,7 +2349,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -2368,7 +2368,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -2377,7 +2377,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2386,7 +2386,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -2395,7 +2395,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -2404,7 +2404,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -2425,7 +2425,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2435,7 +2435,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2445,7 +2445,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2455,7 +2455,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2484,7 +2484,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -2503,7 +2503,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2513,7 +2513,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2523,7 +2523,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2533,7 +2533,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2562,7 +2562,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -2581,7 +2581,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -2590,7 +2590,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2599,7 +2599,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -2608,7 +2608,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -2617,7 +2617,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -2638,7 +2638,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2648,7 +2648,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2658,7 +2658,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2668,7 +2668,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2697,7 +2697,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -2713,7 +2713,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-daURTG dAYiqU"
+              class="bp3-button bp3-disabled bp3-large sc-lkqHmb gCAzMP"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -2727,7 +2727,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
             </button>
           </div>
           <div
-            class="sc-bMVAic gnoFyt"
+            class="sc-iujRgT hdbCHq"
           >
             <h4
               class="bp3-heading"
@@ -2735,7 +2735,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-cQFLBn bcegBR"
+              class="bp3-list sc-daURTG hPJTnL"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -2815,13 +2815,13 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
       class="board-table-container"
     >
       <div
-        class="sc-cmthru eJJcgP"
+        class="sc-cLQEGU hwGJZf"
       >
         <div
-          class="sc-bwzfXH sc-hMFtBS gFeFHl"
+          class="sc-bwzfXH sc-gqPbQI eVSFPs"
         >
           <div
-            class="sc-iuJeZd gmlHVf"
+            class="sc-cmthru gDBFlp"
           >
             <p>
               0
@@ -2830,23 +2830,23 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-GMQeP dcYvRA"
+              class="summary-label sc-cQFLBn fSoOLv"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-exAgwC liBTBs"
+              class="summary-label sc-gojNiO fJlUdq"
             >
               Not Audited: 
               27
             </span>
           </div>
           <div
-            class="sc-esOvli jVpAYR"
+            class="sc-hMFtBS hkaYVQ"
           >
             <button
-              class="bp3-button bp3-intent-success sc-gojNiO hoVeOI"
+              class="bp3-button bp3-intent-success sc-bXGyLb doTSjZ"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
               type="button"
             >
@@ -2863,10 +2863,10 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-cLQEGU mBqav"
+          class="sc-hORach bqIkDb"
         >
           <div
-            class="sc-gqPbQI iqcfVi"
+            class="sc-bMVAic kClWEP"
           >
             <h3
               class="bp3-heading"
@@ -2875,7 +2875,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Audit Board #1
             </h3>
             <div
-              class="sc-hORach iKVYhX"
+              class="sc-bAeIUo jWgAMa"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -3080,7 +3080,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3089,7 +3089,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3098,7 +3098,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         313
                       </p>
@@ -3107,7 +3107,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3116,7 +3116,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -3137,7 +3137,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3146,7 +3146,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3155,7 +3155,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -3164,7 +3164,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3173,7 +3173,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -3194,7 +3194,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3203,7 +3203,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3212,7 +3212,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         1789
                       </p>
@@ -3221,7 +3221,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3230,7 +3230,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -3251,7 +3251,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3260,7 +3260,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3269,7 +3269,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         313
                       </p>
@@ -3278,7 +3278,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3287,7 +3287,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -3308,7 +3308,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3317,7 +3317,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3326,7 +3326,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -3335,7 +3335,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3344,7 +3344,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -3365,7 +3365,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3374,7 +3374,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3383,7 +3383,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         1789
                       </p>
@@ -3392,7 +3392,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3401,7 +3401,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -3422,7 +3422,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3431,7 +3431,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3440,7 +3440,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         313
                       </p>
@@ -3449,7 +3449,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3458,7 +3458,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -3479,7 +3479,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3488,7 +3488,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3497,7 +3497,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -3506,7 +3506,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3515,7 +3515,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -3536,7 +3536,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3545,7 +3545,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3554,7 +3554,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         1789
                       </p>
@@ -3563,7 +3563,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3572,7 +3572,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -3593,7 +3593,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3602,7 +3602,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3611,7 +3611,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         313
                       </p>
@@ -3620,7 +3620,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3629,7 +3629,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -3650,7 +3650,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3659,7 +3659,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3668,7 +3668,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -3677,7 +3677,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3686,7 +3686,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -3707,7 +3707,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3716,7 +3716,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3725,7 +3725,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         1789
                       </p>
@@ -3734,7 +3734,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3743,7 +3743,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -3764,7 +3764,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3773,7 +3773,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3782,7 +3782,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         313
                       </p>
@@ -3791,7 +3791,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3800,7 +3800,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -3821,7 +3821,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3830,7 +3830,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3839,7 +3839,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -3848,7 +3848,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3857,7 +3857,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -3878,7 +3878,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3887,7 +3887,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3896,7 +3896,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         1789
                       </p>
@@ -3905,7 +3905,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3914,7 +3914,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -3935,7 +3935,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -3944,7 +3944,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3953,7 +3953,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         313
                       </p>
@@ -3962,7 +3962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -3971,7 +3971,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -3992,7 +3992,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -4001,7 +4001,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4010,7 +4010,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -4019,7 +4019,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -4028,7 +4028,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -4049,7 +4049,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -4058,7 +4058,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4067,7 +4067,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         1789
                       </p>
@@ -4076,7 +4076,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -4085,7 +4085,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -4106,7 +4106,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -4115,7 +4115,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4124,7 +4124,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         313
                       </p>
@@ -4133,7 +4133,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -4142,7 +4142,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -4163,7 +4163,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -4172,7 +4172,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4181,7 +4181,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -4190,7 +4190,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -4199,7 +4199,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -4220,7 +4220,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -4229,7 +4229,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4238,7 +4238,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         1789
                       </p>
@@ -4247,7 +4247,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -4256,7 +4256,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -4277,7 +4277,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -4286,7 +4286,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4295,7 +4295,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         313
                       </p>
@@ -4304,7 +4304,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -4313,7 +4313,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -4334,7 +4334,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -4343,7 +4343,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4352,7 +4352,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -4361,7 +4361,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -4370,7 +4370,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -4391,7 +4391,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -4400,7 +4400,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4409,7 +4409,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         1789
                       </p>
@@ -4418,7 +4418,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -4427,7 +4427,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -4448,7 +4448,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -4457,7 +4457,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4466,7 +4466,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         313
                       </p>
@@ -4475,7 +4475,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -4484,7 +4484,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -4505,7 +4505,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -4514,7 +4514,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4523,7 +4523,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -4532,7 +4532,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -4541,7 +4541,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -4562,7 +4562,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -4571,7 +4571,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4580,7 +4580,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         1789
                       </p>
@@ -4589,7 +4589,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -4598,7 +4598,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -4616,7 +4616,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-daURTG dAYiqU"
+              class="bp3-button bp3-disabled bp3-large sc-lkqHmb gCAzMP"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -4630,7 +4630,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
             </button>
           </div>
           <div
-            class="sc-bMVAic gnoFyt"
+            class="sc-iujRgT hdbCHq"
           >
             <h4
               class="bp3-heading"
@@ -4638,7 +4638,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-cQFLBn bcegBR"
+              class="bp3-list sc-daURTG hPJTnL"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -4718,13 +4718,13 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
       class="board-table-container"
     >
       <div
-        class="sc-cmthru eJJcgP"
+        class="sc-cLQEGU hwGJZf"
       >
         <div
-          class="sc-bwzfXH sc-hMFtBS gFeFHl"
+          class="sc-bwzfXH sc-gqPbQI eVSFPs"
         >
           <div
-            class="sc-iuJeZd gmlHVf"
+            class="sc-cmthru gDBFlp"
           >
             <p>
               0
@@ -4733,23 +4733,23 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-GMQeP dcYvRA"
+              class="summary-label sc-cQFLBn fSoOLv"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-exAgwC liBTBs"
+              class="summary-label sc-gojNiO fJlUdq"
             >
               Not Audited: 
               0
             </span>
           </div>
           <div
-            class="sc-esOvli jVpAYR"
+            class="sc-hMFtBS hkaYVQ"
           >
             <button
-              class="bp3-button bp3-intent-success sc-gojNiO hoVeOI"
+              class="bp3-button bp3-intent-success sc-bXGyLb doTSjZ"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4766,10 +4766,10 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-cLQEGU mBqav"
+          class="sc-hORach bqIkDb"
         >
           <div
-            class="sc-gqPbQI iqcfVi"
+            class="sc-bMVAic kClWEP"
           >
             <h3
               class="bp3-heading"
@@ -4778,7 +4778,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Audit Board #1
             </h3>
             <div
-              class="sc-hORach iKVYhX"
+              class="sc-bAeIUo jWgAMa"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -4942,7 +4942,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               </table>
             </div>
             <button
-              class="bp3-button bp3-large bp3-intent-success sc-daURTG dAYiqU"
+              class="bp3-button bp3-large bp3-intent-success sc-lkqHmb gCAzMP"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4954,7 +4954,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
             </button>
           </div>
           <div
-            class="sc-bMVAic gnoFyt"
+            class="sc-iujRgT hdbCHq"
           >
             <h4
               class="bp3-heading"
@@ -4962,7 +4962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-cQFLBn bcegBR"
+              class="bp3-list sc-daURTG hPJTnL"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -5042,13 +5042,13 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
       class="board-table-container"
     >
       <div
-        class="sc-cmthru eJJcgP"
+        class="sc-cLQEGU hwGJZf"
       >
         <div
-          class="sc-bwzfXH sc-hMFtBS gFeFHl"
+          class="sc-bwzfXH sc-gqPbQI eVSFPs"
         >
           <div
-            class="sc-iuJeZd gmlHVf"
+            class="sc-cmthru gDBFlp"
           >
             <p>
               18
@@ -5057,23 +5057,23 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-GMQeP dcYvRA"
+              class="summary-label sc-cQFLBn fSoOLv"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-exAgwC liBTBs"
+              class="summary-label sc-gojNiO fJlUdq"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-esOvli jVpAYR"
+            class="sc-hMFtBS hkaYVQ"
           >
             <button
-              class="bp3-button bp3-intent-success sc-gojNiO hoVeOI"
+              class="bp3-button bp3-intent-success sc-bXGyLb doTSjZ"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -5090,10 +5090,10 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-cLQEGU mBqav"
+          class="sc-hORach bqIkDb"
         >
           <div
-            class="sc-gqPbQI iqcfVi"
+            class="sc-bMVAic kClWEP"
           >
             <h3
               class="bp3-heading"
@@ -5102,7 +5102,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Audit Board #1
             </h3>
             <div
-              class="sc-hORach iKVYhX"
+              class="sc-bAeIUo jWgAMa"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -5307,7 +5307,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5317,7 +5317,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5327,7 +5327,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5337,7 +5337,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5366,7 +5366,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -5385,7 +5385,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -5394,7 +5394,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5403,7 +5403,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -5412,7 +5412,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -5421,7 +5421,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -5442,7 +5442,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5452,7 +5452,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5462,7 +5462,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5472,7 +5472,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5501,7 +5501,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -5520,7 +5520,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5530,7 +5530,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5540,7 +5540,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5550,7 +5550,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5579,7 +5579,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -5598,7 +5598,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -5607,7 +5607,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5616,7 +5616,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -5625,7 +5625,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -5634,7 +5634,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -5655,7 +5655,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5665,7 +5665,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5675,7 +5675,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5685,7 +5685,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5714,7 +5714,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -5733,7 +5733,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5743,7 +5743,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5753,7 +5753,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5763,7 +5763,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5792,7 +5792,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -5811,7 +5811,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -5820,7 +5820,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5829,7 +5829,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -5838,7 +5838,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -5847,7 +5847,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -5868,7 +5868,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5878,7 +5878,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5888,7 +5888,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5898,7 +5898,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5927,7 +5927,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -5946,7 +5946,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5956,7 +5956,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5966,7 +5966,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5976,7 +5976,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6005,7 +6005,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -6024,7 +6024,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -6033,7 +6033,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6042,7 +6042,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -6051,7 +6051,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -6060,7 +6060,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -6081,7 +6081,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6091,7 +6091,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6101,7 +6101,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6111,7 +6111,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6140,7 +6140,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -6159,7 +6159,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6169,7 +6169,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6179,7 +6179,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6189,7 +6189,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6218,7 +6218,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -6237,7 +6237,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -6246,7 +6246,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6255,7 +6255,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -6264,7 +6264,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -6273,7 +6273,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -6294,7 +6294,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6304,7 +6304,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6314,7 +6314,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6324,7 +6324,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6353,7 +6353,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -6372,7 +6372,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6382,7 +6382,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6392,7 +6392,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6402,7 +6402,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6431,7 +6431,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -6450,7 +6450,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -6459,7 +6459,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6468,7 +6468,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -6477,7 +6477,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -6486,7 +6486,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -6507,7 +6507,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6517,7 +6517,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6527,7 +6527,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6537,7 +6537,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6566,7 +6566,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -6585,7 +6585,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6595,7 +6595,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6605,7 +6605,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6615,7 +6615,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6644,7 +6644,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -6663,7 +6663,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -6672,7 +6672,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6681,7 +6681,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -6690,7 +6690,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -6699,7 +6699,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -6720,7 +6720,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6730,7 +6730,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6740,7 +6740,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6750,7 +6750,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6779,7 +6779,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -6798,7 +6798,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6808,7 +6808,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6818,7 +6818,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6828,7 +6828,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6857,7 +6857,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -6876,7 +6876,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -6885,7 +6885,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6894,7 +6894,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -6903,7 +6903,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -6912,7 +6912,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -6933,7 +6933,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6943,7 +6943,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6953,7 +6953,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6963,7 +6963,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6992,7 +6992,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -7011,7 +7011,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7021,7 +7021,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -7031,7 +7031,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -7041,7 +7041,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7070,7 +7070,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -7089,7 +7089,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         11
                       </p>
@@ -7098,7 +7098,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -7107,7 +7107,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                       >
                         2112
                       </p>
@@ -7116,7 +7116,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-exAgwC liBTBs"
+                        class="sc-gojNiO fJlUdq"
                       >
                         Not Audited
                       </span>
@@ -7125,7 +7125,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -7146,7 +7146,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7156,7 +7156,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -7166,7 +7166,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -7176,7 +7176,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-bXGyLb jLiywa"
+                        class="sc-eLExRp jVvVyY"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7205,7 +7205,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-bAeIUo jQBIRU"
+                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -7221,7 +7221,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-daURTG dAYiqU"
+              class="bp3-button bp3-disabled bp3-large sc-lkqHmb gCAzMP"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -7235,7 +7235,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
             </button>
           </div>
           <div
-            class="sc-bMVAic gnoFyt"
+            class="sc-iujRgT hdbCHq"
           >
             <h4
               class="bp3-heading"
@@ -7243,7 +7243,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-cQFLBn bcegBR"
+              class="bp3-list sc-daURTG hPJTnL"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -22,6 +22,7 @@ import {
   IBatchTalliesFileInfo,
   IJurisdiction,
   DiscrepancyCountsByJurisdiction,
+  DiscrepanciesByJurisdiction,
 } from './useJurisdictions'
 import { IStandardizedContest } from './useStandardizedContests'
 import { ISampleSizesResponse } from './AuditAdmin/Setup/Review/useSampleSizes'
@@ -1822,8 +1823,11 @@ export const jaApiCalls = {
     },
     response: { status: 'ok' },
   },
-  getJurisdictionContests: (contests: IContest[]) => ({
-    url: `/api/election/1/jurisdiction/jurisdiction-id-1/contest`,
+  getJurisdictionContests: (
+    contests: IContest[],
+    jurisdictionID = 'jurisdiction-id-1'
+  ) => ({
+    url: `/api/election/1/jurisdiction/${jurisdictionID}/contest`,
     response: { contests },
   }),
   getTallyEntryAccountStatus: (status: ITallyEntryAccountStatus) => ({
@@ -2178,6 +2182,10 @@ export const aaApiCalls = {
   },
   getDiscrepancyCounts: (response: DiscrepancyCountsByJurisdiction) => ({
     url: '/api/election/1/discrepancy-counts',
+    response,
+  }),
+  getDiscrepancies: (response: DiscrepanciesByJurisdiction) => ({
+    url: '/api/election/1/discrepancy',
     response,
   }),
   reopenAuditBoard: {

--- a/client/src/components/useJurisdictions.ts
+++ b/client/src/components/useJurisdictions.ts
@@ -166,14 +166,16 @@ export const useDiscrepancyCountsByJurisdiction = (
   )
 }
 
-// { jurisidictionId: { batchName: { contestId: { "reportedVotes": {choiceId: int}, "auditedVotes":  {choiceId: int}, "discrepancies": {choiceId: int}}}}
 export type DiscrepanciesByJurisdiction = Record<
-  string,
-  Record<string, Record<string, ContestDiscrepancies>>
+  string, // [jurisdictionId]
+  Record<
+    string, // [batchName]
+    Record<string, ContestDiscrepancies> // [contestId]: contestDiscrepancies
+  >
 >
 
 type ContestDiscrepancies = {
-  reportedVotes: Record<string, number>
+  reportedVotes: Record<string, number> // `Record` keys are choiceId
   auditedVotes: Record<string, number>
   discrepancies: Record<string, number>
 }
@@ -187,12 +189,7 @@ export const useDiscrepanciesByJurisdiction = (
 ): UseQueryResult<DiscrepanciesByJurisdiction, ApiError> => {
   return useQuery(
     discrepanciesByJurisdictionQueryKey(electionId),
-    async () => {
-      const response: DiscrepanciesByJurisdiction = await fetchApi(
-        `/api/election/${electionId}/discrepancy`
-      )
-      return response
-    },
+    () => fetchApi(`/api/election/${electionId}/discrepancy`),
     options
   )
 }

--- a/client/src/components/useJurisdictions.ts
+++ b/client/src/components/useJurisdictions.ts
@@ -165,3 +165,34 @@ export const useDiscrepancyCountsByJurisdiction = (
     options
   )
 }
+
+// { jurisidictionId: { batchName: { contestId: { "reportedVotes": {choiceId: int}, "auditedVotes":  {choiceId: int}, "discrepancies": {choiceId: int}}}}
+export type DiscrepanciesByJurisdiction = Record<
+  string,
+  Record<string, Record<string, ContestDiscrepancies>>
+>
+
+type ContestDiscrepancies = {
+  reportedVotes: Record<string, number>
+  auditedVotes: Record<string, number>
+  discrepancies: Record<string, number>
+}
+
+const discrepanciesByJurisdictionQueryKey = (electionId: string): string[] =>
+  jurisdictionsQueryKey(electionId).concat('discrepanciesByJurisdiction')
+
+export const useDiscrepanciesByJurisdiction = (
+  electionId: string,
+  options: { enabled?: boolean }
+): UseQueryResult<DiscrepanciesByJurisdiction, ApiError> => {
+  return useQuery(
+    discrepanciesByJurisdictionQueryKey(electionId),
+    async () => {
+      const response: DiscrepanciesByJurisdiction = await fetchApi(
+        `/api/election/${electionId}/discrepancy`
+      )
+      return response
+    },
+    options
+  )
+}


### PR DESCRIPTION
Commit by commit review will probably be easiest

This PR adds the ability to see batch comparison audit discrepancies in the UI from [this issue](https://github.com/votingworks/arlo/issues/1912).

<img width="1342" alt="Screenshot 2024-10-31 at 4 08 19 PM" src="https://github.com/user-attachments/assets/b280a48e-53d7-412f-a77e-6b29f4c2ab7e">

https://github.com/user-attachments/assets/faf2b240-0a5f-41fe-b0b0-946d4c3fa58e

Follow ups:
- Add support for ballot comparison
- Add support for combined batches