### PR TITLE
Prevent race conditions when uploading/removing jurisdiction files

### DIFF
--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -18,6 +18,7 @@ from ..worker.tasks import (
     create_background_task,
 )
 from ..util.file import (
+    any_jurisdiction_file_is_processing,
     FileType,
     get_file_upload_url,
     get_jurisdiction_folder_path,
@@ -203,9 +204,9 @@ def validate_batch_tallies_upload(election: Election, jurisdiction: Jurisdiction
             "Must upload ballot manifest before uploading candidate totals by batch."
         )
 
-    if jurisdiction.manifest_file.is_processing():
+    if any_jurisdiction_file_is_processing(jurisdiction):
         raise Conflict(
-            "Cannot update candidate totals by batch while ballot manifest is processing."
+            "Cannot upload candidate totals by batch while any file upload is processing."
         )
 
 
@@ -335,6 +336,10 @@ def clear_batch_tallies(
     election: Election,  # pylint: disable=unused-argument
     jurisdiction: Jurisdiction,
 ):
+    if any_jurisdiction_file_is_processing(jurisdiction):
+        raise Conflict(
+            "Cannot remove candidate totals by batch while any file upload is processing."
+        )
     if jurisdiction.batch_tallies_file:
         db_session.delete(jurisdiction.batch_tallies_file)
         clear_batch_tallies_data(jurisdiction)

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -3009,7 +3009,7 @@ def test_cvrs_get_upload_url(
         assert response_data["fields"]["key"].endswith(".zip")
 
 
-def test_replace_cvrs_fails_while_processing_manifest_file(
+def test_upload_cvrs_fails_while_processing_manifest_file(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],
@@ -3041,7 +3041,115 @@ def test_replace_cvrs_fails_while_processing_manifest_file(
             "errors": [
                 {
                     "errorType": "Conflict",
-                    "message": "Cannot replace CVRs while manifest file is processing.",
+                    "message": "Cannot upload CVRs while any file upload is processing.",
+                }
+            ]
+        }
+
+
+def test_remove_cvrs_fails_while_processing_manifest_file(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    with no_automatic_task_execution():
+        # Replace the manifest file with a new one, but don't process it yet
+        rv = upload_ballot_manifest(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+        assert_ok(rv)
+
+        rv = client.delete(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/cvrs"
+        )
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot remove CVRs while any file upload is processing.",
+                }
+            ]
+        }
+
+
+def test_upload_ballot_manifest_fails_while_processing_cvr_file(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    manifests,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    with no_automatic_task_execution():
+        # Upload a CVR file, but don't process it yet
+        rv = upload_cvrs(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+            "DOMINION",
+        )
+        assert_ok(rv)
+
+        rv = upload_ballot_manifest(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot upload ballot manifest while any file upload is processing.",
+                }
+            ]
+        }
+
+
+def test_remove_ballot_manifest_fails_while_processing_cvr_file(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    manifests,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    with no_automatic_task_execution():
+        # Upload a CVR file, but don't process it yet
+        rv = upload_cvrs(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+            "DOMINION",
+        )
+        assert_ok(rv)
+
+        rv = client.delete(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest"
+        )
+
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot remove ballot manifest while any file upload is processing.",
                 }
             ]
         }

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -1845,7 +1845,7 @@ def test_batch_inventory_tabulator_status_get_upload_url(
     assert response_data["fields"]["key"].endswith(".xml")
 
 
-def test_replace_tabulator_status_file_while_cvr_file_is_processing_fails(
+def test_upload_tabulator_status_file_while_cvr_file_is_processing_fails(
     client: FlaskClient,
     election_id: str,
     jurisdiction_ids: List[str],
@@ -1886,7 +1886,157 @@ def test_replace_tabulator_status_file_while_cvr_file_is_processing_fails(
             "errors": [
                 {
                     "errorType": "Conflict",
-                    "message": "Cannot update tabulator status while CVR file is being processed.",
+                    "message": "Cannot upload tabulator status while CVR file is processing.",
+                }
+            ]
+        }
+
+
+def test_remove_tabulator_status_file_while_cvr_file_is_processing_fails(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_id: str,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
+    with no_automatic_task_execution():
+        # Upload CVR file, but don't process it
+        rv = upload_batch_inventory_cvr(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+        assert_ok(rv)
+
+        rv = client.delete(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/tabulator-status"
+        )
+
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot remove tabulator status while CVR file is processing.",
+                }
+            ]
+        }
+
+
+def test_upload_cvr_file_while_tabulator_status_file_is_processing_fails(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_id: str,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
+    # Upload CVR file
+    rv = upload_batch_inventory_cvr(
+        client,
+        io.BytesIO(TEST_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
+    )
+    assert_ok(rv)
+
+    with no_automatic_task_execution():
+        # Upload tabulator status file, but don't process it
+        rv = upload_batch_inventory_tabulator_status(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+        assert_ok(rv)
+
+        rv = upload_batch_inventory_cvr(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot upload CVRs while tabulator status file is processing.",
+                }
+            ]
+        }
+
+
+def test_remove_cvr_file_while_tabulator_status_file_is_processing_fails(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: List[str],
+    contest_id: str,  # pylint: disable=unused-argument
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    # Set system type
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.DOMINION},
+    )
+    assert_ok(rv)
+
+    # Upload CVR file
+    rv = upload_batch_inventory_cvr(
+        client,
+        io.BytesIO(TEST_CVR.encode()),
+        election_id,
+        jurisdiction_ids[0],
+    )
+    assert_ok(rv)
+
+    with no_automatic_task_execution():
+        # Upload tabulator status file, but don't process it
+        rv = upload_batch_inventory_tabulator_status(
+            client,
+            io.BytesIO(b"does not matter"),
+            election_id,
+            jurisdiction_ids[0],
+        )
+        assert_ok(rv)
+
+        rv = client.delete(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/cvr"
+        )
+
+        assert rv.status_code == 409
+        assert json.loads(rv.data) == {
+            "errors": [
+                {
+                    "errorType": "Conflict",
+                    "message": "Cannot remove CVRs while tabulator status file is processing.",
                 }
             ]
         }

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -242,3 +242,14 @@ def validate_mimetype(mime_type: str, expected_file_types: List[FileType]) -> No
     expected_types_str = " or ".join([type.value for type in expected_file_types])
     # If we are expecting a CSV file have a clearer error message for that case
     raise BadRequest(f"Please submit a valid file. Expected: {expected_types_str}")
+
+
+def any_jurisdiction_file_is_processing(jurisdiction: Jurisdiction) -> bool:
+    return bool(
+        (jurisdiction.manifest_file and jurisdiction.manifest_file.is_processing())
+        or (jurisdiction.cvr_file and jurisdiction.cvr_file.is_processing())
+        or (
+            jurisdiction.batch_tallies_file
+            and jurisdiction.batch_tallies_file.is_processing()
+        )
+    )


### PR DESCRIPTION
Closes #1532 
Builds on https://github.com/votingworks/arlo/pull/2043

Adds guards to all jurisdiction file uploads to make sure that a JM can't accidentally remove or change a file that another pending file upload depends on. To keep things simple, I added guards on all files. While there are a few cases that may actually be safe, it felt easier to just have a blanket rule.

Note that I didn't have to add any more guards for election-level files, since those were already sufficient (we don't currently have "delete" functionality for those files, only replace).