### PR TITLE
commit db session after logs are added to it in test

### DIFF
--- a/server/tests/api/test_jurisdictions.py
+++ b/server/tests/api/test_jurisdictions.py
@@ -503,7 +503,7 @@ def test_last_login_by_jurisdiction_most_recent(client: FlaskClient, election_id
     )
     assert_ok(rv)
 
-    election = Election.query.filter_by(id=election_id).one()
+    election = Election.query.get(election_id)
     assert [j.name for j in election.jurisdictions] == ["J1"]
 
     jurisdiction = election.jurisdictions[0]
@@ -511,6 +511,8 @@ def test_last_login_by_jurisdiction_most_recent(client: FlaskClient, election_id
         "a1@example.com",
         "a2@example.com",
     ]
+
+    db_session.expunge(election)
 
     user_1 = User.query.filter_by(email="a1@example.com").one()
     user_2 = User.query.filter_by(email="a2@example.com").one()
@@ -548,6 +550,8 @@ def test_last_login_by_jurisdiction_most_recent(client: FlaskClient, election_id
             error=None,
         )
     )
+
+    db_session.commit()
 
     rv = client.get(f"/api/election/{election_id}/jurisdictions/last-login")
     logins = json.loads(rv.data)


### PR DESCRIPTION
Possibly addresses a [flaky test](https://app.circleci.com/pipelines/github/votingworks/arlo/7592/workflows/2fddd1fc-e91a-45ef-bd23-13784f44b71f/jobs/23361).

I wasn't able to repro locally so I can't confirm, but usage of `record_login` in prod routes includes immediately [committing the db session](https://github.com/votingworks/arlo/blob/63c5fd98311d625691181e282298bf3c4c36701a/server/auth/auth_routes.py#L341-L342). The test doesn't explicitly commit the db session, and the db session being flushed some but not all of the time would explain the flakiness and outcome of the test.