### PR TITLE
Fix bug in discrepancy calculation for ES&S overvotes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -93,7 +93,8 @@ disable=raw-checker-failed,
         logging-fstring-interpolation,
         broad-exception-raised,
         use-dict-literal,
-        use-implicit-booleaness-not-comparison
+        use-implicit-booleaness-not-comparison,
+        too-many-return-statements
 
 
 

--- a/server/activity_log/slack_worker.py
+++ b/server/activity_log/slack_worker.py
@@ -11,7 +11,6 @@ from . import activity_log
 from ..sentry import configure_sentry
 
 
-# pylint: disable=too-many-return-statements
 def slack_message(activity: activity_log.Activity):
     base = activity.base
     org_link = urljoin(config.HTTP_ORIGIN, f"/support/orgs/{base.organization_id}")

--- a/server/api/shared.py
+++ b/server/api/shared.py
@@ -526,6 +526,17 @@ def ballot_vote_deltas(
     if reported is None:
         reported = {choice.id: "0" for choice in contest.choices}
 
+    # Special case for ES&S overvotes/undervotes.
+    has_overvote = "o" in reported.values()
+    has_undervote = "u" in reported.values()
+    audited_votes = sum(map(int, (audited.values())))
+    # If the audited result correctly identified overvote/undervote, return
+    # no delta.
+    if has_overvote and audited_votes > 1:
+        return None
+    if has_undervote and audited_votes < 1:
+        return None
+
     deltas = {}
     for choice in contest.choices:
         reported_vote = (


### PR DESCRIPTION
Alternate idea to fix #2100 that mimics the logic from `supersimple.discrepancy`