### PR TITLE
Upgrade to heroku 24

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,5 +25,5 @@
     }
   },
   "name": "arlo",
-  "stack": "heroku-20"
+  "stack": "heroku-24"
 }


### PR DESCRIPTION
Upgrades to Heroku stack 24 following [official docs](https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack#setting-the-stack). All 3 apps have already been upgraded with `heroku stack:set heroku-24 -a <name>` but a successful new build is required to complete the process.

https://github.com/votingworks/arlo/issues/2101

