### PR TITLE
Support combined batches when calculating discrepancies

### DIFF
--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -1089,6 +1089,67 @@ def test_batch_comparison_combined_batches(
     discrepancy_counts = json.loads(rv.data)
     assert discrepancy_counts[jurisdiction_ids[0]] == 1
 
+    # Check discrepancies
+    rv = client.get(f"/api/election/{election_id}/discrepancy")
+    discrepancies = json.loads(rv.data)
+    choices = contests[0]["choices"]
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Combined Batch"][contests[0]["id"]][
+            "discrepancies"
+        ][choices[0]["id"]]
+        == 0
+    )
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Combined Batch"][contests[0]["id"]][
+            "discrepancies"
+        ][choices[1]["id"]]
+        == candidate_2_discrepancy
+    )
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Combined Batch"][contests[0]["id"]][
+            "discrepancies"
+        ][choices[2]["id"]]
+        == candidate_3_discrepancy
+    )
+
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Combined Batch"][contests[0]["id"]][
+            "reportedVotes"
+        ][choices[0]["id"]]
+        == reported_tallies[choice_ids[0]]
+    )
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Combined Batch"][contests[0]["id"]][
+            "reportedVotes"
+        ][choices[1]["id"]]
+        == reported_tallies[choice_ids[1]]
+    )
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Combined Batch"][contests[0]["id"]][
+            "reportedVotes"
+        ][choices[2]["id"]]
+        == reported_tallies[choice_ids[2]]
+    )
+
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Combined Batch"][contests[0]["id"]][
+            "auditedVotes"
+        ][choices[0]["id"]]
+        == reported_tallies[choice_ids[0]]
+    )
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Combined Batch"][contests[0]["id"]][
+            "auditedVotes"
+        ][choices[1]["id"]]
+        == reported_tallies[choice_ids[1]] - candidate_2_discrepancy
+    )
+    assert (
+        discrepancies[jurisdiction_ids[0]]["Combined Batch"][contests[0]["id"]][
+            "auditedVotes"
+        ][choices[2]["id"]]
+        == reported_tallies[choice_ids[2]] - candidate_3_discrepancy
+    )
+
     # Check the discrepancy report
     rv = client.get(f"/api/election/{election_id}/discrepancy-report")
     discrepancy_report = rv.data.decode("utf-8")


### PR DESCRIPTION
This PR closes out https://github.com/votingworks/arlo/issues/1912.

It adds support for combined batches when calculating discrepancies.

<img width="1512" alt="Screenshot 2024-11-07 at 2 07 26 PM" src="https://github.com/user-attachments/assets/d0c47f01-d387-41ae-a003-5f8d60e31d31">
