### PR TITLE
Batch inventory: Trim leading/trailing spaces from CVR choice names

### DIFF
--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -165,9 +165,9 @@ def process_batch_inventory_cvr_file(
         choice_indices = {
             (
                 contests[expected_contest_headers.index(contest_header)].name,
-                choice_name,
+                choice_name_untrimmed.strip(),  # CVR choice names sometimes have accidental leading/trailing spaces
             ): index
-            for index, (contest_header, choice_name) in enumerate(
+            for index, (contest_header, choice_name_untrimmed) in enumerate(
                 zip(contests_row, contest_choices_row)
             )
             if contest_header in expected_contest_headers

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -57,7 +57,7 @@ CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortio
 
 TEST_CVRS_WITH_EXTRA_SPACES = """Test Audit CVR Upload,5.2.16.1,,,,,,,,,,,,,,,
 ,,,,,,,,Contest 1  (Vote For=1),Contest 1  (Vote For=1),Contest 1  (Vote For=1),Contest 2  (Vote For=2),Contest 2  (Vote For=2),Contest 2  (Vote For=2),Contest 2  (Vote For=2)
-,,,,,,,,Choice 1-1,Choice 1-2,Write-In,Choice 2-1,Choice 2-2,Choice 2-3,Write-In
+,,,,,,,,Choice 1-1 ,  Choice 1-2  ,Write-In,Choice 2-1,Choice 2-2,Choice 2-3,Write-In
 CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,CountingGroup,PrecinctPortion,BallotType,REP,DEM,LBR,IND,,
 1,TABULATOR1,BATCH1,1,1-1-1,Election Day,12345,COUNTY,0,0,1,1,1,0,0
 2,TABULATOR1,BATCH1,2,1-1-2,Election Day,12345,COUNTY,1,0,0,1,0,1,0


### PR DESCRIPTION
Similar in spirit to https://github.com/votingworks/arlo/pull/2053 but for leading/trailing spaces in CVR choice names, which we're seeing for a specific choice in Georgia's current batch inventory CVR uploads.

> :x: Could not find contest choices in CVR file: Tim Echols (I) for contest PSC - District 2 - Rep.

In the CVR file, there's a space at the end of `Tim Echols (I) `.