### PR TITLE
Shorten unbounded file processing error messages

### DIFF
--- a/server/api/batch_tallies.py
+++ b/server/api/batch_tallies.py
@@ -38,7 +38,7 @@ from ..util.csv_parse import (
     CSVValueType,
     CSVColumnType,
 )
-from ..util.string import format_count
+from ..util.string import comma_join_until_limit, format_count
 from ..activity_log.activity_log import UploadFile, activity_base, record_activity
 
 BATCH_TALLIES_FILE_PREFIX = "batch_tallies"
@@ -100,12 +100,14 @@ def process_batch_tallies_file(
             raise UserError(
                 "Batch names must match the ballot manifest file."
                 + (
-                    "\nFound extra batch names: " + ", ".join(extra_batch_names)
+                    "\nFound extra batch names: "
+                    + comma_join_until_limit(extra_batch_names, 5)
                     if extra_batch_names
                     else ""
                 )
                 + (
-                    "\nFound missing batch names: " + ", ".join(missing_batch_names)
+                    "\nFound missing batch names: "
+                    + comma_join_until_limit(missing_batch_names, 5)
                     if missing_batch_names
                     else ""
                 )

--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -33,6 +33,7 @@ from werkzeug.exceptions import BadRequest, NotFound, Conflict
 from sqlalchemy import func, and_
 from sqlalchemy.orm import Session
 
+
 from . import api
 from ..database import db_session, engine as db_engine
 from ..models import *  # pylint: disable=wildcard-import
@@ -66,6 +67,7 @@ from ..util.csv_parse import (
 )
 from ..util.collections import find_first_duplicate
 from ..util.hart_parse import find_xml, parse_contest_results
+from ..util.string import comma_join_until_limit
 from ..audit_math.suite import HybridPair
 from ..activity_log.activity_log import UploadFile, activity_base, record_activity
 
@@ -1071,7 +1073,7 @@ def parse_hart_cvrs(
         wrapper_zip_file.close()
         if len(nonCsvZipFiles) > 0:
             raise UserError(
-                f"Unsupported file type. Expected either a ZIP file or a CSV file, but found {(','.join(nonCsvZipFiles))}."
+                f"Unsupported file type. Expected either a ZIP file or a CSV file, but found {comma_join_until_limit(nonCsvZipFiles, 3)}."
             )
 
     def parse_scanned_ballot_information_file(

--- a/server/tests/ballot_comparison/test_cvrs.py
+++ b/server/tests/ballot_comparison/test_cvrs.py
@@ -2824,6 +2824,31 @@ def test_hart_cvr_upload_processing_validation(
             "expected_status_code": 400,
             "expected_response": "Unsupported file type. Expected either a ZIP file or a CSV file, but found scanned-ballot-information.jpg.",
         },
+        {
+            "cvrs": zip_cvrs(
+                [
+                    (zip_hart_cvrs(HART_CVRS), "cvrs.zip"),
+                    (
+                        string_to_bytes_io(""),
+                        "1.xml",
+                    ),
+                    (
+                        string_to_bytes_io(""),
+                        "2.xml",
+                    ),
+                    (
+                        string_to_bytes_io(""),
+                        "3.xml",
+                    ),
+                    (
+                        string_to_bytes_io(""),
+                        "4.xml",
+                    ),
+                ]
+            ),
+            "expected_status_code": 400,
+            "expected_response": "Unsupported file type. Expected either a ZIP file or a CSV file, but found 1.xml, 2.xml, 3.xml, and 1 more.",
+        },
     ]
 
     for test_case in test_cases:

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -435,6 +435,25 @@ def test_batch_tallies_wrong_batch_names(
                 "Found missing batch names: Batch 3"
             ),
         ),
+        (
+            (
+                b"Batch Name,candidate 1,candidate 2,candidate 3\n"
+                b"Batch 1,1,10,100\n"
+                b"Batch 2,2,20,200\n"
+                b"Batch 3,3,30,300\n"
+                b"Batch 4,4,40,400\n"
+                b"Batch 5,4,40,400\n"
+                b"Batch 6,4,40,400\n"
+                b"Batch 7,4,40,400\n"
+                b"Batch 8,4,40,400\n"
+                b"Batch 9,4,40,400\n"
+                b"Batch 10,4,40,400\n"
+            ),
+            (
+                "Batch names must match the ballot manifest file.\n"
+                "Found extra batch names: Batch 10, Batch 4, Batch 5, Batch 6, Batch 7, and 2 more"
+            ),
+        ),
     ]
     for bad_file, expected_error in bad_files:
         rv = upload_batch_tallies(

--- a/server/util/string.py
+++ b/server/util/string.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 
 # Formats a number using the appropriate singular or plural form of a noun.
@@ -9,3 +9,12 @@ def format_count(count: int, singular: str, plural: str) -> str:
 # Returns `value.strip()` or None if `value` is None
 def strip_optional_string(value: Optional[str]) -> str:
     return (value or "").strip()
+
+
+# Joins a list of strings with commas up to a limit, then lists the remaining count.
+def comma_join_until_limit(items: List[str], limit: int) -> str:
+    num_over_limit = len(items) - limit
+    items_to_join = items[:limit]
+    if num_over_limit > 0:
+        items_to_join.append(f"and {num_over_limit:,} more")
+    return ", ".join(items_to_join)


### PR DESCRIPTION
Shortens two error messages that previously contained arbitrarily long lists of items from the uploaded files. Instead of showing the entire list, just show the first few items to make it easier to read.