### PR TITLE
Incorporate pending ballots in batch comparison audits

### DIFF
--- a/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
@@ -171,6 +171,7 @@ export interface IContestValues {
   votesAllowed: string
   choices: IChoiceValues[]
   totalBallotsCast?: string
+  pendingBallots?: string
   jurisdictionIds: string[]
 }
 
@@ -183,6 +184,7 @@ const contestToValues = (contest: IContest): IContestValues => ({
     numVotes: choice.numVotes.toString(),
   })),
   totalBallotsCast: contest.totalBallotsCast?.toString(),
+  pendingBallots: contest.pendingBallots?.toString() || '',
 })
 
 const contestFromValues = (contest: IContestValues): IContest => ({
@@ -196,6 +198,7 @@ const contestFromValues = (contest: IContestValues): IContest => ({
     id: choice.id || uuidv4(),
     numVotes: parseNumber(choice.numVotes),
   })),
+  pendingBallots: parseNumber(contest.pendingBallots),
 })
 
 const ContestForm: React.FC<IProps> = ({
@@ -214,6 +217,7 @@ const ContestForm: React.FC<IProps> = ({
       numWinners: '1',
       votesAllowed: '1',
       jurisdictionIds: [],
+      pendingBallots: '',
       choices: [
         {
           id: '',
@@ -231,6 +235,7 @@ const ContestForm: React.FC<IProps> = ({
 
   const isHybrid = auditType === 'HYBRID'
   const isBallotPolling = auditType === 'BALLOT_POLLING'
+  const isBatchComparison = auditType === 'BATCH_COMPARISON'
 
   const contestsQuery = useContests(electionId)
   const updateContestsMutation = useUpdateContests(electionId, auditType)
@@ -479,6 +484,18 @@ const ContestForm: React.FC<IProps> = ({
                                 component={FormField}
                               />
                             </label>
+                          </FormSection>
+                        )}
+                        {isBatchComparison && isTargeted && (
+                          <FormSection
+                            label="Pending Ballots"
+                            description="Enter a count of ballots that have not been tallied and will not be audited."
+                          >
+                            <Field
+                              aria-label="Pending Ballots"
+                              name={`contests[${i}].pendingBallots`}
+                              component={FormField}
+                            />
                           </FormSection>
                         )}
                         {!isHybrid && (

--- a/client/src/components/AuditAdmin/Setup/Contests/schema.ts
+++ b/client/src/components/AuditAdmin/Setup/Contests/schema.ts
@@ -47,6 +47,12 @@ const contestsSchema = (auditType: IAuditSettings['auditType']) =>
               .required('Required')
               .of(Yup.string()),
           }),
+          ...(auditType === 'BATCH_COMPARISON' && {
+            pendingBallots: number()
+              .typeError('Must be a number')
+              .integer('Must be an integer')
+              .min(0, 'Must be a positive number'),
+          }),
           choices: Yup.array()
             .required()
             .of(

--- a/client/src/components/useContests.ts
+++ b/client/src/components/useContests.ts
@@ -36,6 +36,10 @@ export const useUpdateContests = (
           .map(({ totalBallotsCast, ...c }) =>
             auditType === 'BALLOT_POLLING' ? { totalBallotsCast, ...c } : c
           )
+          // Remove pendingBallots unless this is a batch comparison audit
+          .map(({ pendingBallots, ...c }) =>
+            auditType === 'BATCH_COMPARISON' ? { pendingBallots, ...c } : c
+          )
       ),
       headers: { 'Content-Type': 'application/json' },
     })

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -34,6 +34,7 @@ export interface IContest {
   totalBallotsCast: number
   jurisdictionIds: string[]
   cvrChoiceNameConsistencyError?: ICvrChoiceNameConsistencyError
+  pendingBallots?: number | null
 }
 
 export enum Interpretation {

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -35,6 +35,9 @@ CONTEST_SCHEMA = {
         "choices": {"type": "array", "items": CONTEST_CHOICE_SCHEMA},
         "numWinners": {"type": "integer", "minimum": 1},
         "votesAllowed": {"type": "integer", "minimum": 1},
+        "pendingBallots": {
+            "anyOf": [{"type": "integer", "minimum": 0}, {"type": "null"}]
+        },
         "jurisdictionIds": {
             "type": "array",
             "items": {"type": "string"},
@@ -133,6 +136,9 @@ def serialize_contest(contest: Contest) -> JSONDict:
         "jurisdictionIds": [j.id for j in contest.jurisdictions],
     }
 
+    if contest.election.audit_type == AuditType.BATCH_COMPARISON:
+        serialized_contest["pendingBallots"] = contest.pending_ballots
+
     # Validate CVR choice names across jurisdictions in ballot comparison audits. Load error
     # details, if any, onto the contest object.
     if contest.election.audit_type == AuditType.BALLOT_COMPARISON:
@@ -223,6 +229,7 @@ def deserialize_contest(contest: JSONDict, election_id: str) -> Contest:
         total_ballots_cast=contest.get("totalBallotsCast", None),
         num_winners=contest.get("numWinners", None),
         votes_allowed=contest.get("votesAllowed", None),
+        pending_ballots=contest.get("pendingBallots", None),
         jurisdictions=jurisdictions,
     )
 

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -253,6 +253,11 @@ def contest_rows(election: Election):
             "Tabulated Votes",
         ]
         + (
+            ["Pending Ballots"]
+            if election.audit_type == AuditType.BATCH_COMPARISON
+            else []
+        )
+        + (
             [
                 "Total Ballots Cast: CVR",
                 "Total Ballots Cast: Non-CVR",
@@ -275,6 +280,10 @@ def contest_rows(election: Election):
                 {choice.name: choice.num_votes for choice in contest.choices}
             ),
         ]
+
+        if election.audit_type == AuditType.BATCH_COMPARISON:
+            row.append(contest.pending_ballots or 0)
+
         if election.audit_type == AuditType.HYBRID:
             total_ballots = hybrid_contest_total_ballots(contest)
             vote_counts = hybrid_contest_choice_vote_counts(contest)

--- a/server/audit_math/macro.py
+++ b/server/audit_math/macro.py
@@ -61,6 +61,12 @@ def compute_error(
         a_lp = sampled_results[contest.name][loser]
 
         V_wl = contest.candidates[winner] - contest.candidates[loser]
+
+        # Conservatively assume that any pending ballots would be tallied as
+        # votes for the loser, reducing the reported margin.
+        if contest.pending_ballots:
+            V_wl -= contest.pending_ballots
+
         error = (v_wp - v_lp) - (a_wp - a_lp)
         if error == 0:
             return None
@@ -115,6 +121,11 @@ def compute_max_error(batch_results: BatchResults, contest: Contest) -> Decimal:
             b_cp = batch_results[contest.name]["ballots"]
 
             V_wl = contest.candidates[winner] - contest.candidates[loser]
+
+            # Conservatively assume that any pending ballots would be tallied as
+            # votes for the loser, reducing the reported margin.
+            if contest.pending_ballots:
+                V_wl -= contest.pending_ballots
 
             if V_wl == 0:
                 return Decimal("inf")

--- a/server/audit_math/macro.py
+++ b/server/audit_math/macro.py
@@ -127,7 +127,7 @@ def compute_max_error(batch_results: BatchResults, contest: Contest) -> Decimal:
             if contest.pending_ballots:
                 V_wl -= contest.pending_ballots
 
-            if V_wl == 0:
+            if V_wl <= 0:
                 return Decimal("inf")
 
             u_pwl = Decimal((v_wp - v_lp) + b_cp) / Decimal(V_wl)

--- a/server/audit_math/macro.py
+++ b/server/audit_math/macro.py
@@ -64,8 +64,7 @@ def compute_error(
 
         # Conservatively assume that any pending ballots would be tallied as
         # votes for the loser, reducing the reported margin.
-        if contest.pending_ballots:
-            V_wl -= contest.pending_ballots
+        V_wl -= contest.pending_ballots
 
         error = (v_wp - v_lp) - (a_wp - a_lp)
         if error == 0:
@@ -124,8 +123,7 @@ def compute_max_error(batch_results: BatchResults, contest: Contest) -> Decimal:
 
             # Conservatively assume that any pending ballots would be tallied as
             # votes for the loser, reducing the reported margin.
-            if contest.pending_ballots:
-                V_wl -= contest.pending_ballots
+            V_wl -= contest.pending_ballots
 
             if V_wl <= 0:
                 return Decimal("inf")

--- a/server/audit_math/sampler_contest.py
+++ b/server/audit_math/sampler_contest.py
@@ -43,7 +43,7 @@ class Contest:
     votes_allowed: int  # How many voters are allowed in this contest
     ballots: int  # The total number of ballots cast in this contest
     # Ballots that weren't tallied yet and thus not included in reported results (batch comparison only)
-    pending_ballots: Optional[int]
+    pending_ballots: int
     name: str  # The name of the contest
 
     winners: Dict[str, int]  # List of all the winners
@@ -69,7 +69,7 @@ class Contest:
         self.ballots = contest_info_dict["ballots"]
         self.num_winners = contest_info_dict["numWinners"]
         self.votes_allowed = contest_info_dict["votesAllowed"]
-        self.pending_ballots = contest_info_dict.get("pendingBallots")
+        self.pending_ballots = contest_info_dict.get("pendingBallots") or 0
 
         self.candidates = {}
 

--- a/server/audit_math/sampler_contest.py
+++ b/server/audit_math/sampler_contest.py
@@ -22,6 +22,7 @@ def from_db_contest(db_contest):
         "ballots": db_contest.total_ballots_cast,
         "numWinners": db_contest.num_winners,
         "votesAllowed": db_contest.votes_allowed,
+        "pendingBallots": db_contest.pending_ballots,
     }
 
     # Initialize the choices in this contest and how many votes each received
@@ -41,6 +42,8 @@ class Contest:
     num_winners: int  # How many winners this contest had
     votes_allowed: int  # How many voters are allowed in this contest
     ballots: int  # The total number of ballots cast in this contest
+    # Ballots that weren't tallied yet and thus not included in reported results (batch comparison only)
+    pending_ballots: Optional[int]
     name: str  # The name of the contest
 
     winners: Dict[str, int]  # List of all the winners
@@ -66,6 +69,7 @@ class Contest:
         self.ballots = contest_info_dict["ballots"]
         self.num_winners = contest_info_dict["numWinners"]
         self.votes_allowed = contest_info_dict["votesAllowed"]
+        self.pending_ballots = contest_info_dict.get("pendingBallots")
 
         self.candidates = {}
 
@@ -73,7 +77,7 @@ class Contest:
         self.losers = {}
 
         for cand in contest_info_dict:
-            if cand in ["ballots", "numWinners", "votesAllowed"]:
+            if cand in ["ballots", "numWinners", "votesAllowed", "pendingBallots"]:
                 continue
 
             self.candidates[cand] = contest_info_dict[cand]

--- a/server/migrations/versions/7ca7a4b0bcc0_contest_pending_ballots.py
+++ b/server/migrations/versions/7ca7a4b0bcc0_contest_pending_ballots.py
@@ -1,0 +1,25 @@
+# pylint: disable=invalid-name
+"""Contest.pending_ballots
+
+Revision ID: 7ca7a4b0bcc0
+Revises: 4aec6c8a419f
+Create Date: 2024-11-05 21:12:31.908179+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "7ca7a4b0bcc0"
+down_revision = "4aec6c8a419f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("contest", sa.Column("pending_ballots", sa.Integer(), nullable=True))
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -478,6 +478,12 @@ class Contest(BaseModel):
     num_winners = Column(Integer)
     votes_allowed = Column(Integer)
 
+    # In batch comparison, the audit admin can enter how many ballots haven't
+    # yet been tallied or cannot be audited by the time the audit launches so
+    # that we can include them in the audit math (worst-casing them as votes for
+    # the losing candidates).
+    pending_ballots = Column(Integer)
+
     choices = relationship(
         "ContestChoice",
         back_populates="contest",

--- a/server/tests/audit_math/snapshots/snap_test_macro.py
+++ b/server/tests/audit_math/snapshots/snap_test_macro.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import GenericRepr, Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots["test_pending_ballots 1"] = GenericRepr(
+    "Decimal('4.591836734693877551020408163')"
+)
+
+snapshots["test_pending_ballots 2"] = 0.47861956652949245
+
+snapshots["test_pending_ballots 3"] = 0.48371126404576364

--- a/server/tests/audit_math/test_macro.py
+++ b/server/tests/audit_math/test_macro.py
@@ -921,7 +921,7 @@ def test_combined_batches_sampled_and_unsampled():
     assert res is (expected_p < ALPHA)
 
 
-def test_pending_ballots():
+def test_pending_ballots(snapshot):
     num_pending_ballots = 2
     contest_data = {
         "winner": 200,
@@ -979,6 +979,7 @@ def test_pending_ballots():
     U = macro.compute_U(batches, contest)
     U_without_pending = macro.compute_U(batches, contest_without_pending_ballots)
     assert U > U_without_pending
+    snapshot.assert_match(U)
 
     sample_size = macro.get_sample_sizes(RISK_LIMIT, contest, batches, {}, {}, [])
     assert sample_size == len(batches)
@@ -999,6 +1000,7 @@ def test_pending_ballots():
     expected_p = ((1 - 1 / U) / 1) ** num_sampled_batches
     assert computed_p == float(expected_p)
     assert res is (expected_p < ALPHA)
+    snapshot.assert_match(computed_p)
 
     # 1 discrepancy
     discrepancy_votes = 2
@@ -1029,3 +1031,4 @@ def test_pending_ballots():
     )
     assert computed_p == float(expected_p)
     assert res is (expected_p < ALPHA)
+    snapshot.assert_match(computed_p)

--- a/server/tests/audit_math/test_macro.py
+++ b/server/tests/audit_math/test_macro.py
@@ -927,8 +927,8 @@ def test_pending_ballots(snapshot):
         "winner": 200,
         "loser": 100,
         "third": 50,
-        # Total ballots cast is calculated from reported batch tallies, so
-        # doesn't include pending ballots
+        # Total ballots cast is calculated from ballot manifests, so doesn't
+        # include pending ballots
         "ballots": 350,
         "numWinners": 1,
         "votesAllowed": 1,

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -30,8 +30,8 @@ Organization,Election Name,State\r
 Test Org test_batch_comparison_batches_sampled_multiple_times,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
-Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes,Pending Ballots\r
+Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500,0\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
@@ -58,8 +58,8 @@ Organization,Election Name,State\r
 Test Org test_batch_comparison_combined_batches,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
-Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes,Pending Ballots\r
+Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500,0\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
@@ -91,8 +91,8 @@ Organization,Election Name,State\r
 Test Org test_batch_comparison_pending_ballots,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
-Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes,Pending Ballots\r
+Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500,250\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
@@ -158,8 +158,8 @@ Organization,Election Name,State\r
 Test Org test_batch_comparison_round_2,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
-Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes,Pending Ballots\r
+Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500,0\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -80,6 +80,39 @@ J1,Combined Batch,1500,,Yes,candidate 1: 1500; candidate 2: 745; candidate 3: 75
 Totals,,1700,,,candidate 1: 2200; candidate 2: 1095; candidate 3: 1105,candidate 1: 2200; candidate 2: 1100; candidate 3: 1100,,\r
 """
 
+snapshots["test_batch_comparison_pending_ballots 1"] = [
+    {"key": "macro", "prob": None, "size": 8}
+]
+
+snapshots[
+    "test_batch_comparison_pending_ballots 2"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+Test Org test_batch_comparison_pending_ballots,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
+Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_batch_comparison_pending_ballots,BATCH_COMPARISON,MACRO,10%,1234567890,No\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
+1,Contest 1,Targeted,8,Yes,0.0537356735,DATETIME,DATETIME,candidate 1: 2200; candidate 2: 1100; candidate 3: 1100,6,2200,candidate 1: 2200; candidate 2: 1100; candidate 3: 1100\r
+\r
+######## SAMPLED BATCHES ########\r
+Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?,Audit Results: Contest 1,Reported Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By\r
+J1,Batch 1,500,"Round 1: 0.720194360819624066, 0.777128466487428756",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 3,500,Round 1: 0.753710009967479876,Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 6,100,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,jurisdiction.admin-UUID@example.com\r
+J1,Batch 8,100,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,jurisdiction.admin-UUID@example.com\r
+J2,Batch 3,500,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,jurisdiction.admin-UUID@example.com\r
+J2,Batch 4,500,Round 1: 0.608147659546583410,Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,jurisdiction.admin-UUID@example.com\r
+Totals,,2200,,,candidate 1: 2200; candidate 2: 1100; candidate 3: 1100,candidate 1: 2200; candidate 2: 1100; candidate 3: 1100,,\r
+"""
+
 snapshots["test_batch_comparison_round_1 1"] = {
     "numSamples": 9,
     "numSamplesAudited": 0,

--- a/server/tests/batch_comparison/snapshots/snap_test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_multi_contest_batch_comparison.py
@@ -28,9 +28,9 @@ Organization,Election Name,State\r
 Test Org test_multi_contest_batch_comparison_end_to_end,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
-Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250\r
-Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes,Pending Ballots\r
+Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250,0\r
+Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50,0\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
@@ -62,9 +62,9 @@ Organization,Election Name,State\r
 Test Org test_multi_contest_batch_comparison_end_to_end,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
-Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250\r
-Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes,Pending Ballots\r
+Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250,0\r
+Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50,0\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
@@ -96,9 +96,9 @@ Organization,Election Name,State\r
 Test Org test_multi_contest_batch_comparison_round_2,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
-Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250\r
-Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes,Pending Ballots\r
+Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250,0\r
+Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50,0\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
@@ -130,9 +130,9 @@ Organization,Election Name,State\r
 Test Org test_multi_contest_batch_comparison_round_2,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
-Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250\r
-Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes,Pending Ballots\r
+Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250,0\r
+Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50,0\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
@@ -166,9 +166,9 @@ Organization,Election Name,State\r
 Test Org test_multi_contest_batch_comparison_round_2,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
-Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250\r
-Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes,Pending Ballots\r
+Contest 1,Targeted,1,1,1500,Candidate 1: 750; Candidate 2: 250,0\r
+Contest 2,Targeted,1,2,1000,Candidate 3: 450; Candidate 4: 50,0\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r

--- a/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
@@ -14,8 +14,8 @@ Organization,Election Name,State\r
 TEST-ORG/sample-extra-batches-by-counting-group/automatically-end-audit-after-one-round,Test Election,CA\r
 \r
 ######## CONTESTS ########\r
-Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes\r
-Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Tabulated Votes,Pending Ballots\r
+Contest 1,Targeted,1,2,5000,candidate 1: 5000; candidate 2: 2500; candidate 3: 2500,0\r
 \r
 ######## AUDIT SETTINGS ########\r
 Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -1245,7 +1245,8 @@ def test_batch_comparison_pending_ballots(
 
     # The p-value should be higher with pending ballots, proving that we did in
     # fact incorporate the pending ballots into the risk measurement
-    # calculation, worst-casing them as votes for the loser.
+    # calculation, worst-casing them as votes for the loser. The actual
+    # calculation correctness is tested in test_macro.py.
     assert p_value > p_value_without_pending_ballots
 
 


### PR DESCRIPTION
Task: #1928 

Problem as described by @MarkVVaudits:

> The underlying challenge is that batch data, state-level vote counts at audit launch, and the final certified totals all can be different. This can occur **because some ballots are still pending at audit launch (they have not yet been tallied, and their eligibility may be undetermined)** and/or because some ballots are treated as unauditable and not included in batch uploads.

This feature provides a way for audit admins to tell Arlo about any ballots that have not been tallied before audit launch (aka pending ballots). The batch comparison audit math is then updated to treat these ballots conservatively, assuming they are votes for the loser and modifying the reported margin as such. This increases the resulting sample size and p-value.

This should have minimal, but important, impact in real world audits, according to  @MarkVVaudits:
> I foresee this being used in contexts where pending/unauditable ballots are not a large fraction of any margin.

Note that I will be following up with a second PR to handle "unauditable ballots," which require a different approach.

https://github.com/user-attachments/assets/6bb3d026-0ac5-406a-b6e5-e23bda704e9a


