### PR TITLE
Update Support Tools UI Homepage

### DIFF
--- a/client/src/components/Atoms/Wrapper.tsx
+++ b/client/src/components/Atoms/Wrapper.tsx
@@ -28,8 +28,8 @@ export const SupportToolsInner = styled.div`
   justify-content: center;
   margin-left: auto;
   margin-right: auto;
-  padding: 30px 0;
-  width: 80%;
+  padding: 30px 150px;
+  width: 100%;
 `
 
 export default Wrapper

--- a/client/src/components/Atoms/Wrapper.tsx
+++ b/client/src/components/Atoms/Wrapper.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  width: 85%;
+  width: 100%;
   padding-bottom: 30px;
 `
 
@@ -17,9 +17,19 @@ export const Inner = styled.div<IInnerProps>`
   margin-right: auto;
   margin-left: auto;
   width: 100%;
+  max-width: 1020px;
   padding: 0 30px;
   padding-top: ${props => (props.withTopPadding ? '30px' : undefined)};
   flex-direction: ${props => props.flexDirection || undefined};
+`
+
+export const SupportToolsInner = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 30px 0;
+  width: 80%;
 `
 
 export default Wrapper

--- a/client/src/components/Atoms/Wrapper.tsx
+++ b/client/src/components/Atoms/Wrapper.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  width: 100%;
+  width: 85%;
   padding-bottom: 30px;
 `
 
@@ -17,7 +17,6 @@ export const Inner = styled.div<IInnerProps>`
   margin-right: auto;
   margin-left: auto;
   width: 100%;
-  max-width: 1020px;
   padding: 0 30px;
   padding-top: ${props => (props.withTopPadding ? '30px' : undefined)};
   flex-direction: ${props => props.flexDirection || undefined};

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
@@ -7,19 +7,19 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
     style="width: 100%;"
   >
     <div
-      class="sc-cvbbAY VKHTj"
+      class="sc-jWBwVP loKOAG"
     >
       <h2
-        class="bp3-heading sc-eHgmQL kvtVzr"
+        class="bp3-heading sc-cvbbAY IbGJt"
       >
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-gzOgki emHSJk"
+        class="bp3-card bp3-elevation-0 sc-iyvyFf YETFX"
         style="background: rgb(245, 248, 250);"
       >
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
           style="margin-top: 0px;"
         >
           <h5
@@ -29,7 +29,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
           </h5>
           <div>
             <div
-              class="sc-gzVnrw kvvweo"
+              class="sc-htoDjs GlcDy"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -41,10 +41,10 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               
                Name
               <div
-                class="sc-gqjmRU egaEhI"
+                class="sc-VigVT gububh"
               >
                 <div
-                  class="bp3-input-group sc-VigVT hfLuvB"
+                  class="bp3-input-group sc-jTzLTM heoCiM"
                 >
                   <input
                     class="bp3-input"
@@ -58,7 +58,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             </label>
           </div>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the number of winners for the contest.
           </div>
@@ -67,10 +67,10 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
           >
             Winners
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -83,7 +83,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -92,10 +92,10 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
           >
             Votes Allowed
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -109,7 +109,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
           </label>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
         >
           <h5
             class="bp3-heading"
@@ -117,26 +117,26 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             Candidates/Choices & Vote Totals
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jtRfpW hmuSrk"
+            class="sc-kTUwUJ dsKKbc"
           >
             <div
-              class="sc-kTUwUJ hZCNF"
+              class="sc-dqBHgY kXQNIO"
             >
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -148,15 +148,15 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -169,18 +169,18 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <div
-              class="sc-kTUwUJ hZCNF"
+              class="sc-dqBHgY kXQNIO"
             >
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -192,15 +192,15 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
                 </div>
               </label>
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -213,14 +213,14 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               </label>
             </div>
             <p
-              class="sc-dfVpRl iBZboO"
+              class="sc-gzOgki gzLLVp"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
         >
           <h5
             class="bp3-heading"
@@ -228,7 +228,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             Total Ballot Cards Cast
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -239,10 +239,10 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
              
             
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -256,7 +256,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
           </label>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
           style="margin-bottom: 0px;"
         >
           <h5
@@ -265,7 +265,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
             Contest Universe
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -276,7 +276,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-dnqmqq iQfLYL"
+                class="bp3-button sc-iwsKbI drSRDt"
                 type="button"
               >
                 <span
@@ -324,7 +324,7 @@ exports[`Audit Setup > Contests renders empty opportunistic state correctly 1`] 
       </div>
     </div>
     <div
-      class="sc-elJkPf cZLJPn"
+      class="sc-jtRfpW cLRBN"
       style="margin-top: 15px;"
     >
       <button
@@ -397,19 +397,19 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
     style="width: 100%;"
   >
     <div
-      class="sc-cvbbAY VKHTj"
+      class="sc-jWBwVP loKOAG"
     >
       <h2
-        class="bp3-heading sc-eHgmQL kvtVzr"
+        class="bp3-heading sc-cvbbAY IbGJt"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-gzOgki emHSJk"
+        class="bp3-card bp3-elevation-0 sc-iyvyFf YETFX"
         style="background: rgb(245, 248, 250);"
       >
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
           style="margin-top: 0px;"
         >
           <h5
@@ -419,7 +419,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           </h5>
           <div>
             <div
-              class="sc-gzVnrw kvvweo"
+              class="sc-htoDjs GlcDy"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -431,10 +431,10 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               
                Name
               <div
-                class="sc-gqjmRU egaEhI"
+                class="sc-VigVT gububh"
               >
                 <div
-                  class="bp3-input-group sc-VigVT hfLuvB"
+                  class="bp3-input-group sc-jTzLTM heoCiM"
                 >
                   <input
                     class="bp3-input"
@@ -448,7 +448,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             </label>
           </div>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the number of winners for the contest.
           </div>
@@ -457,10 +457,10 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           >
             Winners
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -473,7 +473,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -482,10 +482,10 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -499,7 +499,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
         >
           <h5
             class="bp3-heading"
@@ -507,26 +507,26 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             Candidates/Choices & Vote Totals
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jtRfpW hmuSrk"
+            class="sc-kTUwUJ dsKKbc"
           >
             <div
-              class="sc-kTUwUJ hZCNF"
+              class="sc-dqBHgY kXQNIO"
             >
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -538,15 +538,15 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -559,18 +559,18 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-kTUwUJ hZCNF"
+              class="sc-dqBHgY kXQNIO"
             >
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -582,15 +582,15 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -603,14 +603,14 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-dfVpRl iBZboO"
+              class="sc-gzOgki gzLLVp"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
         >
           <h5
             class="bp3-heading"
@@ -618,7 +618,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             Total Ballot Cards Cast
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -629,10 +629,10 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
              
             
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -646,7 +646,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
           style="margin-bottom: 0px;"
         >
           <h5
@@ -655,7 +655,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
             Contest Universe
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -666,7 +666,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-dnqmqq iQfLYL"
+                class="bp3-button sc-iwsKbI drSRDt"
                 type="button"
               >
                 <span
@@ -714,7 +714,7 @@ exports[`Audit Setup > Contests renders empty targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-elJkPf cZLJPn"
+      class="sc-jtRfpW cLRBN"
       style="margin-top: 15px;"
     >
       <button
@@ -787,19 +787,19 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
     style="width: 100%;"
   >
     <div
-      class="sc-cvbbAY VKHTj"
+      class="sc-jWBwVP loKOAG"
     >
       <h2
-        class="bp3-heading sc-eHgmQL kvtVzr"
+        class="bp3-heading sc-cvbbAY IbGJt"
       >
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-gzOgki emHSJk"
+        class="bp3-card bp3-elevation-0 sc-iyvyFf YETFX"
         style="background: rgb(245, 248, 250);"
       >
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
           style="margin-top: 0px;"
         >
           <h5
@@ -809,7 +809,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           </h5>
           <div>
             <div
-              class="sc-gzVnrw kvvweo"
+              class="sc-htoDjs GlcDy"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -821,10 +821,10 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               
                Name
               <div
-                class="sc-gqjmRU egaEhI"
+                class="sc-VigVT gububh"
               >
                 <div
-                  class="bp3-input-group sc-VigVT hfLuvB"
+                  class="bp3-input-group sc-jTzLTM heoCiM"
                 >
                   <input
                     class="bp3-input"
@@ -838,7 +838,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             </label>
           </div>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the number of winners for the contest.
           </div>
@@ -847,10 +847,10 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           >
             Winners
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -863,7 +863,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -872,10 +872,10 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           >
             Votes Allowed
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -889,7 +889,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           </label>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
         >
           <h5
             class="bp3-heading"
@@ -897,26 +897,26 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             Candidates/Choices & Vote Totals
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jtRfpW hmuSrk"
+            class="sc-kTUwUJ dsKKbc"
           >
             <div
-              class="sc-kTUwUJ hZCNF"
+              class="sc-dqBHgY kXQNIO"
             >
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -928,15 +928,15 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -949,18 +949,18 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <div
-              class="sc-kTUwUJ hZCNF"
+              class="sc-dqBHgY kXQNIO"
             >
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -972,15 +972,15 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
                 </div>
               </label>
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -993,14 +993,14 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               </label>
             </div>
             <p
-              class="sc-dfVpRl iBZboO"
+              class="sc-gzOgki gzLLVp"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
         >
           <h5
             class="bp3-heading"
@@ -1008,7 +1008,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             Total Ballot Cards Cast
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -1019,10 +1019,10 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
              
             
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -1036,7 +1036,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
           </label>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
           style="margin-bottom: 0px;"
         >
           <h5
@@ -1045,7 +1045,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
             Contest Universe
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -1056,7 +1056,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-dnqmqq iQfLYL"
+                class="bp3-button sc-iwsKbI drSRDt"
                 type="button"
               >
                 <span
@@ -1104,7 +1104,7 @@ exports[`Audit Setup > Contests renders filled opportunistic state correctly 1`]
       </div>
     </div>
     <div
-      class="sc-elJkPf cZLJPn"
+      class="sc-jtRfpW cLRBN"
       style="margin-top: 15px;"
     >
       <button
@@ -1177,19 +1177,19 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
     style="width: 100%;"
   >
     <div
-      class="sc-cvbbAY VKHTj"
+      class="sc-jWBwVP loKOAG"
     >
       <h2
-        class="bp3-heading sc-eHgmQL kvtVzr"
+        class="bp3-heading sc-cvbbAY IbGJt"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-gzOgki emHSJk"
+        class="bp3-card bp3-elevation-0 sc-iyvyFf YETFX"
         style="background: rgb(245, 248, 250);"
       >
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
           style="margin-top: 0px;"
         >
           <h5
@@ -1199,7 +1199,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
           </h5>
           <div>
             <div
-              class="sc-gzVnrw kvvweo"
+              class="sc-htoDjs GlcDy"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -1211,10 +1211,10 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               
                Name
               <div
-                class="sc-gqjmRU egaEhI"
+                class="sc-VigVT gububh"
               >
                 <div
-                  class="bp3-input-group sc-VigVT hfLuvB"
+                  class="bp3-input-group sc-jTzLTM heoCiM"
                 >
                   <input
                     class="bp3-input"
@@ -1228,7 +1228,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             </label>
           </div>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the number of winners for the contest.
           </div>
@@ -1237,10 +1237,10 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
           >
             Winners
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -1253,7 +1253,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -1262,10 +1262,10 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -1279,7 +1279,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
         >
           <h5
             class="bp3-heading"
@@ -1287,26 +1287,26 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             Candidates/Choices & Vote Totals
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jtRfpW hmuSrk"
+            class="sc-kTUwUJ dsKKbc"
           >
             <div
-              class="sc-kTUwUJ hZCNF"
+              class="sc-dqBHgY kXQNIO"
             >
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -1318,15 +1318,15 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -1339,18 +1339,18 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-kTUwUJ hZCNF"
+              class="sc-dqBHgY kXQNIO"
             >
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -1362,15 +1362,15 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -1383,14 +1383,14 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-dfVpRl iBZboO"
+              class="sc-gzOgki gzLLVp"
             >
               Add a new candidate/choice
             </p>
           </div>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
         >
           <h5
             class="bp3-heading"
@@ -1398,7 +1398,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             Total Ballot Cards Cast
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -1409,10 +1409,10 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
              
             
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -1426,7 +1426,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
           style="margin-bottom: 0px;"
         >
           <h5
@@ -1435,7 +1435,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
             Contest Universe
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -1446,7 +1446,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
               class="bp3-popover-target"
             >
               <button
-                class="bp3-button sc-dnqmqq iQfLYL"
+                class="bp3-button sc-iwsKbI drSRDt"
                 type="button"
               >
                 <span
@@ -1494,7 +1494,7 @@ exports[`Audit Setup > Contests renders filled targeted state correctly 1`] = `
       </div>
     </div>
     <div
-      class="sc-elJkPf cZLJPn"
+      class="sc-jtRfpW cLRBN"
       style="margin-top: 15px;"
     >
       <button

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
@@ -7,19 +7,19 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
     style="width: 100%;"
   >
     <div
-      class="sc-cvbbAY VKHTj"
+      class="sc-jWBwVP loKOAG"
     >
       <h2
-        class="bp3-heading sc-eHgmQL kvtVzr"
+        class="bp3-heading sc-cvbbAY IbGJt"
       >
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-gzOgki emHSJk"
+        class="bp3-card bp3-elevation-0 sc-iyvyFf YETFX"
         style="background: rgb(245, 248, 250);"
       >
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
           style="margin-top: 0px;"
         >
           <h5
@@ -29,7 +29,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
           </h5>
           <div>
             <div
-              class="sc-gzVnrw kvvweo"
+              class="sc-htoDjs GlcDy"
             >
               Select the name of the contest that will drive the audit.
             </div>
@@ -42,7 +42,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                Name
               <br />
               <div
-                class="bp3-html-select sc-hwwEjo fSWVqj"
+                class="bp3-html-select sc-kPVwWT hxepak"
               >
                 <select
                   field="[object Object]"
@@ -94,7 +94,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
             </label>
           </div>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the number of winners for the contest.
           </div>
@@ -103,10 +103,10 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
           >
             Winners
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -119,7 +119,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
             </div>
           </label>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -128,10 +128,10 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
           >
             Votes Allowed
             <div
-              class="sc-gqjmRU egaEhI"
+              class="sc-VigVT gububh"
             >
               <div
-                class="bp3-input-group sc-VigVT hfLuvB"
+                class="bp3-input-group sc-jTzLTM heoCiM"
               >
                 <input
                   class="bp3-input"
@@ -145,7 +145,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
           </label>
         </div>
         <div
-          class="sc-bZQynM eQtLAV"
+          class="sc-gzVnrw fZKilH"
         >
           <h5
             class="bp3-heading"
@@ -153,26 +153,26 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
             Candidates/Choices & Vote Totals
           </h5>
           <div
-            class="sc-gzVnrw kvvweo"
+            class="sc-htoDjs GlcDy"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-jtRfpW hmuSrk"
+            class="sc-kTUwUJ dsKKbc"
           >
             <div
-              class="sc-kTUwUJ hZCNF"
+              class="sc-dqBHgY kXQNIO"
             >
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -184,15 +184,15 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -205,18 +205,18 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <div
-              class="sc-kTUwUJ hZCNF"
+              class="sc-dqBHgY kXQNIO"
             >
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -228,15 +228,15 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-gxMtzJ dbFvFE"
+                class="bp3-label sc-dfVpRl TNLpk"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-dqBHgY eJNBod sc-gqjmRU egaEhI"
+                  class="sc-gxMtzJ gJDHuz sc-VigVT gububh"
                 >
                   <div
-                    class="bp3-input-group sc-VigVT hfLuvB"
+                    class="bp3-input-group sc-jTzLTM heoCiM"
                   >
                     <input
                       class="bp3-input"
@@ -249,7 +249,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
               </label>
             </div>
             <p
-              class="sc-dfVpRl iBZboO"
+              class="sc-gzOgki gzLLVp"
             >
               Add a new candidate/choice
             </p>
@@ -291,7 +291,7 @@ exports[`Audit Setup > Contests (Hybrid) Audit Setup > Contests 1`] = `
       </div>
     </div>
     <div
-      class="sc-elJkPf cZLJPn"
+      class="sc-jtRfpW cLRBN"
       style="margin-top: 15px;"
     >
       <button

--- a/client/src/components/AuditAdmin/__snapshots__/ActivityLog.test.tsx.snap
+++ b/client/src/components/AuditAdmin/__snapshots__/ActivityLog.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Activity Log shows a table of activity for the org 1`] = `
 <table
-  class="sc-kGXeez fVIhxz"
+  class="sc-kpOJdX dLlwHp"
   id="activityLog"
   style="table-layout: auto;"
 >

--- a/client/src/components/AuditAdmin/__snapshots__/AuditAdminView.test.tsx.snap
+++ b/client/src/components/AuditAdmin/__snapshots__/AuditAdminView.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
     class="sc-bdVaJa bKocXA"
   >
     <div
-      class="bp3-callout sc-bxivhb dweKfW"
+      class="bp3-callout sc-ifAKCX dZENeW"
     >
       <div
         class="sc-bwzfXH ijTqJq"
@@ -15,7 +15,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
           class="text"
         >
           <h3
-            class="bp3-heading sc-htpNat hodhlw"
+            class="bp3-heading sc-bxivhb fRKsxU"
           >
             Test Audit
           </h3>
@@ -38,10 +38,10 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
       class="sc-bwzfXH ijTqJq"
     >
       <div
-        class="sc-brqgnP lgMuXE"
+        class="sc-cMljjf caNgGf"
       >
         <h2
-          class="bp3-heading sc-bZQynM bTVHiW"
+          class="bp3-heading sc-gzVnrw eWpiCn"
         >
           Audit Setup
         </h2>
@@ -138,20 +138,20 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
         </ul>
       </div>
       <div
-        class="sc-gzVnrw gJSMJx"
+        class="sc-htoDjs tELUi"
       >
         <h2
-          class="bp3-heading sc-bZQynM bTVHiW"
+          class="bp3-heading sc-gzVnrw eWpiCn"
         >
           Participants
         </h2>
         <form>
           <div
-            class="sc-gzVnrw gJSMJx"
+            class="sc-htoDjs tELUi"
           >
             <div>
               <div
-                class="sc-dnqmqq kGMqKN"
+                class="sc-iwsKbI bncGzX"
               >
                 Click "Browse" to choose the appropriate file from your computer. This file should be a comma-separated list of all the jurisdictions participating in the audit, plus email addresses for audit administrators in each participating jurisdiction.
               </div>
@@ -165,7 +165,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
                 file name
               </p>
               <p
-                class="sc-gZMcBi jnaCUP"
+                class="sc-gqjmRU sZbzH"
               >
                 Uploaded at
                  
@@ -174,7 +174,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
               </p>
               <div>
                 <button
-                  class="bp3-button sc-VigVT cQCGhc"
+                  class="bp3-button sc-jTzLTM kWdIFo"
                   type="button"
                 >
                   <span
@@ -203,7 +203,7 @@ exports[`AA setup flow renders sidebar when authenticated on /setup 1`] = `
           </div>
         </form>
         <div
-          class="sc-EHOje jmejrp"
+          class="sc-bZQynM bYVib"
           style="margin-top: 20px;"
         >
           <button

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
     class="sc-bdVaJa bKocXA"
   >
     <div
-      class="bp3-navbar sc-bxivhb jwFLoW"
+      class="bp3-navbar sc-ifAKCX jojstv"
     >
       <div
-        class="sc-bwzfXH sc-EHOje eysEZT"
+        class="sc-bwzfXH sc-bZQynM eYXcfZ"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -61,19 +61,19 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-hGoxap jxCAYo"
+          class="sc-fjmCvl leJAIh"
         >
           <div
-            class="sc-fjmCvl kbbZEq"
+            class="sc-TFwJa gDCruM"
           >
             <div
-              class="sc-TFwJa cuFtfU"
+              class="sc-bHwgHz iHpxHw"
             >
               <div
-                class="sc-dTdPqK XvrMK"
+                class="sc-itybZL ejLWp"
               >
                 <button
-                  class="bp3-button bp3-minimal sc-krDsej eqlcSx"
+                  class="bp3-button bp3-minimal sc-dTdPqK cVJplz"
                   href="/election/1/audit-board/audit-board-1"
                   type="button"
                 >
@@ -103,56 +103,56 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                   </span>
                 </button>
                 <h3
-                  class="bp3-heading sc-laTMn hNxafJ"
+                  class="bp3-heading sc-hGoxap gluOSD"
                 >
                   Audit Ballot Selections
                 </h3>
               </div>
               <div
-                class="bp3-divider sc-krvtoX dSdfvo"
+                class="bp3-divider sc-fYiAbW dxAgxk"
               />
               <div
-                class="sc-fhYwyz cltIWF"
+                class="sc-jzgbtB jblLby"
               >
                 <div>
                   <h5
-                    class="bp3-heading sc-bnXvFD emzaP"
+                    class="bp3-heading sc-gFaPwZ bEnBKi"
                   >
                     Tabulator
                   </h5>
                   <h4
-                    class="bp3-heading sc-jzgbtB HPCxV"
+                    class="bp3-heading sc-gJWqzi elRxiL"
                   >
                     11
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-bnXvFD emzaP"
+                    class="bp3-heading sc-gFaPwZ bEnBKi"
                   >
                     Batch
                   </h5>
                   <h4
-                    class="bp3-heading sc-jzgbtB HPCxV"
+                    class="bp3-heading sc-gJWqzi elRxiL"
                   >
                     0003-04-Precinct 19 (Jonesboro Fire Department)
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-bnXvFD emzaP"
+                    class="bp3-heading sc-gFaPwZ bEnBKi"
                   >
                     Ballot Number
                   </h5>
                   <h4
-                    class="bp3-heading sc-jzgbtB HPCxV"
+                    class="bp3-heading sc-gJWqzi elRxiL"
                   >
                     2112
                   </h4>
                 </div>
                 <div>
                   <button
-                    class="bp3-button bp3-large bp3-intent-danger sc-gJWqzi bimmLP"
+                    class="bp3-button bp3-large bp3-intent-danger sc-rBLzX dDtMXc"
                     type="button"
                   >
                     <span
@@ -164,36 +164,36 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 </div>
               </div>
               <div
-                class="bp3-divider sc-krvtoX dSdfvo"
+                class="bp3-divider sc-fYiAbW dxAgxk"
               />
               <div
-                class="sc-fYiAbW hEmmmp"
+                class="sc-fOKMvo bElCUl"
               >
                 <div
                   class="ballot-main"
                 >
                   <h5
-                    class="bp3-heading sc-bnXvFD emzaP"
+                    class="bp3-heading sc-gFaPwZ bEnBKi"
                   >
                     Ballot Contests
                   </h5>
                   <form>
                     <div
-                      class="sc-fOKMvo ceoafp"
+                      class="sc-dUjcNx fBTewu"
                     >
                       <div
-                        class="sc-emmjRN lkDFwY"
+                        class="sc-cpmLhU dkUHbh"
                       >
                         <div
-                          class="sc-cpmLhU dSHspV"
+                          class="sc-dymIpo Uxgsi"
                         >
                           <h3
-                            class="bp3-heading sc-bMvGRv hwuwxh"
+                            class="bp3-heading sc-CtfFt cQhEcV"
                           >
                             Contest 1
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
+                            class="bp3-control bp3-checkbox sc-fhYwyz dLpLEW"
                           >
                             <input
                               type="checkbox"
@@ -209,7 +209,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
+                            class="bp3-control bp3-checkbox sc-fhYwyz dLpLEW"
                           >
                             <input
                               type="checkbox"
@@ -226,10 +226,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-dymIpo dJmdUv"
+                          class="sc-bnXvFD kNigVl"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
+                            class="bp3-control bp3-checkbox sc-fhYwyz dLpLEW"
                           >
                             <input
                               type="checkbox"
@@ -245,7 +245,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
+                            class="bp3-control bp3-checkbox sc-fhYwyz dLpLEW"
                           >
                             <input
                               type="checkbox"
@@ -261,7 +261,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
+                            class="bp3-control bp3-checkbox sc-fhYwyz dLpLEW"
                           >
                             <input
                               type="checkbox"
@@ -277,7 +277,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-rBLzX kneByf"
+                            class="bp3-input sc-bMvGRv iTsuWx"
                             name="comment-Contest 1"
                             placeholder="Add Note"
                           />
@@ -285,21 +285,21 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-fOKMvo ceoafp"
+                      class="sc-dUjcNx fBTewu"
                     >
                       <div
-                        class="sc-emmjRN lkDFwY"
+                        class="sc-cpmLhU dkUHbh"
                       >
                         <div
-                          class="sc-cpmLhU dSHspV"
+                          class="sc-dymIpo Uxgsi"
                         >
                           <h3
-                            class="bp3-heading sc-bMvGRv hwuwxh"
+                            class="bp3-heading sc-CtfFt cQhEcV"
                           >
                             Contest 2
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
+                            class="bp3-control bp3-checkbox sc-fhYwyz dLpLEW"
                           >
                             <input
                               type="checkbox"
@@ -315,7 +315,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
+                            class="bp3-control bp3-checkbox sc-fhYwyz dLpLEW"
                           >
                             <input
                               type="checkbox"
@@ -332,10 +332,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-dymIpo dJmdUv"
+                          class="sc-bnXvFD kNigVl"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
+                            class="bp3-control bp3-checkbox sc-fhYwyz dLpLEW"
                           >
                             <input
                               type="checkbox"
@@ -351,7 +351,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
+                            class="bp3-control bp3-checkbox sc-fhYwyz dLpLEW"
                           >
                             <input
                               type="checkbox"
@@ -367,7 +367,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-gFaPwZ jeiRzE"
+                            class="bp3-control bp3-checkbox sc-fhYwyz dLpLEW"
                           >
                             <input
                               type="checkbox"
@@ -383,7 +383,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-rBLzX kneByf"
+                            class="bp3-input sc-bMvGRv iTsuWx"
                             name="comment-Contest 2"
                             placeholder="Add Note"
                           />
@@ -391,10 +391,10 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-gHboQg MSZtC"
+                      class="sc-eilVRo dPNVAD"
                     >
                       <button
-                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-CtfFt eWjIDB sc-dnqmqq iQfLYL"
+                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-laTMn hDWEJx sc-iwsKbI drSRDt"
                         disabled=""
                         tabindex="-1"
                         type="submit"
@@ -421,7 +421,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
               </div>
             </div>
             <div
-              class="sc-bHwgHz cmRXTS"
+              class="sc-krDsej jejyqq"
             >
               <h4
                 class="bp3-heading"
@@ -429,7 +429,7 @@ exports[`AuditBoardView ballot interaction renders ballot route 1`] = `
                 Instructions
               </h4>
               <ol
-                class="bp3-list sc-itybZL bFYtBd"
+                class="bp3-list sc-eMigcr ggXtUt"
               >
                 <li>
                   Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -480,10 +480,10 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
     class="sc-bdVaJa bKocXA"
   >
     <div
-      class="bp3-navbar sc-bxivhb jwFLoW"
+      class="bp3-navbar sc-ifAKCX jojstv"
     >
       <div
-        class="sc-bwzfXH sc-EHOje eysEZT"
+        class="sc-bwzfXH sc-bZQynM eYXcfZ"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -534,13 +534,13 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
       class="board-table-container"
     >
       <div
-        class="sc-gqPbQI jusmQx"
+        class="sc-hORach ksqClF"
       >
         <div
-          class="sc-bwzfXH sc-hORach hoVPwJ"
+          class="sc-bwzfXH sc-bMVAic bUKdYf"
         >
           <div
-            class="sc-hMFtBS fymdRq"
+            class="sc-cLQEGU iumUdS"
           >
             <p>
               18
@@ -549,23 +549,23 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-gojNiO cNYwPJ"
+              class="summary-label sc-daURTG bIGEpE"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-daURTG hmBDJZ"
+              class="summary-label sc-bXGyLb dohxps"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-cLQEGU fHzmhT"
+            class="sc-gqPbQI bKhfJc"
           >
             <button
-              class="bp3-button bp3-intent-success sc-lkqHmb lanaPj"
+              class="bp3-button bp3-intent-success sc-eLExRp bNmspL"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -582,10 +582,10 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-bMVAic kdmlRM"
+          class="sc-bAeIUo kgKoWP"
         >
           <div
-            class="sc-bAeIUo cTRzTw"
+            class="sc-iujRgT hgKvHh"
           >
             <h3
               class="bp3-heading"
@@ -594,10 +594,10 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Audit Board #1
             </h3>
             <div
-              class="sc-iujRgT eJYwgz"
+              class="sc-GMQeP FVNiK"
             >
               <table
-                class="sc-kGXeez fVIhxz"
+                class="sc-kpOJdX dLlwHp"
                 role="table"
               >
                 <thead>
@@ -799,7 +799,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -809,7 +809,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -819,7 +819,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -829,7 +829,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -858,7 +858,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -877,7 +877,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -886,7 +886,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -895,7 +895,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -904,7 +904,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -913,7 +913,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -934,7 +934,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -944,7 +944,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -954,7 +954,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -964,7 +964,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -993,7 +993,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -1012,7 +1012,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1022,7 +1022,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1032,7 +1032,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1042,7 +1042,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1071,7 +1071,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -1090,7 +1090,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -1099,7 +1099,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1108,7 +1108,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -1117,7 +1117,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -1126,7 +1126,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -1147,7 +1147,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1157,7 +1157,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1167,7 +1167,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1177,7 +1177,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1206,7 +1206,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -1225,7 +1225,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1235,7 +1235,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1245,7 +1245,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1255,7 +1255,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1284,7 +1284,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -1303,7 +1303,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -1312,7 +1312,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1321,7 +1321,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -1330,7 +1330,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -1339,7 +1339,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -1360,7 +1360,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1370,7 +1370,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1380,7 +1380,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1390,7 +1390,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1419,7 +1419,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -1438,7 +1438,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1448,7 +1448,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1458,7 +1458,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1468,7 +1468,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1497,7 +1497,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -1516,7 +1516,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -1525,7 +1525,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1534,7 +1534,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -1543,7 +1543,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -1552,7 +1552,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -1573,7 +1573,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1583,7 +1583,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1593,7 +1593,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1603,7 +1603,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1632,7 +1632,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -1651,7 +1651,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1661,7 +1661,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1671,7 +1671,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1681,7 +1681,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1710,7 +1710,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -1729,7 +1729,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -1738,7 +1738,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1747,7 +1747,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -1756,7 +1756,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -1765,7 +1765,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -1786,7 +1786,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1796,7 +1796,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1806,7 +1806,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1816,7 +1816,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1845,7 +1845,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -1864,7 +1864,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1874,7 +1874,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1884,7 +1884,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1894,7 +1894,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1923,7 +1923,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -1942,7 +1942,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -1951,7 +1951,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1960,7 +1960,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -1969,7 +1969,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -1978,7 +1978,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -1999,7 +1999,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2009,7 +2009,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2019,7 +2019,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2029,7 +2029,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2058,7 +2058,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -2077,7 +2077,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2087,7 +2087,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2097,7 +2097,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2107,7 +2107,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2136,7 +2136,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -2155,7 +2155,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -2164,7 +2164,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2173,7 +2173,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -2182,7 +2182,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -2191,7 +2191,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -2212,7 +2212,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2222,7 +2222,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2232,7 +2232,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2242,7 +2242,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2271,7 +2271,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -2290,7 +2290,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2300,7 +2300,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2310,7 +2310,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2320,7 +2320,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2349,7 +2349,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -2368,7 +2368,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -2377,7 +2377,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2386,7 +2386,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -2395,7 +2395,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -2404,7 +2404,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -2425,7 +2425,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2435,7 +2435,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2445,7 +2445,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2455,7 +2455,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2484,7 +2484,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -2503,7 +2503,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2513,7 +2513,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2523,7 +2523,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2533,7 +2533,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2562,7 +2562,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -2581,7 +2581,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -2590,7 +2590,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2599,7 +2599,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -2608,7 +2608,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -2617,7 +2617,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -2638,7 +2638,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2648,7 +2648,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2658,7 +2658,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2668,7 +2668,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2697,7 +2697,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -2713,7 +2713,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-eLExRp hquVpU"
+              class="bp3-button bp3-disabled bp3-large sc-cbkKFq bDciPG"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -2727,7 +2727,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
             </button>
           </div>
           <div
-            class="sc-GMQeP geIFCy"
+            class="sc-exAgwC lnSXNM"
           >
             <h4
               class="bp3-heading"
@@ -2735,7 +2735,7 @@ exports[`AuditBoardView ballot interaction renders board table with ballots 1`] 
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bXGyLb iGBOvH"
+              class="bp3-list sc-lkqHmb gGRgAh"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -2761,10 +2761,10 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
     class="sc-bdVaJa bKocXA"
   >
     <div
-      class="bp3-navbar sc-bxivhb jwFLoW"
+      class="bp3-navbar sc-ifAKCX jojstv"
     >
       <div
-        class="sc-bwzfXH sc-EHOje eysEZT"
+        class="sc-bwzfXH sc-bZQynM eYXcfZ"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -2815,13 +2815,13 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
       class="board-table-container"
     >
       <div
-        class="sc-gqPbQI jusmQx"
+        class="sc-hORach ksqClF"
       >
         <div
-          class="sc-bwzfXH sc-hORach hoVPwJ"
+          class="sc-bwzfXH sc-bMVAic bUKdYf"
         >
           <div
-            class="sc-hMFtBS fymdRq"
+            class="sc-cLQEGU iumUdS"
           >
             <p>
               0
@@ -2830,23 +2830,23 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-gojNiO cNYwPJ"
+              class="summary-label sc-daURTG bIGEpE"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-daURTG hmBDJZ"
+              class="summary-label sc-bXGyLb dohxps"
             >
               Not Audited: 
               27
             </span>
           </div>
           <div
-            class="sc-cLQEGU fHzmhT"
+            class="sc-gqPbQI bKhfJc"
           >
             <button
-              class="bp3-button bp3-intent-success sc-lkqHmb lanaPj"
+              class="bp3-button bp3-intent-success sc-eLExRp bNmspL"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
               type="button"
             >
@@ -2863,10 +2863,10 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-bMVAic kdmlRM"
+          class="sc-bAeIUo kgKoWP"
         >
           <div
-            class="sc-bAeIUo cTRzTw"
+            class="sc-iujRgT hgKvHh"
           >
             <h3
               class="bp3-heading"
@@ -2875,10 +2875,10 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Audit Board #1
             </h3>
             <div
-              class="sc-iujRgT eJYwgz"
+              class="sc-GMQeP FVNiK"
             >
               <table
-                class="sc-kGXeez fVIhxz"
+                class="sc-kpOJdX dLlwHp"
                 role="table"
               >
                 <thead>
@@ -3080,7 +3080,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3089,7 +3089,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3098,7 +3098,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         313
                       </p>
@@ -3107,7 +3107,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3116,7 +3116,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -3137,7 +3137,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3146,7 +3146,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3155,7 +3155,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -3164,7 +3164,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3173,7 +3173,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -3194,7 +3194,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3203,7 +3203,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3212,7 +3212,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         1789
                       </p>
@@ -3221,7 +3221,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3230,7 +3230,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -3251,7 +3251,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3260,7 +3260,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3269,7 +3269,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         313
                       </p>
@@ -3278,7 +3278,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3287,7 +3287,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -3308,7 +3308,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3317,7 +3317,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3326,7 +3326,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -3335,7 +3335,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3344,7 +3344,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -3365,7 +3365,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3374,7 +3374,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3383,7 +3383,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         1789
                       </p>
@@ -3392,7 +3392,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3401,7 +3401,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -3422,7 +3422,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3431,7 +3431,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3440,7 +3440,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         313
                       </p>
@@ -3449,7 +3449,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3458,7 +3458,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -3479,7 +3479,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3488,7 +3488,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3497,7 +3497,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -3506,7 +3506,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3515,7 +3515,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -3536,7 +3536,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3545,7 +3545,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3554,7 +3554,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         1789
                       </p>
@@ -3563,7 +3563,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3572,7 +3572,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -3593,7 +3593,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3602,7 +3602,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3611,7 +3611,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         313
                       </p>
@@ -3620,7 +3620,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3629,7 +3629,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -3650,7 +3650,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3659,7 +3659,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3668,7 +3668,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -3677,7 +3677,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3686,7 +3686,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -3707,7 +3707,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3716,7 +3716,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3725,7 +3725,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         1789
                       </p>
@@ -3734,7 +3734,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3743,7 +3743,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -3764,7 +3764,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3773,7 +3773,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3782,7 +3782,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         313
                       </p>
@@ -3791,7 +3791,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3800,7 +3800,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -3821,7 +3821,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3830,7 +3830,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3839,7 +3839,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -3848,7 +3848,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3857,7 +3857,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -3878,7 +3878,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3887,7 +3887,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3896,7 +3896,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         1789
                       </p>
@@ -3905,7 +3905,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3914,7 +3914,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -3935,7 +3935,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -3944,7 +3944,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3953,7 +3953,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         313
                       </p>
@@ -3962,7 +3962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -3971,7 +3971,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -3992,7 +3992,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -4001,7 +4001,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4010,7 +4010,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -4019,7 +4019,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -4028,7 +4028,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -4049,7 +4049,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -4058,7 +4058,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4067,7 +4067,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         1789
                       </p>
@@ -4076,7 +4076,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -4085,7 +4085,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -4106,7 +4106,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -4115,7 +4115,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4124,7 +4124,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         313
                       </p>
@@ -4133,7 +4133,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -4142,7 +4142,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -4163,7 +4163,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -4172,7 +4172,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4181,7 +4181,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -4190,7 +4190,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -4199,7 +4199,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -4220,7 +4220,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -4229,7 +4229,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4238,7 +4238,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         1789
                       </p>
@@ -4247,7 +4247,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -4256,7 +4256,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -4277,7 +4277,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -4286,7 +4286,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4295,7 +4295,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         313
                       </p>
@@ -4304,7 +4304,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -4313,7 +4313,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -4334,7 +4334,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -4343,7 +4343,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4352,7 +4352,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -4361,7 +4361,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -4370,7 +4370,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -4391,7 +4391,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -4400,7 +4400,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4409,7 +4409,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         1789
                       </p>
@@ -4418,7 +4418,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -4427,7 +4427,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -4448,7 +4448,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -4457,7 +4457,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4466,7 +4466,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         313
                       </p>
@@ -4475,7 +4475,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -4484,7 +4484,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -4505,7 +4505,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -4514,7 +4514,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4523,7 +4523,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -4532,7 +4532,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -4541,7 +4541,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -4562,7 +4562,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -4571,7 +4571,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4580,7 +4580,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         1789
                       </p>
@@ -4589,7 +4589,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -4598,7 +4598,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -4616,7 +4616,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-eLExRp hquVpU"
+              class="bp3-button bp3-disabled bp3-large sc-cbkKFq bDciPG"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -4630,7 +4630,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
             </button>
           </div>
           <div
-            class="sc-GMQeP geIFCy"
+            class="sc-exAgwC lnSXNM"
           >
             <h4
               class="bp3-heading"
@@ -4638,7 +4638,7 @@ exports[`AuditBoardView ballot interaction renders board table with no audited b
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bXGyLb iGBOvH"
+              class="bp3-list sc-lkqHmb gGRgAh"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -4664,10 +4664,10 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
     class="sc-bdVaJa bKocXA"
   >
     <div
-      class="bp3-navbar sc-bxivhb jwFLoW"
+      class="bp3-navbar sc-ifAKCX jojstv"
     >
       <div
-        class="sc-bwzfXH sc-EHOje eysEZT"
+        class="sc-bwzfXH sc-bZQynM eYXcfZ"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -4718,13 +4718,13 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
       class="board-table-container"
     >
       <div
-        class="sc-gqPbQI jusmQx"
+        class="sc-hORach ksqClF"
       >
         <div
-          class="sc-bwzfXH sc-hORach hoVPwJ"
+          class="sc-bwzfXH sc-bMVAic bUKdYf"
         >
           <div
-            class="sc-hMFtBS fymdRq"
+            class="sc-cLQEGU iumUdS"
           >
             <p>
               0
@@ -4733,23 +4733,23 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-gojNiO cNYwPJ"
+              class="summary-label sc-daURTG bIGEpE"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-daURTG hmBDJZ"
+              class="summary-label sc-bXGyLb dohxps"
             >
               Not Audited: 
               0
             </span>
           </div>
           <div
-            class="sc-cLQEGU fHzmhT"
+            class="sc-gqPbQI bKhfJc"
           >
             <button
-              class="bp3-button bp3-intent-success sc-lkqHmb lanaPj"
+              class="bp3-button bp3-intent-success sc-eLExRp bNmspL"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4766,10 +4766,10 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-bMVAic kdmlRM"
+          class="sc-bAeIUo kgKoWP"
         >
           <div
-            class="sc-bAeIUo cTRzTw"
+            class="sc-iujRgT hgKvHh"
           >
             <h3
               class="bp3-heading"
@@ -4778,10 +4778,10 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Audit Board #1
             </h3>
             <div
-              class="sc-iujRgT eJYwgz"
+              class="sc-GMQeP FVNiK"
             >
               <table
-                class="sc-kGXeez fVIhxz"
+                class="sc-kpOJdX dLlwHp"
                 role="table"
               >
                 <thead>
@@ -4942,7 +4942,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               </table>
             </div>
             <button
-              class="bp3-button bp3-large bp3-intent-success sc-eLExRp hquVpU"
+              class="bp3-button bp3-large bp3-intent-success sc-cbkKFq bDciPG"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4954,7 +4954,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
             </button>
           </div>
           <div
-            class="sc-GMQeP geIFCy"
+            class="sc-exAgwC lnSXNM"
           >
             <h4
               class="bp3-heading"
@@ -4962,7 +4962,7 @@ exports[`AuditBoardView ballot interaction renders board table with no ballots 1
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bXGyLb iGBOvH"
+              class="bp3-list sc-lkqHmb gGRgAh"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -4988,10 +4988,10 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
     class="sc-bdVaJa bKocXA"
   >
     <div
-      class="bp3-navbar sc-bxivhb jwFLoW"
+      class="bp3-navbar sc-ifAKCX jojstv"
     >
       <div
-        class="sc-bwzfXH sc-EHOje eysEZT"
+        class="sc-bwzfXH sc-bZQynM eYXcfZ"
       >
         <div
           class="bp3-navbar-group bp3-align-left"
@@ -5042,13 +5042,13 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
       class="board-table-container"
     >
       <div
-        class="sc-gqPbQI jusmQx"
+        class="sc-hORach ksqClF"
       >
         <div
-          class="sc-bwzfXH sc-hORach hoVPwJ"
+          class="sc-bwzfXH sc-bMVAic bUKdYf"
         >
           <div
-            class="sc-hMFtBS fymdRq"
+            class="sc-cLQEGU iumUdS"
           >
             <p>
               18
@@ -5057,23 +5057,23 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-gojNiO cNYwPJ"
+              class="summary-label sc-daURTG bIGEpE"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-daURTG hmBDJZ"
+              class="summary-label sc-bXGyLb dohxps"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-cLQEGU fHzmhT"
+            class="sc-gqPbQI bKhfJc"
           >
             <button
-              class="bp3-button bp3-intent-success sc-lkqHmb lanaPj"
+              class="bp3-button bp3-intent-success sc-eLExRp bNmspL"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -5090,10 +5090,10 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
         class="sc-bwzfXH ijTqJq"
       >
         <div
-          class="sc-bMVAic kdmlRM"
+          class="sc-bAeIUo kgKoWP"
         >
           <div
-            class="sc-bAeIUo cTRzTw"
+            class="sc-iujRgT hgKvHh"
           >
             <h3
               class="bp3-heading"
@@ -5102,10 +5102,10 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Audit Board #1
             </h3>
             <div
-              class="sc-iujRgT eJYwgz"
+              class="sc-GMQeP FVNiK"
             >
               <table
-                class="sc-kGXeez fVIhxz"
+                class="sc-kpOJdX dLlwHp"
                 role="table"
               >
                 <thead>
@@ -5307,7 +5307,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5317,7 +5317,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5327,7 +5327,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5337,7 +5337,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5366,7 +5366,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -5385,7 +5385,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -5394,7 +5394,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5403,7 +5403,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -5412,7 +5412,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -5421,7 +5421,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -5442,7 +5442,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5452,7 +5452,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5462,7 +5462,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5472,7 +5472,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5501,7 +5501,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -5520,7 +5520,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5530,7 +5530,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5540,7 +5540,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5550,7 +5550,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5579,7 +5579,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -5598,7 +5598,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -5607,7 +5607,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5616,7 +5616,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -5625,7 +5625,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -5634,7 +5634,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -5655,7 +5655,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5665,7 +5665,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5675,7 +5675,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5685,7 +5685,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5714,7 +5714,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -5733,7 +5733,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5743,7 +5743,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5753,7 +5753,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5763,7 +5763,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5792,7 +5792,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -5811,7 +5811,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -5820,7 +5820,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5829,7 +5829,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -5838,7 +5838,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -5847,7 +5847,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -5868,7 +5868,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5878,7 +5878,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5888,7 +5888,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5898,7 +5898,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5927,7 +5927,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -5946,7 +5946,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5956,7 +5956,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5966,7 +5966,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5976,7 +5976,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6005,7 +6005,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -6024,7 +6024,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -6033,7 +6033,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6042,7 +6042,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -6051,7 +6051,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -6060,7 +6060,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -6081,7 +6081,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6091,7 +6091,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6101,7 +6101,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6111,7 +6111,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6140,7 +6140,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -6159,7 +6159,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6169,7 +6169,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6179,7 +6179,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6189,7 +6189,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6218,7 +6218,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -6237,7 +6237,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -6246,7 +6246,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6255,7 +6255,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -6264,7 +6264,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -6273,7 +6273,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -6294,7 +6294,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6304,7 +6304,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6314,7 +6314,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6324,7 +6324,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6353,7 +6353,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -6372,7 +6372,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6382,7 +6382,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6392,7 +6392,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6402,7 +6402,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6431,7 +6431,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -6450,7 +6450,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -6459,7 +6459,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6468,7 +6468,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -6477,7 +6477,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -6486,7 +6486,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -6507,7 +6507,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6517,7 +6517,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6527,7 +6527,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6537,7 +6537,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6566,7 +6566,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -6585,7 +6585,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6595,7 +6595,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6605,7 +6605,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6615,7 +6615,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6644,7 +6644,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -6663,7 +6663,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -6672,7 +6672,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6681,7 +6681,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -6690,7 +6690,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -6699,7 +6699,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -6720,7 +6720,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6730,7 +6730,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6740,7 +6740,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6750,7 +6750,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6779,7 +6779,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -6798,7 +6798,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6808,7 +6808,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6818,7 +6818,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6828,7 +6828,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6857,7 +6857,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -6876,7 +6876,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -6885,7 +6885,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6894,7 +6894,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -6903,7 +6903,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -6912,7 +6912,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -6933,7 +6933,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6943,7 +6943,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6953,7 +6953,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6963,7 +6963,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6992,7 +6992,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -7011,7 +7011,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7021,7 +7021,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -7031,7 +7031,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -7041,7 +7041,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7070,7 +7070,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -7089,7 +7089,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         11
                       </p>
@@ -7098,7 +7098,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -7107,7 +7107,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                       >
                         2112
                       </p>
@@ -7116,7 +7116,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <span
-                        class="sc-daURTG hmBDJZ"
+                        class="sc-bXGyLb dohxps"
                       >
                         Not Audited
                       </span>
@@ -7125,7 +7125,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -7146,7 +7146,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7156,7 +7156,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -7166,7 +7166,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -7176,7 +7176,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <p
-                        class="sc-cbkKFq iJsTkK"
+                        class="sc-krvtoX hVQYfo"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7205,7 +7205,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-exAgwC Blxue"
+                        class="bp3-button bp3-fill bp3-minimal sc-cQFLBn ivrAGZ"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -7221,7 +7221,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-eLExRp hquVpU"
+              class="bp3-button bp3-disabled bp3-large sc-cbkKFq bDciPG"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -7235,7 +7235,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
             </button>
           </div>
           <div
-            class="sc-GMQeP geIFCy"
+            class="sc-exAgwC lnSXNM"
           >
             <h4
               class="bp3-heading"
@@ -7243,7 +7243,7 @@ exports[`AuditBoardView member form submits, goes to ballot table, and header sh
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-bXGyLb iGBOvH"
+              class="bp3-list sc-lkqHmb gGRgAh"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.

--- a/client/src/components/AuditBoard/__snapshots__/Ballot.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/Ballot.test.tsx.snap
@@ -9,19 +9,19 @@ exports[`Ballot renders correctly with an audited ballot 1`] = `
       class="sc-kGXeez fSmIyR"
     >
       <div
-        class="sc-dxgOiQ cnAnsE"
+        class="sc-ckVGcZ bxAWbg"
       >
         <div
-          class="sc-ckVGcZ dWmLvW"
+          class="sc-jKJlTe ebZSAv"
         >
           <div
-            class="sc-jKJlTe BtGnJ"
+            class="sc-eNQAEJ eawDHL"
           >
             <div
-              class="sc-kEYyzF bYnpXO"
+              class="sc-kkGfuU cJRsCh"
             >
               <button
-                class="bp3-button bp3-minimal sc-hMqMXs gLjYcq"
+                class="bp3-button bp3-minimal sc-kEYyzF cIpjCt"
                 href="/election/1/audit-board/1"
                 type="button"
               >
@@ -51,7 +51,7 @@ exports[`Ballot renders correctly with an audited ballot 1`] = `
                 </span>
               </button>
               <h3
-                class="bp3-heading sc-kpOJdX gOTkwU"
+                class="bp3-heading sc-dxgOiQ iNhIYv"
               >
                 Audit Ballot Selections
               </h3>
@@ -264,7 +264,7 @@ exports[`Ballot renders correctly with an audited ballot 1`] = `
             </div>
           </div>
           <div
-            class="sc-eNQAEJ fdspOC"
+            class="sc-hMqMXs zBIpE"
           >
             <h4
               class="bp3-heading"
@@ -272,7 +272,7 @@ exports[`Ballot renders correctly with an audited ballot 1`] = `
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-kkGfuU drhJhK"
+              class="bp3-list sc-iAyFgw jCvUMF"
             >
               <li>
                 Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -323,19 +323,19 @@ exports[`Ballot renders correctly with an unaudited ballot 1`] = `
       class="sc-kGXeez fSmIyR"
     >
       <div
-        class="sc-dxgOiQ cnAnsE"
+        class="sc-ckVGcZ bxAWbg"
       >
         <div
-          class="sc-ckVGcZ dWmLvW"
+          class="sc-jKJlTe ebZSAv"
         >
           <div
-            class="sc-jKJlTe BtGnJ"
+            class="sc-eNQAEJ eawDHL"
           >
             <div
-              class="sc-kEYyzF bYnpXO"
+              class="sc-kkGfuU cJRsCh"
             >
               <button
-                class="bp3-button bp3-minimal sc-hMqMXs gLjYcq"
+                class="bp3-button bp3-minimal sc-kEYyzF cIpjCt"
                 href="/election/1/audit-board/1"
                 type="button"
               >
@@ -365,7 +365,7 @@ exports[`Ballot renders correctly with an unaudited ballot 1`] = `
                 </span>
               </button>
               <h3
-                class="bp3-heading sc-kpOJdX gOTkwU"
+                class="bp3-heading sc-dxgOiQ iNhIYv"
               >
                 Audit Ballot Selections
               </h3>
@@ -577,7 +577,7 @@ exports[`Ballot renders correctly with an unaudited ballot 1`] = `
             </div>
           </div>
           <div
-            class="sc-eNQAEJ fdspOC"
+            class="sc-hMqMXs zBIpE"
           >
             <h4
               class="bp3-heading"
@@ -585,7 +585,7 @@ exports[`Ballot renders correctly with an unaudited ballot 1`] = `
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-kkGfuU drhJhK"
+              class="bp3-list sc-iAyFgw jCvUMF"
             >
               <li>
                 Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -636,19 +636,19 @@ exports[`Ballot selects Blank Vote 1`] = `
       class="sc-kGXeez fSmIyR"
     >
       <div
-        class="sc-dxgOiQ cnAnsE"
+        class="sc-ckVGcZ bxAWbg"
       >
         <div
-          class="sc-ckVGcZ dWmLvW"
+          class="sc-jKJlTe ebZSAv"
         >
           <div
-            class="sc-jKJlTe BtGnJ"
+            class="sc-eNQAEJ eawDHL"
           >
             <div
-              class="sc-kEYyzF bYnpXO"
+              class="sc-kkGfuU cJRsCh"
             >
               <button
-                class="bp3-button bp3-minimal sc-hMqMXs gLjYcq"
+                class="bp3-button bp3-minimal sc-kEYyzF cIpjCt"
                 href="/election/1/audit-board/1"
                 type="button"
               >
@@ -678,7 +678,7 @@ exports[`Ballot selects Blank Vote 1`] = `
                 </span>
               </button>
               <h3
-                class="bp3-heading sc-kpOJdX gOTkwU"
+                class="bp3-heading sc-dxgOiQ iNhIYv"
               >
                 Audit Ballot Selections
               </h3>
@@ -888,7 +888,7 @@ exports[`Ballot selects Blank Vote 1`] = `
             </div>
           </div>
           <div
-            class="sc-eNQAEJ fdspOC"
+            class="sc-hMqMXs zBIpE"
           >
             <h4
               class="bp3-heading"
@@ -896,7 +896,7 @@ exports[`Ballot selects Blank Vote 1`] = `
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-kkGfuU drhJhK"
+              class="bp3-list sc-iAyFgw jCvUMF"
             >
               <li>
                 Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -947,19 +947,19 @@ exports[`Ballot selects Not on Ballot 1`] = `
       class="sc-kGXeez fSmIyR"
     >
       <div
-        class="sc-dxgOiQ cnAnsE"
+        class="sc-ckVGcZ bxAWbg"
       >
         <div
-          class="sc-ckVGcZ dWmLvW"
+          class="sc-jKJlTe ebZSAv"
         >
           <div
-            class="sc-jKJlTe BtGnJ"
+            class="sc-eNQAEJ eawDHL"
           >
             <div
-              class="sc-kEYyzF bYnpXO"
+              class="sc-kkGfuU cJRsCh"
             >
               <button
-                class="bp3-button bp3-minimal sc-hMqMXs gLjYcq"
+                class="bp3-button bp3-minimal sc-kEYyzF cIpjCt"
                 href="/election/1/audit-board/1"
                 type="button"
               >
@@ -989,7 +989,7 @@ exports[`Ballot selects Not on Ballot 1`] = `
                 </span>
               </button>
               <h3
-                class="bp3-heading sc-kpOJdX gOTkwU"
+                class="bp3-heading sc-dxgOiQ iNhIYv"
               >
                 Audit Ballot Selections
               </h3>
@@ -1199,7 +1199,7 @@ exports[`Ballot selects Not on Ballot 1`] = `
             </div>
           </div>
           <div
-            class="sc-eNQAEJ fdspOC"
+            class="sc-hMqMXs zBIpE"
           >
             <h4
               class="bp3-heading"
@@ -1207,7 +1207,7 @@ exports[`Ballot selects Not on Ballot 1`] = `
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-kkGfuU drhJhK"
+              class="bp3-list sc-iAyFgw jCvUMF"
             >
               <li>
                 Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -1258,19 +1258,19 @@ exports[`Ballot switches audit and review views 1`] = `
       class="sc-kGXeez fSmIyR"
     >
       <div
-        class="sc-dxgOiQ cnAnsE"
+        class="sc-ckVGcZ bxAWbg"
       >
         <div
-          class="sc-ckVGcZ dWmLvW"
+          class="sc-jKJlTe ebZSAv"
         >
           <div
-            class="sc-jKJlTe BtGnJ"
+            class="sc-eNQAEJ eawDHL"
           >
             <div
-              class="sc-kEYyzF bYnpXO"
+              class="sc-kkGfuU cJRsCh"
             >
               <button
-                class="bp3-button bp3-minimal sc-hMqMXs gLjYcq"
+                class="bp3-button bp3-minimal sc-kEYyzF cIpjCt"
                 href="/election/1/audit-board/1"
                 type="button"
               >
@@ -1300,7 +1300,7 @@ exports[`Ballot switches audit and review views 1`] = `
                 </span>
               </button>
               <h3
-                class="bp3-heading sc-kpOJdX gOTkwU"
+                class="bp3-heading sc-dxgOiQ iNhIYv"
               >
                 Audit Ballot Selections
               </h3>
@@ -1510,7 +1510,7 @@ exports[`Ballot switches audit and review views 1`] = `
             </div>
           </div>
           <div
-            class="sc-eNQAEJ fdspOC"
+            class="sc-hMqMXs zBIpE"
           >
             <h4
               class="bp3-heading"
@@ -1518,7 +1518,7 @@ exports[`Ballot switches audit and review views 1`] = `
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-kkGfuU drhJhK"
+              class="bp3-list sc-iAyFgw jCvUMF"
             >
               <li>
                 Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select

--- a/client/src/components/AuditBoard/__snapshots__/BoardTable.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/BoardTable.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
     class="board-table-container"
   >
     <div
-      class="sc-bZQynM gcSISu"
+      class="sc-gzVnrw hDWRhK"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw cXrPFV"
+        class="sc-bxivhb sc-htoDjs jjDggh"
       >
         <div
-          class="sc-ifAKCX Eaynb"
+          class="sc-EHOje gMhbsl"
         >
           <p>
             4
@@ -21,29 +21,29 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
              ballots have been audited.
           </p>
           <span
-            class="summary-label sc-jTzLTM gLFziH"
+            class="summary-label sc-fjdhpX SBXsZ"
           >
             Audited: 
             3
           </span>
           <span
-            class="summary-label sc-fjdhpX cExqPy"
+            class="summary-label sc-jzJRlG jbjTBk"
           >
             Not Audited: 
             0
           </span>
           <span
-            class="summary-label sc-VigVT geuOJG"
+            class="summary-label sc-jTzLTM ghhWOe"
           >
             Not Found: 
             1
           </span>
         </div>
         <div
-          class="sc-EHOje iSYCcM"
+          class="sc-bZQynM iHGTTL"
         >
           <button
-            class="bp3-button bp3-intent-success sc-cSHVUG cVsyeo"
+            class="bp3-button bp3-intent-success sc-kAzzGY brfNjR"
             href="/home/signoff"
             type="button"
           >
@@ -60,10 +60,10 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
       class="sc-bxivhb kYcBbd"
     >
       <div
-        class="sc-htoDjs hxAtLW"
+        class="sc-dnqmqq hvEDwC"
       >
         <div
-          class="sc-dnqmqq iEAKuG"
+          class="sc-iwsKbI bojFoo"
         >
           <h3
             class="bp3-heading"
@@ -72,7 +72,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
             Audit Board #1
           </h3>
           <div
-            class="sc-iwsKbI cgDfoK"
+            class="sc-gZMcBi ebxAVo"
           >
             <table
               class="sc-bdVaJa djjOKa"
@@ -277,7 +277,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -287,7 +287,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -297,7 +297,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -307,7 +307,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -336,7 +336,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/313"
                       type="button"
                     >
@@ -355,7 +355,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -365,7 +365,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
@@ -375,7 +375,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       2112
@@ -385,7 +385,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -414,7 +414,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/2112"
                       type="button"
                     >
@@ -433,7 +433,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -443,7 +443,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -453,7 +453,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       1789
@@ -463,7 +463,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -492,7 +492,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/1789"
                       type="button"
                     >
@@ -511,7 +511,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -521,7 +521,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 31 (Jonesboro Fire Department)
@@ -531,7 +531,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       1965
@@ -541,7 +541,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -570,7 +570,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/1965"
                       type="button"
                     >
@@ -586,7 +586,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
             </table>
           </div>
           <button
-            class="bp3-button bp3-large bp3-intent-success sc-kAzzGY gZMjPs"
+            class="bp3-button bp3-large bp3-intent-success sc-chPdSV hnvKaK"
             href="/home/signoff"
             type="button"
           >
@@ -598,7 +598,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
           </button>
         </div>
         <div
-          class="sc-gZMcBi jxSIXn"
+          class="sc-gqjmRU exwQYX"
         >
           <h4
             class="bp3-heading"
@@ -606,7 +606,7 @@ exports[`BoardTable enables the submit button when all ballots are done 1`] = `
             Instructions
           </h4>
           <ol
-            class="bp3-list sc-jzJRlG bxayEV"
+            class="bp3-list sc-cSHVUG cvmUgq"
           >
             <li>
               Locate and retrieve the list of ballots to audit from storage.
@@ -631,13 +631,13 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
     class="board-table-container"
   >
     <div
-      class="sc-bZQynM gcSISu"
+      class="sc-gzVnrw hDWRhK"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw cXrPFV"
+        class="sc-bxivhb sc-htoDjs jjDggh"
       >
         <div
-          class="sc-ifAKCX Eaynb"
+          class="sc-EHOje gMhbsl"
         >
           <p>
             1
@@ -646,23 +646,23 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
              ballots have been audited.
           </p>
           <span
-            class="summary-label sc-jTzLTM gLFziH"
+            class="summary-label sc-fjdhpX SBXsZ"
           >
             Audited: 
             1
           </span>
           <span
-            class="summary-label sc-fjdhpX cExqPy"
+            class="summary-label sc-jzJRlG jbjTBk"
           >
             Not Audited: 
             0
           </span>
         </div>
         <div
-          class="sc-EHOje iSYCcM"
+          class="sc-bZQynM iHGTTL"
         >
           <button
-            class="bp3-button bp3-intent-success sc-cSHVUG cVsyeo"
+            class="bp3-button bp3-intent-success sc-kAzzGY brfNjR"
             href="/home/signoff"
             type="button"
           >
@@ -679,10 +679,10 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
       class="sc-bxivhb kYcBbd"
     >
       <div
-        class="sc-htoDjs hxAtLW"
+        class="sc-dnqmqq hvEDwC"
       >
         <div
-          class="sc-dnqmqq iEAKuG"
+          class="sc-iwsKbI bojFoo"
         >
           <h3
             class="bp3-heading"
@@ -691,7 +691,7 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
             Audit Board #1
           </h3>
           <div
-            class="sc-iwsKbI cgDfoK"
+            class="sc-gZMcBi ebxAVo"
           >
             <table
               class="sc-bdVaJa djjOKa"
@@ -896,7 +896,7 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       box
@@ -906,7 +906,7 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -916,7 +916,7 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -926,7 +926,7 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -955,7 +955,7 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/313"
                       type="button"
                     >
@@ -971,7 +971,7 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
             </table>
           </div>
           <button
-            class="bp3-button bp3-large bp3-intent-success sc-kAzzGY gZMjPs"
+            class="bp3-button bp3-large bp3-intent-success sc-chPdSV hnvKaK"
             href="/home/signoff"
             type="button"
           >
@@ -983,7 +983,7 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
           </button>
         </div>
         <div
-          class="sc-gZMcBi jxSIXn"
+          class="sc-gqjmRU exwQYX"
         >
           <h4
             class="bp3-heading"
@@ -991,7 +991,7 @@ exports[`BoardTable renders container and no tabulator columns 1`] = `
             Instructions
           </h4>
           <ol
-            class="bp3-list sc-jzJRlG bxayEV"
+            class="bp3-list sc-cSHVUG cvmUgq"
           >
             <li>
               Locate and retrieve the list of ballots to audit from storage.
@@ -1016,13 +1016,13 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
     class="board-table-container"
   >
     <div
-      class="sc-bZQynM gcSISu"
+      class="sc-gzVnrw hDWRhK"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw cXrPFV"
+        class="sc-bxivhb sc-htoDjs jjDggh"
       >
         <div
-          class="sc-ifAKCX Eaynb"
+          class="sc-EHOje gMhbsl"
         >
           <p>
             1
@@ -1031,23 +1031,23 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
              ballots have been audited.
           </p>
           <span
-            class="summary-label sc-jTzLTM gLFziH"
+            class="summary-label sc-fjdhpX SBXsZ"
           >
             Audited: 
             1
           </span>
           <span
-            class="summary-label sc-fjdhpX cExqPy"
+            class="summary-label sc-jzJRlG jbjTBk"
           >
             Not Audited: 
             0
           </span>
         </div>
         <div
-          class="sc-EHOje iSYCcM"
+          class="sc-bZQynM iHGTTL"
         >
           <button
-            class="bp3-button bp3-intent-success sc-cSHVUG cVsyeo"
+            class="bp3-button bp3-intent-success sc-kAzzGY brfNjR"
             href="/home/signoff"
             type="button"
           >
@@ -1064,10 +1064,10 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
       class="sc-bxivhb kYcBbd"
     >
       <div
-        class="sc-htoDjs hxAtLW"
+        class="sc-dnqmqq hvEDwC"
       >
         <div
-          class="sc-dnqmqq iEAKuG"
+          class="sc-iwsKbI bojFoo"
         >
           <h3
             class="bp3-heading"
@@ -1076,7 +1076,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
             Audit Board #1
           </h3>
           <div
-            class="sc-iwsKbI cgDfoK"
+            class="sc-gZMcBi ebxAVo"
           >
             <table
               class="sc-bdVaJa djjOKa"
@@ -1318,7 +1318,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       box
@@ -1328,7 +1328,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -1338,7 +1338,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1348,7 +1348,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -1358,7 +1358,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -1387,7 +1387,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/313"
                       type="button"
                     >
@@ -1403,7 +1403,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
             </table>
           </div>
           <button
-            class="bp3-button bp3-large bp3-intent-success sc-kAzzGY gZMjPs"
+            class="bp3-button bp3-large bp3-intent-success sc-chPdSV hnvKaK"
             href="/home/signoff"
             type="button"
           >
@@ -1415,7 +1415,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
           </button>
         </div>
         <div
-          class="sc-gZMcBi jxSIXn"
+          class="sc-gqjmRU exwQYX"
         >
           <h4
             class="bp3-heading"
@@ -1423,7 +1423,7 @@ exports[`BoardTable renders container and tabulator columns 1`] = `
             Instructions
           </h4>
           <ol
-            class="bp3-list sc-jzJRlG bxayEV"
+            class="bp3-list sc-cSHVUG cvmUgq"
           >
             <li>
               Locate and retrieve the list of ballots to audit from storage.
@@ -1448,13 +1448,13 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
     class="board-table-container"
   >
     <div
-      class="sc-bZQynM gcSISu"
+      class="sc-gzVnrw hDWRhK"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw cXrPFV"
+        class="sc-bxivhb sc-htoDjs jjDggh"
       >
         <div
-          class="sc-ifAKCX Eaynb"
+          class="sc-EHOje gMhbsl"
         >
           <p>
             1
@@ -1463,23 +1463,23 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
              ballots have been audited.
           </p>
           <span
-            class="summary-label sc-jTzLTM gLFziH"
+            class="summary-label sc-fjdhpX SBXsZ"
           >
             Audited: 
             1
           </span>
           <span
-            class="summary-label sc-fjdhpX cExqPy"
+            class="summary-label sc-jzJRlG jbjTBk"
           >
             Not Audited: 
             0
           </span>
         </div>
         <div
-          class="sc-EHOje iSYCcM"
+          class="sc-bZQynM iHGTTL"
         >
           <button
-            class="bp3-button bp3-intent-success sc-cSHVUG cVsyeo"
+            class="bp3-button bp3-intent-success sc-kAzzGY brfNjR"
             href="/home/signoff"
             type="button"
           >
@@ -1496,10 +1496,10 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
       class="sc-bxivhb kYcBbd"
     >
       <div
-        class="sc-htoDjs hxAtLW"
+        class="sc-dnqmqq hvEDwC"
       >
         <div
-          class="sc-dnqmqq iEAKuG"
+          class="sc-iwsKbI bojFoo"
         >
           <h3
             class="bp3-heading"
@@ -1508,7 +1508,7 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
             Audit Board #1
           </h3>
           <div
-            class="sc-iwsKbI cgDfoK"
+            class="sc-gZMcBi ebxAVo"
           >
             <table
               class="sc-bdVaJa djjOKa"
@@ -1676,7 +1676,7 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1686,7 +1686,7 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -1696,7 +1696,7 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -1725,7 +1725,7 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/313"
                       type="button"
                     >
@@ -1741,7 +1741,7 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
             </table>
           </div>
           <button
-            class="bp3-button bp3-large bp3-intent-success sc-kAzzGY gZMjPs"
+            class="bp3-button bp3-large bp3-intent-success sc-chPdSV hnvKaK"
             href="/home/signoff"
             type="button"
           >
@@ -1753,7 +1753,7 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
           </button>
         </div>
         <div
-          class="sc-gZMcBi jxSIXn"
+          class="sc-gqjmRU exwQYX"
         >
           <h4
             class="bp3-heading"
@@ -1761,7 +1761,7 @@ exports[`BoardTable renders no container and no tabulator columns 1`] = `
             Instructions
           </h4>
           <ol
-            class="bp3-list sc-jzJRlG bxayEV"
+            class="bp3-list sc-cSHVUG cvmUgq"
           >
             <li>
               Locate and retrieve the list of ballots to audit from storage.
@@ -1786,13 +1786,13 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
     class="board-table-container"
   >
     <div
-      class="sc-bZQynM gcSISu"
+      class="sc-gzVnrw hDWRhK"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw cXrPFV"
+        class="sc-bxivhb sc-htoDjs jjDggh"
       >
         <div
-          class="sc-ifAKCX Eaynb"
+          class="sc-EHOje gMhbsl"
         >
           <p>
             1
@@ -1801,23 +1801,23 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
              ballots have been audited.
           </p>
           <span
-            class="summary-label sc-jTzLTM gLFziH"
+            class="summary-label sc-fjdhpX SBXsZ"
           >
             Audited: 
             1
           </span>
           <span
-            class="summary-label sc-fjdhpX cExqPy"
+            class="summary-label sc-jzJRlG jbjTBk"
           >
             Not Audited: 
             0
           </span>
         </div>
         <div
-          class="sc-EHOje iSYCcM"
+          class="sc-bZQynM iHGTTL"
         >
           <button
-            class="bp3-button bp3-intent-success sc-cSHVUG cVsyeo"
+            class="bp3-button bp3-intent-success sc-kAzzGY brfNjR"
             href="/home/signoff"
             type="button"
           >
@@ -1834,10 +1834,10 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
       class="sc-bxivhb kYcBbd"
     >
       <div
-        class="sc-htoDjs hxAtLW"
+        class="sc-dnqmqq hvEDwC"
       >
         <div
-          class="sc-dnqmqq iEAKuG"
+          class="sc-iwsKbI bojFoo"
         >
           <h3
             class="bp3-heading"
@@ -1846,7 +1846,7 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
             Audit Board #1
           </h3>
           <div
-            class="sc-iwsKbI cgDfoK"
+            class="sc-gZMcBi ebxAVo"
           >
             <table
               class="sc-bdVaJa djjOKa"
@@ -2051,7 +2051,7 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -2061,7 +2061,7 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2071,7 +2071,7 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -2081,7 +2081,7 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -2110,7 +2110,7 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/313"
                       type="button"
                     >
@@ -2126,7 +2126,7 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
             </table>
           </div>
           <button
-            class="bp3-button bp3-large bp3-intent-success sc-kAzzGY gZMjPs"
+            class="bp3-button bp3-large bp3-intent-success sc-chPdSV hnvKaK"
             href="/home/signoff"
             type="button"
           >
@@ -2138,7 +2138,7 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
           </button>
         </div>
         <div
-          class="sc-gZMcBi jxSIXn"
+          class="sc-gqjmRU exwQYX"
         >
           <h4
             class="bp3-heading"
@@ -2146,7 +2146,7 @@ exports[`BoardTable renders tabulator and no container columns 1`] = `
             Instructions
           </h4>
           <ol
-            class="bp3-list sc-jzJRlG bxayEV"
+            class="bp3-list sc-cSHVUG cvmUgq"
           >
             <li>
               Locate and retrieve the list of ballots to audit from storage.
@@ -2171,13 +2171,13 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
     class="board-table-container"
   >
     <div
-      class="sc-bZQynM gcSISu"
+      class="sc-gzVnrw hDWRhK"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw cXrPFV"
+        class="sc-bxivhb sc-htoDjs jjDggh"
       >
         <div
-          class="sc-ifAKCX Eaynb"
+          class="sc-EHOje gMhbsl"
         >
           <p>
             0
@@ -2186,23 +2186,23 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
              ballots have been audited.
           </p>
           <span
-            class="summary-label sc-jTzLTM gLFziH"
+            class="summary-label sc-fjdhpX SBXsZ"
           >
             Audited: 
             0
           </span>
           <span
-            class="summary-label sc-fjdhpX cExqPy"
+            class="summary-label sc-jzJRlG jbjTBk"
           >
             Not Audited: 
             27
           </span>
         </div>
         <div
-          class="sc-EHOje iSYCcM"
+          class="sc-bZQynM iHGTTL"
         >
           <button
-            class="bp3-button bp3-intent-success sc-cSHVUG cVsyeo"
+            class="bp3-button bp3-intent-success sc-kAzzGY brfNjR"
             href="/home/batch/batch-id-1/ballot/313"
             type="button"
           >
@@ -2219,10 +2219,10 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
       class="sc-bxivhb kYcBbd"
     >
       <div
-        class="sc-htoDjs hxAtLW"
+        class="sc-dnqmqq hvEDwC"
       >
         <div
-          class="sc-dnqmqq iEAKuG"
+          class="sc-iwsKbI bojFoo"
         >
           <h3
             class="bp3-heading"
@@ -2231,7 +2231,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
             Audit Board #1
           </h3>
           <div
-            class="sc-iwsKbI cgDfoK"
+            class="sc-gZMcBi ebxAVo"
           >
             <table
               class="sc-bdVaJa djjOKa"
@@ -2436,7 +2436,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -2445,7 +2445,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
                     </p>
@@ -2454,7 +2454,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       313
                     </p>
@@ -2463,7 +2463,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -2472,7 +2472,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/313"
                       type="button"
                     >
@@ -2493,7 +2493,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -2502,7 +2502,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -2511,7 +2511,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -2520,7 +2520,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -2529,7 +2529,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/2112"
                       type="button"
                     >
@@ -2550,7 +2550,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -2559,7 +2559,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
                     </p>
@@ -2568,7 +2568,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       1789
                     </p>
@@ -2577,7 +2577,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -2586,7 +2586,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/1789"
                       type="button"
                     >
@@ -2607,7 +2607,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -2616,7 +2616,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
                     </p>
@@ -2625,7 +2625,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       313
                     </p>
@@ -2634,7 +2634,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -2643,7 +2643,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-2/ballot/313"
                       type="button"
                     >
@@ -2664,7 +2664,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -2673,7 +2673,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -2682,7 +2682,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -2691,7 +2691,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -2700,7 +2700,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-2/ballot/2112"
                       type="button"
                     >
@@ -2721,7 +2721,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -2730,7 +2730,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
                     </p>
@@ -2739,7 +2739,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       1789
                     </p>
@@ -2748,7 +2748,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -2757,7 +2757,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-2/ballot/1789"
                       type="button"
                     >
@@ -2778,7 +2778,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -2787,7 +2787,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
                     </p>
@@ -2796,7 +2796,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       313
                     </p>
@@ -2805,7 +2805,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -2814,7 +2814,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-3/ballot/313"
                       type="button"
                     >
@@ -2835,7 +2835,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -2844,7 +2844,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -2853,7 +2853,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -2862,7 +2862,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -2871,7 +2871,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-3/ballot/2112"
                       type="button"
                     >
@@ -2892,7 +2892,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -2901,7 +2901,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
                     </p>
@@ -2910,7 +2910,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       1789
                     </p>
@@ -2919,7 +2919,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -2928,7 +2928,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-3/ballot/1789"
                       type="button"
                     >
@@ -2949,7 +2949,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -2958,7 +2958,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
                     </p>
@@ -2967,7 +2967,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       313
                     </p>
@@ -2976,7 +2976,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -2985,7 +2985,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-4/ballot/313"
                       type="button"
                     >
@@ -3006,7 +3006,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3015,7 +3015,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -3024,7 +3024,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -3033,7 +3033,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3042,7 +3042,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-4/ballot/2112"
                       type="button"
                     >
@@ -3063,7 +3063,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3072,7 +3072,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
                     </p>
@@ -3081,7 +3081,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       1789
                     </p>
@@ -3090,7 +3090,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3099,7 +3099,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-4/ballot/1789"
                       type="button"
                     >
@@ -3120,7 +3120,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3129,7 +3129,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
                     </p>
@@ -3138,7 +3138,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       313
                     </p>
@@ -3147,7 +3147,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3156,7 +3156,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-5/ballot/313"
                       type="button"
                     >
@@ -3177,7 +3177,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3186,7 +3186,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -3195,7 +3195,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -3204,7 +3204,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3213,7 +3213,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-5/ballot/2112"
                       type="button"
                     >
@@ -3234,7 +3234,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3243,7 +3243,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
                     </p>
@@ -3252,7 +3252,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       1789
                     </p>
@@ -3261,7 +3261,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3270,7 +3270,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-5/ballot/1789"
                       type="button"
                     >
@@ -3291,7 +3291,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3300,7 +3300,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
                     </p>
@@ -3309,7 +3309,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       313
                     </p>
@@ -3318,7 +3318,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3327,7 +3327,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-6/ballot/313"
                       type="button"
                     >
@@ -3348,7 +3348,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3357,7 +3357,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -3366,7 +3366,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -3375,7 +3375,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3384,7 +3384,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-6/ballot/2112"
                       type="button"
                     >
@@ -3405,7 +3405,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3414,7 +3414,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
                     </p>
@@ -3423,7 +3423,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       1789
                     </p>
@@ -3432,7 +3432,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3441,7 +3441,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-6/ballot/1789"
                       type="button"
                     >
@@ -3462,7 +3462,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3471,7 +3471,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
                     </p>
@@ -3480,7 +3480,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       313
                     </p>
@@ -3489,7 +3489,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3498,7 +3498,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-7/ballot/313"
                       type="button"
                     >
@@ -3519,7 +3519,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3528,7 +3528,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -3537,7 +3537,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -3546,7 +3546,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3555,7 +3555,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-7/ballot/2112"
                       type="button"
                     >
@@ -3576,7 +3576,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3585,7 +3585,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
                     </p>
@@ -3594,7 +3594,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       1789
                     </p>
@@ -3603,7 +3603,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3612,7 +3612,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-7/ballot/1789"
                       type="button"
                     >
@@ -3633,7 +3633,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3642,7 +3642,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
                     </p>
@@ -3651,7 +3651,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       313
                     </p>
@@ -3660,7 +3660,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3669,7 +3669,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-8/ballot/313"
                       type="button"
                     >
@@ -3690,7 +3690,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3699,7 +3699,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -3708,7 +3708,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -3717,7 +3717,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3726,7 +3726,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-8/ballot/2112"
                       type="button"
                     >
@@ -3747,7 +3747,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3756,7 +3756,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
                     </p>
@@ -3765,7 +3765,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       1789
                     </p>
@@ -3774,7 +3774,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3783,7 +3783,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-8/ballot/1789"
                       type="button"
                     >
@@ -3804,7 +3804,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3813,7 +3813,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
                     </p>
@@ -3822,7 +3822,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       313
                     </p>
@@ -3831,7 +3831,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3840,7 +3840,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-9/ballot/313"
                       type="button"
                     >
@@ -3861,7 +3861,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3870,7 +3870,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -3879,7 +3879,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -3888,7 +3888,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3897,7 +3897,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-9/ballot/2112"
                       type="button"
                     >
@@ -3918,7 +3918,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -3927,7 +3927,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
                     </p>
@@ -3936,7 +3936,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       1789
                     </p>
@@ -3945,7 +3945,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -3954,7 +3954,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-9/ballot/1789"
                       type="button"
                     >
@@ -3972,7 +3972,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
             </table>
           </div>
           <button
-            class="bp3-button bp3-disabled bp3-large sc-kAzzGY gZMjPs"
+            class="bp3-button bp3-disabled bp3-large sc-chPdSV hnvKaK"
             disabled=""
             href="/home/signoff"
             tabindex="-1"
@@ -3986,7 +3986,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
           </button>
         </div>
         <div
-          class="sc-gZMcBi jxSIXn"
+          class="sc-gqjmRU exwQYX"
         >
           <h4
             class="bp3-heading"
@@ -3994,7 +3994,7 @@ exports[`BoardTable shows audit first ballot button when no ballots are audited 
             Instructions
           </h4>
           <ol
-            class="bp3-list sc-jzJRlG bxayEV"
+            class="bp3-list sc-cSHVUG cvmUgq"
           >
             <li>
               Locate and retrieve the list of ballots to audit from storage.
@@ -4019,13 +4019,13 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
     class="board-table-container"
   >
     <div
-      class="sc-bZQynM gcSISu"
+      class="sc-gzVnrw hDWRhK"
     >
       <div
-        class="sc-bxivhb sc-gzVnrw cXrPFV"
+        class="sc-bxivhb sc-htoDjs jjDggh"
       >
         <div
-          class="sc-ifAKCX Eaynb"
+          class="sc-EHOje gMhbsl"
         >
           <p>
             18
@@ -4034,23 +4034,23 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
              ballots have been audited.
           </p>
           <span
-            class="summary-label sc-jTzLTM gLFziH"
+            class="summary-label sc-fjdhpX SBXsZ"
           >
             Audited: 
             18
           </span>
           <span
-            class="summary-label sc-fjdhpX cExqPy"
+            class="summary-label sc-jzJRlG jbjTBk"
           >
             Not Audited: 
             9
           </span>
         </div>
         <div
-          class="sc-EHOje iSYCcM"
+          class="sc-bZQynM iHGTTL"
         >
           <button
-            class="bp3-button bp3-intent-success sc-cSHVUG cVsyeo"
+            class="bp3-button bp3-intent-success sc-kAzzGY brfNjR"
             href="/home/batch/batch-id-1/ballot/2112"
             type="button"
           >
@@ -4067,10 +4067,10 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
       class="sc-bxivhb kYcBbd"
     >
       <div
-        class="sc-htoDjs hxAtLW"
+        class="sc-dnqmqq hvEDwC"
       >
         <div
-          class="sc-dnqmqq iEAKuG"
+          class="sc-iwsKbI bojFoo"
         >
           <h3
             class="bp3-heading"
@@ -4079,7 +4079,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
             Audit Board #1
           </h3>
           <div
-            class="sc-iwsKbI cgDfoK"
+            class="sc-gZMcBi ebxAVo"
           >
             <table
               class="sc-bdVaJa djjOKa"
@@ -4284,7 +4284,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -4294,7 +4294,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -4304,7 +4304,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -4314,7 +4314,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -4343,7 +4343,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/313"
                       type="button"
                     >
@@ -4362,7 +4362,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -4371,7 +4371,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -4380,7 +4380,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -4389,7 +4389,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -4398,7 +4398,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/2112"
                       type="button"
                     >
@@ -4419,7 +4419,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -4429,7 +4429,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -4439,7 +4439,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       1789
@@ -4449,7 +4449,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -4478,7 +4478,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-1/ballot/1789"
                       type="button"
                     >
@@ -4497,7 +4497,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -4507,7 +4507,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -4517,7 +4517,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -4527,7 +4527,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -4556,7 +4556,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-2/ballot/313"
                       type="button"
                     >
@@ -4575,7 +4575,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -4584,7 +4584,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -4593,7 +4593,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -4602,7 +4602,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -4611,7 +4611,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-2/ballot/2112"
                       type="button"
                     >
@@ -4632,7 +4632,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -4642,7 +4642,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -4652,7 +4652,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       1789
@@ -4662,7 +4662,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -4691,7 +4691,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-2/ballot/1789"
                       type="button"
                     >
@@ -4710,7 +4710,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -4720,7 +4720,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -4730,7 +4730,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -4740,7 +4740,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -4769,7 +4769,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-3/ballot/313"
                       type="button"
                     >
@@ -4788,7 +4788,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -4797,7 +4797,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -4806,7 +4806,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -4815,7 +4815,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -4824,7 +4824,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-3/ballot/2112"
                       type="button"
                     >
@@ -4845,7 +4845,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -4855,7 +4855,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -4865,7 +4865,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       1789
@@ -4875,7 +4875,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -4904,7 +4904,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-3/ballot/1789"
                       type="button"
                     >
@@ -4923,7 +4923,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -4933,7 +4933,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -4943,7 +4943,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -4953,7 +4953,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -4982,7 +4982,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-4/ballot/313"
                       type="button"
                     >
@@ -5001,7 +5001,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -5010,7 +5010,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -5019,7 +5019,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -5028,7 +5028,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -5037,7 +5037,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-4/ballot/2112"
                       type="button"
                     >
@@ -5058,7 +5058,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -5068,7 +5068,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5078,7 +5078,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       1789
@@ -5088,7 +5088,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -5117,7 +5117,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-4/ballot/1789"
                       type="button"
                     >
@@ -5136,7 +5136,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -5146,7 +5146,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5156,7 +5156,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -5166,7 +5166,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -5195,7 +5195,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-5/ballot/313"
                       type="button"
                     >
@@ -5214,7 +5214,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -5223,7 +5223,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -5232,7 +5232,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -5241,7 +5241,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -5250,7 +5250,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-5/ballot/2112"
                       type="button"
                     >
@@ -5271,7 +5271,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -5281,7 +5281,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5291,7 +5291,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       1789
@@ -5301,7 +5301,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -5330,7 +5330,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-5/ballot/1789"
                       type="button"
                     >
@@ -5349,7 +5349,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -5359,7 +5359,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5369,7 +5369,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -5379,7 +5379,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -5408,7 +5408,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-6/ballot/313"
                       type="button"
                     >
@@ -5427,7 +5427,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -5436,7 +5436,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -5445,7 +5445,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -5454,7 +5454,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -5463,7 +5463,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-6/ballot/2112"
                       type="button"
                     >
@@ -5484,7 +5484,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -5494,7 +5494,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5504,7 +5504,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       1789
@@ -5514,7 +5514,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -5543,7 +5543,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-6/ballot/1789"
                       type="button"
                     >
@@ -5562,7 +5562,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -5572,7 +5572,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5582,7 +5582,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -5592,7 +5592,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -5621,7 +5621,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-7/ballot/313"
                       type="button"
                     >
@@ -5640,7 +5640,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -5649,7 +5649,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -5658,7 +5658,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -5667,7 +5667,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -5676,7 +5676,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-7/ballot/2112"
                       type="button"
                     >
@@ -5697,7 +5697,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -5707,7 +5707,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5717,7 +5717,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       1789
@@ -5727,7 +5727,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -5756,7 +5756,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-7/ballot/1789"
                       type="button"
                     >
@@ -5775,7 +5775,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -5785,7 +5785,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5795,7 +5795,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -5805,7 +5805,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -5834,7 +5834,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-8/ballot/313"
                       type="button"
                     >
@@ -5853,7 +5853,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -5862,7 +5862,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -5871,7 +5871,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -5880,7 +5880,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -5889,7 +5889,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-8/ballot/2112"
                       type="button"
                     >
@@ -5910,7 +5910,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -5920,7 +5920,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5930,7 +5930,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       1789
@@ -5940,7 +5940,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -5969,7 +5969,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-8/ballot/1789"
                       type="button"
                     >
@@ -5988,7 +5988,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -5998,7 +5998,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6008,7 +6008,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       313
@@ -6018,7 +6018,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -6047,7 +6047,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-9/ballot/313"
                       type="button"
                     >
@@ -6066,7 +6066,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       11
                     </p>
@@ -6075,7 +6075,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       0003-04-Precinct 19 (Jonesboro Fire Department)
                     </p>
@@ -6084,7 +6084,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                     >
                       2112
                     </p>
@@ -6093,7 +6093,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <span
-                      class="sc-fjdhpX cExqPy"
+                      class="sc-jzJRlG jbjTBk"
                     >
                       Not Audited
                     </span>
@@ -6102,7 +6102,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-9/ballot/2112"
                       type="button"
                     >
@@ -6123,7 +6123,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       11
@@ -6133,7 +6133,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6143,7 +6143,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       1789
@@ -6153,7 +6153,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <p
-                      class="sc-chPdSV gcANmR"
+                      class="sc-kgoBCf eIUqfm"
                       style="color: rgb(138, 155, 168);"
                     >
                       <span
@@ -6182,7 +6182,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
                     role="cell"
                   >
                     <button
-                      class="bp3-button bp3-fill bp3-minimal sc-gqjmRU wKYES"
+                      class="bp3-button bp3-fill bp3-minimal sc-VigVT iXdFsj"
                       href="/home/batch/batch-id-9/ballot/1789"
                       type="button"
                     >
@@ -6198,7 +6198,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
             </table>
           </div>
           <button
-            class="bp3-button bp3-disabled bp3-large sc-kAzzGY gZMjPs"
+            class="bp3-button bp3-disabled bp3-large sc-chPdSV hnvKaK"
             disabled=""
             href="/home/signoff"
             tabindex="-1"
@@ -6212,7 +6212,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
           </button>
         </div>
         <div
-          class="sc-gZMcBi jxSIXn"
+          class="sc-gqjmRU exwQYX"
         >
           <h4
             class="bp3-heading"
@@ -6220,7 +6220,7 @@ exports[`BoardTable shows audit next ballot button when some are remaining to au
             Instructions
           </h4>
           <ol
-            class="bp3-list sc-jzJRlG bxayEV"
+            class="bp3-list sc-cSHVUG cvmUgq"
           >
             <li>
               Locate and retrieve the list of ballots to audit from storage.

--- a/client/src/components/AuditBoard/__snapshots__/SignOff.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/SignOff.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Sign Off handles inputs 1`] = `
 <div>
   <div
-    class="sc-jzJRlG sc-cSHVUG HPvXI"
+    class="sc-jzJRlG sc-kAzzGY kmYSRA"
   >
     <div>
       <h1
@@ -108,7 +108,7 @@ exports[`Sign Off handles inputs 1`] = `
 exports[`Sign Off renders correctly 1`] = `
 <div>
   <div
-    class="sc-jzJRlG sc-cSHVUG HPvXI"
+    class="sc-jzJRlG sc-kAzzGY kmYSRA"
   >
     <div>
       <h1

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -22,7 +22,7 @@ import LinkButton from './Atoms/LinkButton'
 const SupportBar = styled(Navbar)`
   background-color: ${Colors.ROSE3};
   height: 35px;
-  padding: 0 10%;
+  padding: 0 150px;
   color: ${Colors.WHITE};
   font-weight: 500;
   .bp3-navbar-group {

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -22,7 +22,7 @@ import LinkButton from './Atoms/LinkButton'
 const SupportBar = styled(Navbar)`
   background-color: ${Colors.ROSE3};
   height: 35px;
-  padding: 0;
+  padding: 0 10%;
   color: ${Colors.WHITE};
   font-weight: 500;
   .bp3-navbar-group {
@@ -109,19 +109,17 @@ const Header: React.FC = () => {
     <>
       {auth && auth.supportUser && (
         <SupportBar>
-          <InnerBar>
-            <NavbarGroup align={Alignment.LEFT}>
-              <a href="/support">
-                <Icon icon="eye-open" />
-                <span>Arlo Support Tools</span>
-              </a>
-            </NavbarGroup>
-            <NavbarGroup align={Alignment.RIGHT}>
-              <span>{auth.supportUser.email}</span>
-              <NavbarDivider />
-              <a href="/auth/support/logout">Log out</a>
-            </NavbarGroup>
-          </InnerBar>
+          <NavbarGroup align={Alignment.LEFT}>
+            <a href="/support">
+              <Icon icon="eye-open" />
+              <span style={{ fontWeight: 600 }}>Arlo Support Tools</span>
+            </a>
+          </NavbarGroup>
+          <NavbarGroup align={Alignment.RIGHT}>
+            <span>{auth.supportUser.email}</span>
+            <NavbarDivider />
+            <a href="/auth/support/logout">Log out</a>
+          </NavbarGroup>
         </SupportBar>
       )}
       {!supportMatch && (

--- a/client/src/components/JurisdictionAdmin/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
+++ b/client/src/components/JurisdictionAdmin/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`full hand tally data entry deletes full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-csuQGl dEmjOe"
+    class="sc-Rmtcm jzOgeZ"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -159,7 +159,7 @@ exports[`full hand tally data entry deletes full hand tally batch result 1`] = `
 exports[`full hand tally data entry edits full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-csuQGl dEmjOe"
+    class="sc-Rmtcm jzOgeZ"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -360,7 +360,7 @@ exports[`full hand tally data entry edits full hand tally batch result 1`] = `
 exports[`full hand tally data entry finalizes full hand tally results 1`] = `
 <div>
   <form
-    class="sc-csuQGl dEmjOe"
+    class="sc-Rmtcm jzOgeZ"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -593,7 +593,7 @@ exports[`full hand tally data entry finalizes full hand tally results 1`] = `
 exports[`full hand tally data entry renders 1`] = `
 <div>
   <form
-    class="sc-csuQGl dEmjOe"
+    class="sc-Rmtcm jzOgeZ"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -749,7 +749,7 @@ exports[`full hand tally data entry renders 1`] = `
 exports[`full hand tally data entry renders with full hand tally results 1`] = `
 <div>
   <form
-    class="sc-csuQGl dEmjOe"
+    class="sc-Rmtcm jzOgeZ"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -950,7 +950,7 @@ exports[`full hand tally data entry renders with full hand tally results 1`] = `
 exports[`full hand tally data entry renders with proper totals 1`] = `
 <div>
   <form
-    class="sc-csuQGl dEmjOe"
+    class="sc-Rmtcm jzOgeZ"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -1203,7 +1203,7 @@ exports[`full hand tally data entry renders with proper totals 1`] = `
 exports[`full hand tally data entry submits full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-csuQGl dEmjOe"
+    class="sc-Rmtcm jzOgeZ"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -1404,7 +1404,7 @@ exports[`full hand tally data entry submits full hand tally batch result 1`] = `
 exports[`full hand tally data entry validation error for blank submission 1`] = `
 <div>
   <form
-    class="sc-csuQGl dEmjOe"
+    class="sc-Rmtcm jzOgeZ"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -287,6 +287,7 @@ describe('Support Tools', () => {
   it('home screen shows active audits', async () => {
     const expectedCalls = [
       supportApiCalls.getUser,
+      apiCalls.getOrganizations([]),
       apiCalls.getActiveElections([
         mockElectionForSupport,
         {
@@ -297,7 +298,6 @@ describe('Support Tools', () => {
           currentRound: { id: 'round-1', endedAt: null, roundNum: 1 },
         },
       ]),
-      apiCalls.getOrganizations([]),
       apiCalls.getElection(mockElection),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -318,11 +318,11 @@ describe('Support Tools', () => {
   it('home screen shows a list of orgs', async () => {
     const expectedCalls = [
       supportApiCalls.getUser,
-      apiCalls.getActiveElections([]),
       apiCalls.getOrganizations([
         mockOrganizationBase,
         { id: 'organization-id-2', name: 'Organization 2' },
       ]),
+      apiCalls.getActiveElections([]),
       apiCalls.getOrganization(mockOrganization),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -342,8 +342,8 @@ describe('Support Tools', () => {
   it('home screen handles error', async () => {
     const expectedCalls = [
       supportApiCalls.getUser,
-      apiCalls.getActiveElections([]),
       serverError('getOrganizations', apiCalls.getOrganizations([])),
+      apiCalls.getActiveElections([]),
     ]
     await withMockFetch(expectedCalls, async () => {
       renderRoute('/support')
@@ -354,8 +354,8 @@ describe('Support Tools', () => {
   it('home screen shows a form to create a new org', async () => {
     const expectedCalls = [
       supportApiCalls.getUser,
-      apiCalls.getActiveElections([]),
       apiCalls.getOrganizations([]),
+      apiCalls.getActiveElections([]),
       apiCalls.postOrganization,
       apiCalls.getOrganizations([
         { id: 'new-organization-id', name: 'New Organization' },
@@ -367,12 +367,10 @@ describe('Support Tools', () => {
       await screen.findByRole('heading', { name: 'Organizations' })
 
       userEvent.type(
-        screen.getByPlaceholderText('New organization name'),
+        screen.getByPlaceholderText('Organization name'),
         'New Organization'
       )
-      userEvent.click(
-        screen.getByRole('button', { name: /Create Organization/ })
-      )
+      userEvent.click(screen.getByRole('button', { name: /Create Org/ }))
 
       await screen.findByRole('link', { name: 'New Organization' })
     })
@@ -381,8 +379,8 @@ describe('Support Tools', () => {
   it('home screen handles error on create org', async () => {
     const expectedCalls = [
       supportApiCalls.getUser,
-      apiCalls.getActiveElections([]),
       apiCalls.getOrganizations([]),
+      apiCalls.getActiveElections([]),
       serverError('postOrganization', apiCalls.postOrganization),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -391,12 +389,10 @@ describe('Support Tools', () => {
       await screen.findByRole('heading', { name: 'Organizations' })
 
       userEvent.type(
-        screen.getByPlaceholderText('New organization name'),
+        screen.getByPlaceholderText('Organization name'),
         'New Organization'
       )
-      userEvent.click(
-        screen.getByRole('button', { name: /Create Organization/ })
-      )
+      userEvent.click(screen.getByRole('button', { name: /Create Org/ }))
 
       await findAndCloseToast('something went wrong: postOrganization')
     })
@@ -740,8 +736,8 @@ describe('Support Tools', () => {
       supportApiCalls.getUser,
       apiCalls.getOrganization(mockOrganization),
       apiCalls.deleteOrganization,
-      apiCalls.getActiveElections([]),
       apiCalls.getOrganizations([]),
+      apiCalls.getActiveElections([]),
     ]
     await withMockFetch(expectedCalls, async () => {
       const { history } = renderRoute('/support/orgs/organization-id-1')

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from 'react'
+import React, { useState } from 'react'
 import { Redirect, Route, Switch, Link } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import styled from 'styled-components'
@@ -50,6 +50,7 @@ import Breadcrumbs from './Breadcrumbs'
 import { stateOptions, states } from '../AuditAdmin/Setup/Settings/states'
 import StatusTag from '../Atoms/StatusTag'
 import { sortBy } from '../../utils/array'
+import { FilterInput } from '../Atoms/Table'
 
 const Table = styled(HTMLTable)`
   margin: 10px 0;
@@ -79,15 +80,15 @@ const SupportTools: React.FC = () => {
         <Switch>
           <Route exact path="/support">
             <Row>
-              <Column1>
+              <div style={{ flex: '0 0 25%' }}>
                 <Organizations />
-              </Column1>
-              <Column2>
+              </div>
+              <div style={{ flex: '0 1 50%' }}>
                 <ActiveAudits />
-              </Column2>
-              <Column3>
+              </div>
+              <div style={{ flex: '0 0 25%' }}>
                 <Tools />
-              </Column3>
+              </div>
             </Row>
           </Route>
           <Route path="/support/orgs/:organizationId">
@@ -114,22 +115,9 @@ const Column = styled.div`
   padding-right: 30px;
 `
 
-const Column1 = styled.div`
-  flex: 0 0 25%;
-  padding-right: 30px;
-`
-
-const Column2 = styled.div`
-  flex: 0 0 50%;
-  padding-right: 30px;
-`
-
-const Column3 = styled.div`
-  flex: 0 0 25%;
-`
-
 const Row = styled.div`
   display: flex;
+  gap: 30px;
   width: 100%;
 `
 
@@ -185,27 +173,17 @@ const Organizations = () => {
   const organizations = useOrganizations()
   const [filterText, setFilterText] = useState<string>('')
 
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
-    setFilterText(e.target.value)
-  }
-
   if (!organizations.isSuccess) return null
 
   return (
     <>
       <H3 style={{ marginBottom: '20px' }}>Organizations</H3>
-      <input
-        className={Classes.INPUT}
-        onChange={handleInputChange}
+      <FilterInput
+        onChange={setFilterText}
         placeholder="Filter organizations..."
-        style={{
-          marginBottom: '20px',
-          width: '100%',
-        }}
-        type="text"
         value={filterText}
       />
-      <List>
+      <List style={{ marginTop: '20px' }}>
         {organizations.data
           .filter(org =>
             org.name
@@ -261,7 +239,6 @@ const Tools = () => {
         <form
           style={{
             display: 'flex',
-            // flexDirection: 'column',
             gap: '8px',
           }}
           onSubmit={handleSubmit(onSubmitCreateOrganization)}
@@ -270,8 +247,8 @@ const Tools = () => {
             type="submit"
             icon="insert"
             loading={formState.isSubmitting}
-            className={Classes.BUTTON}
-            disabled={!formState.isDirty || formState.isSubmitting}
+            disabled={!formState.isDirty}
+            style={{ flexShrink: 0 }}
           >
             Create Org
           </Button>
@@ -281,7 +258,7 @@ const Tools = () => {
             className={Classes.INPUT}
             placeholder="Organization name"
             ref={register}
-            style={{ flexGrow: 1 }}
+            style={{ width: '100%' }}
           />
         </form>
         <div>

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -14,6 +14,7 @@ import {
   HTMLSelect,
   Card,
   MenuItem,
+  Tooltip,
 } from '@blueprintjs/core'
 import { MultiSelect } from '@blueprintjs/select'
 import { useForm, Controller } from 'react-hook-form'
@@ -79,9 +80,15 @@ const SupportTools: React.FC = () => {
           <Switch>
             <Route exact path="/support">
               <Row>
-                <SupportUserTools />
-                <ActiveAudits />
-                <Organizations />
+                <Column1>
+                  <Organizations />
+                </Column1>
+                <Column2>
+                  <ActiveAudits />
+                </Column2>
+                <Column3>
+                  <SupportUserTools />
+                </Column3>
               </Row>
             </Route>
             <Route path="/support/orgs/:organizationId">
@@ -105,13 +112,28 @@ const SupportTools: React.FC = () => {
 }
 
 const Column = styled.div`
-  width: 50%;
+  width: 33%;
   padding-right: 30px;
+`
+
+const Column1 = styled.div`
+  flex: 0 0 30%;
+  padding-right: 30px;
+`
+
+const Column2 = styled.div`
+  flex: 0 0 45%;
+  padding-right: 30px;
+`
+
+const Column3 = styled.div`
+  flex: 0 0 25%;
 `
 
 const Row = styled.div`
   display: flex;
   width: 100%;
+  justify-content: flex-start;
 `
 
 const AuditStatusTag = ({ currentRound }: { currentRound: IRound | null }) => {
@@ -134,20 +156,31 @@ const ActiveAudits = () => {
   if (!elections.isSuccess) return null
 
   return (
-    <Column>
+    <>
       <H3>Active Audits</H3>
       <List>
         {elections.data.map(election => (
           <LinkItem key={election.id} to={`/support/audits/${election.id}`}>
-            <div>
-              <div style={{ color: 'black' }}>{election.organization.name}</div>
-              <div className="bp3-text-large">{election.auditName}</div>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                width: '100%',
+              }}
+            >
+              <div>
+                <div style={{ color: 'black' }}>
+                  {election.organization.name}
+                </div>
+                <div className="bp3-text-large">{election.auditName}</div>
+              </div>
               <AuditStatusTag currentRound={election.currentRound} />
             </div>
           </LinkItem>
         ))}
       </List>
-    </Column>
+    </>
   )
 }
 
@@ -156,7 +189,7 @@ const Organizations = () => {
   if (!organizations.isSuccess) return null
 
   return (
-    <Column>
+    <>
       <H3>Organizations</H3>
       <List>
         {organizations.data.map(organization => (
@@ -168,7 +201,7 @@ const Organizations = () => {
           </LinkItem>
         ))}
       </List>
-    </Column>
+    </>
   )
 }
 
@@ -179,7 +212,7 @@ const DownloadUsersButton = styled(AnchorButton)`
 const SupportUserTools = () => {
   const createOrganization = useCreateOrganization()
 
-  const { register, handleSubmit, reset, formState, getValues } = useForm<{
+  const { register, handleSubmit, reset, formState } = useForm<{
     name: string
   }>()
 
@@ -192,16 +225,14 @@ const SupportUserTools = () => {
     }
   }
 
-  console.log(getValues('name'), formState)
-
   return (
-    <Column>
+    <>
       <H3>Tools</H3>
       <div
         style={{
           display: 'flex',
           flexDirection: 'column',
-          gap: '32px',
+          gap: '24px',
           paddingTop: '24px',
         }}
       >
@@ -215,37 +246,43 @@ const SupportUserTools = () => {
         >
           <Button
             type="submit"
-            // icon="insert"
+            icon="insert"
             style={{}}
             loading={formState.isSubmitting}
             className={Classes.BUTTON}
             disabled={!formState.isDirty || formState.isSubmitting}
           >
-            Create
+            Create Org
           </Button>
           <input
             type="text"
             name="name"
             className={Classes.INPUT}
-            placeholder="New organization name"
+            placeholder="Organization name"
             ref={register}
             style={{ flexGrow: 1 }}
           />
         </form>
         <div>
-          <DownloadUsersButton
-            icon="download"
-            href="/api/support/organizations/users"
+          <Tooltip
+            content={
+              <p>
+                Export a list of Audit Admins and Jurisdiction Managers for all
+                audits completed in the last 12 weeks.
+              </p>
+            }
           >
-            Download User List
-          </DownloadUsersButton>
-          <p>
-            Export a list of Audit Admins and Jurisdiction Managers for all
-            audits completed in the last 12 weeks.
-          </p>
+            <DownloadUsersButton
+              icon="download"
+              intent="none"
+              href="/api/support/organizations/users"
+            >
+              Download User List
+            </DownloadUsersButton>
+          </Tooltip>
         </div>
       </div>
-    </Column>
+    </>
   )
 }
 

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -135,7 +135,7 @@ const ActiveAudits = () => {
 
   return (
     <Column>
-      <H2>Active Audits</H2>
+      <H3>Active Audits</H3>
       <List>
         {elections.data.map(election => (
           <LinkItem key={election.id} to={`/support/audits/${election.id}`}>
@@ -172,7 +172,7 @@ const Organizations = () => {
 
   return (
     <Column>
-      <H2>Organizations</H2>
+      <H3>Organizations</H3>
       <form
         style={{ display: 'flex', marginBottom: '10px' }}
         onSubmit={handleSubmit(onSubmitCreateOrganization)}
@@ -215,7 +215,7 @@ const DownloadUsersButton = styled(AnchorButton)`
 const SupportUserTools = () => {
   return (
     <Column>
-      <H2>Downloads</H2>
+      <H3>Downloads</H3>
       <DownloadUsersButton
         icon="download"
         href="/api/support/organizations/users"

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -79,9 +79,9 @@ const SupportTools: React.FC = () => {
           <Switch>
             <Route exact path="/support">
               <Row>
+                <SupportUserTools />
                 <ActiveAudits />
                 <Organizations />
-                <SupportUserTools />
               </Row>
             </Route>
             <Route path="/support/orgs/:organizationId">
@@ -153,47 +153,11 @@ const ActiveAudits = () => {
 
 const Organizations = () => {
   const organizations = useOrganizations()
-  const createOrganization = useCreateOrganization()
-
-  const { register, handleSubmit, reset, formState } = useForm<{
-    name: string
-  }>()
-
   if (!organizations.isSuccess) return null
-
-  const onSubmitCreateOrganization = async ({ name }: { name: string }) => {
-    try {
-      await createOrganization.mutateAsync({ name })
-      reset()
-    } catch (error) {
-      // Do nothing - errors toasted by queryClient
-    }
-  }
 
   return (
     <Column>
       <H3>Organizations</H3>
-      <form
-        style={{ display: 'flex', marginBottom: '10px' }}
-        onSubmit={handleSubmit(onSubmitCreateOrganization)}
-      >
-        <input
-          type="text"
-          name="name"
-          className={Classes.INPUT}
-          placeholder="New organization name"
-          ref={register}
-          style={{ flexGrow: 1 }}
-        />
-        <Button
-          type="submit"
-          icon="insert"
-          style={{ marginLeft: '20px' }}
-          loading={formState.isSubmitting}
-        >
-          Create Organization
-        </Button>
-      </form>
       <List>
         {organizations.data.map(organization => (
           <LinkItem
@@ -213,19 +177,74 @@ const DownloadUsersButton = styled(AnchorButton)`
 `
 
 const SupportUserTools = () => {
+  const createOrganization = useCreateOrganization()
+
+  const { register, handleSubmit, reset, formState, getValues } = useForm<{
+    name: string
+  }>()
+
+  const onSubmitCreateOrganization = async ({ name }: { name: string }) => {
+    try {
+      await createOrganization.mutateAsync({ name })
+      reset()
+    } catch (error) {
+      // Do nothing - errors toasted by queryClient
+    }
+  }
+
+  console.log(getValues('name'), formState)
+
   return (
     <Column>
-      <H3>Downloads</H3>
-      <DownloadUsersButton
-        icon="download"
-        href="/api/support/organizations/users"
+      <H3>Tools</H3>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '32px',
+          paddingTop: '24px',
+        }}
       >
-        Download User List
-      </DownloadUsersButton>
-      <p>
-        Export a list of Audit Admins and Jurisdiction Managers for all audits
-        completed in the last 12 weeks.
-      </p>
+        <form
+          style={{
+            display: 'flex',
+            // flexDirection: 'column',
+            gap: '8px',
+          }}
+          onSubmit={handleSubmit(onSubmitCreateOrganization)}
+        >
+          <Button
+            type="submit"
+            // icon="insert"
+            style={{}}
+            loading={formState.isSubmitting}
+            className={Classes.BUTTON}
+            disabled={!formState.isDirty || formState.isSubmitting}
+          >
+            Create
+          </Button>
+          <input
+            type="text"
+            name="name"
+            className={Classes.INPUT}
+            placeholder="New organization name"
+            ref={register}
+            style={{ flexGrow: 1 }}
+          />
+        </form>
+        <div>
+          <DownloadUsersButton
+            icon="download"
+            href="/api/support/organizations/users"
+          >
+            Download User List
+          </DownloadUsersButton>
+          <p>
+            Export a list of Audit Admins and Jurisdiction Managers for all
+            audits completed in the last 12 weeks.
+          </p>
+        </div>
+      </div>
     </Column>
   )
 }

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ChangeEvent, useState } from 'react'
 import { Redirect, Route, Switch, Link } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import styled from 'styled-components'
@@ -183,20 +183,43 @@ const ActiveAudits = () => {
 
 const Organizations = () => {
   const organizations = useOrganizations()
+  const [filterText, setFilterText] = useState<string>('')
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setFilterText(e.target.value)
+  }
+
   if (!organizations.isSuccess) return null
 
   return (
     <>
       <H3 style={{ marginBottom: '20px' }}>Organizations</H3>
+      <input
+        className={Classes.INPUT}
+        onChange={handleInputChange}
+        placeholder="Filter organizations..."
+        style={{
+          marginBottom: '20px',
+          width: '100%',
+        }}
+        type="text"
+        value={filterText}
+      />
       <List>
-        {organizations.data.map(organization => (
-          <LinkItem
-            key={organization.id}
-            to={`/support/orgs/${organization.id}`}
-          >
-            {organization.name}
-          </LinkItem>
-        ))}
+        {organizations.data
+          .filter(org =>
+            org.name
+              .toLocaleLowerCase()
+              .includes(filterText.toLocaleLowerCase())
+          )
+          .map(organization => (
+            <LinkItem
+              key={organization.id}
+              to={`/support/orgs/${organization.id}`}
+            >
+              {organization.name}
+            </LinkItem>
+          ))}
       </List>
     </>
   )

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -19,7 +19,7 @@ import {
 import { MultiSelect } from '@blueprintjs/select'
 import { useForm, Controller } from 'react-hook-form'
 import { useAuthDataContext } from '../UserContext'
-import { Wrapper, Inner } from '../Atoms/Wrapper'
+import { Wrapper, SupportToolsInner } from '../Atoms/Wrapper'
 import {
   useOrganizations,
   useOrganization,
@@ -75,54 +75,52 @@ const SupportTools: React.FC = () => {
 
   return (
     <Wrapper>
-      <Inner>
-        <div style={{ margin: '30px 0', width: '100%' }}>
-          <Switch>
-            <Route exact path="/support">
-              <Row>
-                <Column1>
-                  <Organizations />
-                </Column1>
-                <Column2>
-                  <ActiveAudits />
-                </Column2>
-                <Column3>
-                  <SupportUserTools />
-                </Column3>
-              </Row>
-            </Route>
-            <Route path="/support/orgs/:organizationId">
-              {({ match }) => (
-                <Organization organizationId={match!.params.organizationId} />
-              )}
-            </Route>
-            <Route path="/support/audits/:electionId">
-              {({ match }) => <Audit electionId={match!.params.electionId} />}
-            </Route>
-            <Route path="/support/jurisdictions/:jurisdictionId">
-              {({ match }) => (
-                <Jurisdiction jurisdictionId={match!.params.jurisdictionId} />
-              )}
-            </Route>
-          </Switch>
-        </div>
-      </Inner>
+      <SupportToolsInner>
+        <Switch>
+          <Route exact path="/support">
+            <Row>
+              <Column1>
+                <Organizations />
+              </Column1>
+              <Column2>
+                <ActiveAudits />
+              </Column2>
+              <Column3>
+                <Tools />
+              </Column3>
+            </Row>
+          </Route>
+          <Route path="/support/orgs/:organizationId">
+            {({ match }) => (
+              <Organization organizationId={match!.params.organizationId} />
+            )}
+          </Route>
+          <Route path="/support/audits/:electionId">
+            {({ match }) => <Audit electionId={match!.params.electionId} />}
+          </Route>
+          <Route path="/support/jurisdictions/:jurisdictionId">
+            {({ match }) => (
+              <Jurisdiction jurisdictionId={match!.params.jurisdictionId} />
+            )}
+          </Route>
+        </Switch>
+      </SupportToolsInner>
     </Wrapper>
   )
 }
 
 const Column = styled.div`
-  width: 33%;
+  width: 50%;
   padding-right: 30px;
 `
 
 const Column1 = styled.div`
-  flex: 0 0 30%;
+  flex: 0 0 25%;
   padding-right: 30px;
 `
 
 const Column2 = styled.div`
-  flex: 0 0 45%;
+  flex: 0 0 50%;
   padding-right: 30px;
 `
 
@@ -133,7 +131,6 @@ const Column3 = styled.div`
 const Row = styled.div`
   display: flex;
   width: 100%;
-  justify-content: flex-start;
 `
 
 const AuditStatusTag = ({ currentRound }: { currentRound: IRound | null }) => {
@@ -157,7 +154,7 @@ const ActiveAudits = () => {
 
   return (
     <>
-      <H3>Active Audits</H3>
+      <H3 style={{ marginBottom: '20px' }}>Active Audits</H3>
       <List>
         {elections.data.map(election => (
           <LinkItem key={election.id} to={`/support/audits/${election.id}`}>
@@ -190,7 +187,7 @@ const Organizations = () => {
 
   return (
     <>
-      <H3>Organizations</H3>
+      <H3 style={{ marginBottom: '20px' }}>Organizations</H3>
       <List>
         {organizations.data.map(organization => (
           <LinkItem
@@ -209,7 +206,7 @@ const DownloadUsersButton = styled(AnchorButton)`
   margin-bottom: 10px;
 `
 
-const SupportUserTools = () => {
+const Tools = () => {
   const createOrganization = useCreateOrganization()
 
   const { register, handleSubmit, reset, formState } = useForm<{
@@ -219,6 +216,9 @@ const SupportUserTools = () => {
   const onSubmitCreateOrganization = async ({ name }: { name: string }) => {
     try {
       await createOrganization.mutateAsync({ name })
+      toast.success(
+        `Created organization for '${name}'. You will find it in the Organizations list.`
+      )
       reset()
     } catch (error) {
       // Do nothing - errors toasted by queryClient
@@ -227,13 +227,12 @@ const SupportUserTools = () => {
 
   return (
     <>
-      <H3>Tools</H3>
+      <H3 style={{ marginBottom: '20px' }}>Tools</H3>
       <div
         style={{
           display: 'flex',
           flexDirection: 'column',
-          gap: '24px',
-          paddingTop: '24px',
+          gap: '20px',
         }}
       >
         <form
@@ -247,7 +246,6 @@ const SupportUserTools = () => {
           <Button
             type="submit"
             icon="insert"
-            style={{}}
             loading={formState.isSubmitting}
             className={Classes.BUTTON}
             disabled={!formState.isDirty || formState.isSubmitting}
@@ -429,7 +427,6 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
         </Button>
       </div>
       <p>Default State: {defaultState ? states[defaultState] : 'None'}</p>
-
       <div style={{ display: 'flex', width: '100%' }}>
         <Column>
           <H3>Audits</H3>
@@ -551,7 +548,7 @@ const Audit = ({ electionId }: { electionId: string }) => {
   } = election.data
 
   return (
-    <div>
+    <div style={{ width: '100%' }}>
       <Breadcrumbs>
         <Link to={`/support/orgs/${organization.id}`}>{organization.name}</Link>
       </Breadcrumbs>


### PR DESCRIPTION
Updated with Fixed Padding


https://github.com/user-attachments/assets/d0cb0ea6-be43-46af-bd72-8fc75a91c2b8



Updated with Filter Input:

https://github.com/user-attachments/assets/36cd9445-4d3b-4a41-b033-2ca4347c00fb


Updated after PR feedback:

https://github.com/user-attachments/assets/95cd42f5-a993-4315-a2fa-aed159ac88d9


Outdated:

https://github.com/user-attachments/assets/9399c5ad-a0c3-44c6-b35a-d62016c980ce


Main changes:

1. Increase width of support tools pages. Next, I plan to improve the spacing of the Organization, Audit, and Jurisdiction sub-pages.
2. Make Active Audits the widest column. This is just preference for how the page looks with it. Also move the status tag to the right side.
3. Rename Downloads to Tools, move Create Org button there, disable button until input is dirty, add success toast. Add tooltip to Download User List.
4. Misc changes: remove extra wrapper divs, extra margin/padding, reduce H2s to H3s