### PR TITLE
Don't surface total row error when a CSV has only two rows

### DIFF
--- a/server/tests/util/test_csv_parse.py
+++ b/server/tests/util/test_csv_parse.py
@@ -475,6 +475,21 @@ def test_parse_csv_total_row():
         {"Batch Name": "Batch C", "Candidate 1": 40, "Candidate 2": 10},
     ]
 
+    # Shouldn't raise an error if just two rows
+    parsed = list(
+        parse_csv(
+            ("Batch Name,Number of Ballots\n" "Batch A,10\n" "Batch B,10\n"),
+            [
+                CSVColumnType("Batch Name", CSVValueType.TEXT, unique=True),
+                CSVColumnType("Number of Ballots", CSVValueType.NUMBER),
+            ],
+        )
+    )
+    assert parsed == [
+        {"Batch Name": "Batch A", "Number of Ballots": 10},
+        {"Batch Name": "Batch B", "Number of Ballots": 10},
+    ]
+
 
 # Cases where we are lenient
 

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -355,16 +355,22 @@ def reject_total_rows(csv: CSVDictIterator) -> CSVDictIterator:
 def reject_final_total_row(csv: CSVDictIterator, columns: List[CSVColumnType]):
     numeric_column_values = defaultdict(list)
 
+    num_rows = 0
     for row in csv:
+        num_rows += 1
         for column in columns:
             value = row.get(column.name)
             if column.value_type == CSVValueType.NUMBER and value is not None:
                 numeric_column_values[column.name].append(value)
         yield row
 
-    if len(numeric_column_values) > 0 and all(
-        sum(values[:-1]) == values[-1] and values[-1] != 0
-        for values in numeric_column_values.values()
+    if (
+        num_rows > 2
+        and len(numeric_column_values) > 0
+        and all(
+            sum(values[:-1]) == values[-1] and values[-1] != 0
+            for values in numeric_column_values.values()
+        )
     ):
         raise CSVParseError(
             "It looks like the last row in the CSV might be a total row."


### PR DESCRIPTION
We have a valid ballot manifest in Georgia that's getting flagged as having a total row, i.e., a row where the last row is simply the sum of all rows above, and thereby rejected.

| Container | Batch Name | Number of Ballots |
| :- | :- | :- |
| Advanced Voting | AV-Elections Office ICP 1 - 0 | 6 |
| Election Day | Election Day Central ICP 1 - 0 | 6 |

> :x: It looks like the last row in the CSV might be a total row. Please remove this row from the CSV.

To get this file through, I'm disabling the total row check when a CSV has only two rows, which generally seems like a good idea.