### PR TITLE
Auto-restart web dynos regularly

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 release: ./heroku-release-phase.sh
-web: gunicorn server.app:app --preload
+web: gunicorn server.app:app --preload --max-requests 5000 --max-requests-jitter 20
 worker: python -m server.worker.worker
 slack_worker: python -m server.activity_log.slack_worker

--- a/Procfile
+++ b/Procfile
@@ -7,7 +7,7 @@ release: ./heroku-release-phase.sh
 # configure gunicorn to restart each worker after a certain number of requests
 # (with some random jitter). This threshold was set by observing how long it
 # took for memory to rise to an unacceptable level during peak traffic, then
-# counting the number of requests in that internval and dividing by the number
+# counting the number of requests in that interval and dividing by the number
 # of workers.
 web: gunicorn server.app:app --preload --max-requests 1000 --max-requests-jitter 50
 worker: python -m server.worker.worker

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,14 @@
 release: ./heroku-release-phase.sh
-web: gunicorn server.app:app --preload --max-requests 5000 --max-requests-jitter 20
+# gunicorn runs multiple worker processes based on the WEB_CONCURRENCY
+# environment variable (set by Heroku automatically based on dyno size).
+# https://devcenter.heroku.com/articles/python-concurrency#common-runtime
+# At the time of writing, we use Standard-2x dynos, which results in 4 workers.
+# To tame slow memory leakage that we've observed but haven't solved, we
+# configure gunicorn to restart each worker after a certain number of requests
+# (with some random jitter). This threshold was set by observing how long it
+# took for memory to rise to an unacceptable level during peak traffic, then
+# counting the number of requests in that internval and dividing by the number
+# of workers.
+web: gunicorn server.app:app --preload --max-requests 1000 --max-requests-jitter 50
 worker: python -m server.worker.worker
 slack_worker: python -m server.activity_log.slack_worker


### PR DESCRIPTION
Configures `gunicorn` to restart web workers after every N requests (with a random "jitter" to avoid simultaneous worker restarts). This will contain slow memory leakage.

To set the threshold, I observed from logs that each dyno is fielding about 1.6k requests per hour at peak traffic. There are 4 workers per dyno, so that's about 400 requests per worker per hour. Based on how quickly memory has been rising, it seemed like restarting each worker around once every 2-3 hours would be sufficient to contain the issue, so I set the request limit to 1000.