### PR TITLE
Ballot polling: Account for not-found ballots during sample size calculation

### DIFF
--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -8,7 +8,7 @@ from werkzeug.exceptions import BadRequest
 from . import api
 from ..models import *  # pylint: disable=wildcard-import
 from ..database import db_session
-from .shared import BatchTallies, combined_batch_keys
+from .shared import BatchTallies, combined_batch_keys, samples_not_found_by_round
 from ..auth import restrict_access, UserType
 from ..audit_math import (
     ballot_polling,
@@ -133,6 +133,7 @@ def sample_size_options(election: Election) -> Dict[str, Dict[str, SampleSizeOpt
                 election.risk_limit,
                 sampler_contest.from_db_contest(contest),
                 sample_results,
+                samples_not_found_by_round(contest),
                 AuditMathType(election.audit_math_type),
                 rounds.round_sizes(contest),
             )

--- a/server/audit_math/ballot_polling.py
+++ b/server/audit_math/ballot_polling.py
@@ -19,6 +19,7 @@ def get_sample_size(
     risk_limit: int,
     contest: Contest,
     sample_results: Optional[BALLOT_POLLING_SAMPLE_RESULTS],
+    samples_not_found: Dict[str, int],
     math_type: AuditMathType,
     round_sizes: Optional[BALLOT_POLLING_ROUND_SIZES],
 ) -> Dict[str, SampleSizeOption]:
@@ -34,6 +35,11 @@ def get_sample_size(
         - A sample size dictionary containing sample sizes for different
           finishing probabilities
     """
+    # When a sampled ballot can't be found, count it as a vote for every loser
+    if sample_results:
+        for round_id, num_not_found in samples_not_found.items():
+            for loser in contest.losers:
+                sample_results[round_id][loser] += num_not_found
 
     if math_type == AuditMathType.MINERVA:
         return minerva.get_sample_size(risk_limit, contest, sample_results, round_sizes)


### PR DESCRIPTION
## Overview

This PR addresses an edge case in the ballot polling audit math.

We recently encountered a ballot polling audit that required escalation to a round 2 but for which sample size calculation was finding that the audit should be considered complete. This surfaced in the UI confusingly as such:

<table>
<img width="2994" height="292" alt="before" src="https://github.com/user-attachments/assets/a2302b42-7f1f-487f-89a8-fc468e336fda" />
</table>

The issue was in our accounting of ballots that could not be found. When a ballot cannot be found in an audit, we assume the "worst" and count it as a vote for the losing candidate(s). We properly make this assumption when calculating whether the risk limit has been met but are forgetting to do so when calculating round 2 sample sizes. In this audit, there was 1 ballot that could not be found, and that 1 ballot was the decisive factor in determining whether the risk limit was met.

The fix was simple, applying the not-found logic not only during risk limit calculation but also during sample size calculation.

<table>
<img width="2994" height="334" alt="after" src="https://github.com/user-attachments/assets/0a1931f8-1012-4afb-9fdc-46dd2ed51808" />
</table>

Note that, because the risk limit calculation has always been correct, we can be confident that no past audits were considered done when they shouldn't have been :relieved:

## Testing

- [x] Updated automated tests
- [x] Tested manually using a production DB snapshot