### PR TITLE
Standardize Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
       - run:
           name: create data model
           command: |
-            make resetdb
+            make db-clean
       # Generate the en_US.UTF-8 locale (which for some reason isn't set up in
       # the Docker container we use). arlo uses this locale to parse numbers in CSVs.
       - run:
@@ -54,16 +54,16 @@ jobs:
       - run:
           name: typecheck server
           command: |
-            make typecheck-server
+            make typecheck
       - run:
           name: format server
           command: |
-            make format-server
+            make format
             git diff-index --quiet HEAD -- || (echo "Found unexpected changes!" && git diff && exit 1)
       - run:
           name: lint server
           command: |
-            make lint-server
+            make lint
 
   build-and-test-server:
     executor: arlo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
       - run:
           name: test client
           command: |
-            make test-client
+            make -C client test
 
   cypress:
     executor: arlo

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Prepare environment for development
+## Prepare environment for development
 
 prepare:
 	sudo apt update
@@ -17,15 +17,13 @@ prepare:
 	@echo "User action required: Make poetry available in your PATH. This will vary depending on your configuration"
 	@echo "If using bash, add 'export PATH=\"\$$PATH:\$$HOME/.local/bin\"' to your .bashrc and then run 'source ~/.bashrc'"
 
-# Local 
-
 db-prepare:
 	sudo systemctl start postgresql
 	sudo -u postgres psql -c "create user arlo superuser password 'arlo';"
 	sudo -u postgres psql -c "create database arlo with owner arlo;"
 	make db-clean
 
-# Local development
+## Local development
 
 dev-environment: prepare db-prepare install 
 

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,18 @@ prepare:
 	sudo apt-get install -y nodejs
 	# Install poetry: https://python-poetry.org/docs/#installing-with-the-official-installer
 	curl -sSL https://install.python-poetry.org | python3.9 -
-	# Allow poetry to be called from the command line and make commands
-	@if ! echo "$$PATH" | grep -q "$$HOME/.local/bin"; then \
-		export PATH="$$PATH:$$HOME/.local/bin"; \
-	fi
 	# Install yarn
 	sudo npm install -g yarn
 	yarn install
 	yarn prepare # Sets up Git hooks
+	# Ensure poetry can be called from the command line and make commands; add to .bashrc and current shell
+	@if ! echo "$$PATH" | grep -q "$$HOME/.local/bin"; then \
+		echo 'export PATH="$$PATH:$$HOME/.local/bin"' >> $$HOME/.bashrc; \
+		export PATH="$$PATH:$$HOME/.local/bin"; \
+		echo "Added $$HOME/.local/bin to PATH for current shell and future sessions."; \
+	fi
+
+# Local 
 
 db-prepare:
 	sudo systemctl start postgresql
@@ -36,7 +40,7 @@ run: # Used for development, not during production deployment. Defaults to 3 por
 install:
 	poetry install
 	yarn install
-	yarn --cwd client install
+	make -C client install
 
 typecheck:
 	poetry run mypy server scripts fixtures
@@ -51,20 +55,16 @@ test:
 	poetry run pytest -n auto --ignore=server/tests/arlo-extra-tests 
 
 test-clean:
-	FLASK_ENV=test make resetdb
+	FLASK_ENV=test make db-clean
 
-test-with-coverage:
+test-coverage:
 	poetry run pytest -n auto --cov=. --ignore=server/tests/arlo-extra-tests
 
-test-all: # This runs the _extra files_ repo tests as well (must download first)
+test-extra: # This runs the _extra files_ repo tests as well (must download first)
 	poetry run pytest -n auto 
 
-test-all-with-coverage:
+test-extra-coverage:
 	poetry run pytest -n auto --cov=.
-
-test-client:
-	yarn --cwd client lint
-	yarn --cwd client test
 
 ## Database
 

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,9 @@ prepare:
 	sudo npm install -g yarn
 	yarn install
 	yarn prepare # Sets up Git hooks
-	# Ensure poetry can be called from the command line and make commands; add to .bashrc and current shell
-	@if ! echo "$$PATH" | grep -q "$$HOME/.local/bin"; then \
-		echo 'export PATH="$$PATH:$$HOME/.local/bin"' >> $$HOME/.bashrc; \
-		export PATH="$$PATH:$$HOME/.local/bin"; \
-		echo "Added $$HOME/.local/bin to PATH for current shell and future sessions."; \
-	fi
+	# Ensure poetry can be called from the command line and make commands
+	@echo "User action required: Make poetry available in your PATH. This will vary depending on your configuration"
+	@echo "If using bash, add 'export PATH=\"\$$PATH:\$$HOME/.local/bin\"' to your .bashrc and then run 'source ~/.bashrc'"
 
 # Local 
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -1,16 +1,15 @@
 
 install:
 	yarn install
-	npm install
 
 run:
-	npm run start
+	yarn start
 
 lint:
-	npm run lint
+	yarn lint
 
 test:
-	npm run test
+	yarn test
 
 build:
-	npm run build
+	yarn build

--- a/client/Makefile
+++ b/client/Makefile
@@ -1,0 +1,16 @@
+
+install:
+	yarn install
+	npm install
+
+run:
+	npm run start
+
+lint:
+	npm run lint
+
+test:
+	npm run test
+
+build:
+	npm run build


### PR DESCRIPTION
This PR makes updates to Makefile to better mirror the commands of VxSuite and more common make commands.

The inspiration for this was that as a new developer to Arlo, I found myself stumbling a bit when figuring out what commands to run. My hope is that this would be intuitive for both more familiar and newer engineers.

I've made some opinionated choices, with the idea that feedback will help me find the right balance. I'm definitely not attached to any of these changes!

Main points:
1. If possible, choose a command name that mirrors VxSuite [commands](https://github.com/votingworks/vxsuite/blob/main/apps/mark/backend/Makefile) and fallback to other common commands
2. Since the root directory is also the root of the server, let all base commands (like `make typecheck`) reference the server by default. This is a change that I thought would be helpful as I developed, but it may be opposed which I'd understand! I think it is intuitive, with a separate Makefile in the client directory
3. Other small reorganizations, consolidations, or command renames

Next steps:
1. Get feedback
2. Test out as I develop within Arlo