### PR TITLE
chore: clean up dead code

### DIFF
--- a/client/src/components/AuditBoard/MemberForm.tsx
+++ b/client/src/components/AuditBoard/MemberForm.tsx
@@ -81,7 +81,7 @@ const MemberForm: React.FC<IProps> = ({
               intent="primary"
               type="button"
               loading={isSubmitting}
-              disabled={!(values[0].name || (values[0].name && values[1].name))}
+              disabled={!values[0].name || !values[1].name}
               onClick={handleSubmit}
             >
               Next


### PR DESCRIPTION
Removes a portion of a binary logical expression that must always be false in order to reach that part of the code.