### PR TITLE
Make list of audits for support users easier to navigate

### DIFF
--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -15,15 +15,15 @@ import AuthDataProvider from '../UserContext'
 import { supportApiCalls } from '../_mocks'
 import {
   IOrganizationBase,
-  IOrganization,
-  IElectionBase,
   IElection,
   IJurisdictionBase,
   IJurisdiction,
   IRound,
-  IElectionWithOrg,
   IBatch,
   ICombinedBatch,
+  IElectionForSupport,
+  IOrganizationForSupport,
+  IElectionBase,
 } from './support-api'
 
 const mockOrganizationBase: IOrganizationBase = {
@@ -37,6 +37,11 @@ const mockElectionBase: IElectionBase = {
   auditType: 'BALLOT_POLLING',
   online: true,
   deletedAt: null,
+}
+
+const mockElectionForSupport: IElectionForSupport = {
+  ...mockElectionBase,
+  organization: mockOrganizationBase,
   createdAt: '2022-02-08T21:03:35.487Z',
   currentRound: null,
 }
@@ -46,11 +51,11 @@ const mockJurisdictionBase: IJurisdictionBase = {
   name: 'Jurisdiction 1',
 }
 
-const mockOrganization: IOrganization = {
+const mockOrganization: IOrganizationForSupport = {
   ...mockOrganizationBase,
   defaultState: null,
   elections: [
-    mockElectionBase,
+    mockElectionForSupport,
     {
       id: 'election-id-2',
       auditName: 'Audit 2',
@@ -58,6 +63,7 @@ const mockOrganization: IOrganization = {
       online: false,
       deletedAt: null,
       createdAt: '2022-02-08T21:03:35.487Z',
+      organization: mockOrganizationBase,
       currentRound: {
         id: 'round-2',
         endedAt: null,
@@ -71,6 +77,7 @@ const mockOrganization: IOrganization = {
       online: false,
       deletedAt: '2022-03-08T21:03:35.487Z',
       createdAt: '2022-02-08T21:03:35.487Z',
+      organization: mockOrganizationBase,
       currentRound: {
         id: 'round-3',
         endedAt: '2022-03-07T21:03:35.487Z',
@@ -84,6 +91,7 @@ const mockOrganization: IOrganization = {
       online: false,
       deletedAt: null,
       createdAt: '2022-02-08T21:03:35.487Z',
+      organization: mockOrganizationBase,
       currentRound: {
         id: 'round-3',
         endedAt: '2022-03-07T21:03:35.487Z',
@@ -97,13 +105,8 @@ const mockOrganization: IOrganization = {
   ],
 }
 
-const mockElectionWithOrg: IElectionWithOrg = {
-  ...mockElectionBase,
-  organization: mockOrganizationBase,
-}
-
 const mockElection: IElection = {
-  ...mockElectionWithOrg,
+  ...mockElectionForSupport,
   jurisdictions: [
     mockJurisdictionBase,
     {
@@ -162,7 +165,7 @@ const apiCalls = {
     },
     response: { status: 'ok' },
   },
-  getOrganization: (response: IOrganization) => ({
+  getOrganization: (response: IOrganizationForSupport) => ({
     url: '/api/support/organizations/organization-id-1',
     response,
   }),
@@ -188,7 +191,7 @@ const apiCalls = {
     options: { method: 'DELETE' },
     response: { status: 'ok' },
   },
-  getActiveElections: (response: IElectionWithOrg[]) => ({
+  getActiveElections: (response: IElectionForSupport[]) => ({
     url: '/api/support/elections/active',
     response,
   }),
@@ -285,11 +288,12 @@ describe('Support Tools', () => {
     const expectedCalls = [
       supportApiCalls.getUser,
       apiCalls.getActiveElections([
-        mockElectionWithOrg,
+        mockElectionForSupport,
         {
-          ...mockElectionWithOrg,
+          ...mockElectionForSupport,
           id: 'election-id-2',
           auditName: 'Audit 2',
+          organization: mockOrganizationBase,
           currentRound: { id: 'round-1', endedAt: null, roundNum: 1 },
         },
       ]),

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -37,6 +37,8 @@ const mockElectionBase: IElectionBase = {
   auditType: 'BALLOT_POLLING',
   online: true,
   deletedAt: null,
+  createdAt: '2022-02-08T21:03:35.487Z',
+  currentRound: null,
 }
 
 const mockJurisdictionBase: IJurisdictionBase = {
@@ -55,6 +57,12 @@ const mockOrganization: IOrganization = {
       auditType: 'BALLOT_COMPARISON',
       online: false,
       deletedAt: null,
+      createdAt: '2022-02-08T21:03:35.487Z',
+      currentRound: {
+        id: 'round-2',
+        endedAt: null,
+        roundNum: 1,
+      },
     },
     {
       id: 'election-id-3',
@@ -62,6 +70,25 @@ const mockOrganization: IOrganization = {
       auditType: 'BATCH_COMPARISON',
       online: false,
       deletedAt: '2022-03-08T21:03:35.487Z',
+      createdAt: '2022-02-08T21:03:35.487Z',
+      currentRound: {
+        id: 'round-3',
+        endedAt: '2022-03-07T21:03:35.487Z',
+        roundNum: 1,
+      },
+    },
+    {
+      id: 'election-id-3',
+      auditName: 'Audit 4',
+      auditType: 'BATCH_COMPARISON',
+      online: false,
+      deletedAt: null,
+      createdAt: '2022-02-08T21:03:35.487Z',
+      currentRound: {
+        id: 'round-3',
+        endedAt: '2022-03-07T21:03:35.487Z',
+        roundNum: 1,
+      },
     },
   ],
   auditAdmins: [
@@ -263,6 +290,7 @@ describe('Support Tools', () => {
           ...mockElectionWithOrg,
           id: 'election-id-2',
           auditName: 'Audit 2',
+          currentRound: { id: 'round-1', endedAt: null, roundNum: 1 },
         },
       ]),
       apiCalls.getOrganizations([]),
@@ -272,9 +300,11 @@ describe('Support Tools', () => {
       const { history } = renderRoute('/support')
 
       await screen.findByRole('heading', { name: 'Active Audits' })
-      screen.getByRole('link', { name: 'Organization 1 Audit 2' })
+      screen.getByRole('link', {
+        name: 'Organization 1 Audit 2 Round 1 In Progress',
+      })
       userEvent.click(
-        screen.getByRole('link', { name: 'Organization 1 Audit 1' })
+        screen.getByRole('link', { name: 'Organization 1 Audit 1 Not Started' })
       )
       await screen.findByRole('heading', { name: 'Audit 1' })
       expect(history.location.pathname).toEqual('/support/audits/election-id-1')
@@ -380,13 +410,14 @@ describe('Support Tools', () => {
       await screen.findByRole('heading', { name: 'Organization 1' })
 
       screen.getByRole('heading', { name: 'Audits' })
-      screen.getByRole('link', { name: 'Audit 2' })
-      screen.getByRole('link', { name: 'Audit 1' })
+      screen.getByRole('link', { name: 'Audit 2 Round 1 In Progress' })
+      screen.getByRole('link', { name: 'Audit 4 Completed' })
+      screen.getByRole('link', { name: 'Audit 1 Not Started' })
 
       screen.getByRole('heading', { name: 'Deleted Audits' })
       screen.getByRole('row', { name: /Audit 3/ })
 
-      userEvent.click(screen.getByRole('link', { name: 'Audit 1' }))
+      userEvent.click(screen.getByRole('link', { name: 'Audit 1 Not Started' }))
       await screen.findByRole('heading', { name: 'Audit 1' })
       expect(history.location.pathname).toEqual('/support/audits/election-id-1')
     })

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -48,6 +48,7 @@ import { List, LinkItem } from './List'
 import Breadcrumbs from './Breadcrumbs'
 import { stateOptions, states } from '../AuditAdmin/Setup/Settings/states'
 import StatusTag from '../Atoms/StatusTag'
+import { sortBy } from '../../utils/array'
 
 const Table = styled(HTMLTable)`
   margin: 10px 0;
@@ -239,8 +240,8 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
 
   const { name, defaultState, elections, auditAdmins } = organization.data
 
-  const sortedElections = elections.sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  const sortedElections = sortBy(elections, a =>
+    new Date(a.createdAt).getTime()
   )
 
   const onClickRemoveAuditAdmin = (auditAdmin: IAuditAdmin) =>

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -10,7 +10,13 @@ export interface IOrganizationBase {
 
 export interface IOrganization extends IOrganizationBase {
   defaultState: string | null
-  elections: IElectionBase[]
+  elections: IElection[]
+  auditAdmins: IAuditAdmin[]
+}
+
+export interface IOrganizationForSupport extends IOrganizationBase {
+  defaultState: string | null
+  elections: IElectionForSupport[]
   auditAdmins: IAuditAdmin[]
 }
 
@@ -24,8 +30,6 @@ export interface IElectionBase {
     | 'HYBRID'
   online: boolean
   deletedAt: string | null
-  createdAt: string
-  currentRound: IRound | null
 }
 
 export interface IAuditAdmin {
@@ -46,6 +50,11 @@ export interface IElectionWithOrg extends IElectionBase {
 export interface IElection extends IElectionWithOrg {
   jurisdictions: IJurisdictionBase[]
   rounds: IRound[]
+}
+
+export interface IElectionForSupport extends IElectionWithOrg {
+  createdAt: string
+  currentRound: IRound | null
 }
 
 export interface IJurisdictionBase {
@@ -82,7 +91,7 @@ export interface ICombinedBatch {
 }
 
 export const useActiveElections = () =>
-  useQuery<IElectionWithOrg[], Error>(['elections', 'active'], () =>
+  useQuery<IElectionForSupport[], Error>(['elections', 'active'], () =>
     fetchApi('/api/support/elections/active')
   )
 
@@ -107,8 +116,9 @@ export const useCreateOrganization = () => {
 }
 
 export const useOrganization = (organizationId: string) =>
-  useQuery<IOrganization, Error>(['organizations', organizationId], () =>
-    fetchApi(`/api/support/organizations/${organizationId}`)
+  useQuery<IOrganizationForSupport, Error>(
+    ['organizations', organizationId],
+    () => fetchApi(`/api/support/organizations/${organizationId}`)
   )
 
 export const useUpdateOrganization = (organizationId: string) => {

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -24,6 +24,8 @@ export interface IElectionBase {
     | 'HYBRID'
   online: boolean
   deletedAt: string | null
+  createdAt: string
+  currentRound: IRound | null
 }
 
 export interface IAuditAdmin {

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -69,6 +69,10 @@ def test_support_get_organization(client: FlaskClient, org_id: str, election_id:
                     "deletedAt": None,
                     "createdAt": assert_is_date,
                     "currentRound": None,
+                    "organization": {
+                        "id": org_id,
+                        "name": "Test Org test_support_get_organization",
+                    },
                 }
             ],
             "auditAdmins": [
@@ -99,6 +103,10 @@ def test_support_get_organization_round(
                     "auditType": "BALLOT_POLLING",
                     "online": True,
                     "deletedAt": None,
+                    "organization": {
+                        "id": org_id,
+                        "name": "Test Org test_support_get_organization_round",
+                    },
                     "createdAt": assert_is_date,
                     "currentRound": {"id": round_1_id, "endedAt": None, "roundNum": 1},
                 }

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -67,6 +67,40 @@ def test_support_get_organization(client: FlaskClient, org_id: str, election_id:
                     "auditType": "BALLOT_POLLING",
                     "online": True,
                     "deletedAt": None,
+                    "createdAt": assert_is_date,
+                    "currentRound": None,
+                }
+            ],
+            "auditAdmins": [
+                {
+                    "id": User.query.filter_by(email=DEFAULT_AA_EMAIL).one().id,
+                    "email": DEFAULT_AA_EMAIL,
+                }
+            ],
+        },
+    )
+
+
+def test_support_get_organization_round(
+    client: FlaskClient, org_id: str, election_id: str, round_1_id: str
+):
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+    rv = client.get(f"/api/support/organizations/{org_id}")
+    compare_json(
+        json.loads(rv.data),
+        {
+            "id": org_id,
+            "name": "Test Org test_support_get_organization_round",
+            "defaultState": None,
+            "elections": [
+                {
+                    "id": election_id,
+                    "auditName": "Test Audit test_support_get_organization_round",
+                    "auditType": "BALLOT_POLLING",
+                    "online": True,
+                    "deletedAt": None,
+                    "createdAt": assert_is_date,
+                    "currentRound": {"id": round_1_id, "endedAt": None, "roundNum": 1},
                 }
             ],
             "auditAdmins": [
@@ -182,17 +216,22 @@ def test_support_list_active_elections(
     assert other_election is None
 
     election = next(election for election in elections if election["id"] == election_id)
-    assert election == {
-        "id": election_id,
-        "auditName": "Test Audit test_support_list_active_elections",
-        "auditType": "BALLOT_POLLING",
-        "online": True,
-        "deletedAt": None,
-        "organization": {
-            "id": org_id,
-            "name": "Test Org test_support_list_active_elections",
+    compare_json(
+        election,
+        {
+            "id": election_id,
+            "auditName": "Test Audit test_support_list_active_elections",
+            "auditType": "BALLOT_POLLING",
+            "online": True,
+            "deletedAt": None,
+            "createdAt": assert_is_date,
+            "currentRound": None,
+            "organization": {
+                "id": org_id,
+                "name": "Test Org test_support_list_active_elections",
+            },
         },
-    }
+    )
 
 
 def test_support_get_election(


### PR DESCRIPTION
Tweaks the list of audits on the support users home screen and the per-organization view to include a "status" tag with one of the following statuses: 

- Not Started - Round 1 has not started
- Round X In Progress
- Completed

The active audits list on the home page is already querying for audits updated in the last 2 weeks, I tweaked this to order the results by the last update date as I have personally found this confusing behavior. 

The organization page now orders audits by creation date (most recent first) to match the audit admin view 

New Screens 
<img width="1235" alt="Screenshot 2024-11-07 at 3 05 54 PM" src="https://github.com/user-attachments/assets/ea036de3-000e-41eb-b4ce-c43550daa16f">
<img width="1064" alt="Screenshot 2024-11-07 at 3 05 45 PM" src="https://github.com/user-attachments/assets/14f8b5f5-3bfd-4e91-8d53-21141ec7dc3b">


