### PR TITLE
RCV pilot: Cache RAIRE assertions using a Python pickle (pilot only of course)

### DIFF
--- a/server/api/cvrs.py
+++ b/server/api/cvrs.py
@@ -286,6 +286,8 @@ def parse_portland_cvrs(
     jurisdiction: Jurisdiction,
     working_directory: str,
 ) -> tuple[CVR_CONTESTS_METADATA, Iterable[CvrBallot]]:
+    jurisdiction.election.raire_assertions_pickle = None
+
     cvr_file = retrieve_file_to_buffer(jurisdiction.cvr_file, working_directory)
     cvrs = csv_reader_for_cvr(cvr_file)
     headers = next(cvrs)

--- a/server/api/rounds.py
+++ b/server/api/rounds.py
@@ -30,6 +30,7 @@ from .shared import (
     sampled_batch_results,
     sampled_batches_by_ticket_number,
     samples_not_found_by_round,
+    cache_compute_raire_assertions,
 )
 from ..auth import restrict_access, UserType
 from ..util.isoformat import isoformat
@@ -40,7 +41,6 @@ from ..audit_math import (
     supersimple_raire,
     sampler_contest,
     suite,
-    raire,
 )
 from .ballot_manifest import hybrid_contest_total_ballots
 from ..worker.tasks import (
@@ -308,10 +308,7 @@ def calculate_risk_measurements(election: Election, round: Round):
                 sampler_contest.from_db_contest(contest),
                 cvrs_for_contest(contest),  # TODO: Should this be all CVRs? Unsure
                 sampled_ballot_interpretations_to_cvrs(contest),
-                raire.compute_raire_assertions(
-                    sampler_contest.from_db_contest(contest),
-                    cvrs_for_contest(contest, sampled_only=False),
-                ),
+                cache_compute_raire_assertions(election, contest),
             )
         else:
             assert election.audit_type == AuditType.HYBRID

--- a/server/api/sample_sizes.py
+++ b/server/api/sample_sizes.py
@@ -8,7 +8,12 @@ from werkzeug.exceptions import BadRequest
 from . import api
 from ..models import *
 from ..database import db_session
-from .shared import BatchTallies, combined_batch_keys, samples_not_found_by_round
+from .shared import (
+    BatchTallies,
+    combined_batch_keys,
+    samples_not_found_by_round,
+    cache_compute_raire_assertions,
+)
 from ..auth import restrict_access, UserType
 from ..audit_math import (
     ballot_polling,
@@ -16,7 +21,6 @@ from ..audit_math import (
     supersimple_raire,
     sampler_contest,
     suite,
-    raire,
 )
 from ..audit_math.ballot_polling import SampleSizeOption
 from . import rounds
@@ -196,10 +200,7 @@ def sample_size_options(election: Election) -> dict[str, dict[str, SampleSizeOpt
                 contest_for_sampler,
                 rounds.cvrs_for_contest(contest, sampled_only=False),
                 None,  # Fine for a round 1 calculation
-                raire.compute_raire_assertions(
-                    contest_for_sampler,
-                    rounds.cvrs_for_contest(contest, sampled_only=False),
-                ),
+                cache_compute_raire_assertions(election, contest),
             )
 
             return {"default": {"key": "default", "size": sample_size, "prob": None}}

--- a/server/migrations/versions/17dd7b178a3a_election_raire_assertions_pickle.py
+++ b/server/migrations/versions/17dd7b178a3a_election_raire_assertions_pickle.py
@@ -1,0 +1,28 @@
+"""Election.raire_assertions_pickle
+
+Revision ID: 17dd7b178a3a
+Revises: b2de019d30ab
+Create Date: 2025-12-11 17:57:16.981448+00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "17dd7b178a3a"
+down_revision = "b2de019d30ab"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "election",
+        sa.Column("raire_assertions_pickle", sa.LargeBinary(), nullable=True),
+    )
+
+
+def downgrade():
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
     UniqueConstraint,
     PrimaryKeyConstraint,
     CheckConstraint,
+    LargeBinary,
 )
 from sqlalchemy.orm import relationship, backref, validates
 from sqlalchemy.types import TypeDecorator
@@ -227,6 +228,8 @@ class Election(BaseModel):
     sample_preview_task = relationship(
         "BackgroundTask", single_parent=True, cascade="all, delete-orphan"
     )
+
+    raire_assertions_pickle = Column(LargeBinary)
 
     __table_args__ = (UniqueConstraint("organization_id", "audit_name"),)
 


### PR DESCRIPTION
As hacky as it gets lol

Also, probably should've cached on the Contest model instead of Election, but fine for the Portland pilot since it's a single contest audit