### PR TITLE
Expect zipped CVR file uploads in audit admin view

### DIFF
--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
@@ -163,7 +163,10 @@ const CvrsFileUpload = ({
         {...cvrsUpload}
         uploadFiles={uploadFiles}
         acceptFileTypes={
-          selectedCvrFileType === CvrFileType.HART ? ['zip', 'csv'] : ['csv']
+          selectedCvrFileType &&
+          [CvrFileType.HART, CvrFileType.ESS].includes(selectedCvrFileType)
+            ? ['zip']
+            : ['csv']
         }
         allowMultipleFiles={false}
         uploadDisabled={uploadDisabled || (!cvrs.file && !selectedCvrFileType)}


### PR DESCRIPTION
We already changed the jurisdiction manager UI for uploading ES&S CVR files to accept zips rather than CSVs, but didn't also change this audit admin interface. (See #2012)

Had to manual test since there's not an easy way to automated test this that I know of.