### PR TITLE
CircleCI: Install Cypress again if cache restoration didn't work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,13 @@ jobs:
           key: v1-cypress-cache-{{ checksum "client/yarn.lock" }}
           paths:
             - ~/.cache/Cypress
+      # We've seen a weird issue where the Cypress cache appears to restore
+      # successfully but the Cypress binary is still missing. So we just check
+      # for it and reinstall if necessary.
+      - run:
+          name: "Verifying Cypress installation"
+          command: |
+            yarn --cwd client cypress verify || yarn --cwd client cypress install
       - browser-tools/install-chrome
       - create-data-model
       - run:


### PR DESCRIPTION
Sometimes, it appears that the Cypress cache is restored successfully but the actual files are not present in the filesystem as far as I can tell. This causes the CI job to fail.

Until we can get to the bottom of what's going on, this PR implements a workaround to check if Cypress is installed and, if not, install it.