### PR TITLE
Adjust active election filtering

### DIFF
--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -560,11 +560,8 @@ def get_last_login_by_jurisdiction(election: Election):
             ActivityLogRecord.organization_id == election.organization_id,
             ActivityLogRecord.timestamp > query_timestamp_after,
             ActivityLogRecord.activity_name == "JurisdictionAdminLogin",
-            # SQLAlchemy requires == operator. See https://stackoverflow.com/questions/5602918/select-null-values-in-sqlalchemy
-            # pylint: disable-next=singleton-comparison
-            ActivityLogRecord.info["error"].astext == None,
-            # pylint: disable-next=singleton-comparison
-            ActivityLogRecord.info["base"]["support_user_email"].astext == None,
+            ActivityLogRecord.info["error"].astext.is_(None),
+            ActivityLogRecord.info["base"]["support_user_email"].astext.is_(None),
         )
         .order_by(Jurisdiction.id, ActivityLogRecord.timestamp.desc())
         .distinct(Jurisdiction.id)

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -94,7 +94,7 @@ def list_active_elections():
         )
         .filter(
             ActivityLogRecord.timestamp
-            > datetime.now(timezone.utc) - timedelta(days=14),
+            > datetime.now(timezone.utc) - timedelta(days=7),
             # SQLAlchemy requires == operator. See https://stackoverflow.com/questions/5602918/select-null-values-in-sqlalchemy
             # pylint: disable-next=singleton-comparison
             Election.deleted_at == None,

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -95,9 +95,7 @@ def list_active_elections():
         .filter(
             ActivityLogRecord.timestamp
             > datetime.now(timezone.utc) - timedelta(days=7),
-            # SQLAlchemy requires == operator. See https://stackoverflow.com/questions/5602918/select-null-values-in-sqlalchemy
-            # pylint: disable-next=singleton-comparison
-            Election.deleted_at == None,
+            Election.deleted_at.is_(None),
         )
         .order_by(ActivityLogRecord.timestamp.desc())
         .options(

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -94,7 +94,10 @@ def list_active_elections():
         )
         .filter(
             ActivityLogRecord.timestamp
-            > datetime.now(timezone.utc) - timedelta(days=14)
+            > datetime.now(timezone.utc) - timedelta(days=14),
+            # SQLAlchemy requires == operator. See https://stackoverflow.com/questions/5602918/select-null-values-in-sqlalchemy
+            # pylint: disable-next=singleton-comparison
+            Election.deleted_at == None,
         )
         .order_by(ActivityLogRecord.timestamp.desc())
         .options(

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -241,6 +241,12 @@ def test_support_list_active_elections(
         },
     )
 
+    # Mark election as deleted and make sure it's not visible
+    client.delete(f"/api/election/{election_id}")
+    rv = client.get("/api/support/elections/active")
+    elections = json.loads(rv.data)
+    assert len(elections) == 0
+
 
 def test_support_get_election(
     client: FlaskClient,

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -210,7 +210,7 @@ def test_support_list_active_elections(
         ActivityLogRecord.info["base"]["election_id"].as_string() == older_election_id
     ).all()
     for activity in older_election_activities:
-        activity.timestamp = activity.timestamp - timedelta(days=14)
+        activity.timestamp = activity.timestamp - timedelta(days=7)
     db_session.commit()
 
     set_support_user(client, DEFAULT_SUPPORT_EMAIL)

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -245,7 +245,10 @@ def test_support_list_active_elections(
     client.delete(f"/api/election/{election_id}")
     rv = client.get("/api/support/elections/active")
     elections = json.loads(rv.data)
-    assert len(elections) == 0
+    election = next(
+        (election for election in elections if election["id"] == election_id), None
+    )
+    assert election is None
 
 
 def test_support_get_election(


### PR DESCRIPTION
https://github.com/votingworks/arlo/issues/1891

* Filters soft-deleted elections from support users' active elections page
* Reduces active window from 14 to 7 days


**Previous broken behavior**
Soft-deleted elections are listed, allowing user to click in and eventually trigger error.

https://github.com/user-attachments/assets/87ef69d7-97fc-48cb-9bfd-928af8b411de

**After filtering**
Soft-deleted election no longer listed.

![Screenshot 2024-11-18 at 2 14 23 PM](https://github.com/user-attachments/assets/49ae1e5d-19e3-46e2-82e2-0fb38fb3ca91)

