### PR TITLE
differentiate logged-in status from in-progress status

### DIFF
--- a/client/src/components/Atoms/StatusTag.tsx
+++ b/client/src/components/Atoms/StatusTag.tsx
@@ -13,10 +13,10 @@ const StyledTag = styled(({ hasProgressBar: _, ...props }) => (
   text-transform: uppercase;
   font-weight: 500;
   ${p =>
-    p.intent === 'alert' &&
-    // Gold 4 in RGBA
-    `background-color: rgba(240, 183, 38, 0.2);
-     color: ${Colors.GOLD1}`}
+    p.intent === 'in-progress' &&
+    // Cobalt 4 in RGBA
+    `background-color: rgba(69, 128, 230, 0.2);
+     color: ${Colors.COBALT1}`}
   ${props =>
     props.hasProgressBar &&
     `border-bottom-left-radius: 0;
@@ -35,7 +35,7 @@ const StyledProgressBar = styled(ProgressBar).attrs({ stripes: false })`
   }
 `
 
-export type ExtendedIntent = Intent | 'alert'
+export type ExtendedIntent = Intent | 'in-progress'
 
 export interface IStatusTagProps extends Omit<ITagProps, 'minimal' | 'intent'> {
   progress?: number
@@ -54,7 +54,9 @@ const StatusTag: React.FC<IStatusTagProps> = ({
         value={progress}
         // Filter out nonstandard Intent
         intent={
-          props.intent && props.intent !== 'alert' ? props.intent : undefined
+          props.intent && props.intent !== 'in-progress'
+            ? props.intent
+            : undefined
         }
       />
     )}

--- a/client/src/components/Atoms/StatusTag.tsx
+++ b/client/src/components/Atoms/StatusTag.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Tag, ProgressBar, ITagProps } from '@blueprintjs/core'
+import { Colors, Tag, ProgressBar, ITagProps, Intent } from '@blueprintjs/core'
 
 // Not sure why we need to disable this rule
 /* stylelint-disable value-keyword-case */
@@ -12,7 +12,11 @@ const StyledTag = styled(({ hasProgressBar: _, ...props }) => (
   position: relative;
   text-transform: uppercase;
   font-weight: 500;
-
+  ${p =>
+    p.intent === 'alert' &&
+    // Gold 4 in RGBA
+    `background-color: rgba(240, 183, 38, 0.2);
+     color: ${Colors.GOLD1}`}
   ${props =>
     props.hasProgressBar &&
     `border-bottom-left-radius: 0;
@@ -31,8 +35,11 @@ const StyledProgressBar = styled(ProgressBar).attrs({ stripes: false })`
   }
 `
 
-interface IStatusTagProps extends Omit<ITagProps, 'minimal'> {
+export type ExtendedIntent = Intent | 'alert'
+
+export interface IStatusTagProps extends Omit<ITagProps, 'minimal' | 'intent'> {
   progress?: number
+  intent?: ExtendedIntent
 }
 
 const StatusTag: React.FC<IStatusTagProps> = ({
@@ -43,7 +50,13 @@ const StatusTag: React.FC<IStatusTagProps> = ({
   <StyledTag {...props} hasProgressBar={progress !== undefined}>
     {children}
     {progress !== undefined && (
-      <StyledProgressBar value={progress} intent={props.intent} />
+      <StyledProgressBar
+        value={progress}
+        // Filter out nonstandard Intent
+        intent={
+          props.intent && props.intent !== 'alert' ? props.intent : undefined
+        }
+      />
     )}
   </StyledTag>
 )

--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { screen, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Intent } from '@blueprintjs/core'
 import { QueryClientProvider } from 'react-query'
 import { Route } from 'react-router-dom'
 import {
@@ -23,6 +22,7 @@ import {
 import Progress, { IProgressProps } from './Progress'
 import { dummyBallots } from '../../AuditBoard/_mocks'
 import * as utilities from '../../utilities'
+import { ExtendedIntent } from '../../Atoms/StatusTag'
 
 // Borrowed from generateSheets.test.tsx
 const mockSavePDF = jest.fn()
@@ -40,7 +40,11 @@ jest.mock('jspdf', () => {
 window.URL.createObjectURL = jest.fn()
 window.open = jest.fn()
 
-const expectStatusTag = (cell: HTMLElement, status: string, intent: Intent) => {
+const expectStatusTag = (
+  cell: HTMLElement,
+  status: string,
+  intent: ExtendedIntent
+) => {
   const statusTag = within(cell)
     .getByText(status)
     .closest('.bp3-tag') as HTMLElement
@@ -107,7 +111,7 @@ describe('Progress screen', () => {
       expect(row1[2]).toBeEmpty()
       const row2 = within(rows[2]).getAllByRole('cell')
       expect(row2[0]).toHaveTextContent('Jurisdiction 2')
-      expectStatusTag(row2[1], 'Logged in', 'warning')
+      expectStatusTag(row2[1], 'Logged in', 'alert')
       expect(row2[2]).toBeEmpty()
       const row3 = within(rows[3]).getAllByRole('cell')
       expect(row3[0]).toHaveTextContent('Jurisdiction 3')
@@ -257,7 +261,7 @@ describe('Progress screen', () => {
       expect(row1[4]).toHaveTextContent('6')
       const row2 = within(rows[2]).getAllByRole('cell')
       expect(row2[0]).toHaveTextContent('Jurisdiction 2')
-      expectStatusTag(row2[1], 'Logged in', 'warning')
+      expectStatusTag(row2[1], 'Logged in', 'alert')
       expect(row2[2]).toHaveTextContent('2,117')
       expect(row2[3]).toHaveTextContent('0')
       expect(row2[4]).toHaveTextContent('20')
@@ -756,7 +760,7 @@ describe('Progress screen', () => {
       expect(row2[5]).toHaveTextContent('10')
       // Jurisdiction 3 - no manifest, no CVR
       const row3 = within(rows[3]).getAllByRole('cell')
-      expectStatusTag(row3[1], 'Logged in', 'warning')
+      expectStatusTag(row3[1], 'Logged in', 'alert')
       expect(row3[2]).toBeEmpty()
       expect(row3[3]).toBeEmpty()
       expect(row3[4]).toBeEmpty()

--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -1196,14 +1196,14 @@ describe('Progress screen', () => {
       expect(container.querySelectorAll('.bp3-spinner').length).toBe(0)
 
       expect(container.querySelectorAll('.county.gray').length).toBe(1) // not logged in
-      expect(container.querySelectorAll('.county.progress').length).toBe(1) // in progress
+      expect(container.querySelectorAll('.county.progress-2').length).toBe(1) // in progress
       expect(container.querySelectorAll('.county.danger').length).toBe(1) // errored
 
       // Check that the county tooltip shows on hover
-      userEvent.hover(container.querySelector('.county.progress')!)
+      userEvent.hover(container.querySelector('.county.progress-2')!)
       expect(container.querySelector('#tooltip')).toBeVisible()
       expect(container.querySelector('#tooltip')).toHaveTextContent('Geneva')
-      userEvent.unhover(container.querySelector('.county.progress')!)
+      userEvent.unhover(container.querySelector('.county.progress-2')!)
       expect(container.querySelector('#tooltip')).not.toBeVisible()
     })
   })

--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -111,7 +111,7 @@ describe('Progress screen', () => {
       expect(row1[2]).toBeEmpty()
       const row2 = within(rows[2]).getAllByRole('cell')
       expect(row2[0]).toHaveTextContent('Jurisdiction 2')
-      expectStatusTag(row2[1], 'Logged in', 'alert')
+      expectStatusTag(row2[1], 'Logged in', 'warning')
       expect(row2[2]).toBeEmpty()
       const row3 = within(rows[3]).getAllByRole('cell')
       expect(row3[0]).toHaveTextContent('Jurisdiction 3')
@@ -255,13 +255,13 @@ describe('Progress screen', () => {
       expect(rows).toHaveLength(jurisdictionMocks.oneComplete.length + 2) // includes headers and footers
       const row1 = within(rows[1]).getAllByRole('cell')
       expect(row1[0]).toHaveTextContent('Jurisdiction 1')
-      expectStatusTag(row1[1], 'In progress', 'warning')
+      expectStatusTag(row1[1], 'In progress', 'in-progress')
       expect(row1[2]).toHaveTextContent('2,117')
       expect(row1[3]).toHaveTextContent('4')
       expect(row1[4]).toHaveTextContent('6')
       const row2 = within(rows[2]).getAllByRole('cell')
       expect(row2[0]).toHaveTextContent('Jurisdiction 2')
-      expectStatusTag(row2[1], 'Logged in', 'alert')
+      expectStatusTag(row2[1], 'Logged in', 'warning')
       expect(row2[2]).toHaveTextContent('2,117')
       expect(row2[3]).toHaveTextContent('0')
       expect(row2[4]).toHaveTextContent('20')
@@ -493,7 +493,7 @@ describe('Progress screen', () => {
       expect(rows).toHaveLength(jurisdictionMocks.oneComplete.length + 2) // includes headers and footers
       const row1 = within(rows[1]).getAllByRole('cell')
       expect(row1[0]).toHaveTextContent('Jurisdiction 1')
-      expectStatusTag(row1[1], 'In progress', 'warning')
+      expectStatusTag(row1[1], 'In progress', 'in-progress')
       expect(row1[2]).toHaveTextContent('2,117')
       // Discrepancies hidden until jurisdiction is complete
       expect(row1[3]).toHaveTextContent('')
@@ -655,7 +655,7 @@ describe('Progress screen', () => {
       expect(row1[4]).toBeEmpty()
       // Jurisdiction 2 - manifest success, no tallies
       const row2 = within(rows[2]).getAllByRole('cell')
-      expectStatusTag(row2[1], '1/2 files uploaded', 'warning')
+      expectStatusTag(row2[1], '1/2 files uploaded', 'in-progress')
       expect(row2[2]).toHaveTextContent('2,117')
       expect(row2[3]).toHaveTextContent('10')
       expect(row2[4]).toBeEmpty()
@@ -697,7 +697,7 @@ describe('Progress screen', () => {
       const rows = screen.getAllByRole('row')
       // Jurisdiction 1 - manifest success, no CVR
       const row1 = within(rows[1]).getAllByRole('cell')
-      expectStatusTag(row1[1], '1/2 files uploaded', 'warning')
+      expectStatusTag(row1[1], '1/2 files uploaded', 'in-progress')
       expect(row1[2]).toHaveTextContent('2,117')
       expect(row1[3]).toBeEmpty()
       // Jurisdiction 2 - manifest success, CVR success
@@ -707,7 +707,7 @@ describe('Progress screen', () => {
       expect(row2[3]).toHaveTextContent('10')
       // Jurisdiction 3 - manifest success, no CVR
       const row3 = within(rows[3]).getAllByRole('cell')
-      expectStatusTag(row3[1], '1/2 files uploaded', 'warning')
+      expectStatusTag(row3[1], '1/2 files uploaded', 'in-progress')
       expect(row3[2]).toHaveTextContent('2,117')
       expect(row3[3]).toBeEmpty()
 
@@ -746,7 +746,7 @@ describe('Progress screen', () => {
       const rows = screen.getAllByRole('row')
       // Jurisdiction 1 - manifest success, no CVR
       const row1 = within(rows[1]).getAllByRole('cell')
-      expectStatusTag(row1[1], '1/2 files uploaded', 'warning')
+      expectStatusTag(row1[1], '1/2 files uploaded', 'in-progress')
       expect(row1[2]).toHaveTextContent('2,117')
       expect(row1[3]).toHaveTextContent('117')
       expect(row1[4]).toHaveTextContent('2,000')
@@ -760,7 +760,7 @@ describe('Progress screen', () => {
       expect(row2[5]).toHaveTextContent('10')
       // Jurisdiction 3 - no manifest, no CVR
       const row3 = within(rows[3]).getAllByRole('cell')
-      expectStatusTag(row3[1], 'Logged in', 'alert')
+      expectStatusTag(row3[1], 'Logged in', 'warning')
       expect(row3[2]).toBeEmpty()
       expect(row3[3]).toBeEmpty()
       expect(row3[4]).toBeEmpty()
@@ -1160,7 +1160,7 @@ describe('Progress screen', () => {
       expectStatusTag(
         within(rows[2]).getAllByRole('cell')[1],
         '1/2 files uploaded',
-        'warning'
+        'in-progress'
       )
       expectStatusTag(
         within(rows[3]).getAllByRole('cell')[1],

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -171,17 +171,17 @@ const Progress: React.FC<IProgressProps> = ({
               </Status>
             )
           case JurisdictionProgressStatus.UPLOADS_IN_PROGRESS:
-            return <Status intent="warning">{filesUploadedText}</Status>
+            return <Status intent="in-progress">{filesUploadedText}</Status>
           case JurisdictionProgressStatus.UPLOADS_NOT_STARTED_LOGGED_IN:
-            return <Status intent="alert">Logged in</Status>
+            return <Status intent="warning">Logged in</Status>
           case JurisdictionProgressStatus.UPLOADS_NOT_STARTED_NO_LOGIN:
             return <Status>Not logged in</Status>
           case JurisdictionProgressStatus.AUDIT_IN_PROGRESS:
-            return <Status intent="warning">In progress</Status>
+            return <Status intent="in-progress">In progress</Status>
           case JurisdictionProgressStatus.AUDIT_COMPLETE:
             return <Status intent="success">Complete</Status>
           case JurisdictionProgressStatus.AUDIT_NOT_STARTED_LOGGED_IN:
-            return <Status intent="alert">Logged in</Status>
+            return <Status intent="warning">Logged in</Status>
           case JurisdictionProgressStatus.AUDIT_NOT_STARTED_NO_LOGIN:
             return <Status>Not logged in</Status>
           /* istanbul ignore next - unreachable when exhaustive */

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -3,14 +3,7 @@ import React, { useState, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { Column, Cell, TableInstance, SortingRule } from 'react-table'
-import {
-  Button,
-  Switch,
-  ITagProps,
-  Icon,
-  AnchorButton,
-  Spinner,
-} from '@blueprintjs/core'
+import { Button, Switch, Icon, AnchorButton, Spinner } from '@blueprintjs/core'
 import H2Title from '../../Atoms/H2Title'
 import {
   JurisdictionRoundStatus,
@@ -29,7 +22,7 @@ import {
   downloadTableAsCSV,
 } from '../../Atoms/Table'
 import { IRound } from '../useRoundsAuditAdmin'
-import StatusTag from '../../Atoms/StatusTag'
+import StatusTag, { IStatusTagProps } from '../../Atoms/StatusTag'
 import { IAuditSettings } from '../../useAuditSettings'
 import { FileProcessingStatus, IFileInfo } from '../../useCSV'
 import ProgressMap from './ProgressMap'
@@ -138,7 +131,7 @@ const Progress: React.FC<IProgressProps> = ({
       accessor: jurisdiction => {
         const { ballotManifest, batchTallies, cvrs } = jurisdiction
 
-        const Status = (props: Omit<ITagProps, 'minimal'>) => (
+        const Status = (props: IStatusTagProps) => (
           <StatusTag
             {...props}
             interactive
@@ -159,6 +152,7 @@ const Progress: React.FC<IProgressProps> = ({
           jurisdiction,
           lastLoginQuery.data![jurisdiction.id]
         )
+
         switch (jurisdictionStatus) {
           case JurisdictionProgressStatus.UPLOADS_COMPLETE:
             return (
@@ -179,7 +173,7 @@ const Progress: React.FC<IProgressProps> = ({
           case JurisdictionProgressStatus.UPLOADS_IN_PROGRESS:
             return <Status intent="warning">{filesUploadedText}</Status>
           case JurisdictionProgressStatus.UPLOADS_NOT_STARTED_LOGGED_IN:
-            return <Status intent="warning">Logged in</Status>
+            return <Status intent="alert">Logged in</Status>
           case JurisdictionProgressStatus.UPLOADS_NOT_STARTED_NO_LOGIN:
             return <Status>Not logged in</Status>
           case JurisdictionProgressStatus.AUDIT_IN_PROGRESS:
@@ -187,7 +181,7 @@ const Progress: React.FC<IProgressProps> = ({
           case JurisdictionProgressStatus.AUDIT_COMPLETE:
             return <Status intent="success">Complete</Status>
           case JurisdictionProgressStatus.AUDIT_NOT_STARTED_LOGGED_IN:
-            return <Status intent="warning">Logged in</Status>
+            return <Status intent="alert">Logged in</Status>
           case JurisdictionProgressStatus.AUDIT_NOT_STARTED_NO_LOGIN:
             return <Status>Not logged in</Status>
           /* istanbul ignore next - unreachable when exhaustive */

--- a/client/src/components/AuditAdmin/Progress/ProgressMap.tsx
+++ b/client/src/components/AuditAdmin/Progress/ProgressMap.tsx
@@ -58,6 +58,9 @@ const SVGMap = styled.svg`
   .success {
     fill: ${Colors.GREEN4};
   }
+  .gold {
+    fill: ${Colors.GOLD4};
+  }
   .progress {
     fill: ${Colors.ORANGE4};
   }
@@ -105,6 +108,9 @@ const MapLabelsBoxes = styled.div`
   &.progress {
     background-color: ${Colors.ORANGE4};
   }
+  &.gold {
+    background-color: ${Colors.GOLD4};
+  }
   &.gray {
     background-color: ${Colors.GRAY4};
   }
@@ -140,6 +146,7 @@ const Map: React.FC<IProps> = ({
   ) => {
     const jurisdictionStatus =
       jurisdiction && getJurisdictionStatus(jurisdiction)
+
     switch (jurisdictionStatus) {
       case JurisdictionProgressStatus.UPLOADS_COMPLETE:
       case JurisdictionProgressStatus.AUDIT_COMPLETE:
@@ -148,9 +155,10 @@ const Map: React.FC<IProps> = ({
         return 'danger'
       case JurisdictionProgressStatus.UPLOADS_IN_PROGRESS:
       case JurisdictionProgressStatus.AUDIT_IN_PROGRESS:
+        return 'progress'
       case JurisdictionProgressStatus.UPLOADS_NOT_STARTED_LOGGED_IN:
       case JurisdictionProgressStatus.AUDIT_NOT_STARTED_LOGGED_IN:
-        return 'progress'
+        return 'gold'
       case JurisdictionProgressStatus.UPLOADS_NOT_STARTED_NO_LOGIN:
       case JurisdictionProgressStatus.AUDIT_NOT_STARTED_NO_LOGIN:
         return 'gray'
@@ -274,7 +282,10 @@ const Map: React.FC<IProps> = ({
                 <MapLabelsBoxes className="progress" /> In progress
               </MapLabelsRow>
               <MapLabelsRow>
-                <MapLabelsBoxes className="gray" /> Not started
+                <MapLabelsBoxes className="gold" /> Logged in
+              </MapLabelsRow>
+              <MapLabelsRow>
+                <MapLabelsBoxes className="gray" /> Not logged in
               </MapLabelsRow>
               <MapLabelsRow>
                 <MapLabelsBoxes className="default" /> No data
@@ -289,7 +300,10 @@ const Map: React.FC<IProps> = ({
                 <MapLabelsBoxes className="danger" /> Manifest upload failed
               </MapLabelsRow>
               <MapLabelsRow>
-                <MapLabelsBoxes className="gray" /> No manifest uploaded
+                <MapLabelsBoxes className="gold" /> Logged in
+              </MapLabelsRow>
+              <MapLabelsRow>
+                <MapLabelsBoxes className="gray" /> Not logged in
               </MapLabelsRow>
               <MapLabelsRow>
                 <MapLabelsBoxes className="default" /> No data
@@ -307,7 +321,10 @@ const Map: React.FC<IProps> = ({
                 <MapLabelsBoxes className="progress" /> Uploads in progress
               </MapLabelsRow>
               <MapLabelsRow>
-                <MapLabelsBoxes className="gray" /> No files uploaded
+                <MapLabelsBoxes className="gold" /> Logged in
+              </MapLabelsRow>
+              <MapLabelsRow>
+                <MapLabelsBoxes className="gray" /> Not logged in
               </MapLabelsRow>
               <MapLabelsRow>
                 <MapLabelsBoxes className="default" /> No data

--- a/client/src/components/AuditAdmin/Progress/ProgressMap.tsx
+++ b/client/src/components/AuditAdmin/Progress/ProgressMap.tsx
@@ -58,10 +58,10 @@ const SVGMap = styled.svg`
   .success {
     fill: ${Colors.GREEN4};
   }
-  .gold {
-    fill: ${Colors.GOLD4};
+  .progress-2 {
+    fill: ${Colors.COBALT4};
   }
-  .progress {
+  .progress-1 {
     fill: ${Colors.ORANGE4};
   }
   .gray {
@@ -105,11 +105,11 @@ const MapLabelsBoxes = styled.div`
   &.success {
     background-color: ${Colors.GREEN4};
   }
-  &.progress {
-    background-color: ${Colors.ORANGE4};
+  &.progress-2 {
+    background-color: ${Colors.COBALT4};
   }
-  &.gold {
-    background-color: ${Colors.GOLD4};
+  &.progress-1 {
+    background-color: ${Colors.ORANGE4};
   }
   &.gray {
     background-color: ${Colors.GRAY4};
@@ -155,10 +155,10 @@ const Map: React.FC<IProps> = ({
         return 'danger'
       case JurisdictionProgressStatus.UPLOADS_IN_PROGRESS:
       case JurisdictionProgressStatus.AUDIT_IN_PROGRESS:
-        return 'progress'
+        return 'progress-2'
       case JurisdictionProgressStatus.UPLOADS_NOT_STARTED_LOGGED_IN:
       case JurisdictionProgressStatus.AUDIT_NOT_STARTED_LOGGED_IN:
-        return 'gold'
+        return 'progress-1'
       case JurisdictionProgressStatus.UPLOADS_NOT_STARTED_NO_LOGIN:
       case JurisdictionProgressStatus.AUDIT_NOT_STARTED_NO_LOGIN:
         return 'gray'
@@ -279,10 +279,10 @@ const Map: React.FC<IProps> = ({
                 <MapLabelsBoxes className="success" /> Complete
               </MapLabelsRow>
               <MapLabelsRow>
-                <MapLabelsBoxes className="progress" /> In progress
+                <MapLabelsBoxes className="progress-2" /> In progress
               </MapLabelsRow>
               <MapLabelsRow>
-                <MapLabelsBoxes className="gold" /> Logged in
+                <MapLabelsBoxes className="progress-1" /> Logged in
               </MapLabelsRow>
               <MapLabelsRow>
                 <MapLabelsBoxes className="gray" /> Not logged in
@@ -297,10 +297,10 @@ const Map: React.FC<IProps> = ({
                 <MapLabelsBoxes className="success" /> Manifest uploaded
               </MapLabelsRow>
               <MapLabelsRow>
-                <MapLabelsBoxes className="danger" /> Manifest upload failed
+                <MapLabelsBoxes className="progress-2" /> Manifest upload failed
               </MapLabelsRow>
               <MapLabelsRow>
-                <MapLabelsBoxes className="gold" /> Logged in
+                <MapLabelsBoxes className="progress-1" /> Logged in
               </MapLabelsRow>
               <MapLabelsRow>
                 <MapLabelsBoxes className="gray" /> Not logged in
@@ -318,10 +318,10 @@ const Map: React.FC<IProps> = ({
                 <MapLabelsBoxes className="danger" /> File upload failed
               </MapLabelsRow>
               <MapLabelsRow>
-                <MapLabelsBoxes className="progress" /> Uploads in progress
+                <MapLabelsBoxes className="progress-2" /> Uploads in progress
               </MapLabelsRow>
               <MapLabelsRow>
-                <MapLabelsBoxes className="gold" /> Logged in
+                <MapLabelsBoxes className="progress-1" /> Logged in
               </MapLabelsRow>
               <MapLabelsRow>
                 <MapLabelsBoxes className="gray" /> Not logged in

--- a/client/src/components/AuditAdmin/Progress/ProgressMap.tsx
+++ b/client/src/components/AuditAdmin/Progress/ProgressMap.tsx
@@ -297,7 +297,7 @@ const Map: React.FC<IProps> = ({
                 <MapLabelsBoxes className="success" /> Manifest uploaded
               </MapLabelsRow>
               <MapLabelsRow>
-                <MapLabelsBoxes className="progress-2" /> Manifest upload failed
+                <MapLabelsBoxes className="danger" /> Manifest upload failed
               </MapLabelsRow>
               <MapLabelsRow>
                 <MapLabelsBoxes className="progress-1" /> Logged in


### PR DESCRIPTION
https://github.com/votingworks/arlo/issues/2065

Updates `Logged in` status to be a different color than the various `In progress` statuses. The latter is now `GOLD1`/`GOLD4` in [Blueprint](https://blueprintjs.com/docs/#core/colors) upon which Arlo's design system is based. `Logged in` used to use the `warning` `Intent` that `In progress` also uses. `warning` uses orange per [Blueprint docs](https://blueprintjs.com/docs/#core/colors).

I didn't want to get into changing the vendored design system so I added a non-standard `alert` intent on the Arlo component that needs it. The non-standard intent is filtered out so we don't pass it as an invalid prop to the underlying Blueprint components.

![Screenshot 2024-12-03 at 3 57 40 PM](https://github.com/user-attachments/assets/d753fdf8-e7d6-4b3d-9d87-444606e684fe)
