### PR TITLE
Add icon to download discrepancy report button

### DIFF
--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -436,6 +436,7 @@ const Progress: React.FC<IProgressProps> = ({
       </Button>
       {showDiscrepancies && (
         <AsyncButton
+          icon="flag"
           onClick={() =>
             apiDownload(`/election/${electionId}/discrepancy-report`)
           }


### PR DESCRIPTION
This PR follows up [this](https://github.com/votingworks/arlo/pull/2033) to add the icon that was removed from the download button. @jonahkagan [suggested](https://github.com/votingworks/arlo/pull/2033#issuecomment-2455501439) removing the danger intent from the flag, and I mistakenly removed the icon altogether.

I currently lean towards the Flag instead of the Download icon to match the flag used for discrepancies elsewhere on the page, and because it is a slightly different sort of report in that it is flagging issues rather than being a data dump, but happy to go with either.

<img width="1512" alt="Screenshot 2024-11-04 at 8 21 51 PM" src="https://github.com/user-attachments/assets/5ed0c937-c859-43a5-a71b-5eeb68f17b1f">
