### PR TITLE
Add tests and fix small issues with ess batch inventory flow

### DIFF
--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -329,14 +329,23 @@ def process_batch_inventory_cvr_file(
                 )
 
             for row_index, row in enumerate(cvr_csv):
-                for contest in contests:
-                    cvr_number = column_value(
-                        row,
-                        "Cast Vote Record",
-                        row_index + 1,
-                        header_indices,
-                        required=True,
+                cvr_number = column_value(
+                    row,
+                    "Cast Vote Record",
+                    row_index + 1,
+                    header_indices,
+                    required=True,
+                )
+
+                if cvr_number not in cvr_number_to_batch:
+                    raise UserError(
+                        f"Unable to find batch for CVR number {cvr_number} in ballots files"
                     )
+                batch = cvr_number_to_batch[cvr_number]
+                batch_key: BatchKey = ("", batch)
+                ballot_count_by_batch[batch_key] += 1
+
+                for contest in contests:
                     choice_name = column_value(
                         row,
                         contest.name,
@@ -344,16 +353,8 @@ def process_batch_inventory_cvr_file(
                         header_indices,
                         required=False,
                     )
-
-                    if cvr_number not in cvr_number_to_batch:
-                        raise UserError(
-                            f"Unable to find batch for CVR number {cvr_number} in ballots files"
-                        )
-                    batch = cvr_number_to_batch[cvr_number]
-                    batch_key: BatchKey = ("", batch)
                     choice_id = validate_choice_name_and_get_choice_id(choice_name)
 
-                    ballot_count_by_batch[batch_key] += 1
                     if choice_id:
                         batch_tallies[batch_key][choice_id] += 1
 

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -280,11 +280,11 @@ def process_batch_inventory_cvr_file(
             if (
                 not choice_id
                 and choice_name
-                and choice_name != "overvote"
-                and choice_name != "undervote"
+                and choice_name.lower() != "overvote"
+                and choice_name.lower() != "undervote"
                 # If the user configured a write-in candidate choice when setting up the audit choice_id
                 # will be set in the for loop above. If the audit wasn't configured for write-ins we can parse them out.
-                and choice_name != "Write-in"
+                and choice_name.lower() != "write-in"
             ):
                 raise UserError(f"Unrecognized choice in CVR file: {choice_name}")
             return choice_id

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -317,9 +317,25 @@ def process_batch_inventory_cvr_file(
                         header_indices,
                         required=True,
                     )
-                    batch = column_value(
-                        row, "Batch", cvr_number, header_indices, required=True
+                    batch_col = column_value(
+                        row,
+                        "Batch",
+                        row_index + 1,
+                        header_indices,
+                        required=False,
                     )
+                    batch_name_col = column_value(
+                        row,
+                        "Batch Name",
+                        row_index + 1,
+                        header_indices,
+                        required=False,
+                    )
+                    batch = batch_col if batch_col is not None else batch_name_col
+                    if batch is None:
+                        raise UserError(
+                            "Missing Batch and Batch Name columns from CSV, at least one must be defined."
+                        )
                     cvr_number_to_batch[cvr_number] = batch
 
             validate_comma_delimited(primary_cvr_file)
@@ -371,13 +387,25 @@ def process_batch_inventory_cvr_file(
             header_indices = get_header_indices(headers)
             for row_index, row in enumerate(cvrs):
                 for contest in contests:
-                    batch = column_value(
+                    batch_col = column_value(
                         row,
                         "Batch",
                         row_index + 1,
                         header_indices,
-                        required=True,
+                        required=False,
                     )
+                    batch_name_col = column_value(
+                        row,
+                        "Batch Name",
+                        row_index + 1,
+                        header_indices,
+                        required=False,
+                    )
+                    batch = batch_col if batch_col is not None else batch_name_col
+                    if batch is None:
+                        raise UserError(
+                            "Missing Batch and Batch Name columns from CSV, at least one must be defined."
+                        )
                     choice_name = column_value(
                         row,
                         contest.name,

--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -272,12 +272,18 @@ def process_batch_inventory_cvr_file(
                 if choice.name == choice_name:
                     choice_id = choice.id
                     break
+                # handle capitalization mismatches for the write in column
+                if choice.name.lower() == choice_name.lower() == "write-in":
+                    choice_id = choice.id
+                    break
 
             if (
                 not choice_id
                 and choice_name
                 and choice_name != "overvote"
                 and choice_name != "undervote"
+                # If the user configured a write-in candidate choice when setting up the audit choice_id
+                # will be set in the for loop above. If the audit wasn't configured for write-ins we can parse them out.
                 and choice_name != "Write-in"
             ):
                 raise UserError(f"Unrecognized choice in CVR file: {choice_name}")

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
@@ -78,6 +78,22 @@ BATCH2,4,4,0,2,4,2,0\r
 """
 
 snapshots[
+    "test_batch_inventory_ess_cvr_upload_no_ballot_file 1"
+] = """Batch Name,Number of Ballots\r
+Batch 1,4\r
+Batch 2,5\r
+Batch 3,5\r
+"""
+
+snapshots[
+    "test_batch_inventory_ess_cvr_upload_no_ballot_file 2"
+] = """Batch Name,Choice 1-1,Choice 1-2,Write-In\r
+Batch 1,2,2,0\r
+Batch 2,1,2,0\r
+Batch 3,3,2,0\r
+"""
+
+snapshots[
     "test_batch_inventory_excel_tabulator_status_file 1"
 ] = """Batch Inventory Worksheet\r
 \r

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
@@ -88,9 +88,9 @@ Batch 3,5\r
 snapshots[
     "test_batch_inventory_ess_cvr_upload_no_ballot_file 2"
 ] = """Batch Name,Choice 1-1,Choice 1-2,Write-In\r
-Batch 1,2,2,0\r
+Batch 1,2,1,1\r
 Batch 2,1,2,0\r
-Batch 3,3,2,0\r
+Batch 3,2,2,1\r
 """
 
 snapshots[

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
@@ -64,6 +64,20 @@ BATCH2,4,4,0\r
 """
 
 snapshots[
+    "test_batch_inventory_ess_cvr_upload_multi_contest 1"
+] = """Batch Name,Number of Ballots\r
+BATCH1,6\r
+BATCH2,8\r
+"""
+
+snapshots[
+    "test_batch_inventory_ess_cvr_upload_multi_contest 2"
+] = """Batch Name,Contest 1 - Choice 1-1,Contest 1 - Choice 1-2,Contest 1 - Write-In,Contest 2 - Choice 2-1,Contest 2 - Choice 2-2,Contest 2 - Choice 2-3,Contest 2 - Write-In\r
+BATCH1,2,2,0,6,0,0,0\r
+BATCH2,4,4,0,2,4,2,0\r
+"""
+
+snapshots[
     "test_batch_inventory_excel_tabulator_status_file 1"
 ] = """Batch Inventory Worksheet\r
 \r
@@ -206,11 +220,11 @@ Election Day,Tabulator 2 - BATCH2,6\r
 
 snapshots[
     "test_batch_inventory_happy_path_multi_contest_batch_comparison 3"
-] = """Batch Name,Contest 1 - Choice 1-1,Contest 1 - Choice 1-2,Contest 1 - Write-In,Contest 2 - Choice 2-1,Contest 2 - Choice 2-2,Contest 2 - Write-In\r
-Tabulator 1 - BATCH1,1,1,1,3,2,0\r
-Tabulator 1 - BATCH2,2,1,0,3,1,0\r
-Tabulator 2 - BATCH1,2,1,0,3,2,0\r
-Tabulator 2 - BATCH2,2,0,0,6,2,0\r
+] = """Batch Name,Contest 1 - Choice 1-1,Contest 1 - Choice 1-2,Contest 1 - Write-In,Contest 2 - Choice 2-1,Contest 2 - Choice 2-2,Contest 2 - Choice 2-3,Contest 2 - Write-In\r
+Tabulator 1 - BATCH1,1,1,1,3,2,1,0\r
+Tabulator 1 - BATCH2,2,1,0,3,1,2,0\r
+Tabulator 2 - BATCH1,2,1,0,3,2,1,0\r
+Tabulator 2 - BATCH2,2,0,0,6,2,4,0\r
 """
 
 snapshots[
@@ -229,4 +243,22 @@ BATCH1,1,2,0\r
 BATCH2,2,1,0\r
 BATCH4,1,0,1\r
 BATCH3,0,0,0\r
+"""
+
+snapshots[
+    "test_batch_inventory_hart_cvr_upload_multi_contest 1"
+] = """Batch Name,Number of Ballots\r
+BATCH1,3\r
+BATCH2,3\r
+BATCH3,2\r
+BATCH4,2\r
+"""
+
+snapshots[
+    "test_batch_inventory_hart_cvr_upload_multi_contest 2"
+] = """Batch Name,Contest 1 - Choice 1-1,Contest 1 - Choice 1-2,Contest 1 - Write-In,Contest 2 - Choice 2-1,Contest 2 - Choice 2-2,Contest 2 - Choice 2-3,Contest 2 - Write-In\r
+BATCH1,1,2,0,3,2,1,0\r
+BATCH2,2,1,0,3,1,2,0\r
+BATCH3,0,0,0,0,1,1,0\r
+BATCH4,1,0,1,0,0,1,1\r
 """

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
@@ -8,6 +8,62 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots[
+    "test_batch_inventory_ess_cvr_upload 1"
+] = """Batch Name,Number of Ballots\r
+BATCH1,6\r
+BATCH2,8\r
+"""
+
+snapshots[
+    "test_batch_inventory_ess_cvr_upload 2"
+] = """Batch Name,Choice 1-1,Choice 1-2,Write-In\r
+BATCH1,2,2,0\r
+BATCH2,4,4,0\r
+"""
+
+snapshots[
+    "test_batch_inventory_ess_cvr_upload 3"
+] = """Batch Name,Number of Ballots\r
+BATCH1,6\r
+BATCH2,8\r
+"""
+
+snapshots[
+    "test_batch_inventory_ess_cvr_upload 4"
+] = """Batch Name,Choice 1-1,Choice 1-2,Write-In\r
+BATCH1,2,2,0\r
+BATCH2,4,4,0\r
+"""
+
+snapshots[
+    "test_batch_inventory_ess_cvr_upload 5"
+] = """Batch Name,Number of Ballots\r
+BATCH1,6\r
+BATCH2,8\r
+"""
+
+snapshots[
+    "test_batch_inventory_ess_cvr_upload 6"
+] = """Batch Name,Choice 1-1,Choice 1-2,Write-In\r
+BATCH1,2,2,0\r
+BATCH2,4,4,0\r
+"""
+
+snapshots[
+    "test_batch_inventory_ess_cvr_upload 7"
+] = """Batch Name,Number of Ballots\r
+BATCH1,6\r
+BATCH2,8\r
+"""
+
+snapshots[
+    "test_batch_inventory_ess_cvr_upload 8"
+] = """Batch Name,Choice 1-1,Choice 1-2,Write-In\r
+BATCH1,2,2,0\r
+BATCH2,4,4,0\r
+"""
+
+snapshots[
     "test_batch_inventory_excel_tabulator_status_file 1"
 ] = """Batch Inventory Worksheet\r
 \r

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_inventory.py
@@ -94,6 +94,22 @@ Batch 3,2,2,1\r
 """
 
 snapshots[
+    "test_batch_inventory_ess_cvr_upload_no_ballot_file 3"
+] = """Batch Name,Number of Ballots\r
+Batch 1,4\r
+Batch 2,5\r
+Batch 3,5\r
+"""
+
+snapshots[
+    "test_batch_inventory_ess_cvr_upload_no_ballot_file 4"
+] = """Batch Name,Choice 1-1,Choice 1-2,Write-In\r
+Batch 1,2,1,1\r
+Batch 2,1,2,0\r
+Batch 3,2,2,1\r
+"""
+
+snapshots[
     "test_batch_inventory_excel_tabulator_status_file 1"
 ] = """Batch Inventory Worksheet\r
 \r

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -2041,6 +2041,136 @@ def test_batch_inventory_ess_cvr_upload(
         assert_ok(rv)
 
 
+ESS_CVR_WITH_BATCH_CVR_COLUMN = """Unknown Column,Cast Vote Record,Precinct,Ballot Style,Batch,Contest 1,Contest 2
+x,1,p,bs,Batch 1,Choice 1-2,Choice 2-1
+x,2,p,bs,Batch 1,Choice 1-1,Choice 2-1
+x,3,p,bs,Batch 2,undervote,Choice 2-1
+x,4,p,bs,Batch 2,overvote,Choice 2-1
+x,5,p,bs,Batch 1,Choice 1-2,Choice 2-1
+x,6,p,bs,Batch 1,Choice 1-1,Choice 2-1
+x,7,p,bs,Batch 2,Choice 1-2,Choice 2-1
+x,8,p,bs,Batch 2,Choice 1-1,Choice 2-1
+x,9,p,bs,Batch 2,Choice 1-2,Choice 2-2
+x,10,p,bs,Batch 3,Choice 1-1,Choice 2-2
+x,11,p,bs,Batch 3,Choice 1-2,Choice 2-2
+x,12,p,bs,Batch 3,Choice 1-1,Choice 2-2
+x,13,p,bs,Batch 3,Choice 1-2,Choice 2-3
+x,15,p,bs,Batch 3,Choice 1-1,Choice 2-3
+"""
+
+
+def test_batch_inventory_ess_cvr_upload_no_ballot_file(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_id: str,  # pylint: disable=unused-argument
+    snapshot,
+):
+    # Set the logged-in user to Jurisdiction Admin
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.ESS},
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type"
+    )
+    compare_json(json.loads(rv.data), {"systemType": CvrFileType.ESS})
+
+    # Upload ESS CVR file
+    rv = upload_batch_inventory_cvr(
+        client,
+        io.BytesIO(ESS_CVR_WITH_BATCH_CVR_COLUMN.encode()),
+        election_id,
+        jurisdiction_ids[0],
+        "text/csv",
+    )
+    assert_ok(rv)
+
+    # Verify the uploaded CVR file
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type"
+    )
+    compare_json(json.loads(rv.data), {"systemType": CvrFileType.ESS})
+
+    # Download manifest
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/ballot-manifest"
+    )
+    ballot_manifest = rv.data.decode("utf-8")
+    snapshot.assert_match(ballot_manifest)
+
+    # Download batch tallies
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/batch-tallies"
+    )
+    batch_tallies = rv.data.decode("utf-8")
+    snapshot.assert_match(batch_tallies)
+
+    # Upload manifest - should be a valid file
+    rv = upload_ballot_manifest(
+        client,
+        io.BytesIO(ballot_manifest.encode()),
+        election_id,
+        jurisdiction_ids[0],
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest"
+    )
+    compare_json(
+        json.loads(rv.data),
+        {
+            "file": {
+                "name": asserts_startswith("manifest"),
+                "uploadedAt": assert_is_date,
+            },
+            "processing": {
+                "status": ProcessingStatus.PROCESSED,
+                "startedAt": assert_is_date,
+                "completedAt": assert_is_date,
+                "error": None,
+            },
+        },
+    )
+
+    # Upload batch tallies - should be a valid file
+    rv = upload_batch_tallies(
+        client,
+        io.BytesIO(batch_tallies.encode()),
+        election_id,
+        jurisdiction_ids[0],
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-tallies"
+    )
+    compare_json(
+        json.loads(rv.data),
+        {
+            "file": {
+                "name": asserts_startswith("batchTallies"),
+                "uploadedAt": assert_is_date,
+            },
+            "processing": {
+                "status": ProcessingStatus.PROCESSED,
+                "startedAt": assert_is_date,
+                "completedAt": assert_is_date,
+                "error": None,
+            },
+        },
+    )
+
+
 def test_batch_inventory_ess_cvr_upload_multi_contest(
     client: FlaskClient,
     election_id: str,

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -2046,12 +2046,12 @@ x,1,p,bs,Batch 1,Choice 1-2,Choice 2-1
 x,2,p,bs,Batch 1,Choice 1-1,Choice 2-1
 x,3,p,bs,Batch 2,undervote,Choice 2-1
 x,4,p,bs,Batch 2,overvote,Choice 2-1
-x,5,p,bs,Batch 1,Choice 1-2,Choice 2-1
+x,5,p,bs,Batch 1,Write-in,Choice 2-1
 x,6,p,bs,Batch 1,Choice 1-1,Choice 2-1
 x,7,p,bs,Batch 2,Choice 1-2,Choice 2-1
 x,8,p,bs,Batch 2,Choice 1-1,Choice 2-1
 x,9,p,bs,Batch 2,Choice 1-2,Choice 2-2
-x,10,p,bs,Batch 3,Choice 1-1,Choice 2-2
+x,10,p,bs,Batch 3,Write-in,Choice 2-2
 x,11,p,bs,Batch 3,Choice 1-2,Choice 2-2
 x,12,p,bs,Batch 3,Choice 1-1,Choice 2-2
 x,13,p,bs,Batch 3,Choice 1-2,Choice 2-3


### PR DESCRIPTION
https://github.com/votingworks/arlo/issues/2037
Adds testing and updates ESS batch inventory flow to:
- Not double count ballots for the manifest when used with multiple contests
- Handle write-ins better 
- Adds a fallback to check for a "Batch Name" column to name the batches if "Batch" does not exist as I noticed this in some real world CVR examples 

We still don't handle vote for many contests which are also not handled in the regular ESS cvr parsing flow 