### PR TITLE
Add stronger validation for storage path on upload complete endpoints

### DIFF
--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -60,8 +60,8 @@ from ..util.get_json import safe_get_json_dict
 TABULATOR_ID = "Tabulator Id"
 NAME = "Name"
 
-BATCH_CVR_FILE_NAME_PREFIX = "batch-inventory-cvrs"
-TABULATOR_STATUS_FILE_NAME_PREFIX = "batch-inventory-tabulator-status"
+BATCH_CVR_FILE_NAME_PREFIX = "batch_inventory_cvrs"
+TABULATOR_STATUS_FILE_NAME_PREFIX = "batch_inventory_tabulator_status"
 
 EXPECTED_CVR_FILE_TYPE_MAPPING = {
     CvrFileType.ESS: [FileType.CSV, FileType.ZIP],

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -63,6 +63,12 @@ NAME = "Name"
 BATCH_CVR_FILE_NAME_PREFIX = "batch-inventory-cvrs"
 TABULATOR_STATUS_FILE_NAME_PREFIX = "batch-inventory-tabulator-status"
 
+EXPECTED_CVR_FILE_TYPE_MAPPING = {
+    CvrFileType.ESS: [FileType.CSV, FileType.ZIP],
+    CvrFileType.HART: [FileType.ZIP],
+    CvrFileType.DOMINION: [FileType.CSV],
+}
+
 # (tabulator_id, batch_id)
 BatchKey = Tuple[str, str]
 
@@ -790,12 +796,10 @@ def complete_upload_for_batch_inventory_cvr(
     if not batch_inventory_data or not batch_inventory_data.system_type:
         raise Conflict("Must select system type before uploading CVR file.")
 
-    expected_file_types = [FileType.CSV]
-    if batch_inventory_data.system_type == CvrFileType.ESS:
-        expected_file_types = [FileType.CSV, FileType.ZIP]
-    elif batch_inventory_data.system_type == CvrFileType.HART:
-        expected_file_types = [FileType.ZIP]
-    elif batch_inventory_data.system_type != CvrFileType.DOMINION:
+    expected_file_types = EXPECTED_CVR_FILE_TYPE_MAPPING.get(
+        batch_inventory_data.system_type
+    )
+    if expected_file_types is None:
         raise Conflict(
             f"Batch Inventory CVR uploads not supported for cvr file type: {batch_inventory_data.system_type}"
         )
@@ -892,7 +896,6 @@ def download_batch_inventory_cvr(
 def start_upload_for_batch_inventory_tabulator_status(
     election: Election, jurisdiction: Jurisdiction
 ):
-
     file_type = request.args.get("fileType")
     if file_type is None:
         raise BadRequest("Missing expected query parameter: fileType")

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -212,6 +212,23 @@ def test_ballot_manifest_upload_bad_csv(
         json={
             "storagePathKey": "test_dir/random.txt",
             "fileName": "random.txt",
+            "fileType": "text/csv",
+        },
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "Invalid storage path",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+    rv = client.post(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest/upload-complete",
+        json={
+            "storagePathKey": f"{get_jurisdiction_folder_path(election_id, jurisdiction_ids[0])}/{timestamp_filename('manifest', 'csv')}",
+            "fileName": "random.txt",
             "fileType": "text/plain",
         },
     )

--- a/server/tests/ballot_comparison/test_standardized_contests.py
+++ b/server/tests/ballot_comparison/test_standardized_contests.py
@@ -27,7 +27,7 @@ def test_upload_standardized_contests(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("standardizedContests"),
+                "name": asserts_startswith("standardized_contests"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -51,7 +51,7 @@ def test_upload_standardized_contests(
 
     rv = client.get(f"/api/election/{election_id}/standardized-contests/file/csv")
     assert rv.headers["Content-Disposition"].startswith(
-        'attachment; filename="standardizedContests'
+        'attachment; filename="standardized_contests'
     )
     assert rv.data.decode("utf-8") == standardized_contests_file
 
@@ -122,7 +122,7 @@ def test_standardized_contests_bad_jurisdiction(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("standardizedContests"),
+                "name": asserts_startswith("standardized_contests"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -155,7 +155,7 @@ def test_standardized_contests_no_jurisdictions(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("standardizedContests"),
+                "name": asserts_startswith("standardized_contests"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -200,6 +200,24 @@ def test_standardized_contests_bad_csv(
         f"/api/election/{election_id}/standardized-contests/file/upload-complete",
         json={
             "storagePathKey": "test_dir/random.txt",
+            "fileName": "random.txt",
+            "fileType": "text/csv",
+        },
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "Invalid storage path",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+
+    rv = client.post(
+        f"/api/election/{election_id}/standardized-contests/file/upload-complete",
+        json={
+            "storagePathKey": f"{get_audit_folder_path(election_id)}/{timestamp_filename('standardized_contests', 'csv')}",
             "fileName": "random.txt",
             "fileType": "text/plain",
         },
@@ -398,7 +416,7 @@ def test_standardized_contests_change_jurisdictions_file(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("standardizedContests"),
+                "name": asserts_startswith("standardized_contests"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -205,7 +205,7 @@ def test_batch_inventory_happy_path(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batch-inventory-cvrs"),
+                "name": asserts_startswith("batch_inventory_cvrs"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -233,7 +233,7 @@ def test_batch_inventory_happy_path(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batch-inventory-tabulator-status"),
+                "name": asserts_startswith("batch_inventory_tabulator_status"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -416,7 +416,7 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batch-inventory-cvrs"),
+                "name": asserts_startswith("batch_inventory_cvrs"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -444,7 +444,7 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batch-inventory-tabulator-status"),
+                "name": asserts_startswith("batch_inventory_tabulator_status"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -627,7 +627,7 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batch-inventory-cvrs"),
+                "name": asserts_startswith("batch_inventory_cvrs"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -655,7 +655,7 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batch-inventory-tabulator-status"),
+                "name": asserts_startswith("batch_inventory_tabulator_status"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -1150,7 +1150,7 @@ def test_batch_inventory_excel_tabulator_status_file(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batch-inventory-tabulator-status"),
+                "name": asserts_startswith("batch_inventory_tabulator_status"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -1566,7 +1566,7 @@ def test_batch_inventory_cvr_get_upload_url(
 
     assert response_data["url"] == expected_url
     assert response_data["fields"]["key"].startswith(
-        f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/batch-inventory-cvrs_"
+        f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/batch_inventory_cvrs_"
     )
     assert response_data["fields"]["key"].endswith(".csv")
 
@@ -1608,7 +1608,7 @@ def test_batch_inventory_tabulator_status_get_upload_url(
 
     assert response_data["url"] == expected_url
     assert response_data["fields"]["key"].startswith(
-        f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/batch-inventory-tabulator-status_"
+        f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/batch_inventory_tabulator_status_"
     )
     assert response_data["fields"]["key"].endswith(".xml")
 

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -205,7 +205,7 @@ def test_batch_inventory_happy_path(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchInventoryCvr"),
+                "name": asserts_startswith("batch-inventory-cvrs"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -233,7 +233,7 @@ def test_batch_inventory_happy_path(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("tabulator-status"),
+                "name": asserts_startswith("batch-inventory-tabulator-status"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -325,7 +325,7 @@ def test_batch_inventory_happy_path(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchTallies"),
+                "name": asserts_startswith("batch_tallies"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -416,7 +416,7 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchInventoryCvr"),
+                "name": asserts_startswith("batch-inventory-cvrs"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -444,7 +444,7 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("tabulator-status"),
+                "name": asserts_startswith("batch-inventory-tabulator-status"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -536,7 +536,7 @@ def test_batch_inventory_happy_path_cvrs_with_leading_equal_signs(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchTallies"),
+                "name": asserts_startswith("batch_tallies"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -627,7 +627,7 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchInventoryCvr"),
+                "name": asserts_startswith("batch-inventory-cvrs"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -655,7 +655,7 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("tabulator-status"),
+                "name": asserts_startswith("batch-inventory-tabulator-status"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -747,7 +747,7 @@ def test_batch_inventory_happy_path_multi_contest_batch_comparison(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchTallies"),
+                "name": asserts_startswith("batch_tallies"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -1150,7 +1150,7 @@ def test_batch_inventory_excel_tabulator_status_file(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("tabulator-status"),
+                "name": asserts_startswith("batch-inventory-tabulator-status"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -1783,7 +1783,7 @@ def test_batch_inventory_hart_cvr_upload(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchTallies"),
+                "name": asserts_startswith("batch_tallies"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -1919,7 +1919,7 @@ def test_batch_inventory_hart_cvr_upload_multi_contest(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchTallies"),
+                "name": asserts_startswith("batch_tallies"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -2057,7 +2057,7 @@ def test_batch_inventory_ess_cvr_upload(
             json.loads(rv.data),
             {
                 "file": {
-                    "name": asserts_startswith("batchTallies"),
+                    "name": asserts_startswith("batch_tallies"),
                     "uploadedAt": assert_is_date,
                 },
                 "processing": {
@@ -2225,7 +2225,7 @@ def test_batch_inventory_ess_cvr_upload_no_ballot_file(
             json.loads(rv.data),
             {
                 "file": {
-                    "name": asserts_startswith("batchTallies"),
+                    "name": asserts_startswith("batch_tallies"),
                     "uploadedAt": assert_is_date,
                 },
                 "processing": {
@@ -2343,7 +2343,7 @@ def test_batch_inventory_ess_cvr_upload_multi_contest(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchTallies"),
+                "name": asserts_startswith("batch_tallies"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -60,7 +60,7 @@ def test_batch_tallies_upload(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchTallies"),
+                "name": asserts_startswith("batch_tallies"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -110,7 +110,7 @@ def test_batch_tallies_upload(
         jurisdictions[0]["batchTallies"],
         {
             "file": {
-                "name": asserts_startswith("batchTallies"),
+                "name": asserts_startswith("batch_tallies"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -129,7 +129,7 @@ def test_batch_tallies_upload(
     )
     assert rv.status_code == 200
     assert rv.headers["Content-Disposition"].startswith(
-        'attachment; filename="batchTallies'
+        'attachment; filename="batch_tallies'
     )
     assert rv.data == batch_tallies_file
 
@@ -316,6 +316,23 @@ def test_batch_tallies_upload_bad_csv(
         json={
             "storagePathKey": "test_dir/random.txt",
             "fileName": "random.txt",
+            "fileType": "text/csv",
+        },
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "Invalid storage path",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+    rv = client.post(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies/upload-complete",
+        json={
+            "storagePathKey": f"{get_jurisdiction_folder_path(election_id, jurisdiction_ids[0])}/{timestamp_filename('batch_tallies', 'csv')}",
+            "fileName": "random.txt",
             "fileType": "text/plain",
         },
     )
@@ -360,7 +377,7 @@ def test_batch_tallies_upload_missing_choice(
             json.loads(rv.data),
             {
                 "file": {
-                    "name": asserts_startswith("batchTallies"),
+                    "name": asserts_startswith("batch_tallies"),
                     "uploadedAt": assert_is_date,
                 },
                 "processing": {
@@ -432,7 +449,7 @@ def test_batch_tallies_wrong_batch_names(
             json.loads(rv.data),
             {
                 "file": {
-                    "name": asserts_startswith("batchTallies"),
+                    "name": asserts_startswith("batch_tallies"),
                     "uploadedAt": assert_is_date,
                 },
                 "processing": {
@@ -475,7 +492,7 @@ def test_batch_tallies_too_many_tallies(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchTallies"),
+                "name": asserts_startswith("batch_tallies"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -631,7 +648,7 @@ def test_batch_tallies_reprocess_after_manifest_reupload(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchTallies"),
+                "name": asserts_startswith("batch_tallies"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {
@@ -667,7 +684,7 @@ def test_batch_tallies_reprocess_after_manifest_reupload(
         json.loads(rv.data),
         {
             "file": {
-                "name": asserts_startswith("batchTallies"),
+                "name": asserts_startswith("batch_tallies"),
                 "uploadedAt": assert_is_date,
             },
             "processing": {

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -561,9 +561,9 @@ def upload_batch_inventory_cvr(
     file_type: str = "text/csv",
 ):
     if file_type in ["application/zip", "application/x-zip-compressed"]:
-        filename = timestamp_filename("batch-inventory-cvrs", "zip")
+        filename = timestamp_filename("batch_inventory_cvrs", "zip")
     else:
-        filename = timestamp_filename("batch-inventory-cvrs", "csv")
+        filename = timestamp_filename("batch_inventory_cvrs", "csv")
     return upload_file_helper(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-inventory/cvr",
@@ -580,7 +580,7 @@ def upload_batch_inventory_tabulator_status(
     election_id: str,
     jurisdiction_id: str,
 ):
-    filename = timestamp_filename("batch-inventory-tabulator-status", "xml")
+    filename = timestamp_filename("batch_inventory_tabulator_status", "xml")
     return upload_file_helper(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-inventory/tabulator-status",

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -9,7 +9,12 @@ from werkzeug.wrappers import Response
 from sqlalchemy.exc import IntegrityError
 
 from .. import config
-from ..util.file import zip_files, timestamp_filename
+from ..util.file import (
+    get_audit_folder_path,
+    get_jurisdiction_folder_path,
+    zip_files,
+    timestamp_filename,
+)
 from ..auth.auth_helpers import UserType
 from ..auth import auth_helpers
 from ..database import db_session
@@ -427,6 +432,7 @@ def upload_file_helper(
     client: FlaskClient,
     url: str,
     filename: str,
+    file_path: str,
     file_type: str,
     file_content: io.BytesIO,
     cvr_file_type: Optional[str] = None,
@@ -438,7 +444,7 @@ def upload_file_helper(
                 file_content,
                 filename,
             ),
-            "key": f"test_dir/{filename}",
+            "key": f"{file_path}/{filename}",
         },
     )
     assert_ok(rv)
@@ -446,7 +452,7 @@ def upload_file_helper(
     return client.post(
         f"{url}/upload-complete",
         json={
-            "storagePathKey": f"test_dir/{filename}",
+            "storagePathKey": f"{file_path}/{filename}",
             "fileName": filename,
             "fileType": file_type,
             "cvrFileType": cvr_file_type,
@@ -465,6 +471,7 @@ def upload_ballot_manifest(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/ballot-manifest",
         filename,
+        get_jurisdiction_folder_path(election_id, jurisdiction_id),
         "text/csv",
         file_content,
     )
@@ -476,11 +483,12 @@ def upload_batch_tallies(
     election_id: str,
     jurisdiction_id: str,
 ):
-    filename = timestamp_filename("batchTallies", "csv")
+    filename = timestamp_filename("batch_tallies", "csv")
     return upload_file_helper(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-tallies",
         filename,
+        get_jurisdiction_folder_path(election_id, jurisdiction_id),
         "text/csv",
         file_content,
     )
@@ -493,13 +501,11 @@ def upload_cvrs(
     jurisdiction_id: str,
     cvr_file_type: str,
     file_type: Optional[str] = None,
-    filename: Optional[str] = None,
 ):
-    if filename is None:
-        if file_type in ["application/zip", "application/x-zip-compressed"]:
-            filename = timestamp_filename("cvrs", "zip")
-        else:
-            filename = timestamp_filename("cvrs", "csv")
+    if file_type in ["application/zip", "application/x-zip-compressed"]:
+        filename = timestamp_filename("cvrs", "zip")
+    else:
+        filename = timestamp_filename("cvrs", "csv")
 
     if file_type is None:
         file_type = "text/csv"
@@ -508,6 +514,7 @@ def upload_cvrs(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/cvrs",
         filename,
+        get_jurisdiction_folder_path(election_id, jurisdiction_id),
         file_type,
         file_content,
         cvr_file_type,
@@ -519,11 +526,12 @@ def upload_jurisdictions_file(
     file_content: io.BytesIO,
     election_id: str,
 ):
-    filename = timestamp_filename("jurisdictions", "csv")
+    filename = timestamp_filename("participating_jurisdictions", "csv")
     return upload_file_helper(
         client,
         f"/api/election/{election_id}/jurisdiction/file",
         filename,
+        get_audit_folder_path(election_id),
         "text/csv",
         file_content,
     )
@@ -534,11 +542,12 @@ def upload_standardized_contests(
     file_content: io.BytesIO,
     election_id: str,
 ):
-    filename = timestamp_filename("standardizedContests", "csv")
+    filename = timestamp_filename("standardized_contests", "csv")
     return upload_file_helper(
         client,
         f"/api/election/{election_id}/standardized-contests/file",
         filename,
+        get_audit_folder_path(election_id),
         "text/csv",
         file_content,
     )
@@ -552,13 +561,14 @@ def upload_batch_inventory_cvr(
     file_type: str = "text/csv",
 ):
     if file_type in ["application/zip", "application/x-zip-compressed"]:
-        filename = timestamp_filename("batchInventoryCvr", "zip")
+        filename = timestamp_filename("batch-inventory-cvrs", "zip")
     else:
-        filename = timestamp_filename("batchInventoryCvr", "csv")
+        filename = timestamp_filename("batch-inventory-cvrs", "csv")
     return upload_file_helper(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-inventory/cvr",
         filename,
+        get_jurisdiction_folder_path(election_id, jurisdiction_id),
         file_type,
         file_content,
     )
@@ -570,11 +580,12 @@ def upload_batch_inventory_tabulator_status(
     election_id: str,
     jurisdiction_id: str,
 ):
-    filename = timestamp_filename("tabulator-status", "xml")
+    filename = timestamp_filename("batch-inventory-tabulator-status", "xml")
     return upload_file_helper(
         client,
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/batch-inventory/tabulator-status",
         filename,
+        get_jurisdiction_folder_path(election_id, jurisdiction_id),
         "text/xml",
         file_content,
     )

--- a/server/tests/util/test_csv_parse.py
+++ b/server/tests/util/test_csv_parse.py
@@ -1,7 +1,6 @@
 # pylint: disable=implicit-str-concat
 from typing import BinaryIO, Union, List
 import os, io, pytest
-from werkzeug.exceptions import BadRequest
 
 from ...api.jurisdictions import JURISDICTIONS_COLUMNS
 from ...util.csv_parse import (
@@ -9,7 +8,6 @@ from ...util.csv_parse import (
     CSVParseError,
     CSVColumnType,
     CSVValueType,
-    validate_csv_mimetype,
 )
 
 BALLOT_MANIFEST_COLUMNS = [
@@ -993,24 +991,6 @@ def test_parse_csv_real_world_examples():
     for csv, expected_rows, columns in REAL_WORLD_ACCEPTED_CSVS:
         parsed = do_parse(csv, columns)
         assert len(parsed) == expected_rows
-
-
-def test_validate_csv_mimetype():
-    validate_csv_mimetype("text/csv")
-    validate_csv_mimetype("application/vnd.ms-excel")
-
-    for invalid_mimetype in [
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "application/pdf",
-        "text/plain",
-    ]:
-        with pytest.raises(BadRequest) as error:
-            validate_csv_mimetype(invalid_mimetype)
-            assert error.value.description == (
-                "Please submit a valid CSV."
-                " If you are working with an Excel spreadsheet,"
-                " make sure you export it as a .csv file before uploading."
-            )
 
 
 def test_parse_csv_excel_file():

--- a/server/tests/util/test_file_storage.py
+++ b/server/tests/util/test_file_storage.py
@@ -3,21 +3,21 @@ import os.path
 import shutil
 import tempfile
 import io
+from typing import List, Tuple
 from unittest.mock import patch
 from werkzeug.exceptions import BadRequest
 import pytest
 
 from ...util.file import (
+    FileType,
     delete_file,
+    get_full_storage_path,
     retrieve_file,
     retrieve_file_to_buffer,
     store_file,
     get_file_upload_url,
-    get_standard_file_upload_request_params,
-    validate_zip_mimetype,
-    validate_csv_or_zip_mimetype,
-    validate_xml_mimetype,
-    get_full_storage_path,
+    validate_and_get_standard_file_upload_request_params,
+    timestamp_filename,
 )
 from ... import config
 
@@ -147,96 +147,163 @@ def test_file_storage_local_file():
 
 
 ## Tests for general file type utils
+@patch("flask.Request", autospec=True)
+def test_validate_and_get_standard_file_upload_request_params(mock_request):
+    happy_path_tests: Tuple[FileType, str, List[FileType]] = [
+        # test file type, test file mimetype, [allowed types]
+        [FileType.CSV, "text/csv", [FileType.CSV]],
+        [FileType.ZIP, "application/zip", [FileType.ZIP]],
+        [FileType.XML, "text/xml", [FileType.XML]],
+        [FileType.XML, "text/xml", [FileType.CSV, FileType.XML]],
+        [FileType.ZIP, "application/x-zip-compressed", [FileType.ZIP, FileType.XML]],
+        [FileType.CSV, "application/vnd.ms-excel", [FileType.ZIP, FileType.CSV]],
+        [FileType.CSV, "text/csv", [FileType.ZIP, FileType.CSV, FileType.XML]],
+        [FileType.XML, "text/xml", [FileType.ZIP, FileType.CSV, FileType.XML]],
+    ]
+    for test_file_type, test_mime_type, allowed_types in happy_path_tests:
+        expected_filename = timestamp_filename("test_file", test_file_type)
+        mock_request.get_json.return_value = {
+            "storagePathKey": f"test_dir/{expected_filename}",
+            "fileName": expected_filename,
+            "fileType": test_mime_type,
+        }
+        (storage_path, filename, file_type) = (
+            validate_and_get_standard_file_upload_request_params(
+                mock_request, "test_dir", "test_file", allowed_types
+            )
+        )
+        assert (
+            storage_path
+            == f"{config.FILE_UPLOAD_STORAGE_PATH}/test_dir/{expected_filename}"
+        )
+        assert filename == expected_filename
+        assert file_type == test_mime_type
 
 
 @patch("flask.Request", autospec=True)
-def test_get_standard_file_upload_request_params(mock_request):
-    mock_request.get_json.return_value = {
-        "storagePathKey": "test_dir/test_file.csv",
-        "fileName": "test_file.csv",
-        "fileType": "text/csv",
-    }
-    (storage_path, filename, file_type) = get_standard_file_upload_request_params(
-        mock_request
-    )
-    assert storage_path == f"{config.FILE_UPLOAD_STORAGE_PATH}/test_dir/test_file.csv"
-    assert filename == "test_file.csv"
-    assert file_type == "text/csv"
-
+def test_validate_and_get_standard_file_upload_request_params_errors(mock_request):
+    expected_filename = timestamp_filename("test_file", "csv")
     with pytest.raises(
         BadRequest, match="Missing required JSON parameter: storagePathKey"
     ):
         mock_request.get_json.return_value = {
-            "fileName": "test_file.csv",
+            "fileName": expected_filename,
             "fileType": "text/csv",
         }
-        get_standard_file_upload_request_params(mock_request)
+        validate_and_get_standard_file_upload_request_params(
+            mock_request, "test_dir", "test_file", [FileType.CSV]
+        )
 
     with pytest.raises(BadRequest, match="Missing required JSON parameter: fileName"):
         mock_request.get_json.return_value = {
-            "storagePathKey": "test_dir/test_file.csv",
+            "storagePathKey": f"test_dir/{expected_filename}",
             "fileType": "text/csv",
         }
-        get_standard_file_upload_request_params(mock_request)
+        validate_and_get_standard_file_upload_request_params(
+            mock_request, "test_dir", "test_file", [FileType.CSV]
+        )
 
     with pytest.raises(BadRequest, match="Missing required JSON parameter: fileType"):
         mock_request.get_json.return_value = {
-            "storagePathKey": "test_dir/test_file.csv",
-            "fileName": "test_file.csv",
+            "storagePathKey": f"test_dir/{expected_filename}",
+            "fileName": expected_filename,
         }
-        get_standard_file_upload_request_params(mock_request)
+        validate_and_get_standard_file_upload_request_params(
+            mock_request, "test_dir", "test_file", [FileType.CSV]
+        )
 
     with pytest.raises(BadRequest, match="Missing JSON request body"):
         mock_request.get_json.return_value = None
-        get_standard_file_upload_request_params(mock_request)
+        validate_and_get_standard_file_upload_request_params(
+            mock_request, "test_dir", "test_file", [FileType.CSV]
+        )
 
+    file_type_error_tests: Tuple[FileType, str, List[FileType], str] = [
+        # test file type, test file mimetype, [allowed types], expected error message
+        [
+            FileType.CSV,
+            "text/csv",
+            [FileType.ZIP],
+            "Please submit a valid file. Expected: zip",
+        ],
+        [
+            FileType.ZIP,
+            "application/zip",
+            [FileType.XML],
+            "Please submit a valid file. Expected: xml",
+        ],
+        [
+            FileType.XML,
+            "text/xml",
+            [FileType.CSV],
+            "Please submit a valid CSV. If you are working with an Excel spreadsheet, make sure you export it as a .csv file before uploading.",
+        ],
+        [
+            FileType.XML,
+            "text/xml",
+            [FileType.CSV, FileType.ZIP],
+            "Please submit a valid file. Expected: csv or zip",
+        ],
+        [
+            FileType.ZIP,
+            "application/x-zip-compressed",
+            [FileType.CSV, FileType.XML],
+            "Please submit a valid file. Expected: csv or xml",
+        ],
+        [
+            FileType.CSV,
+            "application/vnd.ms-excel",
+            [FileType.ZIP, FileType.XML],
+            "Please submit a valid file. Expected: zip or xml",
+        ],
+        [
+            FileType.CSV,
+            "invalid",
+            [FileType.ZIP, FileType.CSV, FileType.XML],
+            "Please submit a valid file. Expected: zip or csv or xml",
+        ],
+        [
+            FileType.XML,
+            "text/xaml",
+            [FileType.ZIP, FileType.CSV, FileType.XML],
+            "Please submit a valid file. Expected: zip or csv or xml",
+        ],
+    ]
+    for (
+        test_file_type,
+        test_mime_type,
+        allowed_types,
+        expected_err,
+    ) in file_type_error_tests:
+        expected_filename = timestamp_filename("test_file", test_file_type)
+        mock_request.get_json.return_value = {
+            "storagePathKey": f"test_dir/{expected_filename}",
+            "fileName": expected_filename,
+            "fileType": test_mime_type,
+        }
+        with pytest.raises(BadRequest, match=expected_err):
+            validate_and_get_standard_file_upload_request_params(
+                mock_request, "test_dir", "test_file", allowed_types
+            )
 
-def test_validate_zip_mimetype():
-    validate_zip_mimetype("application/zip")
-    validate_zip_mimetype("application/x-zip-compressed")
+    storage_path_tests = [
+        f"test_dir/{timestamp_filename('test_file', 'zip')}",
+        f"test_dir/{timestamp_filename('test_file', 'xml')}",
+        f"test_dir/{timestamp_filename('something_else', 'csv')}",
+        f"something_else/{timestamp_filename('test_file', 'csv')}",
+        "something_else/test_file_2024-05-05.csv",
+    ]
 
-    for invalid_mimetype in [
-        "text/csv",
-        "application/pdf",
-        "text/plain",
-    ]:
-        with pytest.raises(
-            BadRequest, match="400 Bad Request: Please submit a valid ZIP file."
-        ):
-            validate_zip_mimetype(invalid_mimetype)
-
-
-def test_validate_xml_mimetype():
-    validate_xml_mimetype("text/xml")
-
-    for invalid_mimetype in [
-        "text/csv",
-        "application/pdf",
-        "text/plain",
-        "application/zip",
-    ]:
-        with pytest.raises(
-            BadRequest, match="400 Bad Request: Please submit a valid XML file."
-        ):
-            validate_xml_mimetype(invalid_mimetype)
-
-
-def test_validate_csv_or_zip_mimetype():
-    validate_csv_or_zip_mimetype("text/csv")
-    validate_csv_or_zip_mimetype("application/vnd.ms-excel")
-    validate_csv_or_zip_mimetype("application/zip")
-    validate_csv_or_zip_mimetype("application/x-zip-compressed")
-
-    for invalid_mimetype in [
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "application/pdf",
-        "text/plain",
-        "text/xml",
-    ]:
-        with pytest.raises(
-            BadRequest, match="400 Bad Request: Please submit a valid CSV or ZIP file."
-        ):
-            validate_csv_or_zip_mimetype(invalid_mimetype)
+    for storage_path_test in storage_path_tests:
+        with pytest.raises(BadRequest, match="Invalid storage path"):
+            mock_request.get_json.return_value = {
+                "storagePathKey": storage_path_test,
+                "fileName": expected_filename,
+                "fileType": "text/csv",
+            }
+            validate_and_get_standard_file_upload_request_params(
+                mock_request, "test_dir", "test_file", [FileType.CSV]
+            )
 
 
 def test_get_full_storage_path():

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -15,7 +15,6 @@ from typing import (
 )
 import csv as py_csv
 import io, re, locale, chardet
-from werkzeug.exceptions import BadRequest
 
 from .jsonschema import EMAIL_REGEX
 from .collections import find_first_duplicate
@@ -83,11 +82,6 @@ def parse_csv(file: BinaryIO, columns: List[CSVColumnType]) -> CSVDictIterator:
 
 def is_filetype_csv_mimetype(file_type: str) -> bool:
     return file_type in ["text/csv", "application/vnd.ms-excel"]
-
-
-def validate_csv_mimetype(file_type: str) -> None:
-    if not is_filetype_csv_mimetype(file_type):
-        raise BadRequest(INVALID_CSV_ERROR)
 
 
 def read_chunks(file: IO[bytes], chunk_size: int) -> Iterable[bytes]:


### PR DESCRIPTION
https://github.com/votingworks/arlo/issues/2039 

Validates that the storage path passed to upload-complete is the expected path before saving. 