### PR TITLE
Only surface discrepancies in single jurisdiction for finalized batches

### DIFF
--- a/server/api/discrepancies.py
+++ b/server/api/discrepancies.py
@@ -109,8 +109,6 @@ def get_batch_comparison_discrepancies_by_jurisdiction(
         show_batch_comparison_discrepancies_by_jurisdiction(election)
     )
 
-    is_single_jurisdiction_election = len(list(election.jurisdictions)) == 1
-
     for contest in list(election.contests):
         audited_batch_results = sampled_batch_results(
             contest, include_non_rla_batches=True
@@ -124,13 +122,6 @@ def get_batch_comparison_discrepancies_by_jurisdiction(
                 continue
 
             if batch_key not in batch_keys_in_round:
-                continue
-
-            # Special case: for single jurisdiction elections we show discrepancies even if the round isn't closed,
-            # but we only want to show a batch's discrepancies if the batch is finalized
-            if is_single_jurisdiction_election and not is_audited_batch_finalized(
-                audited_batch_result
-            ):
                 continue
 
             audited_contest_result = audited_batch_result[contest.id]
@@ -195,15 +186,6 @@ def show_batch_comparison_discrepancies_by_jurisdiction(
         jurisdiction.id: (jurisdiction.id in finalized_jurisdiction_ids)
         for jurisdiction in jurisdictions
     }
-
-
-# Check if any value is non-zero for the audited batch result, indicating the batch has actually been audited
-def is_audited_batch_finalized(audited_batch_result: Dict[str, Dict[str, int]]) -> bool:
-    return any(
-        value != 0
-        for contest in audited_batch_result.values()
-        for value in contest.values()
-    )
 
 
 def get_ballot_comparison_discrepancies_by_jurisdiction(

--- a/server/api/shared.py
+++ b/server/api/shared.py
@@ -159,6 +159,7 @@ def sampled_batch_results(
         .filter(Contest.id == contest.id)
         .join(ContestChoice)
         .outerjoin(BatchResultTallySheet)
+        .filter(BatchResultTallySheet.batch_id.isnot(None))
         .outerjoin(
             BatchResult,
             and_(

--- a/server/tests/batch_comparison/test_single_jurisdiction_batch_comparison.py
+++ b/server/tests/batch_comparison/test_single_jurisdiction_batch_comparison.py
@@ -100,6 +100,12 @@ def test_batch_comparison_single_jurisdiction_discrepancies(
     choice_names = [choice["name"] for choice in contests[0]["choices"]]
     choice_ids = [choice["id"] for choice in contests[0]["choices"]]
 
+    # No discrepancies should show before any batches are audited
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/discrepancy")
+    discrepancies = json.loads(rv.data)
+    assert len(discrepancies) == 0
+
     # Audit batches
     set_logged_in_user(
         client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)


### PR DESCRIPTION
We recently introduced a special case where we surface discrepancies for single jurisdiction batch comparison audits even before the round is finalized. But, this meant that immediately upon the round opening, we were showing discrepancies.

<img width="1512" alt="Screenshot 2024-12-13 at 3 54 54 PM" src="https://github.com/user-attachments/assets/6b91927b-5ad5-4ef3-bda0-d933073a27cd" />

We only want to show discrepancies for batches that have been audited. There may be a more correct way to do this using a db query, but this PR uses the approach of checking the `audited_batch_result` object that we are already using, and looks for a single non-zero entry indicating the result is valid.

Now we no longer see the discrepancies upon launching. 

<img width="1512" alt="Screenshot 2024-12-13 at 3 54 09 PM" src="https://github.com/user-attachments/assets/a2d36413-2f85-4736-ab12-310cac02887b" />

But once a single batch is audited, we see only those discrepancies.

<img width="1229" alt="Screenshot 2024-12-13 at 3 59 21 PM" src="https://github.com/user-attachments/assets/de63c256-9492-45f8-b4a6-df16c93b691e" />


1. The discrepancy report already handled this by checking if a batch is `audited` using [this check ](https://github.com/votingworks/arlo/blob/main/server/api/reports.py#L950) which uses a [set of queries](https://github.com/votingworks/arlo/blob/main/server/api/reports.py#L858-L886) to build the `audited_results_by_batch` versus the `discrepancies` endpoint which uses the `sampled_batch_results` function. This way seems _more_ correct, but is more expensive
2. Ballot comparison audits did not have this issue in my test. Only audited ballots have discrepancies visible

