### PR TITLE
Truncate long error messages in Slack activity notifications

### DIFF
--- a/server/activity_log/slack_worker.py
+++ b/server/activity_log/slack_worker.py
@@ -190,7 +190,11 @@ def slack_message(activity: activity_log.Activity):
                             dict(
                                 type="context",
                                 elements=[
-                                    dict(type="mrkdwn", text=f":x: {activity.error}")
+                                    dict(
+                                        type="mrkdwn",
+                                        # Truncate long error messages to avoid Slack API limits
+                                        text=f":x: {activity.error[:4000]}",
+                                    )
                                 ],
                             )
                             if activity.error


### PR DESCRIPTION
Otherwise we get a `msg_too_long` error. I based the limit of 4000 characters on the Slack API docs: https://api.slack.com/methods/chat.postMessage#truncating