### PR TITLE
Batch audit file prep tool: Skip Hart overvotes

### DIFF
--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -510,10 +510,20 @@ def process_batch_inventory_cvr_file(
             contest_results = parse_contest_results(cvr_xml)
             for contest in contests:
                 choices = contest_results.get(contest.name, set())
+                validated_choice_ids = []
                 for choice_name in choices:
-                    choice_id = validate_choice_name_and_get_choice_id(choice_name)
-                    if choice_id is not None:
-                        batch_tallies[batch_key][choice_id] += 1
+                    validated_choice_id = validate_choice_name_and_get_choice_id(
+                        choice_name
+                    )
+                    if validated_choice_id:
+                        validated_choice_ids.append(validated_choice_id)
+
+                # Skip overvotes
+                if len(validated_choice_ids) > contest.votes_allowed:
+                    continue
+
+                for choice_id in validated_choice_ids:
+                    batch_tallies[batch_key][choice_id] += 1
 
         # Set explicit zeros for choices with zero votes in a batch to avoid KeyErrors when
         # generating files and to make sure every batch is included even if it has no votes for the contest(s)


### PR DESCRIPTION
As Verified Voting tried using the batch audit file prep tool for Lancaster this morning, we encountered an overvoted Hart CVR which the code didn't know to skip. This resulted in a mismatch between the generated ballot manifest and candidate-totals-by-batch file. We didn't have a handy example of what an overvoted Hart CVR looked like as we were developing.

We have an example now! I'm quickly patching the code to unblock Lancaster/PA. We'll add additional tests after the fact. I have tested that this fix works on Lancaster's CVRs. And existing tests do still pass, so we aren't skipping where we shouldn't be.