### PR TITLE
Attempt to fix Cypress CI caching issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
           name: "Saving Cypress cache"
           key: v1-cypress-cache-{{ checksum "client/yarn.lock" }}
           paths:
-            - ~/.cache/Cypress
+            - /.cache/Cypress
       - browser-tools/install-chrome
       - create-data-model
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,12 +42,10 @@ jobs:
       - python/install-packages:
           pkg-manager: poetry
       - create-data-model
-
       - run:
           name: typecheck server
           command: |
             make typecheck-server
-
       - run:
           name: format server
           command: |
@@ -88,7 +86,6 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install graphicsmagick
-
       - run:
           name: test client
           command: |
@@ -116,13 +113,6 @@ jobs:
           key: v1-cypress-cache-{{ checksum "client/yarn.lock" }}
           paths:
             - ~/.cache/Cypress
-      # We've seen a weird issue where the Cypress cache appears to restore
-      # successfully but the Cypress binary is still missing. So we just check
-      # for it and reinstall if necessary.
-      - run:
-          name: "Verifying Cypress installation"
-          command: |
-            yarn --cwd client cypress verify || yarn --cwd client cypress install
       - browser-tools/install-chrome
       - create-data-model
       - run:
@@ -133,6 +123,7 @@ jobs:
           path: client/cypress/screenshots
       - store_artifacts:
           path: client/cypress/videos
+
 workflows:
   version: 2
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,10 +107,10 @@ jobs:
           cache-version: v10
       - restore_cache:
           name: "Restoring Cypress cache"
-          key: v1-cypress-cache-{{ checksum "client/yarn.lock" }}
+          key: v2-cypress-cache-{{ checksum "client/yarn.lock" }}
       - save_cache:
           name: "Saving Cypress cache"
-          key: v1-cypress-cache-{{ checksum "client/yarn.lock" }}
+          key: v2-cypress-cache-{{ checksum "client/yarn.lock" }}
           paths:
             - /.cache/Cypress
       - browser-tools/install-chrome

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,17 @@
 version: 2.1
 orbs:
-  python: circleci/python@2.2.0
-  node: circleci/node@6.3.0
   browser-tools: circleci/browser-tools@1.4.0
+  node: circleci/node@6.3.0
+  python: circleci/python@2.2.0
+
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - preflight
+      - build-and-test-server
+      - build-and-test-client
+      - cypress
 
 executors:
   arlo:
@@ -127,12 +136,3 @@ jobs:
           path: client/cypress/screenshots
       - store_artifacts:
           path: client/cypress/videos
-
-workflows:
-  version: 2
-  build-and-test:
-    jobs:
-      - preflight
-      - build-and-test-server
-      - build-and-test-client
-      - cypress

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,16 +107,16 @@ jobs:
           cache-version: v10
       - restore_cache:
           name: "Restoring Cypress cache"
-          key: v3-cypress-cache-{{ checksum "client/yarn.lock" }}
+          key: v4-cypress-cache-{{ checksum "client/yarn.lock" }}
       - run:
           name: "Verifying Cypress installation"
           command: |
             yarn --cwd client cypress verify || yarn --cwd client cypress install
       - save_cache:
           name: "Saving Cypress cache"
-          key: v3-cypress-cache-{{ checksum "client/yarn.lock" }}
+          key: v4-cypress-cache-{{ checksum "client/yarn.lock" }}
           paths:
-            - /.cache/Cypress
+            - /home/circleci/.cache/Cypress
       - browser-tools/install-chrome
       - create-data-model
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,10 @@ jobs:
       - restore_cache:
           name: "Restoring Cypress cache"
           key: v2-cypress-cache-{{ checksum "client/yarn.lock" }}
+      - run:
+          name: "Verifying Cypress installation"
+          command: |
+            yarn --cwd client cypress verify || yarn --cwd client cypress install
       - save_cache:
           name: "Saving Cypress cache"
           key: v2-cypress-cache-{{ checksum "client/yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,14 +107,14 @@ jobs:
           cache-version: v10
       - restore_cache:
           name: "Restoring Cypress cache"
-          key: v2-cypress-cache-{{ checksum "client/yarn.lock" }}
+          key: v3-cypress-cache-{{ checksum "client/yarn.lock" }}
       - run:
           name: "Verifying Cypress installation"
           command: |
             yarn --cwd client cypress verify || yarn --cwd client cypress install
       - save_cache:
           name: "Saving Cypress cache"
-          key: v2-cypress-cache-{{ checksum "client/yarn.lock" }}
+          key: v3-cypress-cache-{{ checksum "client/yarn.lock" }}
           paths:
             - /.cache/Cypress
       - browser-tools/install-chrome

--- a/README.md
+++ b/README.md
@@ -148,5 +148,3 @@ To run tests while developing, you can use these commands to make things more in
 - Server tests: `poetry run pytest` (you can add flags - e.g. `-k <pattern>` only runs tests that match the pattern, `-n auto` to run the tests in parallel)
 - Client tests: `yarn --cwd client test` (runs interactive test CLI)
 - End-to-end tests: first run `FLASK_ENV=test ./run-dev.sh` to run the server, then, in a separate shell, run `yarn --cwd client run cypress open` (opens the Cypress test app for interactive test running/debugging)
-
-Another test

--- a/README.md
+++ b/README.md
@@ -148,3 +148,5 @@ To run tests while developing, you can use these commands to make things more in
 - Server tests: `poetry run pytest` (you can add flags - e.g. `-k <pattern>` only runs tests that match the pattern, `-n auto` to run the tests in parallel)
 - Client tests: `yarn --cwd client test` (runs interactive test CLI)
 - End-to-end tests: first run `FLASK_ENV=test ./run-dev.sh` to run the server, then, in a separate shell, run `yarn --cwd client run cypress open` (opens the Cypress test app for interactive test running/debugging)
+
+Another test


### PR DESCRIPTION
We've been seeing issues the last couple weeks with the cached Cypress binary being found in the cache, supposedly restored, but then it is missing when Cypress runs.

We implemented a safe fail last week, where we check if Cypress is there, and then install it if not. This has unblocked development, but recent builds have been needing to use the failsafe, reinstalling Cypress on [main](https://app.circleci.com/jobs/github/votingworks/arlo/23455) and this recent [branch](https://app.circleci.com/pipelines/github/votingworks/arlo/7630/workflows/2936d6fa-1f68-49c2-978c-7dfacd1dbac2/jobs/23519) during the `Verify Cypress` step. 

1. This PR changes the cache path from using a `~` to indicate the home path, to explicitly using the home path of `home/circleci`. In a somewhat unrelated post, it was suggested that circle can have issues with the `~`, even though it is what they use in their documentation. I gave it a try, and I've seen Cypress consistently restore from cache now.
2. Maintains the `Verify Cypress` step, but now puts it before the `Save Cache` step, so that way when we do have to generate a new binary when the `package.json` changes, we automatically generate the new binary and cache it
3. Small cleanup of the CI file, including moving Workflows to the top. This is just stylistic preference, treating it kind of like a "table of contents" so it's clear what the main steps in the workflow are.