### PR TITLE
fix(security): prevent path traversal in `/api/file-upload`

### DIFF
--- a/server/tests/api/test_public.py
+++ b/server/tests/api/test_public.py
@@ -573,6 +573,28 @@ def test_public_file_upload(client: FlaskClient):
             assert stored_file.read() == b"hello, I am a file"
 
 
+def test_public_file_upload_path_traversal(client: FlaskClient):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.post(
+        "/api/file-upload",
+        data={
+            "file": (
+                io.BytesIO(b"hello, I am a file"),
+                "random.txt",
+            ),
+            "key": "../test_dir/random.txt",
+        },
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "errorType": "Bad Request",
+                "message": "Invalid storage path",
+            }
+        ]
+    }
+
 def test_public_file_upload_unauthorized(client: FlaskClient):
     rv = client.post(
         "/api/file-upload",

--- a/server/tests/api/test_public.py
+++ b/server/tests/api/test_public.py
@@ -595,6 +595,7 @@ def test_public_file_upload_path_traversal(client: FlaskClient):
         ]
     }
 
+
 def test_public_file_upload_unauthorized(client: FlaskClient):
     rv = client.post(
         "/api/file-upload",

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -140,8 +140,10 @@ def get_full_storage_path(file_path: str) -> str:
         bucket_name = urlparse(config.FILE_UPLOAD_STORAGE_PATH).netloc
         return f"s3://{bucket_name}/{file_path}"
     else:
-        return os.path.join(config.FILE_UPLOAD_STORAGE_PATH, file_path)
-
+        full_path = os.path.normpath(os.path.join(config.FILE_UPLOAD_STORAGE_PATH, file_path))
+        if os.path.relpath(full_path, config.FILE_UPLOAD_STORAGE_PATH).startswith("../"):
+            raise BadRequest("Invalid storage path")
+        return full_path
 
 def get_file_upload_url(
     storage_prefix: str, file_name: str, file_type: str

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -140,12 +140,17 @@ def get_full_storage_path(file_path: str) -> str:
         bucket_name = urlparse(config.FILE_UPLOAD_STORAGE_PATH).netloc
         return f"s3://{bucket_name}/{file_path}"
     else:
-        full_path = os.path.normpath(os.path.join(config.FILE_UPLOAD_STORAGE_PATH, file_path))
+        full_path = os.path.normpath(
+            os.path.join(config.FILE_UPLOAD_STORAGE_PATH, file_path)
+        )
         storage_root = os.path.realpath(config.FILE_UPLOAD_STORAGE_PATH)
-        full_path = os.path.realpath(os.path.normpath(os.path.join(storage_root, file_path)))
+        full_path = os.path.realpath(
+            os.path.normpath(os.path.join(storage_root, file_path))
+        )
         if os.path.commonpath([full_path, storage_root]) != storage_root:
             raise BadRequest("Invalid storage path")
         return full_path
+
 
 def get_file_upload_url(
     storage_prefix: str, file_name: str, file_type: str

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -141,7 +141,9 @@ def get_full_storage_path(file_path: str) -> str:
         return f"s3://{bucket_name}/{file_path}"
     else:
         full_path = os.path.normpath(os.path.join(config.FILE_UPLOAD_STORAGE_PATH, file_path))
-        if os.path.relpath(full_path, config.FILE_UPLOAD_STORAGE_PATH).startswith("../"):
+        storage_root = os.path.realpath(config.FILE_UPLOAD_STORAGE_PATH)
+        full_path = os.path.realpath(os.path.normpath(os.path.join(storage_root, file_path)))
+        if os.path.commonpath([full_path, storage_root]) != storage_root:
             raise BadRequest("Invalid storage path")
         return full_path
 


### PR DESCRIPTION
Prevents a user-controllable string (`key` in the request) from being used to write data to an arbitrary path on the local file system.