### PR TITLE
Audit board UI: Sort yes before no for propositions

### DIFF
--- a/client/src/components/AuditBoard/AuditBoardView.test.tsx
+++ b/client/src/components/AuditBoard/AuditBoardView.test.tsx
@@ -784,5 +784,26 @@ describe('AuditBoardView', () => {
         expect(contest2InvalidWriteInButton).toBeChecked()
       })
     })
+
+    it('sorts yes before no for propositions', async () => {
+      const expectedCalls = [
+        apiCalls.getAuditBoard,
+        apiCalls.getAuditBoard,
+        {
+          ...apiCalls.getContests,
+          response: { contests: contestMocks.oneProposition },
+        },
+        apiCalls.getBallotsInitial,
+      ]
+      await withMockFetch(expectedCalls, async () => {
+        renderBallot()
+
+        const yes = await screen.findByRole('checkbox', { name: 'Yes' })
+        const no = await screen.findByRole('checkbox', { name: 'No' })
+        expect(yes.compareDocumentPosition(no)).toEqual(
+          Node.DOCUMENT_POSITION_FOLLOWING
+        )
+      })
+    })
   })
 })

--- a/client/src/components/AuditBoard/BallotAudit.tsx
+++ b/client/src/components/AuditBoard/BallotAudit.tsx
@@ -267,12 +267,19 @@ const BallotAuditContest = ({
     }
   }
 
+  // Sort yes before no for propositions
+  const yesOption = contest.choices.find(c => c.name.toLowerCase() === 'yes')
+  const noOption = contest.choices.find(c => c.name.toLowerCase() === 'no')
+  const sortedContestChoices =
+    contest.choices.length === 2 && yesOption && noOption
+      ? [yesOption, noOption]
+      : contest.choices
   return (
     <ContestCard>
       <BlockCheckboxes>
         <LeftCheckboxes>
           <ContestTitle>{contest.name}</ContestTitle>
-          {contest.choices.map(c => (
+          {sortedContestChoices.map(c => (
             <BlockCheckbox
               key={c.id}
               handleChange={onCheckboxClick(c.id)}

--- a/client/src/components/_mocks.ts
+++ b/client/src/components/_mocks.ts
@@ -1144,6 +1144,34 @@ export const contestMocks = mocksOfType<IContest[]>()({
       ],
     },
   ],
+  oneProposition: [
+    {
+      id: 'contest-id-1',
+      name: 'Contest 1',
+      isTargeted: true,
+      totalBallotsCast: 30,
+      numWinners: 1,
+      votesAllowed: 1,
+      jurisdictionIds: [
+        'jurisdiction-id-1',
+        'jurisdiction-id-2',
+        'jurisdiction-id-3',
+      ],
+      // Intentionally order no before yes to test sorting logic
+      choices: [
+        {
+          id: 'choice-id-1',
+          name: 'No',
+          numVotes: 10,
+        },
+        {
+          id: 'choice-id-2',
+          name: 'Yes',
+          numVotes: 20,
+        },
+      ],
+    },
+  ],
   two: [
     {
       id: 'contest-id-1',


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/arlo/issues/2191

The bigger long-term goal here is to have the audit board UI display candidates in the same order as the retrieved ballot, which as a reminder can vary across ballot style given rotation rules. But TBD which CVR types include the granular order info needed to make that possible.

For the time being, we're tackling the one easy case of a proposition, always displaying the yes option before no option. Before this PR, that order wasn't guaranteed and the no option could sometimes end up ahead of the yes option.

<img width="745" height="450" alt="audit-board-ui" src="https://github.com/user-attachments/assets/029bbb3d-df8b-45b7-8c00-02706ea120d7" />

## Testing

- [x] Updated automated tests
- [x] Tested manually