### PR TITLE
Fix spacing on icon for review discrepancies button

### DIFF
--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -331,12 +331,8 @@ const Progress: React.FC<IProgressProps> = ({
           return (
             <Button
               onClick={() => setJurisdictionDiscrepanciesId(jurisdiction.id)}
+              icon={<Icon icon="flag" intent="danger" />}
             >
-              <Icon
-                icon="flag"
-                intent="danger"
-                style={{ marginRight: '4px' }}
-              />
               Review {value.toLocaleString()}
             </Button>
           )


### PR DESCRIPTION
Before
<img width="156" alt="Screenshot 2024-11-07 at 12 48 28 PM" src="https://github.com/user-attachments/assets/4efa4ed2-8420-4eb2-846f-809f76880852">


After
<img width="192" alt="Screenshot 2024-11-07 at 12 48 09 PM" src="https://github.com/user-attachments/assets/1fa0c603-49eb-45ff-876b-f83d336ae18c">
