### PR TITLE
Refactor Audit Progress to use discrepancy query instead of discrepancy counts endpoint

### DIFF
--- a/client/src/components/AuditAdmin/Progress/JurisdictionDiscrepancies.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDiscrepancies.tsx
@@ -3,7 +3,7 @@ import { Classes, Colors, Dialog, H6, HTMLTable } from '@blueprintjs/core'
 import styled from 'styled-components'
 import {
   IJurisdiction,
-  useDiscrepanciesByJurisdiction,
+  DiscrepanciesByJurisdiction,
 } from '../../useJurisdictions'
 import useContestsJurisdictionAdmin from '../../JurisdictionAdmin/useContestsJurisdictionAdmin'
 import { IContest } from '../../../types'
@@ -65,27 +65,28 @@ function formatVoteCount(val: string | number | undefined): string {
 }
 
 export interface IJurisdictionDiscrepanciesProps {
+  discrepancies: DiscrepanciesByJurisdiction
   electionId: string
   handleClose: () => void
   jurisdiction: IJurisdiction
 }
 
 const JurisdictionDiscrepancies: React.FC<IJurisdictionDiscrepanciesProps> = ({
+  discrepancies,
   handleClose,
   jurisdiction,
   electionId,
 }) => {
-  const discrepancyQuery = useDiscrepanciesByJurisdiction(electionId, {})
   const contestsQuery = useContestsJurisdictionAdmin(
     electionId,
     jurisdiction.id
   )
 
-  if (!discrepancyQuery.isSuccess || !contestsQuery.isSuccess) {
+  if (!contestsQuery.isSuccess) {
     return null
   }
 
-  const discrepanciesByBatchOrBallot = discrepancyQuery.data[jurisdiction.id]
+  const discrepanciesByBatchOrBallot = discrepancies[jurisdiction.id]
   const contests = contestsQuery.data
 
   return (

--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -242,11 +242,6 @@ describe('Progress screen', () => {
   it('shows round and discrepancy status for ballot comparison', async () => {
     const expectedCalls = [
       aaApiCalls.getMapData,
-      aaApiCalls.getDiscrepancyCounts({
-        [jurisdictionMocks.allComplete[0].id]: 0,
-        [jurisdictionMocks.allComplete[1].id]: 2,
-        [jurisdictionMocks.allComplete[2].id]: 1,
-      }),
       aaApiCalls.getDiscrepancies({
         [jurisdictionMocks.oneComplete[1].id]: {
           ballot1: {
@@ -259,6 +254,15 @@ describe('Progress screen', () => {
               reportedVotes: {}, // undefined, seemingly can occur if no vote was reported
               auditedVotes: { [contestMocks.two[1].choices[0].id]: 'o' },
               discrepancies: { [contestMocks.two[1].choices[0].id]: 1 },
+            },
+          },
+        },
+        [jurisdictionMocks.oneComplete[2].id]: {
+          ballot2: {
+            [contestMocks.one[0].id]: {
+              reportedVotes: { [contestMocks.one[0].choices[0].id]: '0' },
+              auditedVotes: { [contestMocks.one[0].choices[0].id]: '1' },
+              discrepancies: { [contestMocks.one[0].choices[0].id]: -1 },
             },
           },
         },
@@ -369,6 +373,11 @@ describe('Progress screen', () => {
       expect(footers[4]).toHaveTextContent('60')
       expect(footers[5]).toHaveTextContent('0')
 
+      userEvent.click(within(dialog).getByRole('button', { name: 'Close' }))
+      await waitFor(() => {
+        expect(dialog).not.toBeInTheDocument()
+      })
+
       const downloadReportButton = screen.getByRole('button', {
         name: /Download Discrepancy Report/,
       })
@@ -390,11 +399,6 @@ describe('Progress screen', () => {
   it('shows round and discrepancy status for batch comparison', async () => {
     const expectedCalls = [
       aaApiCalls.getMapData,
-      aaApiCalls.getDiscrepancyCounts({
-        [jurisdictionMocks.oneComplete[0].id]: 3,
-        [jurisdictionMocks.oneComplete[1].id]: 2,
-        [jurisdictionMocks.oneComplete[2].id]: 1,
-      }),
       aaApiCalls.getDiscrepancies({
         [jurisdictionMocks.oneComplete[2].id]: {
           batch1: {
@@ -726,11 +730,7 @@ describe('Progress screen', () => {
   it('shows a different toggle label for batch audits', async () => {
     const expectedCalls = [
       aaApiCalls.getMapData,
-      aaApiCalls.getDiscrepancyCounts({
-        [jurisdictionMocks.oneComplete[0].id]: 0,
-        [jurisdictionMocks.oneComplete[1].id]: 0,
-        [jurisdictionMocks.oneComplete[2].id]: 0,
-      }),
+      aaApiCalls.getDiscrepancies({}),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { container } = render({

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -68,8 +68,8 @@ const countDiscrepanciesForJurisdiction = (
   jurisdictionId: string
 ) => {
   return sum(
-    Object.entries(discrepancies[jurisdictionId] ?? {}).map(
-      ([_, contestDiscrepancies]) => Object.keys(contestDiscrepancies).length
+    Object.values(discrepancies[jurisdictionId] ?? {}).map(
+      contestDiscrepancies => Object.keys(contestDiscrepancies).length
     )
   )
 }

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -17,7 +17,8 @@ import {
   IJurisdiction,
   getJurisdictionStatus,
   JurisdictionProgressStatus,
-  useDiscrepancyCountsByJurisdiction,
+  useDiscrepanciesByJurisdiction,
+  DiscrepanciesByJurisdiction,
 } from '../../useJurisdictions'
 import JurisdictionDetail from './JurisdictionDetail'
 import {
@@ -60,6 +61,19 @@ const totalFooter = <T extends object>(headerName: string) => (
   info: TableInstance<T>
 ) => sum(info.rows.map(row => row.values[headerName])).toLocaleString()
 
+// We count the number of batch-contest pairs with discrepancies, not the number
+// of batches with discrepancies.
+const countDiscrepanciesForJurisdiction = (
+  discrepancies: DiscrepanciesByJurisdiction,
+  jurisdictionId: string
+) => {
+  return sum(
+    Object.entries(discrepancies[jurisdictionId] ?? {}).map(
+      ([_, contestDiscrepancies]) => Object.keys(contestDiscrepancies).length
+    )
+  )
+}
+
 export interface IProgressProps {
   jurisdictions: IJurisdiction[]
   auditSettings: IAuditSettings
@@ -76,10 +90,9 @@ const Progress: React.FC<IProgressProps> = ({
   const showDiscrepancies =
     Boolean(round) &&
     (auditType === 'BALLOT_COMPARISON' || auditType === 'BATCH_COMPARISON')
-  const discrepancyCountsQuery = useDiscrepancyCountsByJurisdiction(
-    electionId,
-    { enabled: showDiscrepancies }
-  )
+  const discrepancyQuery = useDiscrepanciesByJurisdiction(electionId, {
+    enabled: showDiscrepancies,
+  })
   // Store sort and filter state in URL search params to allow it to persist
   // across page refreshes
   const [sortAndFilterState, setSortAndFilterState] = useSearchParams<{
@@ -315,12 +328,13 @@ const Progress: React.FC<IProgressProps> = ({
         accessor: ({ id, currentRoundStatus: s }) =>
           s &&
           s.status === JurisdictionRoundStatus.COMPLETE &&
-          discrepancyCountsQuery.data?.[id],
+          discrepancyQuery.isSuccess &&
+          countDiscrepanciesForJurisdiction(discrepancyQuery.data, id),
         Cell: ({
           value,
           row: { original: jurisdiction },
         }: Cell<IJurisdiction>) => {
-          if (discrepancyCountsQuery.isLoading) {
+          if (discrepancyQuery.isLoading) {
             return (
               <div style={{ display: 'flex', justifyContent: 'start' }}>
                 <Spinner size={Spinner.SIZE_SMALL} />
@@ -337,7 +351,7 @@ const Progress: React.FC<IProgressProps> = ({
             </Button>
           )
         },
-        Footer: discrepancyCountsQuery.isLoading
+        Footer: discrepancyQuery.isLoading
           ? () => null
           : totalFooter('Discrepancies'),
       })
@@ -505,6 +519,7 @@ const Progress: React.FC<IProgressProps> = ({
       )}
       {jurisdictionDiscrepanciesId && (
         <JurisdictionDiscrepancies
+          discrepancies={discrepancyQuery.data!}
           jurisdiction={
             jurisdictions.find(
               jurisdiction => jurisdiction.id === jurisdictionDiscrepanciesId

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -21,7 +21,6 @@ import {
   IBallotManifestInfo,
   IBatchTalliesFileInfo,
   IJurisdiction,
-  DiscrepancyCountsByJurisdiction,
   DiscrepanciesByJurisdiction,
 } from './useJurisdictions'
 import { IStandardizedContest } from './useStandardizedContests'
@@ -2180,10 +2179,6 @@ export const aaApiCalls = {
     url: '/us-states-counties.json',
     response: mapTopology,
   },
-  getDiscrepancyCounts: (response: DiscrepancyCountsByJurisdiction) => ({
-    url: '/api/election/1/discrepancy-counts',
-    response,
-  }),
   getDiscrepancies: (response: DiscrepanciesByJurisdiction) => ({
     url: '/api/election/1/discrepancy',
     response,

--- a/client/src/components/useJurisdictions.ts
+++ b/client/src/components/useJurisdictions.ts
@@ -144,28 +144,6 @@ export const useJurisdictions = (
   })
 }
 
-// { jurisidictionId: discrepancyCount }
-export type DiscrepancyCountsByJurisdiction = Record<string, number>
-
-const discrepancyCountsQueryKey = (electionId: string): string[] =>
-  jurisdictionsQueryKey(electionId).concat('discrepancy-counts')
-
-export const useDiscrepancyCountsByJurisdiction = (
-  electionId: string,
-  options: { enabled?: boolean }
-): UseQueryResult<DiscrepancyCountsByJurisdiction, ApiError> => {
-  return useQuery(
-    discrepancyCountsQueryKey(electionId),
-    async () => {
-      const response: DiscrepancyCountsByJurisdiction = await fetchApi(
-        `/api/election/${electionId}/discrepancy-counts`
-      )
-      return response
-    },
-    options
-  )
-}
-
 export type DiscrepanciesByJurisdiction = Record<
   string, // [jurisdictionId]
   Record<

--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -1,4 +1,4 @@
-from collections import Counter, defaultdict
+from collections import defaultdict
 import logging
 from typing import Dict, List, Optional, Mapping, Union, cast as typing_cast
 import enum
@@ -626,113 +626,6 @@ def complete_upload_for_jurisdictions_file(election: Election):
     )
     db_session.commit()
     return jsonify(status="ok")
-
-
-@api.route("/election/<election_id>/discrepancy-counts", methods=["GET"])
-@restrict_access([UserType.AUDIT_ADMIN])
-def get_discrepancy_counts_by_jurisdiction(election: Election):
-    discrepancy_count_by_jurisdiction: Dict[str, int] = Counter()
-    round = get_current_round(election)
-    if not round:
-        raise Conflict("Audit not started")
-
-    if election.audit_type == AuditType.BALLOT_COMPARISON:
-        ballots_in_round = (
-            SampledBallot.query.join(SampledBallotDraw)
-            .filter_by(round_id=round.id)
-            .distinct(SampledBallot.id)
-            .with_entities(SampledBallot.id)
-            .subquery()
-        )
-        sampled_ballot_id_to_jurisdiction_id = dict(
-            SampledBallot.query.filter(SampledBallot.id.in_(ballots_in_round))
-            .join(Batch)
-            .with_entities(SampledBallot.id, Batch.jurisdiction_id)
-        )
-        for contest in election.contests:
-            reported_results = cvrs_for_contest(contest)
-            audited_results = sampled_ballot_interpretations_to_cvrs(contest)
-            for ballot_id, audited_result in audited_results.items():
-                vote_deltas = ballot_vote_deltas(
-                    contest,
-                    reported_results.get(ballot_id),
-                    audited_result["cvr"],
-                )
-                if vote_deltas and ballot_id in sampled_ballot_id_to_jurisdiction_id:
-                    jurisdiction_id = sampled_ballot_id_to_jurisdiction_id[ballot_id]
-                    discrepancy_count_by_jurisdiction[jurisdiction_id] += 1
-
-    elif election.audit_type == AuditType.BATCH_COMPARISON:
-        batch_keys_in_round = set(
-            SampledBatchDraw.query.filter_by(round_id=round.id)
-            .join(Batch)
-            .join(Jurisdiction)
-            .with_entities(Jurisdiction.name, Batch.name)
-            .all()
-        )
-        jurisdiction_name_to_id = dict(
-            Jurisdiction.query.filter_by(election_id=election.id).with_entities(
-                Jurisdiction.name, Jurisdiction.id
-            )
-        )
-        contests = list(election.contests)
-        combined_batches = group_combined_batches(
-            Batch.query.join(Jurisdiction)
-            .filter_by(election_id=election.id)
-            .filter(Batch.combined_batch_name.isnot(None))
-            .all()
-        )
-        all_combined_batch_keys = {
-            (sub_batch.jurisdiction.name, sub_batch.name)
-            for combined_batch in combined_batches
-            for sub_batch in combined_batch["sub_batches"]
-        }
-        representative_combined_batch_keys = {
-            (
-                combined_batch["representative_batch"].jurisdiction.name,
-                combined_batch["representative_batch"].name,
-            )
-            for combined_batch in combined_batches
-        }
-
-        # If a batch has a discrepancy in multiple contests, the discrepancy count will be incremented
-        # multiple times. In other words, the discrepancy count represents the number of batch-contest
-        # pairs with discrepancies, not the number of batches with discrepancies.
-        for contest in contests:
-            reported_batch_results = batch_tallies(contest)
-            audited_batch_results = sampled_batch_results(
-                contest, include_non_rla_batches=True
-            )
-            for batch_key, audited_batch_result in audited_batch_results.items():
-
-                # Special case: for combined batches, only count discrepancies in the representative batch
-                if (
-                    batch_key in all_combined_batch_keys
-                    and batch_key not in representative_combined_batch_keys
-                ):
-                    continue
-
-                if batch_key in batch_keys_in_round:
-                    vote_deltas = batch_vote_deltas(
-                        reported_batch_results[batch_key][contest.id],
-                        audited_batch_result[contest.id],
-                    )
-                    if vote_deltas:
-                        jurisdiction_name, _ = batch_key
-                        jurisdiction_id = jurisdiction_name_to_id[jurisdiction_name]
-                        discrepancy_count_by_jurisdiction[jurisdiction_id] += 1
-
-    else:
-        raise Conflict(
-            "Discrepancy counts are only available for ballot comparison and batch comparison audits"
-        )
-
-    return jsonify(
-        {
-            jurisdiction.id: discrepancy_count_by_jurisdiction[jurisdiction.id]
-            for jurisdiction in election.jurisdictions
-        }
-    )
 
 
 DiscrepanciesByJurisdiction = Dict[

--- a/server/tests/api/test_jurisdictions.py
+++ b/server/tests/api/test_jurisdictions.py
@@ -396,41 +396,6 @@ def test_jurisdictions_round_status_offline(
     snapshot.assert_match(jurisdictions[0]["currentRoundStatus"])
 
 
-def test_discrepancy_counts_wrong_audit_type(
-    client: FlaskClient,
-    election_id: str,
-    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
-    round_1_id: str,  # pylint: disable=unused-argument
-):
-    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
-    assert rv.status_code == 409
-    assert json.loads(rv.data) == {
-        "errors": [
-            {
-                "errorType": "Conflict",
-                "message": "Discrepancy counts are only available for ballot comparison and batch comparison audits",
-            }
-        ]
-    }
-
-
-def test_discrepancy_counts_before_audit_launch(
-    client: FlaskClient,
-    election_id: str,
-    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
-):
-    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
-    assert rv.status_code == 409
-    assert json.loads(rv.data) == {
-        "errors": [
-            {
-                "errorType": "Conflict",
-                "message": "Audit not started",
-            }
-        ]
-    }
-
-
 def test_discrepancy_before_audit_launch(
     client: FlaskClient,
     election_id: str,

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -331,13 +331,6 @@ def test_batch_comparison_round_2(
     snapshot.assert_match(jurisdictions[0]["currentRoundStatus"])
     snapshot.assert_match(jurisdictions[1]["currentRoundStatus"])
 
-    # Check discrepancy counts
-    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
-    discrepancy_counts = json.loads(rv.data)
-    assert discrepancy_counts[jurisdictions[0]["id"]] == len(expected_discrepancies_j1)
-    # In J2, single sampled batch hasn't been audited yet. The frontend won't show this to the user.
-    assert discrepancy_counts[jurisdictions[1]["id"]] == 1
-
     # Check discrepancies
     rv = client.get(f"/api/election/{election_id}/discrepancy")
     discrepancies = json.loads(rv.data)
@@ -426,12 +419,6 @@ def test_batch_comparison_round_2(
     jurisdictions = json.loads(rv.data)["jurisdictions"]
     snapshot.assert_match(jurisdictions[0]["currentRoundStatus"])
     snapshot.assert_match(jurisdictions[1]["currentRoundStatus"])
-
-    # Check discrepancy counts
-    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
-    discrepancy_counts = json.loads(rv.data)
-    assert discrepancy_counts[jurisdictions[0]["id"]] == len(expected_discrepancies_j1)
-    assert discrepancy_counts[jurisdictions[1]["id"]] == len(expected_discrepancies_j2)
 
     # End the round
     rv = client.post(f"/api/election/{election_id}/round/current/finish")
@@ -708,12 +695,6 @@ def test_batch_comparison_batches_sampled_multiple_times(
     jurisdictions = json.loads(rv.data)["jurisdictions"]
     snapshot.assert_match(jurisdictions[0]["currentRoundStatus"])
     snapshot.assert_match(jurisdictions[1]["currentRoundStatus"])
-
-    # Check discrepancy counts
-    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
-    discrepancy_counts = json.loads(rv.data)
-    assert discrepancy_counts[jurisdictions[0]["id"]] == 0
-    assert discrepancy_counts[jurisdictions[1]["id"]] == 0
 
     # Check discrepancies
     rv = client.get(f"/api/election/{election_id}/discrepancy")
@@ -1083,13 +1064,8 @@ def test_batch_comparison_combined_batches(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches/finalize",
     )
 
-    # Check discrepancy counts
-    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
-    discrepancy_counts = json.loads(rv.data)
-    assert discrepancy_counts[jurisdiction_ids[0]] == 1
-
     # Check discrepancies
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/discrepancy")
     discrepancies = json.loads(rv.data)
     choices = contests[0]["choices"]

--- a/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
+++ b/server/tests/batch_comparison/test_multi_contest_batch_comparison.py
@@ -684,15 +684,8 @@ def test_multi_contest_batch_comparison_end_to_end(
     )
     assert_ok(rv)
 
-    # Check discrepancy counts
-    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
-    discrepancy_counts = json.loads(rv.data)
-    assert discrepancy_counts[jurisdictions[0]["id"]] == 4
-    assert discrepancy_counts[jurisdictions[1]["id"]] == 0
-    assert discrepancy_counts[jurisdictions[2]["id"]] == 1
-
     # Check discrepancies
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/discrepancy")
     discrepancies = json.loads(rv.data)
     assert (
@@ -894,15 +887,8 @@ def test_multi_contest_batch_comparison_round_2(
     )
     assert_ok(rv)
 
-    # Check discrepancy counts
-    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
-    discrepancy_counts = json.loads(rv.data)
-    assert discrepancy_counts[jurisdiction_ids[0]] == 1
-    assert discrepancy_counts[jurisdiction_ids[1]] == 0
-    assert discrepancy_counts[jurisdiction_ids[2]] == 0
-
     # Check discrepancies
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/discrepancy")
     discrepancies = json.loads(rv.data)
 
@@ -1051,15 +1037,8 @@ def test_multi_contest_batch_comparison_round_2(
     )
     assert_ok(rv)
 
-    # Check discrepancy counts
-    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/discrepancy-counts")
-    discrepancy_counts = json.loads(rv.data)
-    assert discrepancy_counts[jurisdiction_ids[0]] == 0
-    assert discrepancy_counts[jurisdiction_ids[1]] == 0
-    assert discrepancy_counts[jurisdiction_ids[2]] == 0
-
     # Check discrepancies
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/discrepancy")
     discrepancies = json.loads(rv.data)
 


### PR DESCRIPTION
Now that we load the discrepancies themselves, we don't need to make a separate query to load the counts - we can just count them.