### PR TITLE
fix: prevent some updates that would affect incomplete jobs

### DIFF
--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -872,7 +872,9 @@ def complete_upload_for_batch_inventory_tabulator_status(
         raise Conflict("Must upload CVR file before uploading tabulator status file.")
 
     if batch_inventory_data.cvr_file.is_processing():
-        raise Conflict("Cannot update tabulator status while CVR file is being processed.")
+        raise Conflict(
+            "Cannot update tabulator status while CVR file is being processed."
+        )
 
     (storage_path, filename, file_type) = get_standard_file_upload_request_params(
         request

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -871,6 +871,9 @@ def complete_upload_for_batch_inventory_tabulator_status(
     if not batch_inventory_data or not batch_inventory_data.cvr_file_id:
         raise Conflict("Must upload CVR file before uploading tabulator status file.")
 
+    if batch_inventory_data.cvr_file.is_processing():
+        raise Conflict("Cannot update tabulator status while CVR file is being processed.")
+
     (storage_path, filename, file_type) = get_standard_file_upload_request_params(
         request
     )

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -199,6 +199,9 @@ def validate_batch_tallies_upload(election: Election, jurisdiction: Jurisdiction
     if not jurisdiction.manifest_file_id:
         raise Conflict("Must upload ballot manifest before uploading batch tallies.")
 
+    if jurisdiction.manifest_file.is_processing():
+        raise Conflict("Cannot update batch tallies while manifest file is processing.")
+
 
 def clear_batch_tallies_data(jurisdiction: Jurisdiction):
     jurisdiction.batch_tallies = None

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -197,10 +197,14 @@ def validate_batch_tallies_upload(election: Election, jurisdiction: Jurisdiction
         raise Conflict("Jurisdiction does not have any contests assigned")
 
     if not jurisdiction.manifest_file_id:
-        raise Conflict("Must upload ballot manifest before uploading candidate totals by batch.")
+        raise Conflict(
+            "Must upload ballot manifest before uploading candidate totals by batch."
+        )
 
     if jurisdiction.manifest_file.is_processing():
-        raise Conflict("Cannot update candidate totals by batch while ballot manifest is processing.")
+        raise Conflict(
+            "Cannot update candidate totals by batch while ballot manifest is processing."
+        )
 
 
 def clear_batch_tallies_data(jurisdiction: Jurisdiction):

--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -190,17 +190,17 @@ def process_batch_tallies_file(
 def validate_batch_tallies_upload(election: Election, jurisdiction: Jurisdiction):
     if election.audit_type != AuditType.BATCH_COMPARISON:
         raise Conflict(
-            "Can only upload batch tallies file for batch comparison audits."
+            "Can only upload candidate totals by batch for batch comparison audits."
         )
 
     if len(list(jurisdiction.contests)) == 0:
         raise Conflict("Jurisdiction does not have any contests assigned")
 
     if not jurisdiction.manifest_file_id:
-        raise Conflict("Must upload ballot manifest before uploading batch tallies.")
+        raise Conflict("Must upload ballot manifest before uploading candidate totals by batch.")
 
     if jurisdiction.manifest_file.is_processing():
-        raise Conflict("Cannot update batch tallies while manifest file is processing.")
+        raise Conflict("Cannot update candidate totals by batch while ballot manifest is processing.")
 
 
 def clear_batch_tallies_data(jurisdiction: Jurisdiction):

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -303,6 +303,17 @@ def create_or_update_all_contests(election: Election):
     if election.audit_type == AuditType.BATCH_COMPARISON:
         user = get_loggedin_user(session)
         assert user[0] is not None
+
+        if election.jurisdictions_file and election.jurisdictions_file.is_processing():
+            raise Conflict("Cannot update contests while jurisdictions file is being processed.")
+
+        if any(
+            jurisdiction.batch_tallies_file
+            and jurisdiction.batch_tallies_file.is_processing()
+            for jurisdiction in election.jurisdictions
+        ):
+            raise Conflict("Cannot update contests while batch tallies file is being processed.")
+
         for jurisdiction in election.jurisdictions:
             batch_tallies.reprocess_batch_tallies_file_if_uploaded(
                 jurisdiction,

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -305,14 +305,18 @@ def create_or_update_all_contests(election: Election):
         assert user[0] is not None
 
         if election.jurisdictions_file and election.jurisdictions_file.is_processing():
-            raise Conflict("Cannot update contests while jurisdictions file is being processed.")
+            raise Conflict(
+                "Cannot update contests while jurisdictions file is being processed."
+            )
 
         if any(
             jurisdiction.batch_tallies_file
             and jurisdiction.batch_tallies_file.is_processing()
             for jurisdiction in election.jurisdictions
         ):
-            raise Conflict("Cannot update contests while batch tallies file is being processed.")
+            raise Conflict(
+                "Cannot update contests while batch tallies file is being processed."
+            )
 
         for jurisdiction in election.jurisdictions:
             batch_tallies.reprocess_batch_tallies_file_if_uploaded(

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -1538,6 +1538,9 @@ def validate_cvr_upload(
     if not jurisdiction.manifest_file_id:
         raise Conflict("Must upload ballot manifest before uploading CVR file.")
 
+    if jurisdiction.manifest_file.is_processing():
+        raise Conflict("Cannot replace CVRs while manifest file is processing.")
+
     data = request.get_json()
     cvr_file_type = data.get("cvrFileType") if data else None
     if cvr_file_type is None:

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -222,7 +222,9 @@ def complete_upload_for_standardized_contests_file(election: Election):
         )
 
     if election.jurisdictions_file and election.jurisdictions_file.is_processing():
-        raise Conflict("Cannot replace standardized contests while jurisdictions file is processing.")
+        raise Conflict(
+            "Cannot replace standardized contests while jurisdictions file is processing."
+        )
 
     (storage_path, filename, file_type) = get_standard_file_upload_request_params(
         request

--- a/server/api/standardized_contests.py
+++ b/server/api/standardized_contests.py
@@ -221,6 +221,9 @@ def complete_upload_for_standardized_contests_file(election: Election):
             "Must upload jurisdictions file before uploading standardized contests file."
         )
 
+    if election.jurisdictions_file and election.jurisdictions_file.is_processing():
+        raise Conflict("Cannot replace standardized contests while jurisdictions file is processing.")
+
     (storage_path, filename, file_type) = get_standard_file_upload_request_params(
         request
     )

--- a/server/models.py
+++ b/server/models.py
@@ -1029,6 +1029,11 @@ class File(BaseModel):
     task_id = Column(String(200), ForeignKey("background_task.id"))
     task = relationship("BackgroundTask")
 
+    def is_processing(self):
+        if self.task is None:
+            return False
+        return self.task.completed_at is None
+
 
 class BackgroundTask(BaseModel):
     id = Column(String(200), primary_key=True)

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -2995,7 +2995,6 @@ def test_replace_cvrs_fails_while_processing_manifest_file(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],
-    manifests,  # pylint: disable=unused-argument
 ):
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -2989,3 +2989,41 @@ def test_cvrs_get_upload_url(
             f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/cvrs_"
         )
         assert response_data["fields"]["key"].endswith(".zip")
+
+def test_replace_cvrs_fails_while_processing_manifest_file(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    manifests,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    with no_automatic_task_execution():
+        # Replace the manifest file with a new one, but don't process it yet
+        rv = upload_ballot_manifest(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+        assert_ok(rv)
+
+        rv = upload_cvrs(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+            "DOMINION",
+        )
+
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot replace CVRs while manifest file is processing.",
+                }
+            ]
+        }

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -2990,6 +2990,7 @@ def test_cvrs_get_upload_url(
         )
         assert response_data["fields"]["key"].endswith(".zip")
 
+
 def test_replace_cvrs_fails_while_processing_manifest_file(
     client: FlaskClient,
     election_id: str,

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -591,3 +591,34 @@ def test_standardized_contests_get_upload_url(client: FlaskClient, election_id: 
         f"audits/{election_id}/standardized_contests_"
     )
     assert response_data["fields"]["key"].endswith(".csv")
+
+def test_replace_standardized_contests_file_while_processing_jurisdictions_file_fails(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+):
+    with no_automatic_task_execution():
+        # upload jurisdictions file, but don't process it
+        rv = upload_jurisdictions_file(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+        )
+        assert_ok(rv)
+
+        # upload standardized contests file
+        rv = upload_standardized_contests(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+        )
+
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot replace standardized contests while jurisdictions file is processing.",
+                }
+            ]
+        }

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -592,6 +592,7 @@ def test_standardized_contests_get_upload_url(client: FlaskClient, election_id: 
     )
     assert response_data["fields"]["key"].endswith(".csv")
 
+
 def test_replace_standardized_contests_file_while_processing_jurisdictions_file_fails(
     client: FlaskClient,
     election_id: str,

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -1739,6 +1739,7 @@ def test_batch_inventory_hart_cvr_upload(
         },
     )
 
+
 def test_replace_tabulator_status_file_while_cvr_file_is_processing_fails(
     client: FlaskClient,
     election_id: str,

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -1738,3 +1738,49 @@ def test_batch_inventory_hart_cvr_upload(
             },
         },
     )
+
+def test_replace_tabulator_status_file_while_cvr_file_is_processing_fails(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_id: str,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
+    with no_automatic_task_execution():
+        # upload CVR file, but don't process it
+        rv = upload_batch_inventory_cvr(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+        assert_ok(rv)
+
+        # upload tabulator status file
+        rv = upload_batch_inventory_tabulator_status(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot update tabulator status while CVR file is being processed.",
+                }
+            ]
+        }

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -757,7 +757,6 @@ def test_replace_batch_tallies_fails_while_processing_jurisdiction_file(
     election_id: str,
     jurisdiction_ids: List[str],
     contest_id: str,
-    manifests,  # pylint: disable=unused-argument
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
 

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -756,7 +756,7 @@ def test_replace_batch_tallies_fails_while_processing_jurisdiction_file(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],
-    contest_id: str, # pylint: disable=unused-argument
+    contest_id: str,  # pylint: disable=unused-argument
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
 

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -750,3 +750,42 @@ def test_batch_tallies_get_upload_url(
             f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/batch_tallies_"
         )
         assert response_data["fields"]["key"].endswith(".csv")
+
+def test_replace_batch_tallies_fails_while_processing_jurisdiction_file(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_id: str,
+    manifests,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(
+        client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL
+    )
+
+    with no_automatic_task_execution():
+        # replace the ballot manifest file, but don't process it yet
+        rv = upload_ballot_manifest(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+        assert_ok(rv)
+
+        # try to replace the batch tallies file
+        rv = upload_batch_tallies(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot update batch tallies while manifest file is processing.",
+                }
+            ]
+        }

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -756,7 +756,7 @@ def test_replace_batch_tallies_fails_while_processing_jurisdiction_file(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],
-    contest_id: str,
+    contest_id: str, # pylint: disable=unused-argument
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
 

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -520,7 +520,7 @@ def test_batch_tallies_ballot_polling(
         "errors": [
             {
                 "errorType": "Conflict",
-                "message": "Can only upload batch tallies file for batch comparison audits.",
+                "message": "Can only upload candidate totals by batch for batch comparison audits.",
             }
         ]
     }
@@ -583,7 +583,7 @@ def test_batch_tallies_before_manifests(
         "errors": [
             {
                 "errorType": "Conflict",
-                "message": "Must upload ballot manifest before uploading batch tallies.",
+                "message": "Must upload ballot manifest before uploading candidate totals by batch.",
             }
         ]
     }
@@ -783,7 +783,7 @@ def test_replace_batch_tallies_fails_while_processing_jurisdiction_file(
             "errors": [
                 {
                     "errorType": "Conflict",
-                    "message": "Cannot update batch tallies while manifest file is processing.",
+                    "message": "Cannot update candidate totals by batch while ballot manifest is processing.",
                 }
             ]
         }

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -751,6 +751,7 @@ def test_batch_tallies_get_upload_url(
         )
         assert response_data["fields"]["key"].endswith(".csv")
 
+
 def test_replace_batch_tallies_fails_while_processing_jurisdiction_file(
     client: FlaskClient,
     election_id: str,
@@ -758,9 +759,7 @@ def test_replace_batch_tallies_fails_while_processing_jurisdiction_file(
     contest_id: str,
     manifests,  # pylint: disable=unused-argument
 ):
-    set_logged_in_user(
-        client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL
-    )
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
 
     with no_automatic_task_execution():
         # replace the ballot manifest file, but don't process it yet

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -1198,6 +1198,7 @@ def test_multi_contest_batch_comparison_editing_contests_after_uploads(
         assert batch_tallies_status["status"] == "PROCESSED"
         assert batch_tallies_status["error"] is None
 
+
 def test_updating_contests_while_jurisdictions_file_is_being_processed(
     client: FlaskClient,
     election_id: str,
@@ -1232,10 +1233,11 @@ def test_updating_contests_while_jurisdictions_file_is_being_processed(
             "errors": [
                 {
                     "errorType": "Conflict",
-                    "message": "Cannot update contests while jurisdictions file is being processed."
+                    "message": "Cannot update contests while jurisdictions file is being processed.",
                 }
             ]
         }
+
 
 def test_updating_contests_while_batch_tallies_file_is_being_processed(
     client: FlaskClient,
@@ -1272,7 +1274,7 @@ def test_updating_contests_while_batch_tallies_file_is_being_processed(
             "errors": [
                 {
                     "errorType": "Conflict",
-                    "message": "Cannot update contests while batch tallies file is being processed."
+                    "message": "Cannot update contests while batch tallies file is being processed.",
                 }
             ]
         }

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -1204,9 +1204,6 @@ def test_updating_contests_while_jurisdictions_file_is_being_processed(
     election_id: str,
     jurisdiction_ids,  # pylint: disable=unused-argument
     contest_ids,  # pylint: disable=unused-argument
-    election_settings,  # pylint: disable=unused-argument
-    manifests,  # pylint: disable=unused-argument
-    batch_tallies,  # pylint: disable=unused-argument
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
 
@@ -1244,9 +1241,7 @@ def test_updating_contests_while_batch_tallies_file_is_being_processed(
     election_id: str,
     jurisdiction_ids,  # pylint: disable=unused-argument
     contest_ids,  # pylint: disable=unused-argument
-    election_settings,  # pylint: disable=unused-argument
     manifests,  # pylint: disable=unused-argument
-    batch_tallies,  # pylint: disable=unused-argument
 ):
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
 

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -1197,3 +1197,82 @@ def test_multi_contest_batch_comparison_editing_contests_after_uploads(
         batch_tallies_status = jurisdiction["batchTallies"]["processing"]
         assert batch_tallies_status["status"] == "PROCESSED"
         assert batch_tallies_status["error"] is None
+
+def test_updating_contests_while_jurisdictions_file_is_being_processed(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids,  # pylint: disable=unused-argument
+    contest_ids,  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    batch_tallies,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+
+    with no_automatic_task_execution():
+        # cause the jurisdictions file to start processing, but don't wait for it to finish
+        rv = upload_jurisdictions_file(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+        )
+        assert_ok(rv)
+
+        rv = client.get(f"/api/election/{election_id}/contest")
+        assert rv.status_code == 200
+        contests = json.loads(rv.data)["contests"]
+
+        for contest in contests:
+            del contest["totalBallotsCast"]
+
+        # Re-post the same contests, fails because the jurisdictions file is still being processed
+        rv = put_json(client, f"/api/election/{election_id}/contest", contests)
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot update contests while jurisdictions file is being processed."
+                }
+            ]
+        }
+
+def test_updating_contests_while_batch_tallies_file_is_being_processed(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids,  # pylint: disable=unused-argument
+    contest_ids,  # pylint: disable=unused-argument
+    election_settings,  # pylint: disable=unused-argument
+    manifests,  # pylint: disable=unused-argument
+    batch_tallies,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+
+    with no_automatic_task_execution():
+        # cause the batch tallies file to start processing, but don't wait for it to finish
+        rv = upload_batch_tallies(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+        assert_ok(rv)
+
+        rv = client.get(f"/api/election/{election_id}/contest")
+        assert rv.status_code == 200
+        contests = json.loads(rv.data)["contests"]
+
+        for contest in contests:
+            del contest["totalBallotsCast"]
+
+        # Re-post the same contests, fails because the batch tallies file is still being processed
+        rv = put_json(client, f"/api/election/{election_id}/contest", contests)
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot update contests while batch tallies file is being processed."
+                }
+            ]
+        }

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import io
 import uuid, json, re
 from datetime import datetime
@@ -7,6 +8,7 @@ from flask.testing import FlaskClient
 from werkzeug.wrappers import Response
 from sqlalchemy.exc import IntegrityError
 
+from .. import config
 from ..util.file import zip_files, timestamp_filename
 from ..auth.auth_helpers import UserType
 from ..auth import auth_helpers
@@ -595,3 +597,11 @@ def zip_hart_cvrs(cvrs: List[str]):
     # make sure it gets skipped
     files["WriteIns"] = io.BytesIO()
     return io.BytesIO(zip_files(files).read())
+
+@contextmanager
+def no_automatic_task_execution():
+    config.RUN_BACKGROUND_TASKS_IMMEDIATELY = False
+    try:
+        yield
+    finally:
+        config.RUN_BACKGROUND_TASKS_IMMEDIATELY = True

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -601,8 +601,9 @@ def zip_hart_cvrs(cvrs: List[str]):
 
 @contextmanager
 def no_automatic_task_execution():
+    old_run_background_tasks_immediately = config.RUN_BACKGROUND_TASKS_IMMEDIATELY
     config.RUN_BACKGROUND_TASKS_IMMEDIATELY = False
     try:
         yield
     finally:
-        config.RUN_BACKGROUND_TASKS_IMMEDIATELY = True
+        config.RUN_BACKGROUND_TASKS_IMMEDIATELY = old_run_background_tasks_immediately

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -598,6 +598,7 @@ def zip_hart_cvrs(cvrs: List[str]):
     files["WriteIns"] = io.BytesIO()
     return io.BytesIO(zip_files(files).read())
 
+
 @contextmanager
 def no_automatic_task_execution():
     config.RUN_BACKGROUND_TASKS_IMMEDIATELY = False

--- a/server/tests/test_background_tasks.py
+++ b/server/tests/test_background_tasks.py
@@ -664,6 +664,7 @@ def test_task_missing_parameter(db_session):
     ):
         create_background_task(missing_parameters, dict(arg2=2), db_session)
 
+
 def test_file_is_processing(db_session):
     file = File(
         id=1,
@@ -678,7 +679,7 @@ def test_file_is_processing(db_session):
     @background_task
     def process_file(election_id):
         pass
-    
+
     # queue the task
     file.task = create_background_task(
         process_file, dict(election_id="election-01"), db_session

--- a/server/tests/test_background_tasks.py
+++ b/server/tests/test_background_tasks.py
@@ -674,19 +674,19 @@ def test_file_is_processing(db_session):
 
     db_session.commit()
 
-    assert file.is_processing() == False
+    assert file.is_processing() is False
 
     @background_task
-    def process_file(election_id):
+    def process_file(election_id): # pylint: disable=unused-argument
         pass
 
     # queue the task
     file.task = create_background_task(
         process_file, dict(election_id="election-01"), db_session
     )
-    assert file.is_processing() == True
+    assert file.is_processing() is True
     db_session.commit()
 
     # run the task
     run_task(claim_next_task("test_worker", db_session), db_session)
-    assert file.is_processing() == False
+    assert file.is_processing() is False

--- a/server/tests/test_background_tasks.py
+++ b/server/tests/test_background_tasks.py
@@ -677,7 +677,7 @@ def test_file_is_processing(db_session):
     assert file.is_processing() is False
 
     @background_task
-    def process_file(election_id): # pylint: disable=unused-argument
+    def process_file(election_id):  # pylint: disable=unused-argument
         pass
 
     # queue the task


### PR DESCRIPTION
Refs https://github.com/votingworks/arlo/issues/1532

When making updates we'd like to check that no incomplete background jobs are dependent on the data we're about to change. This change takes steps in that direction, but does not fully fix the issue. For example, this change does not prevent deleting files where an incomplete job references that file.

I'd appreciate a more thorough review of this since it's the first non-trivial change I've made to Arlo in a while. See [this Slack thread](https://votingworks.slack.com/archives/CKCVA0F9S/p1730750352776399) for context.