### PR TITLE
Add tool for support users to export Audit Admins and Jurisdiction Managers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,11 +103,11 @@ jobs:
           docker_layer_caching: true
       - python/install-packages:
           pkg-manager: poetry
-          cache-version: v5
+          cache-version: v7
       - node/install-packages:
           pkg-manager: yarn
           app-dir: client
-          cache-version: v5
+          cache-version: v7
       - restore_cache:
           name: "Restoring Cypress cache"
           key: v1-cypress-cache-{{ checksum "client/yarn.lock" }}

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
@@ -7,15 +7,15 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
     style="width: 100%;"
   >
     <div
-      class="sc-eHgmQL dVdNaN"
+      class="sc-cvbbAY VKHTj"
     >
       <h2
-        class="bp3-heading sc-hSdWYo hYxqFn"
+        class="bp3-heading sc-eHgmQL kvtVzr"
       >
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-dfVpRl dcBoUA"
+        class="bp3-card bp3-elevation-0 sc-gzOgki emHSJk"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -122,18 +122,18 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-elJkPf coSrCL"
+            class="sc-jtRfpW hmuSrk"
           >
             <div
-              class="sc-jtRfpW fBMFJb"
+              class="sc-kTUwUJ hZCNF"
             >
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -148,12 +148,12 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -169,15 +169,15 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <div
-              class="sc-jtRfpW fBMFJb"
+              class="sc-kTUwUJ hZCNF"
             >
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -192,12 +192,12 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -213,7 +213,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <p
-              class="sc-gxMtzJ gHoIvt"
+              class="sc-dfVpRl iBZboO"
             >
               Add a new candidate/choice
             </p>
@@ -324,7 +324,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
       </div>
     </div>
     <div
-      class="sc-bYSBpT jGvioy"
+      class="sc-elJkPf cZLJPn"
       style="margin-top: 15px;"
     >
       <button
@@ -397,15 +397,15 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
     style="width: 100%;"
   >
     <div
-      class="sc-eHgmQL dVdNaN"
+      class="sc-cvbbAY VKHTj"
     >
       <h2
-        class="bp3-heading sc-hSdWYo hYxqFn"
+        class="bp3-heading sc-eHgmQL kvtVzr"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-dfVpRl dcBoUA"
+        class="bp3-card bp3-elevation-0 sc-gzOgki emHSJk"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -512,18 +512,18 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-elJkPf coSrCL"
+            class="sc-jtRfpW hmuSrk"
           >
             <div
-              class="sc-jtRfpW fBMFJb"
+              class="sc-kTUwUJ hZCNF"
             >
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -538,12 +538,12 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -559,15 +559,15 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-jtRfpW fBMFJb"
+              class="sc-kTUwUJ hZCNF"
             >
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -582,12 +582,12 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -603,7 +603,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-gxMtzJ gHoIvt"
+              class="sc-dfVpRl iBZboO"
             >
               Add a new candidate/choice
             </p>
@@ -714,7 +714,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-bYSBpT jGvioy"
+      class="sc-elJkPf cZLJPn"
       style="margin-top: 15px;"
     >
       <button
@@ -787,15 +787,15 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
     style="width: 100%;"
   >
     <div
-      class="sc-eHgmQL dVdNaN"
+      class="sc-cvbbAY VKHTj"
     >
       <h2
-        class="bp3-heading sc-hSdWYo hYxqFn"
+        class="bp3-heading sc-eHgmQL kvtVzr"
       >
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-dfVpRl dcBoUA"
+        class="bp3-card bp3-elevation-0 sc-gzOgki emHSJk"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -902,18 +902,18 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-elJkPf coSrCL"
+            class="sc-jtRfpW hmuSrk"
           >
             <div
-              class="sc-jtRfpW fBMFJb"
+              class="sc-kTUwUJ hZCNF"
             >
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -928,12 +928,12 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -949,15 +949,15 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <div
-              class="sc-jtRfpW fBMFJb"
+              class="sc-kTUwUJ hZCNF"
             >
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -972,12 +972,12 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -993,7 +993,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <p
-              class="sc-gxMtzJ gHoIvt"
+              class="sc-dfVpRl iBZboO"
             >
               Add a new candidate/choice
             </p>
@@ -1104,7 +1104,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
       </div>
     </div>
     <div
-      class="sc-bYSBpT jGvioy"
+      class="sc-elJkPf cZLJPn"
       style="margin-top: 15px;"
     >
       <button
@@ -1177,15 +1177,15 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
     style="width: 100%;"
   >
     <div
-      class="sc-eHgmQL dVdNaN"
+      class="sc-cvbbAY VKHTj"
     >
       <h2
-        class="bp3-heading sc-hSdWYo hYxqFn"
+        class="bp3-heading sc-eHgmQL kvtVzr"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-dfVpRl dcBoUA"
+        class="bp3-card bp3-elevation-0 sc-gzOgki emHSJk"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -1292,18 +1292,18 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-elJkPf coSrCL"
+            class="sc-jtRfpW hmuSrk"
           >
             <div
-              class="sc-jtRfpW fBMFJb"
+              class="sc-kTUwUJ hZCNF"
             >
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1318,12 +1318,12 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1339,15 +1339,15 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-jtRfpW fBMFJb"
+              class="sc-kTUwUJ hZCNF"
             >
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1362,12 +1362,12 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -1383,7 +1383,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-gxMtzJ gHoIvt"
+              class="sc-dfVpRl iBZboO"
             >
               Add a new candidate/choice
             </p>
@@ -1494,7 +1494,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-bYSBpT jGvioy"
+      class="sc-elJkPf cZLJPn"
       style="margin-top: 15px;"
     >
       <button

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
@@ -7,15 +7,15 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
     style="width: 100%;"
   >
     <div
-      class="sc-eHgmQL dVdNaN"
+      class="sc-cvbbAY VKHTj"
     >
       <h2
-        class="bp3-heading sc-hSdWYo hYxqFn"
+        class="bp3-heading sc-eHgmQL kvtVzr"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-dfVpRl dcBoUA"
+        class="bp3-card bp3-elevation-0 sc-gzOgki emHSJk"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -42,7 +42,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                Name
               <br />
               <div
-                class="bp3-html-select sc-iyvyFf hVQKkz"
+                class="bp3-html-select sc-hwwEjo fSWVqj"
               >
                 <select
                   field="[object Object]"
@@ -158,18 +158,18 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-elJkPf coSrCL"
+            class="sc-jtRfpW hmuSrk"
           >
             <div
-              class="sc-jtRfpW fBMFJb"
+              class="sc-kTUwUJ hZCNF"
             >
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -184,12 +184,12 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -205,15 +205,15 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <div
-              class="sc-jtRfpW fBMFJb"
+              class="sc-kTUwUJ hZCNF"
             >
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -228,12 +228,12 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-dqBHgY kfBGWI"
+                class="bp3-label sc-gxMtzJ dbFvFE"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-kTUwUJ kzABvA sc-gqjmRU egaEhI"
+                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
                 >
                   <div
                     class="bp3-input-group sc-VigVT hfLuvB"
@@ -249,7 +249,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <p
-              class="sc-gxMtzJ gHoIvt"
+              class="sc-dfVpRl iBZboO"
             >
               Add a new candidate/choice
             </p>
@@ -291,7 +291,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
       </div>
     </div>
     <div
-      class="sc-bYSBpT jGvioy"
+      class="sc-elJkPf cZLJPn"
       style="margin-top: 15px;"
     >
       <button

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -61,19 +61,19 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-laTMn hAAKnY"
+          class="sc-hGoxap jxCAYo"
         >
           <div
-            class="sc-hGoxap caLCHz"
+            class="sc-fjmCvl kbbZEq"
           >
             <div
-              class="sc-fjmCvl kMxBci"
+              class="sc-TFwJa cuFtfU"
             >
               <div
-                class="sc-krDsej ehqnVq"
+                class="sc-dTdPqK XvrMK"
               >
                 <button
-                  class="bp3-button bp3-minimal sc-bHwgHz bMElXT"
+                  class="bp3-button bp3-minimal sc-krDsej eqlcSx"
                   href="/election/1/audit-board/audit-board-1"
                   type="button"
                 >
@@ -103,56 +103,56 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                   </span>
                 </button>
                 <h3
-                  class="bp3-heading sc-CtfFt kZgVRS"
+                  class="bp3-heading sc-laTMn hNxafJ"
                 >
                   Audit Ballot Selections
                 </h3>
               </div>
               <div
-                class="bp3-divider sc-cbkKFq ODwFP"
+                class="bp3-divider sc-krvtoX dSdfvo"
               />
               <div
-                class="sc-gFaPwZ cHJJmb"
+                class="sc-fhYwyz cltIWF"
               >
                 <div>
                   <h5
-                    class="bp3-heading sc-dymIpo biKLRv"
+                    class="bp3-heading sc-bnXvFD emzaP"
                   >
                     Tabulator
                   </h5>
                   <h4
-                    class="bp3-heading sc-fhYwyz FZsZD"
+                    class="bp3-heading sc-jzgbtB HPCxV"
                   >
                     11
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-dymIpo biKLRv"
+                    class="bp3-heading sc-bnXvFD emzaP"
                   >
                     Batch
                   </h5>
                   <h4
-                    class="bp3-heading sc-fhYwyz FZsZD"
+                    class="bp3-heading sc-jzgbtB HPCxV"
                   >
                     0003-04-Precinct 19 (Jonesboro Fire Department)
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-dymIpo biKLRv"
+                    class="bp3-heading sc-bnXvFD emzaP"
                   >
                     Ballot Number
                   </h5>
                   <h4
-                    class="bp3-heading sc-fhYwyz FZsZD"
+                    class="bp3-heading sc-jzgbtB HPCxV"
                   >
                     2112
                   </h4>
                 </div>
                 <div>
                   <button
-                    class="bp3-button bp3-large bp3-intent-danger sc-jzgbtB eofazy"
+                    class="bp3-button bp3-large bp3-intent-danger sc-gJWqzi bimmLP"
                     type="button"
                   >
                     <span
@@ -164,36 +164,36 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 </div>
               </div>
               <div
-                class="bp3-divider sc-cbkKFq ODwFP"
+                class="bp3-divider sc-krvtoX dSdfvo"
               />
               <div
-                class="sc-krvtoX NyKrz"
+                class="sc-fYiAbW hEmmmp"
               >
                 <div
                   class="ballot-main"
                 >
                   <h5
-                    class="bp3-heading sc-dymIpo biKLRv"
+                    class="bp3-heading sc-bnXvFD emzaP"
                   >
                     Ballot Contests
                   </h5>
                   <form>
                     <div
-                      class="sc-fYiAbW bbEbqb"
+                      class="sc-fOKMvo ceoafp"
                     >
                       <div
-                        class="sc-eerKOB ggGbtG"
+                        class="sc-emmjRN lkDFwY"
                       >
                         <div
-                          class="sc-emmjRN dZjvLQ"
+                          class="sc-cpmLhU dSHspV"
                         >
                           <h3
-                            class="bp3-heading sc-rBLzX cWmzGW"
+                            class="bp3-heading sc-bMvGRv hwuwxh"
                           >
                             Contest 1
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
+                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
                           >
                             <input
                               type="checkbox"
@@ -209,7 +209,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
+                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
                           >
                             <input
                               type="checkbox"
@@ -226,10 +226,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-cpmLhU hTfvkj"
+                          class="sc-dymIpo dJmdUv"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
+                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
                           >
                             <input
                               type="checkbox"
@@ -245,7 +245,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
+                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
                           >
                             <input
                               type="checkbox"
@@ -261,7 +261,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
+                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
                           >
                             <input
                               type="checkbox"
@@ -277,7 +277,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-gJWqzi GKtRR"
+                            class="bp3-input sc-rBLzX kneByf"
                             name="comment-Contest 1"
                             placeholder="Add Note"
                           />
@@ -285,21 +285,21 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-fYiAbW bbEbqb"
+                      class="sc-fOKMvo ceoafp"
                     >
                       <div
-                        class="sc-eerKOB ggGbtG"
+                        class="sc-emmjRN lkDFwY"
                       >
                         <div
-                          class="sc-emmjRN dZjvLQ"
+                          class="sc-cpmLhU dSHspV"
                         >
                           <h3
-                            class="bp3-heading sc-rBLzX cWmzGW"
+                            class="bp3-heading sc-bMvGRv hwuwxh"
                           >
                             Contest 2
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
+                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
                           >
                             <input
                               type="checkbox"
@@ -315,7 +315,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
+                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
                           >
                             <input
                               type="checkbox"
@@ -332,10 +332,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-cpmLhU hTfvkj"
+                          class="sc-dymIpo dJmdUv"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
+                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
                           >
                             <input
                               type="checkbox"
@@ -351,7 +351,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
+                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
                           >
                             <input
                               type="checkbox"
@@ -367,7 +367,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-bnXvFD cVjWrH"
+                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
                           >
                             <input
                               type="checkbox"
@@ -383,7 +383,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-gJWqzi GKtRR"
+                            class="bp3-input sc-rBLzX kneByf"
                             name="comment-Contest 2"
                             placeholder="Add Note"
                           />
@@ -391,10 +391,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-dUjcNx dkzrkJ"
+                      class="sc-gHboQg MSZtC"
                     >
                       <button
-                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-bMvGRv linPlW sc-dnqmqq iQfLYL"
+                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-CtfFt eWjIDB sc-dnqmqq iQfLYL"
                         disabled=""
                         tabindex="-1"
                         type="submit"
@@ -421,7 +421,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
               </div>
             </div>
             <div
-              class="sc-TFwJa bLnEQX"
+              class="sc-bHwgHz cmRXTS"
             >
               <h4
                 class="bp3-heading"
@@ -429,7 +429,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 Instructions
               </h4>
               <ol
-                class="bp3-list sc-dTdPqK bFxpEO"
+                class="bp3-list sc-itybZL bFYtBd"
               >
                 <li>
                   Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -534,13 +534,13 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
       class="board-table-container"
     >
       <div
-        class="sc-cLQEGU hwGJZf"
+        class="sc-gqPbQI jusmQx"
       >
         <div
-          class="sc-bwzfXH sc-gqPbQI eVSFPs"
+          class="sc-bwzfXH sc-hORach hoVPwJ"
         >
           <div
-            class="sc-cmthru gDBFlp"
+            class="sc-hMFtBS fymdRq"
           >
             <p>
               18
@@ -549,23 +549,23 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-cQFLBn fSoOLv"
+              class="summary-label sc-gojNiO cNYwPJ"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-gojNiO fJlUdq"
+              class="summary-label sc-daURTG hmBDJZ"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-hMFtBS hkaYVQ"
+            class="sc-cLQEGU fHzmhT"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bXGyLb doTSjZ"
+              class="bp3-button bp3-intent-success sc-lkqHmb lanaPj"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -582,10 +582,10 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-hORach bqIkDb"
+          class="sc-bMVAic kdmlRM"
         >
           <div
-            class="sc-bMVAic kClWEP"
+            class="sc-bAeIUo cTRzTw"
           >
             <h3
               class="bp3-heading"
@@ -594,7 +594,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Audit Board #1
             </h3>
             <div
-              class="sc-bAeIUo jWgAMa"
+              class="sc-iujRgT eJYwgz"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -799,7 +799,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -809,7 +809,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -819,7 +819,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -829,7 +829,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -858,7 +858,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -877,7 +877,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -886,7 +886,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -895,7 +895,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -904,7 +904,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -913,7 +913,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -934,7 +934,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -944,7 +944,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -954,7 +954,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -964,7 +964,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -993,7 +993,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -1012,7 +1012,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1022,7 +1022,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1032,7 +1032,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1042,7 +1042,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1071,7 +1071,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -1090,7 +1090,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -1099,7 +1099,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1108,7 +1108,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -1117,7 +1117,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -1126,7 +1126,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -1147,7 +1147,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1157,7 +1157,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1167,7 +1167,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1177,7 +1177,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1206,7 +1206,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -1225,7 +1225,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1235,7 +1235,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1245,7 +1245,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1255,7 +1255,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1284,7 +1284,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -1303,7 +1303,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -1312,7 +1312,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1321,7 +1321,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -1330,7 +1330,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -1339,7 +1339,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -1360,7 +1360,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1370,7 +1370,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1380,7 +1380,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1390,7 +1390,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1419,7 +1419,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -1438,7 +1438,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1448,7 +1448,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1458,7 +1458,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1468,7 +1468,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1497,7 +1497,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -1516,7 +1516,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -1525,7 +1525,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1534,7 +1534,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -1543,7 +1543,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -1552,7 +1552,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -1573,7 +1573,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1583,7 +1583,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1593,7 +1593,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1603,7 +1603,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1632,7 +1632,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -1651,7 +1651,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1661,7 +1661,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1671,7 +1671,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1681,7 +1681,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1710,7 +1710,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -1729,7 +1729,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -1738,7 +1738,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1747,7 +1747,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -1756,7 +1756,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -1765,7 +1765,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -1786,7 +1786,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1796,7 +1796,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1806,7 +1806,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1816,7 +1816,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1845,7 +1845,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -1864,7 +1864,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1874,7 +1874,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1884,7 +1884,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1894,7 +1894,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1923,7 +1923,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -1942,7 +1942,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -1951,7 +1951,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1960,7 +1960,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -1969,7 +1969,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -1978,7 +1978,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -1999,7 +1999,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2009,7 +2009,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2019,7 +2019,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2029,7 +2029,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2058,7 +2058,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -2077,7 +2077,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2087,7 +2087,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2097,7 +2097,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2107,7 +2107,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2136,7 +2136,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -2155,7 +2155,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -2164,7 +2164,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2173,7 +2173,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -2182,7 +2182,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -2191,7 +2191,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -2212,7 +2212,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2222,7 +2222,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2232,7 +2232,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2242,7 +2242,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2271,7 +2271,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -2290,7 +2290,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2300,7 +2300,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2310,7 +2310,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2320,7 +2320,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2349,7 +2349,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -2368,7 +2368,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -2377,7 +2377,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2386,7 +2386,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -2395,7 +2395,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -2404,7 +2404,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -2425,7 +2425,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2435,7 +2435,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2445,7 +2445,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2455,7 +2455,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2484,7 +2484,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -2503,7 +2503,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2513,7 +2513,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2523,7 +2523,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2533,7 +2533,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2562,7 +2562,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -2581,7 +2581,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -2590,7 +2590,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2599,7 +2599,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -2608,7 +2608,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -2617,7 +2617,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -2638,7 +2638,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2648,7 +2648,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2658,7 +2658,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2668,7 +2668,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2697,7 +2697,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -2713,7 +2713,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-lkqHmb gCAzMP"
+              class="bp3-button bp3-disabled bp3-large sc-eLExRp hquVpU"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -2727,7 +2727,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
             </button>
           </div>
           <div
-            class="sc-iujRgT hdbCHq"
+            class="sc-GMQeP geIFCy"
           >
             <h4
               class="bp3-heading"
@@ -2735,7 +2735,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-daURTG hPJTnL"
+              class="bp3-list sc-bXGyLb iGBOvH"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -2815,13 +2815,13 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
       class="board-table-container"
     >
       <div
-        class="sc-cLQEGU hwGJZf"
+        class="sc-gqPbQI jusmQx"
       >
         <div
-          class="sc-bwzfXH sc-gqPbQI eVSFPs"
+          class="sc-bwzfXH sc-hORach hoVPwJ"
         >
           <div
-            class="sc-cmthru gDBFlp"
+            class="sc-hMFtBS fymdRq"
           >
             <p>
               0
@@ -2830,23 +2830,23 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-cQFLBn fSoOLv"
+              class="summary-label sc-gojNiO cNYwPJ"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-gojNiO fJlUdq"
+              class="summary-label sc-daURTG hmBDJZ"
             >
               Not Audited: 
               27
             </span>
           </div>
           <div
-            class="sc-hMFtBS hkaYVQ"
+            class="sc-cLQEGU fHzmhT"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bXGyLb doTSjZ"
+              class="bp3-button bp3-intent-success sc-lkqHmb lanaPj"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
               type="button"
             >
@@ -2863,10 +2863,10 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-hORach bqIkDb"
+          class="sc-bMVAic kdmlRM"
         >
           <div
-            class="sc-bMVAic kClWEP"
+            class="sc-bAeIUo cTRzTw"
           >
             <h3
               class="bp3-heading"
@@ -2875,7 +2875,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Audit Board #1
             </h3>
             <div
-              class="sc-bAeIUo jWgAMa"
+              class="sc-iujRgT eJYwgz"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -3080,7 +3080,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3089,7 +3089,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3098,7 +3098,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         313
                       </p>
@@ -3107,7 +3107,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3116,7 +3116,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -3137,7 +3137,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3146,7 +3146,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3155,7 +3155,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -3164,7 +3164,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3173,7 +3173,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -3194,7 +3194,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3203,7 +3203,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3212,7 +3212,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         1789
                       </p>
@@ -3221,7 +3221,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3230,7 +3230,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -3251,7 +3251,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3260,7 +3260,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3269,7 +3269,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         313
                       </p>
@@ -3278,7 +3278,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3287,7 +3287,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -3308,7 +3308,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3317,7 +3317,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3326,7 +3326,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -3335,7 +3335,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3344,7 +3344,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -3365,7 +3365,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3374,7 +3374,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3383,7 +3383,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         1789
                       </p>
@@ -3392,7 +3392,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3401,7 +3401,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -3422,7 +3422,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3431,7 +3431,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3440,7 +3440,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         313
                       </p>
@@ -3449,7 +3449,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3458,7 +3458,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -3479,7 +3479,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3488,7 +3488,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3497,7 +3497,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -3506,7 +3506,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3515,7 +3515,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -3536,7 +3536,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3545,7 +3545,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3554,7 +3554,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         1789
                       </p>
@@ -3563,7 +3563,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3572,7 +3572,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -3593,7 +3593,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3602,7 +3602,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3611,7 +3611,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         313
                       </p>
@@ -3620,7 +3620,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3629,7 +3629,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -3650,7 +3650,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3659,7 +3659,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3668,7 +3668,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -3677,7 +3677,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3686,7 +3686,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -3707,7 +3707,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3716,7 +3716,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3725,7 +3725,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         1789
                       </p>
@@ -3734,7 +3734,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3743,7 +3743,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -3764,7 +3764,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3773,7 +3773,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3782,7 +3782,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         313
                       </p>
@@ -3791,7 +3791,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3800,7 +3800,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -3821,7 +3821,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3830,7 +3830,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3839,7 +3839,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -3848,7 +3848,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3857,7 +3857,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -3878,7 +3878,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3887,7 +3887,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3896,7 +3896,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         1789
                       </p>
@@ -3905,7 +3905,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3914,7 +3914,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -3935,7 +3935,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -3944,7 +3944,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3953,7 +3953,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         313
                       </p>
@@ -3962,7 +3962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -3971,7 +3971,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -3992,7 +3992,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -4001,7 +4001,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4010,7 +4010,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -4019,7 +4019,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -4028,7 +4028,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -4049,7 +4049,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -4058,7 +4058,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4067,7 +4067,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         1789
                       </p>
@@ -4076,7 +4076,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -4085,7 +4085,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -4106,7 +4106,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -4115,7 +4115,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4124,7 +4124,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         313
                       </p>
@@ -4133,7 +4133,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -4142,7 +4142,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -4163,7 +4163,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -4172,7 +4172,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4181,7 +4181,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -4190,7 +4190,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -4199,7 +4199,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -4220,7 +4220,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -4229,7 +4229,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4238,7 +4238,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         1789
                       </p>
@@ -4247,7 +4247,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -4256,7 +4256,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -4277,7 +4277,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -4286,7 +4286,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4295,7 +4295,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         313
                       </p>
@@ -4304,7 +4304,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -4313,7 +4313,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -4334,7 +4334,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -4343,7 +4343,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4352,7 +4352,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -4361,7 +4361,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -4370,7 +4370,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -4391,7 +4391,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -4400,7 +4400,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4409,7 +4409,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         1789
                       </p>
@@ -4418,7 +4418,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -4427,7 +4427,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -4448,7 +4448,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -4457,7 +4457,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4466,7 +4466,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         313
                       </p>
@@ -4475,7 +4475,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -4484,7 +4484,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -4505,7 +4505,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -4514,7 +4514,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4523,7 +4523,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -4532,7 +4532,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -4541,7 +4541,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -4562,7 +4562,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -4571,7 +4571,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4580,7 +4580,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         1789
                       </p>
@@ -4589,7 +4589,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -4598,7 +4598,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -4616,7 +4616,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-lkqHmb gCAzMP"
+              class="bp3-button bp3-disabled bp3-large sc-eLExRp hquVpU"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -4630,7 +4630,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
             </button>
           </div>
           <div
-            class="sc-iujRgT hdbCHq"
+            class="sc-GMQeP geIFCy"
           >
             <h4
               class="bp3-heading"
@@ -4638,7 +4638,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-daURTG hPJTnL"
+              class="bp3-list sc-bXGyLb iGBOvH"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -4718,13 +4718,13 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
       class="board-table-container"
     >
       <div
-        class="sc-cLQEGU hwGJZf"
+        class="sc-gqPbQI jusmQx"
       >
         <div
-          class="sc-bwzfXH sc-gqPbQI eVSFPs"
+          class="sc-bwzfXH sc-hORach hoVPwJ"
         >
           <div
-            class="sc-cmthru gDBFlp"
+            class="sc-hMFtBS fymdRq"
           >
             <p>
               0
@@ -4733,23 +4733,23 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-cQFLBn fSoOLv"
+              class="summary-label sc-gojNiO cNYwPJ"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-gojNiO fJlUdq"
+              class="summary-label sc-daURTG hmBDJZ"
             >
               Not Audited: 
               0
             </span>
           </div>
           <div
-            class="sc-hMFtBS hkaYVQ"
+            class="sc-cLQEGU fHzmhT"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bXGyLb doTSjZ"
+              class="bp3-button bp3-intent-success sc-lkqHmb lanaPj"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4766,10 +4766,10 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-hORach bqIkDb"
+          class="sc-bMVAic kdmlRM"
         >
           <div
-            class="sc-bMVAic kClWEP"
+            class="sc-bAeIUo cTRzTw"
           >
             <h3
               class="bp3-heading"
@@ -4778,7 +4778,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Audit Board #1
             </h3>
             <div
-              class="sc-bAeIUo jWgAMa"
+              class="sc-iujRgT eJYwgz"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -4942,7 +4942,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               </table>
             </div>
             <button
-              class="bp3-button bp3-large bp3-intent-success sc-lkqHmb gCAzMP"
+              class="bp3-button bp3-large bp3-intent-success sc-eLExRp hquVpU"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4954,7 +4954,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
             </button>
           </div>
           <div
-            class="sc-iujRgT hdbCHq"
+            class="sc-GMQeP geIFCy"
           >
             <h4
               class="bp3-heading"
@@ -4962,7 +4962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-daURTG hPJTnL"
+              class="bp3-list sc-bXGyLb iGBOvH"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -5042,13 +5042,13 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
       class="board-table-container"
     >
       <div
-        class="sc-cLQEGU hwGJZf"
+        class="sc-gqPbQI jusmQx"
       >
         <div
-          class="sc-bwzfXH sc-gqPbQI eVSFPs"
+          class="sc-bwzfXH sc-hORach hoVPwJ"
         >
           <div
-            class="sc-cmthru gDBFlp"
+            class="sc-hMFtBS fymdRq"
           >
             <p>
               18
@@ -5057,23 +5057,23 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-cQFLBn fSoOLv"
+              class="summary-label sc-gojNiO cNYwPJ"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-gojNiO fJlUdq"
+              class="summary-label sc-daURTG hmBDJZ"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-hMFtBS hkaYVQ"
+            class="sc-cLQEGU fHzmhT"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bXGyLb doTSjZ"
+              class="bp3-button bp3-intent-success sc-lkqHmb lanaPj"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -5090,10 +5090,10 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-hORach bqIkDb"
+          class="sc-bMVAic kdmlRM"
         >
           <div
-            class="sc-bMVAic kClWEP"
+            class="sc-bAeIUo cTRzTw"
           >
             <h3
               class="bp3-heading"
@@ -5102,7 +5102,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Audit Board #1
             </h3>
             <div
-              class="sc-bAeIUo jWgAMa"
+              class="sc-iujRgT eJYwgz"
             >
               <table
                 class="sc-kGXeez fVIhxz"
@@ -5307,7 +5307,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5317,7 +5317,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5327,7 +5327,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5337,7 +5337,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5366,7 +5366,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -5385,7 +5385,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -5394,7 +5394,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5403,7 +5403,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -5412,7 +5412,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -5421,7 +5421,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -5442,7 +5442,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5452,7 +5452,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5462,7 +5462,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5472,7 +5472,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5501,7 +5501,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -5520,7 +5520,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5530,7 +5530,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5540,7 +5540,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5550,7 +5550,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5579,7 +5579,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -5598,7 +5598,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -5607,7 +5607,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5616,7 +5616,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -5625,7 +5625,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -5634,7 +5634,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -5655,7 +5655,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5665,7 +5665,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5675,7 +5675,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5685,7 +5685,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5714,7 +5714,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -5733,7 +5733,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5743,7 +5743,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5753,7 +5753,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5763,7 +5763,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5792,7 +5792,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -5811,7 +5811,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -5820,7 +5820,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5829,7 +5829,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -5838,7 +5838,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -5847,7 +5847,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -5868,7 +5868,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5878,7 +5878,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5888,7 +5888,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5898,7 +5898,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5927,7 +5927,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -5946,7 +5946,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5956,7 +5956,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5966,7 +5966,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5976,7 +5976,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6005,7 +6005,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -6024,7 +6024,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -6033,7 +6033,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6042,7 +6042,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -6051,7 +6051,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -6060,7 +6060,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -6081,7 +6081,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6091,7 +6091,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6101,7 +6101,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6111,7 +6111,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6140,7 +6140,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -6159,7 +6159,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6169,7 +6169,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6179,7 +6179,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6189,7 +6189,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6218,7 +6218,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -6237,7 +6237,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -6246,7 +6246,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6255,7 +6255,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -6264,7 +6264,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -6273,7 +6273,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -6294,7 +6294,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6304,7 +6304,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6314,7 +6314,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6324,7 +6324,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6353,7 +6353,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -6372,7 +6372,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6382,7 +6382,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6392,7 +6392,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6402,7 +6402,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6431,7 +6431,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -6450,7 +6450,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -6459,7 +6459,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6468,7 +6468,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -6477,7 +6477,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -6486,7 +6486,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -6507,7 +6507,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6517,7 +6517,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6527,7 +6527,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6537,7 +6537,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6566,7 +6566,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -6585,7 +6585,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6595,7 +6595,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6605,7 +6605,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6615,7 +6615,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6644,7 +6644,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -6663,7 +6663,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -6672,7 +6672,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6681,7 +6681,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -6690,7 +6690,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -6699,7 +6699,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -6720,7 +6720,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6730,7 +6730,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6740,7 +6740,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6750,7 +6750,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6779,7 +6779,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -6798,7 +6798,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6808,7 +6808,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6818,7 +6818,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6828,7 +6828,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6857,7 +6857,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -6876,7 +6876,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -6885,7 +6885,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6894,7 +6894,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -6903,7 +6903,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -6912,7 +6912,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -6933,7 +6933,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6943,7 +6943,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6953,7 +6953,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6963,7 +6963,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6992,7 +6992,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -7011,7 +7011,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7021,7 +7021,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -7031,7 +7031,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -7041,7 +7041,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7070,7 +7070,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -7089,7 +7089,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         11
                       </p>
@@ -7098,7 +7098,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -7107,7 +7107,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                       >
                         2112
                       </p>
@@ -7116,7 +7116,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-gojNiO fJlUdq"
+                        class="sc-daURTG hmBDJZ"
                       >
                         Not Audited
                       </span>
@@ -7125,7 +7125,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -7146,7 +7146,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7156,7 +7156,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -7166,7 +7166,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -7176,7 +7176,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-eLExRp jVvVyY"
+                        class="sc-cbkKFq iJsTkK"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7205,7 +7205,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-GMQeP kRLmOg"
+                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -7221,7 +7221,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-lkqHmb gCAzMP"
+              class="bp3-button bp3-disabled bp3-large sc-eLExRp hquVpU"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -7235,7 +7235,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
             </button>
           </div>
           <div
-            class="sc-iujRgT hdbCHq"
+            class="sc-GMQeP geIFCy"
           >
             <h4
               class="bp3-heading"
@@ -7243,7 +7243,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-daURTG hPJTnL"
+              class="bp3-list sc-bXGyLb iGBOvH"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.

--- a/client/src/components/JurisdictionAdmin/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
+++ b/client/src/components/JurisdictionAdmin/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`full hand tally data entry deletes full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-gipzik hvuvct"
+    class="sc-csuQGl dEmjOe"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -159,7 +159,7 @@ exports[`full hand tally data entry deletes full hand tally batch result 1`] = `
 exports[`full hand tally data entry edits full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-gipzik hvuvct"
+    class="sc-csuQGl dEmjOe"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -360,7 +360,7 @@ exports[`full hand tally data entry edits full hand tally batch result 1`] = `
 exports[`full hand tally data entry finalizes full hand tally results 1`] = `
 <div>
   <form
-    class="sc-gipzik hvuvct"
+    class="sc-csuQGl dEmjOe"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -593,7 +593,7 @@ exports[`full hand tally data entry finalizes full hand tally results 1`] = `
 exports[`full hand tally data entry renders 1`] = `
 <div>
   <form
-    class="sc-gipzik hvuvct"
+    class="sc-csuQGl dEmjOe"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -749,7 +749,7 @@ exports[`full hand tally data entry renders 1`] = `
 exports[`full hand tally data entry renders with full hand tally results 1`] = `
 <div>
   <form
-    class="sc-gipzik hvuvct"
+    class="sc-csuQGl dEmjOe"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -950,7 +950,7 @@ exports[`full hand tally data entry renders with full hand tally results 1`] = `
 exports[`full hand tally data entry renders with proper totals 1`] = `
 <div>
   <form
-    class="sc-gipzik hvuvct"
+    class="sc-csuQGl dEmjOe"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -1203,7 +1203,7 @@ exports[`full hand tally data entry renders with proper totals 1`] = `
 exports[`full hand tally data entry submits full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-gipzik hvuvct"
+    class="sc-csuQGl dEmjOe"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -1404,7 +1404,7 @@ exports[`full hand tally data entry submits full hand tally batch result 1`] = `
 exports[`full hand tally data entry validation error for blank submission 1`] = `
 <div>
   <form
-    class="sc-gipzik hvuvct"
+    class="sc-csuQGl dEmjOe"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -81,6 +81,7 @@ const SupportTools: React.FC = () => {
               <Row>
                 <ActiveAudits />
                 <Organizations />
+                <SupportUserTools />
               </Row>
             </Route>
             <Route path="/support/orgs/:organizationId">
@@ -111,9 +112,6 @@ const Column = styled.div`
 const Row = styled.div`
   display: flex;
   width: 100%;
-`
-const DownloadUserListButton = styled(AnchorButton)`
-  margin: 10px 0;
 `
 
 const AuditStatusTag = ({ currentRound }: { currentRound: IRound | null }) => {
@@ -206,15 +204,27 @@ const Organizations = () => {
           </LinkItem>
         ))}
       </List>
-      <DownloadUserListButton
+    </Column>
+  )
+}
+
+const DownloadUsersButton = styled(AnchorButton)`
+  margin-bottom: 10px;
+`
+
+const SupportUserTools = () => {
+  return (
+    <Column>
+      <H2>Downloads</H2>
+      <DownloadUsersButton
         icon="download"
         href="/api/support/organizations/users"
       >
         Download User List
-      </DownloadUserListButton>
+      </DownloadUsersButton>
       <p>
-        Export a list of Audit Admins and Jurisdiction Managers for recently
-        completed audits for all organizations.
+        Export a list of Audit Admins and Jurisdiction Managers for all audits
+        completed in the last 12 weeks.
       </p>
     </Column>
   )

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -112,6 +112,9 @@ const Row = styled.div`
   display: flex;
   width: 100%;
 `
+const DownloadUserListButton = styled(AnchorButton)`
+  margin: 10px 0;
+`
 
 const AuditStatusTag = ({ currentRound }: { currentRound: IRound | null }) => {
   if (!currentRound) {
@@ -203,6 +206,16 @@ const Organizations = () => {
           </LinkItem>
         ))}
       </List>
+      <DownloadUserListButton
+        icon="download"
+        href="/api/support/organizations/users"
+      >
+        Download User List
+      </DownloadUserListButton>
+      <p>
+        Export a list of Audit Admins and Jurisdiction Managers for recently
+        completed audits for all organizations.
+      </p>
     </Column>
   )
 }

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -152,7 +152,7 @@ def list_users_by_organization():
     elections_with_users = (
         Election.query.filter(
             Election.deleted_at.is_(None),
-            Election.created_at > datetime.now(timezone.utc) - timedelta(weeks=52),
+            Election.created_at > datetime.now(timezone.utc) - timedelta(weeks=12),
         )
         .options(
             subqueryload(Election.jurisdictions)

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -1,4 +1,6 @@
+import csv
 from datetime import datetime, timedelta
+import io
 import uuid
 import secrets
 from typing import Optional
@@ -8,7 +10,9 @@ from auth0.v3.authentication import GetToken
 from auth0.v3.management import Auth0
 from auth0.v3.exceptions import Auth0Error
 from werkzeug.exceptions import BadRequest, Conflict
-from sqlalchemy.orm import contains_eager
+from sqlalchemy.orm import contains_eager, subqueryload
+
+from server.util.csv_download import csv_response
 
 from . import api
 from ..models import *  # pylint: disable=wildcard-import
@@ -29,7 +33,11 @@ from ..util.jsonschema import validate
 from ..util.isoformat import isoformat
 from ..util.file import delete_file
 from ..util.redirect import redirect
-from .rounds import delete_round_and_corresponding_sampled_ballots, get_current_round
+from .rounds import (
+    delete_round_and_corresponding_sampled_ballots,
+    get_current_round,
+    is_audit_complete,
+)
 from ..util.get_json import safe_get_json_dict
 from .shared import combined_batch_representative, group_combined_batches
 
@@ -130,6 +138,68 @@ def list_organizations():
             dict(id=organization.id, name=organization.name)
             for organization in organizations
         ]
+    )
+
+
+@api.route("/support/organizations/users", methods=["GET"])
+@restrict_access_support
+def list_users_by_organization():
+    string_io = io.StringIO()
+    csv_writer = csv.writer(string_io)
+    headers = ["Organization Name", "Audit Name", "Role", "Email", "Jurisdiction Name"]
+    csv_writer.writerow(headers)
+
+    elections_with_users = (
+        Election.query.filter(
+            Election.deleted_at.is_(None),
+            Election.created_at > datetime.now(timezone.utc) - timedelta(weeks=52),
+        )
+        .options(
+            subqueryload(Election.jurisdictions)
+            # pylint: disable=no-member
+            .subqueryload(Jurisdiction.jurisdiction_administrations).subqueryload(
+                JurisdictionAdministration.user
+            ),
+            subqueryload(Election.organization)
+            # pylint: disable=no-member
+            .subqueryload(Organization.audit_administrations).subqueryload(
+                AuditAdministration.user
+            ),
+        )
+        .all()
+    )
+
+    for election in elections_with_users:
+        if is_audit_complete(get_current_round(election)):
+            # Audit Admins
+            for administration in election.organization.audit_administrations:
+                csv_writer.writerow(
+                    [
+                        election.organization.name,
+                        election.audit_name,
+                        "Audit Admin",
+                        administration.user.email,
+                    ]
+                )
+
+            # Jurisdiction Managers
+            for jurisdiction in election.jurisdictions:
+                for administration in jurisdiction.jurisdiction_administrations:
+                    csv_writer.writerow(
+                        [
+                            election.organization.name,
+                            election.audit_name,
+                            "Jurisdiction Manager",
+                            administration.user.email,
+                            jurisdiction.name,
+                        ]
+                    )
+
+    string_io.seek(0)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    return csv_response(
+        string_io,
+        filename=f"users_by_organization-{timestamp}.csv",
     )
 
 

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -1001,3 +1001,29 @@ def test_support_reopen_current_round_when_round_in_progress(
             }
         ]
     }
+
+
+def test_list_users_by_organization(
+    client: FlaskClient,
+    election_id: str,  # pylint: disable=unused-argument
+    jurisdiction_ids: List[str],  # pylint: disable=unused-argument
+    contest_ids: List[str],
+    round_1_id: str,
+):
+    run_audit_round(round_1_id, contest_ids[0], contest_ids, 0.9)
+    rv = client.post(f"/api/election/{election_id}/round/current/finish")
+    assert_ok(rv)
+
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+
+    rv = client.get("/api/support/organizations/users")
+    assert rv.status_code == 200
+    expectation = (
+        "Organization Name,Audit Name,Role,Email,Jurisdiction Name\r\n"
+        "Test Org test_list_users_by_organization,Test Audit test_list_users_by_organization,Audit Admin,admin@example.com\r\n"
+        f"Test Org test_list_users_by_organization,Test Audit test_list_users_by_organization,Jurisdiction Manager,jurisdiction.admin-{election_id}@example.com,J1\r\n"
+        f"Test Org test_list_users_by_organization,Test Audit test_list_users_by_organization,Jurisdiction Manager,jurisdiction.admin-{election_id}@example.com,J2\r\n"
+        f"Test Org test_list_users_by_organization,Test Audit test_list_users_by_organization,Jurisdiction Manager,j3-{election_id}@example.com,J3\r\n"
+    )
+    csv_contents = rv.data.decode("utf-8")
+    assert csv_contents == expectation

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -1018,12 +1018,15 @@ def test_list_users_by_organization(
 
     rv = client.get("/api/support/organizations/users")
     assert rv.status_code == 200
-    expectation = (
-        "Organization Name,Audit Name,Role,Email,Jurisdiction Name\r\n"
+    csv_contents = rv.data.decode("utf-8")
+    # Loads all users from all fixture orgs, so we can't check exact value
+    headers = "Organization Name,Audit Name,Role,Email,Jurisdiction Name\r\n"
+    assert csv_contents.startswith(headers) is True
+    expected_users = [
         "Test Org test_list_users_by_organization,Test Audit test_list_users_by_organization,Audit Admin,admin@example.com\r\n"
         f"Test Org test_list_users_by_organization,Test Audit test_list_users_by_organization,Jurisdiction Manager,jurisdiction.admin-{election_id}@example.com,J1\r\n"
         f"Test Org test_list_users_by_organization,Test Audit test_list_users_by_organization,Jurisdiction Manager,jurisdiction.admin-{election_id}@example.com,J2\r\n"
         f"Test Org test_list_users_by_organization,Test Audit test_list_users_by_organization,Jurisdiction Manager,j3-{election_id}@example.com,J3\r\n"
-    )
-    csv_contents = rv.data.decode("utf-8")
-    assert csv_contents == expectation
+    ]
+    for line in expected_users:
+        assert line in csv_contents


### PR DESCRIPTION
https://github.com/votingworks/arlo/issues/1854

Adds a tool to the bottom of the Organizations column on the support page to export a csv of Audit Admins and Jurisdiction Managers.

![Screenshot 2024-11-21 at 5 27 13 PM](https://github.com/user-attachments/assets/e3d975a3-04f3-4285-8715-3d256d65edf4)

