### PR TITLE
Audit majority claim for runoff-subject contests

### DIFF
--- a/client/src/components/Atoms/Form/FormSection.tsx
+++ b/client/src/components/Atoms/Form/FormSection.tsx
@@ -11,6 +11,7 @@ export const Section = styled.div`
 
 export const FormSectionDescription = styled.div`
   margin: 10px 0;
+  max-width: 540px;
 `
 
 interface IProps {

--- a/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
@@ -217,18 +217,21 @@ const computeRunoffPreview = (choices: IChoiceValues[]): string => {
     name: c.name,
     votes: parseNumber(c.numVotes) || 0,
   }))
-  const totalValid = sum(parsed.map(c => c.votes))
-  if (totalValid <= 0) return ''
+  const totalVotes = sum(parsed.map(c => c.votes))
+  if (totalVotes <= 0) return ''
   const sorted = sortBy(parsed, c => -c.votes)
   const leader = sorted[0]
-  if (leader.votes > totalValid - leader.votes) {
+  if (leader.votes > totalVotes - leader.votes) {
     return `Reported results: ${leader.name} received a majority, no runoff required.`
   }
   const runnerUp = sorted[1]
   return `Reported results: ${leader.name} and ${runnerUp.name} are the top two vote-getters and neither received a majority, runoff required.`
 }
 
-const contestFromValues = (contest: IContestValues): IContest => ({
+const contestFromValues = (
+  contest: IContestValues,
+  auditType: AuditType
+): IContest => ({
   ...contest,
   id: contest.id || uuidv4(), // preserve given id if present, generate new one if empty string
   totalBallotsCast: parseNumber(contest.totalBallotsCast),
@@ -240,10 +243,10 @@ const contestFromValues = (contest: IContestValues): IContest => ({
     numVotes: parseNumber(choice.numVotes),
   })),
   pendingBallots: parseNumber(contest.pendingBallots),
-  // Only include when true; the API defaults missing values for batch-comparison
-  // to false and non-batch-comparison schemas will reject
   isSubjectToRunoff:
-    contest.numWinners === '1' && contest.isSubjectToRunoff ? true : undefined,
+    auditType === 'BATCH_COMPARISON'
+      ? contest.numWinners === '1' && !!contest.isSubjectToRunoff
+      : undefined,
 })
 
 const ContestForm: React.FC<IProps> = ({
@@ -329,7 +332,9 @@ const ContestForm: React.FC<IProps> = ({
         }))
       : values.contests
     await updateContestsMutation.mutateAsync(
-      contestsToUpdate.map(contestFromValues).concat(restContests)
+      contestsToUpdate
+        .map(c => contestFromValues(c, auditType))
+        .concat(restContests)
     )
     goToNextStage()
   }

--- a/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
@@ -43,8 +43,9 @@ import { testNumber } from '../../../utilities'
 import { isObjectEmpty } from '../../../../utils/objects'
 import useStandardizedContests from '../../../useStandardizedContests'
 import { ErrorLabel } from '../../../Atoms/Form/_helpers'
-import { partition } from '../../../../utils/array'
-import { AuditType } from '../../../useAuditSettings'
+import { partition, sortBy } from '../../../../utils/array'
+import { sum } from '../../../../utils/number'
+import { AuditType, IAuditSettings } from '../../../useAuditSettings'
 import { parse as parseNumber } from '../../../../utils/number-schema'
 
 const CustomMenuItem = styled.li`
@@ -171,6 +172,7 @@ interface IProps {
   electionId: string
   isTargeted: boolean
   auditType: AuditType
+  electionState: IAuditSettings['state']
   goToPrevStage: () => void
   goToNextStage: () => void
 }
@@ -192,6 +194,7 @@ export interface IContestValues {
   choices: IChoiceValues[]
   totalBallotsCast?: string
   pendingBallots?: string
+  isSubjectToRunoff?: boolean
   jurisdictionIds: string[]
 }
 
@@ -205,7 +208,25 @@ const contestToValues = (contest: IContest): IContestValues => ({
   })),
   totalBallotsCast: contest.totalBallotsCast?.toString(),
   pendingBallots: contest.pendingBallots?.toString() || '',
+  isSubjectToRunoff: contest.isSubjectToRunoff ?? false,
 })
+
+const computeRunoffPreview = (choices: IChoiceValues[]): string => {
+  if (!choices.every(c => c.name && c.numVotes !== '')) return ''
+  const parsed = choices.map(c => ({
+    name: c.name,
+    votes: parseNumber(c.numVotes) || 0,
+  }))
+  const totalValid = sum(parsed.map(c => c.votes))
+  if (totalValid <= 0) return ''
+  const sorted = sortBy(parsed, c => -c.votes)
+  const leader = sorted[0]
+  if (leader.votes > totalValid - leader.votes) {
+    return `Reported results: ${leader.name} received a majority, no runoff required.`
+  }
+  const runnerUp = sorted[1]
+  return `Reported results: ${leader.name} and ${runnerUp.name} are the top two vote-getters and neither received a majority, runoff required.`
+}
 
 const contestFromValues = (contest: IContestValues): IContest => ({
   ...contest,
@@ -219,6 +240,10 @@ const contestFromValues = (contest: IContestValues): IContest => ({
     numVotes: parseNumber(choice.numVotes),
   })),
   pendingBallots: parseNumber(contest.pendingBallots),
+  // Only include when true; the API defaults missing values for batch-comparison
+  // to false and non-batch-comparison schemas will reject
+  isSubjectToRunoff:
+    contest.numWinners === '1' && contest.isSubjectToRunoff ? true : undefined,
 })
 
 const ContestForm: React.FC<IProps> = ({
@@ -227,6 +252,7 @@ const ContestForm: React.FC<IProps> = ({
   goToPrevStage,
   goToNextStage,
   auditType,
+  electionState,
 }) => {
   const contestValues: IContestValues[] = [
     {
@@ -238,6 +264,7 @@ const ContestForm: React.FC<IProps> = ({
       votesAllowed: '1',
       jurisdictionIds: [],
       pendingBallots: '',
+      isSubjectToRunoff: false,
       choices: [
         {
           id: '',
@@ -268,6 +295,8 @@ const ContestForm: React.FC<IProps> = ({
     !contestsQuery.isSuccess
   )
     return null // Still loading
+
+  const showRunoffOption = isBatchComparison && electionState === 'GA'
 
   const contests = contestsQuery.data
   const [formContests, restContests] = partition(
@@ -340,6 +369,14 @@ const ContestForm: React.FC<IProps> = ({
                       value: j.id,
                       checked: contest.jurisdictionIds.indexOf(j.id) > -1,
                     }))
+                    const isRunoffEligible = contest.numWinners === '1'
+                    const shouldShowRunoffPreview =
+                      showRunoffOption &&
+                      isRunoffEligible &&
+                      !!contest.isSubjectToRunoff
+                    const runoffPreview = shouldShowRunoffPreview
+                      ? computeRunoffPreview(contest.choices)
+                      : ''
                     return (
                       /* eslint-disable react/no-array-index-key */
                       <Card
@@ -520,6 +557,35 @@ const ContestForm: React.FC<IProps> = ({
                               name={`contests[${i}].pendingBallots`}
                               component={FormField}
                             />
+                          </FormSection>
+                        )}
+                        {showRunoffOption && (
+                          <FormSection label="Runoff Law">
+                            <Checkbox
+                              checked={
+                                isRunoffEligible && !!contest.isSubjectToRunoff
+                              }
+                              disabled={!isRunoffEligible}
+                              label="Subject to runoff law"
+                              onChange={e =>
+                                setFieldValue(
+                                  `contests[${i}].isSubjectToRunoff`,
+                                  (e.target as HTMLInputElement).checked
+                                )
+                              }
+                            />
+                            {!isRunoffEligible && (
+                              <FormSectionDescription>
+                                Only available for single-winner contests.
+                              </FormSectionDescription>
+                            )}
+                            {isRunoffEligible &&
+                              contest.isSubjectToRunoff &&
+                              runoffPreview && (
+                                <FormSectionDescription>
+                                  {runoffPreview}
+                                </FormSectionDescription>
+                              )}
                           </FormSection>
                         )}
                         {!isHybrid && (

--- a/client/src/components/AuditAdmin/Setup/Contests/ContestSelect.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/ContestSelect.test.tsx
@@ -19,6 +19,7 @@ const renderContests = (props: Partial<IContestsProps> = {}) => {
         <Contests
           electionId="1"
           auditType="BALLOT_COMPARISON"
+          electionState={null}
           isTargeted
           goToNextStage={goToNextStage}
           goToPrevStage={goToPrevStage}

--- a/client/src/components/AuditAdmin/Setup/Contests/Contests.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/Contests.test.tsx
@@ -512,6 +512,7 @@ describe('Audit Setup > Contests', () => {
         numWinners: 1,
         votesAllowed: 1,
         pendingBallots: null,
+        isSubjectToRunoff: false,
       },
       {
         id: 'contest-id-2',
@@ -525,6 +526,7 @@ describe('Audit Setup > Contests', () => {
         numWinners: 1,
         votesAllowed: 1,
         pendingBallots: null,
+        isSubjectToRunoff: false,
       },
     ]
     const expectedCalls = [
@@ -592,6 +594,7 @@ describe('Audit Setup > Contests', () => {
       ...contestMocks.filledTargeted[0],
       totalBallotsCast: undefined,
       pendingBallots: numPendingBallots,
+      isSubjectToRunoff: false,
     }
     const expectedCalls = [
       aaApiCalls.getContests(contestMocks.empty),

--- a/client/src/components/AuditAdmin/Setup/Contests/Contests.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/Contests.test.tsx
@@ -29,6 +29,7 @@ const renderContests = (props: Partial<IContestsProps> = {}) => {
         <Contests
           electionId="1"
           auditType="BALLOT_POLLING"
+          electionState={null}
           isTargeted
           goToNextStage={goToNextStage}
           goToPrevStage={goToPrevStage}

--- a/client/src/components/AuditAdmin/Setup/Contests/Contests.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/Contests.tsx
@@ -7,6 +7,7 @@ import { IAuditSettings } from '../../../useAuditSettings'
 export interface IContestsProps {
   electionId: string
   auditType: IAuditSettings['auditType']
+  electionState: IAuditSettings['state']
   isTargeted: boolean
   goToNextStage: () => void
   goToPrevStage: () => void

--- a/client/src/components/AuditAdmin/Setup/Contests/HybridContestForm.test.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/HybridContestForm.test.tsx
@@ -77,6 +77,7 @@ const renderContests = (props: Partial<IContestsProps> = {}) => {
         <Contests
           electionId="1"
           auditType="HYBRID"
+          electionState={null}
           isTargeted
           goToNextStage={goToNextStage}
           goToPrevStage={goToPrevStage}

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
           </h3>
           <div>
             <div
-              class="sc-iwsKbI bncGzX"
+              class="sc-iwsKbI jeNrVx"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -59,7 +59,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
             </label>
           </div>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the number of winners for the contest.
           </div>
@@ -84,7 +84,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
             </div>
           </label>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -118,7 +118,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
             Candidates/Choices & Vote Totals
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
@@ -234,7 +234,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
             Total Ballot Cards Cast
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -271,7 +271,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
             Contest Universe
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -437,7 +437,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
           </h3>
           <div>
             <div
-              class="sc-iwsKbI bncGzX"
+              class="sc-iwsKbI jeNrVx"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -466,7 +466,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
             </label>
           </div>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the number of winners for the contest.
           </div>
@@ -491,7 +491,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
             </div>
           </label>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -525,7 +525,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
             Candidates/Choices & Vote Totals
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
@@ -641,7 +641,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
             Total Ballot Cards Cast
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -678,7 +678,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
             Contest Universe
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -844,7 +844,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
           </h3>
           <div>
             <div
-              class="sc-iwsKbI bncGzX"
+              class="sc-iwsKbI jeNrVx"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -873,7 +873,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
             </label>
           </div>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the number of winners for the contest.
           </div>
@@ -898,7 +898,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
             </div>
           </label>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -932,7 +932,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
             Candidates/Choices & Vote Totals
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
@@ -1048,7 +1048,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
             Total Ballot Cards Cast
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -1085,7 +1085,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
             Contest Universe
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
@@ -1251,7 +1251,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
           </h3>
           <div>
             <div
-              class="sc-iwsKbI bncGzX"
+              class="sc-iwsKbI jeNrVx"
             >
               Enter the name of the contest that will drive the audit.
             </div>
@@ -1280,7 +1280,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
             </label>
           </div>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the number of winners for the contest.
           </div>
@@ -1305,7 +1305,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
             </div>
           </label>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -1339,7 +1339,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
             Candidates/Choices & Vote Totals
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
@@ -1455,7 +1455,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
             Total Ballot Cards Cast
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the overall number of ballot cards cast in jurisdictions containing this contest.
           </div>
@@ -1492,7 +1492,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
             Contest Universe
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Select the jurisdictions where this contest appeared on the ballot.
           </div>

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
           </h3>
           <div>
             <div
-              class="sc-iwsKbI bncGzX"
+              class="sc-iwsKbI jeNrVx"
             >
               Select the name of the contest that will drive the audit.
             </div>
@@ -95,7 +95,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
             </label>
           </div>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the number of winners for the contest.
           </div>
@@ -120,7 +120,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
             </div>
           </label>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Number of selections the voter can make in the contest.
           </div>
@@ -154,7 +154,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
             Candidates/Choices & Vote Totals
           </h3>
           <div
-            class="sc-iwsKbI bncGzX"
+            class="sc-iwsKbI jeNrVx"
           >
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>

--- a/client/src/components/AuditAdmin/Setup/Contests/schema.ts
+++ b/client/src/components/AuditAdmin/Setup/Contests/schema.ts
@@ -52,6 +52,7 @@ const contestsSchema = (auditType: IAuditSettings['auditType']) =>
               .typeError('Must be a number')
               .integer('Must be an integer')
               .min(0, 'Must be a positive number'),
+            isSubjectToRunoff: Yup.boolean(),
             jurisdictionIds: Yup.array()
               .required('Select at least one jurisdiction')
               .of(Yup.string()),

--- a/client/src/components/AuditAdmin/Setup/Setup.tsx
+++ b/client/src/components/AuditAdmin/Setup/Setup.tsx
@@ -119,6 +119,7 @@ const Setup: React.FC<ISetupProps> = ({
                   electionId={electionId}
                   isTargeted
                   auditType={auditType}
+                  electionState={auditSettings.state}
                   goToPrevStage={goToPrevStage}
                   goToNextStage={goToNextStage}
                 />
@@ -130,6 +131,7 @@ const Setup: React.FC<ISetupProps> = ({
                   electionId={electionId}
                   isTargeted={false}
                   auditType={auditType}
+                  electionState={auditSettings.state}
                   goToPrevStage={goToPrevStage}
                   goToNextStage={goToNextStage}
                 />

--- a/client/src/components/AuditAdmin/__snapshots__/AuditAdminView.test.tsx.snap
+++ b/client/src/components/AuditAdmin/__snapshots__/AuditAdminView.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`AA setup flow > renders sidebar when authenticated on /setup 1`] = `
             >
               <div>
                 <div
-                  class="sc-gqjmRU fOytwc"
+                  class="sc-gqjmRU jqRxta"
                 >
                   Click "Browse" to choose the appropriate file from your computer. This file should be a comma-separated list of all the jurisdictions participating in the audit, plus email addresses for audit administrators in each participating jurisdiction.
                 </div>

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -35,6 +35,7 @@ export interface IContest {
   jurisdictionIds: string[]
   cvrChoiceNameConsistencyError?: ICvrChoiceNameConsistencyError
   pendingBallots?: number | null
+  isSubjectToRunoff?: boolean
 }
 
 export enum Interpretation {

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -282,12 +282,16 @@ def validate_contests(contests: list[JSONDict], election: Election):
             continue
         if election.audit_type != AuditType.BATCH_COMPARISON:
             raise BadRequest(
-                "Runoff-subject contests are only supported for batch comparison audits"
+                "isSubjectToRunoff is only supported for batch comparison audits"
             )
         if contest["numWinners"] != 1:
-            raise BadRequest("Runoff-subject contests must have num_winners=1")
+            raise BadRequest(
+                "isSubjectToRunoff can only be true for contests with num_winners=1"
+            )
         if len(contest["choices"]) < 3:
-            raise BadRequest("Runoff-subject contests must have at least 3 choices")
+            raise BadRequest(
+                "isSubjectToRunoff can only be true for contests with at least 3 choices"
+            )
 
 
 # In various audit types, we set different pieces of contest metadata from
@@ -333,10 +337,6 @@ def should_reprocess_batch_tallies(
         contest["choices"] = sorted(
             contest["choices"], key=lambda choice: str(choice["id"])
         )
-        # Client conditionally omits this when false; serialize_contest always
-        # emits it. Normalize missing → False so a no-op save doesn't look like
-        # a flag change.
-        contest.setdefault("isSubjectToRunoff", False)
         return contest
 
     return any(

--- a/server/api/contests.py
+++ b/server/api/contests.py
@@ -37,6 +37,7 @@ CONTEST_SCHEMA = {
         "pendingBallots": {
             "anyOf": [{"type": "integer", "minimum": 0}, {"type": "null"}]
         },
+        "isSubjectToRunoff": {"type": "boolean"},
         "jurisdictionIds": {
             "type": "array",
             "items": {"type": "string"},
@@ -101,6 +102,7 @@ BALLOT_COMPARISON_CONTEST_SCHEMA = {
         "isTargeted": {"type": "boolean"},
         "numWinners": {"type": "integer", "minimum": 1},
         "jurisdictionIds": {"type": "array", "items": {"type": "string"}},
+        "isSubjectToRunoff": {"type": "boolean"},
     },
     "additionalProperties": False,
     "required": ["id", "name", "isTargeted", "numWinners", "jurisdictionIds"],
@@ -137,6 +139,7 @@ def serialize_contest(contest: Contest) -> JSONDict:
 
     if contest.election.audit_type == AuditType.BATCH_COMPARISON:
         serialized_contest["pendingBallots"] = contest.pending_ballots
+        serialized_contest["isSubjectToRunoff"] = contest.is_subject_to_runoff
 
     # Validate CVR choice names across jurisdictions in ballot comparison audits. Load error
     # details, if any, onto the contest object.
@@ -229,6 +232,7 @@ def deserialize_contest(contest: JSONDict, election_id: str) -> Contest:
         num_winners=contest.get("numWinners", None),
         votes_allowed=contest.get("votesAllowed", None),
         pending_ballots=contest.get("pendingBallots", None),
+        is_subject_to_runoff=contest.get("isSubjectToRunoff", False),
         jurisdictions=jurisdictions,
     )
 
@@ -272,6 +276,18 @@ def validate_contests(contests: list[JSONDict], election: Election):
                     f"Too many votes cast in contest: {contest['name']}"
                     f" ({total_votes} votes, {total_allowed_votes} allowed)"
                 )
+
+    for contest in contests:
+        if not contest.get("isSubjectToRunoff", False):
+            continue
+        if election.audit_type != AuditType.BATCH_COMPARISON:
+            raise BadRequest(
+                "Runoff-subject contests are only supported for batch comparison audits"
+            )
+        if contest["numWinners"] != 1:
+            raise BadRequest("Runoff-subject contests must have num_winners=1")
+        if len(contest["choices"]) < 3:
+            raise BadRequest("Runoff-subject contests must have at least 3 choices")
 
 
 # In various audit types, we set different pieces of contest metadata from
@@ -317,6 +333,10 @@ def should_reprocess_batch_tallies(
         contest["choices"] = sorted(
             contest["choices"], key=lambda choice: str(choice["id"])
         )
+        # Client conditionally omits this when false; serialize_contest always
+        # emits it. Normalize missing → False so a no-op save doesn't look like
+        # a flag change.
+        contest.setdefault("isSubjectToRunoff", False)
         return contest
 
     return any(

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -244,6 +244,10 @@ def election_info_rows(election: Election):
 
 
 def contest_rows(election: Election):
+    show_runoff_columns = any(
+        contest.is_subject_to_runoff for contest in election.contests
+    )
+
     rows = [
         heading("CONTESTS"),
         [
@@ -268,7 +272,8 @@ def contest_rows(election: Election):
             ]
             if election.audit_type == AuditType.HYBRID
             else []
-        ),
+        )
+        + (["Runoff Law", "Reported Runoff Results"] if show_runoff_columns else []),
     ]
 
     for contest in election.contests:
@@ -321,6 +326,18 @@ def contest_rows(election: Election):
                         }
                     ),
                 ]
+
+        if show_runoff_columns:
+            if contest.is_subject_to_runoff:
+                row += [
+                    "Subject to runoff law",
+                    reported_runoff_results_label(
+                        [choice.num_votes for choice in contest.choices]
+                    ),
+                ]
+            else:
+                row += ["Not subject to runoff law", ""]
+
         rows.append(row)
     return rows
 
@@ -395,6 +412,14 @@ def audit_board_rows(election: Election):
                 ]
             )
     return rows
+
+
+def reported_runoff_results_label(choice_votes: list[int]) -> str:
+    valid_votes = sum(choice_votes)
+    leader_votes = max(choice_votes)
+    if leader_votes > valid_votes - leader_votes:
+        return "Majority received, no runoff required"
+    return "No majority, runoff required"
 
 
 def round_rows(election: Election):

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -336,7 +336,7 @@ def contest_rows(election: Election):
                     ),
                 ]
             else:
-                row += ["Not subject to runoff law", ""]
+                row += ["", ""]
 
         rows.append(row)
     return rows

--- a/server/audit_math/macro.py
+++ b/server/audit_math/macro.py
@@ -27,21 +27,6 @@ class BatchError(TypedDict):
     weighted_error: Decimal
 
 
-def add_aggregate_tallies(contest: Contest, batch_results: BatchResults) -> None:
-    """
-    For runoff-subject contests, augments a single batch's per-contest tally
-    dict with `__not_<X>` aggregate entries (one per entry in `contest.winners`),
-    where each aggregate's batch tally is `sum_of_real_candidates_in_batch −
-    X_votes_in_batch`. Idempotent. No-op if the contest isn't runoff-subject.
-    """
-    if not contest.is_subject_to_runoff:
-        return
-    contest_batch = batch_results[contest.name]
-    real_total = sum(contest_batch.get(c, 0) for c in contest.candidates)
-    for w_id in contest.winners:
-        contest_batch[f"__not_{w_id}"] = real_total - contest_batch.get(w_id, 0)
-
-
 def compute_unauditable_ballots(
     batch_results: dict[BatchKey, BatchResults],
     contest: Contest,
@@ -93,15 +78,15 @@ def compute_error(
     Outputs:
         the maximum across-contest relative overstatement for batch p
     """
-    add_aggregate_tallies(contest, batch_results)
-    add_aggregate_tallies(contest, sampled_results)
 
-    def error_for_pair(winner: str, loser: str, V_wl: int) -> BatchError | None:
+    def error_for_candidate_pair(winner: str, loser: str) -> BatchError | None:
         v_wp = batch_results[contest.name][winner]
         v_lp = batch_results[contest.name][loser]
 
         a_wp = sampled_results[contest.name][winner]
         a_lp = sampled_results[contest.name][loser]
+
+        V_wl = contest.candidates[winner] - contest.candidates[loser]
 
         # Conservatively assume that any pending ballots would be tallied as
         # votes for the loser, reducing the reported margin.
@@ -118,22 +103,78 @@ def compute_error(
         weighted_error = Decimal(error) / Decimal(V_wl) if V_wl > 0 else Decimal("inf")
         return BatchError(counted_as=error, weighted_error=weighted_error)
 
-    maybe_errors = [
-        error_for_pair(
-            winner, loser, contest.candidates[winner] - contest.candidates[loser]
+    def error_for_threshold(winner: str) -> BatchError | None:
+        valid_votes = sum(contest.candidates.values())
+        w_total = contest.candidates[winner]
+        not_w_total = valid_votes - w_total
+
+        batch_total = sum(
+            batch_results[contest.name].get(c, 0) for c in contest.candidates
         )
+        sampled_total = sum(
+            sampled_results[contest.name].get(c, 0) for c in contest.candidates
+        )
+
+        w_batch = batch_results[contest.name][winner]
+        w_sampled = sampled_results[contest.name][winner]
+
+        if w_total > not_w_total:
+            # If the winner is above the majority threshold, we are checking that
+            # the winner received more votes than all other candidates combined.
+            # This is modeled as a candidate pair where the "loser" is the aggregate
+            # of all other candidates.
+            v_wp = w_batch
+            v_lp = batch_total - w_batch
+            a_wp = w_sampled
+            a_lp = sampled_total - w_sampled
+            # V_w is the number of votes for the winner minus the number of votes for all other candidates,
+            # which is equivalent to 2 * votes for winner - total votes
+            V_wl = 2 * w_total - valid_votes
+        else:
+            # Else, we are checking that the other candidates received more votes than the winner
+            # This is modeled as a candidate pair where the "winner" is the aggregate of all other
+            # candidates and the "loser" is the winner.
+            v_wp = batch_total - w_batch
+            v_lp = w_batch
+            a_wp = sampled_total - w_sampled
+            a_lp = w_sampled
+            # V_w is the number of votes for all other candidates minus the number of votes for the winner,
+            # which is equivalent to total votes - 2 * votes for winner
+            V_wl = valid_votes - 2 * w_total
+
+        # Conservatively assume that any pending ballots would be tallied as
+        # votes for the loser, reducing the reported margin.
+        V_wl -= contest.pending_ballots
+
+        # Conservatively assume that any unauditable ballots would be tallied as
+        # votes for the loser, reducing the reported margin.
+        V_wl -= unauditable_ballots
+
+        error = (v_wp - v_lp) - (a_wp - a_lp)
+        if error == 0:
+            return None
+
+        weighted_error = Decimal(error) / Decimal(V_wl) if V_wl > 0 else Decimal("inf")
+        return BatchError(counted_as=error, weighted_error=weighted_error)
+
+    maybe_candidate_pair_errors = [
+        error_for_candidate_pair(winner, loser)
         for winner in contest.margins["winners"]
         for loser in contest.margins["losers"]
     ]
-    maybe_errors += [
-        error_for_pair(
-            p["winner_id"],
-            p["loser_id"],
-            p["winner_votes"] - p["loser_votes"],
-        )
-        for p in contest.runoff_pairs
+    errors: list[BatchError] = [
+        error for error in maybe_candidate_pair_errors if error is not None
     ]
-    errors: list[BatchError] = [error for error in maybe_errors if error is not None]
+
+    if contest.is_subject_to_runoff:
+        maybe_threshold_errors = [
+            error_for_threshold(winner) for winner in contest.margins["winners"]
+        ]
+        threshold_errors: list[BatchError] = [
+            error for error in maybe_threshold_errors if error is not None
+        ]
+        errors += threshold_errors
+
     if len(errors) == 0:
         return None
     return max(errors, key=lambda error: error["weighted_error"])
@@ -168,13 +209,48 @@ def compute_max_error(
     if contest.name not in batch_results:
         return Decimal(0.0)
 
-    add_aggregate_tallies(contest, batch_results)
-
-    def max_error_for_pair(winner: str, loser: str, V_wl: int) -> Decimal:
+    def max_error_for_candidate_pair(winner: str, loser: str) -> Decimal:
         v_wp = batch_results[contest.name][winner]
         v_lp = batch_results[contest.name][loser]
 
         b_cp = batch_results[contest.name]["ballots"]
+
+        V_wl = contest.candidates[winner] - contest.candidates[loser]
+
+        # Conservatively assume that any pending ballots would be tallied as
+        # votes for the loser, reducing the reported margin.
+        V_wl -= contest.pending_ballots
+
+        # Conservatively assume that any unauditable ballots would be tallied as
+        # votes for the loser, reducing the reported margin.
+        V_wl -= unauditable_ballots
+
+        if V_wl <= 0:
+            return Decimal("inf")
+
+        return Decimal((v_wp - v_lp) + b_cp) / Decimal(V_wl)
+
+    def max_error_for_threshold(winner: str) -> Decimal:
+        valid_votes = sum(contest.candidates.values())
+        w_total = contest.candidates[winner]
+        not_w_total = valid_votes - w_total
+
+        batch_total = sum(
+            batch_results[contest.name].get(c, 0) for c in contest.candidates
+        )
+        w_batch = batch_results[contest.name][winner]
+        b_cp = batch_results[contest.name]["ballots"]
+
+        if w_total > not_w_total:
+            # Majority threshold: winner vs aggregate of all other candidates.
+            v_wp = w_batch
+            v_lp = batch_total - w_batch
+            V_wl = 2 * w_total - valid_votes
+        else:
+            # No-majority threshold: aggregate of all other candidates vs winner.
+            v_wp = batch_total - w_batch
+            v_lp = w_batch
+            V_wl = valid_votes - 2 * w_total
 
         # Conservatively assume that any pending ballots would be tallied as
         # votes for the loser, reducing the reported margin.
@@ -192,22 +268,15 @@ def compute_max_error(
     margins = contest.margins
     for winner in margins["winners"]:
         for loser in margins["losers"]:
-            u_pwl = max_error_for_pair(
-                winner, loser, contest.candidates[winner] - contest.candidates[loser]
-            )
-            if u_pwl == Decimal("inf"):
-                return Decimal("inf")
+            u_pwl = max_error_for_candidate_pair(winner, loser)
             if u_pwl > error:
                 error = u_pwl
 
-    for p in contest.runoff_pairs:
-        u_pwl = max_error_for_pair(
-            p["winner_id"],
-            p["loser_id"],
-            p["winner_votes"] - p["loser_votes"],
-        )
-        if u_pwl > error:
-            error = u_pwl
+    if contest.is_subject_to_runoff:
+        for winner in margins["winners"]:
+            u_pwl = max_error_for_threshold(winner)
+            if u_pwl > error:
+                error = u_pwl
 
     return error
 

--- a/server/audit_math/macro.py
+++ b/server/audit_math/macro.py
@@ -27,6 +27,21 @@ class BatchError(TypedDict):
     weighted_error: Decimal
 
 
+def add_aggregate_tallies(contest: Contest, batch_results: BatchResults) -> None:
+    """
+    For runoff-subject contests, augments a single batch's per-contest tally
+    dict with `__not_<X>` aggregate entries (one per entry in `contest.winners`),
+    where each aggregate's batch tally is `sum_of_real_candidates_in_batch −
+    X_votes_in_batch`. Idempotent. No-op if the contest isn't runoff-subject.
+    """
+    if not contest.is_subject_to_runoff:
+        return
+    contest_batch = batch_results[contest.name]
+    real_total = sum(contest_batch.get(c, 0) for c in contest.candidates)
+    for w_id in contest.winners:
+        contest_batch[f"__not_{w_id}"] = real_total - contest_batch.get(w_id, 0)
+
+
 def compute_unauditable_ballots(
     batch_results: dict[BatchKey, BatchResults],
     contest: Contest,
@@ -78,15 +93,15 @@ def compute_error(
     Outputs:
         the maximum across-contest relative overstatement for batch p
     """
+    add_aggregate_tallies(contest, batch_results)
+    add_aggregate_tallies(contest, sampled_results)
 
-    def error_for_candidate_pair(winner, loser) -> BatchError | None:
+    def error_for_pair(winner: str, loser: str, V_wl: int) -> BatchError | None:
         v_wp = batch_results[contest.name][winner]
         v_lp = batch_results[contest.name][loser]
 
         a_wp = sampled_results[contest.name][winner]
         a_lp = sampled_results[contest.name][loser]
-
-        V_wl = contest.candidates[winner] - contest.candidates[loser]
 
         # Conservatively assume that any pending ballots would be tallied as
         # votes for the loser, reducing the reported margin.
@@ -104,9 +119,19 @@ def compute_error(
         return BatchError(counted_as=error, weighted_error=weighted_error)
 
     maybe_errors = [
-        error_for_candidate_pair(winner, loser)
+        error_for_pair(
+            winner, loser, contest.candidates[winner] - contest.candidates[loser]
+        )
         for winner in contest.margins["winners"]
         for loser in contest.margins["losers"]
+    ]
+    maybe_errors += [
+        error_for_pair(
+            p["winner_id"],
+            p["loser_id"],
+            p["winner_votes"] - p["loser_votes"],
+        )
+        for p in contest.runoff_pairs
     ]
     errors: list[BatchError] = [error for error in maybe_errors if error is not None]
     if len(errors) == 0:
@@ -143,31 +168,46 @@ def compute_max_error(
     if contest.name not in batch_results:
         return Decimal(0.0)
 
+    add_aggregate_tallies(contest, batch_results)
+
+    def max_error_for_pair(winner: str, loser: str, V_wl: int) -> Decimal:
+        v_wp = batch_results[contest.name][winner]
+        v_lp = batch_results[contest.name][loser]
+
+        b_cp = batch_results[contest.name]["ballots"]
+
+        # Conservatively assume that any pending ballots would be tallied as
+        # votes for the loser, reducing the reported margin.
+        V_wl -= contest.pending_ballots
+
+        # Conservatively assume that any unauditable ballots would be tallied as
+        # votes for the loser, reducing the reported margin.
+        V_wl -= unauditable_ballots
+
+        if V_wl <= 0:
+            return Decimal("inf")
+
+        return Decimal((v_wp - v_lp) + b_cp) / Decimal(V_wl)
+
     margins = contest.margins
     for winner in margins["winners"]:
         for loser in margins["losers"]:
-            v_wp = batch_results[contest.name][winner]
-            v_lp = batch_results[contest.name][loser]
-
-            b_cp = batch_results[contest.name]["ballots"]
-
-            V_wl = contest.candidates[winner] - contest.candidates[loser]
-
-            # Conservatively assume that any pending ballots would be tallied as
-            # votes for the loser, reducing the reported margin.
-            V_wl -= contest.pending_ballots
-
-            # Conservatively assume that any unauditable ballots would be tallied as
-            # votes for the loser, reducing the reported margin.
-            V_wl -= unauditable_ballots
-
-            if V_wl <= 0:
+            u_pwl = max_error_for_pair(
+                winner, loser, contest.candidates[winner] - contest.candidates[loser]
+            )
+            if u_pwl == Decimal("inf"):
                 return Decimal("inf")
-
-            u_pwl = Decimal((v_wp - v_lp) + b_cp) / Decimal(V_wl)
-
             if u_pwl > error:
                 error = u_pwl
+
+    for p in contest.runoff_pairs:
+        u_pwl = max_error_for_pair(
+            p["winner_id"],
+            p["loser_id"],
+            p["winner_votes"] - p["loser_votes"],
+        )
+        if u_pwl > error:
+            error = u_pwl
 
     return error
 

--- a/server/audit_math/sampler_contest.py
+++ b/server/audit_math/sampler_contest.py
@@ -54,8 +54,6 @@ class Contest:
 
     diluted_margin: float  # The smallest diluted margin in this contest
     margins: dict[str, dict]  # dict of the margins for this contest
-    # Threshold pairs for runoff-subject contests (real candidate vs aggregate __not_X)
-    runoff_pairs: list[dict]
 
     def __init__(self, name: str, contest_info_dict: dict[str, int]):
         """
@@ -178,32 +176,6 @@ class Contest:
             self.diluted_margin = float(min_margin) / self.ballots
         else:
             self.diluted_margin = -1.0
-
-        self.runoff_pairs = []
-        if self.is_subject_to_runoff:
-            for w_id, w_votes in self.winners.items():
-                not_id = f"__not_{w_id}"
-                not_votes = valid_votes - w_votes
-                if w_votes > not_votes:
-                    # Majority case for this winner: assert W > not-W.
-                    self.runoff_pairs.append(
-                        {
-                            "winner_id": w_id,
-                            "winner_votes": w_votes,
-                            "loser_id": not_id,
-                            "loser_votes": not_votes,
-                        }
-                    )
-                else:
-                    # No-majority case for this winner: assert not-W > W.
-                    self.runoff_pairs.append(
-                        {
-                            "winner_id": not_id,
-                            "winner_votes": not_votes,
-                            "loser_id": w_id,
-                            "loser_votes": w_votes,
-                        }
-                    )
 
     def __repr__(self) -> str:
         """

--- a/server/audit_math/sampler_contest.py
+++ b/server/audit_math/sampler_contest.py
@@ -23,6 +23,7 @@ def from_db_contest(db_contest):
         "numWinners": db_contest.num_winners,
         "votesAllowed": db_contest.votes_allowed,
         "pendingBallots": db_contest.pending_ballots,
+        "isSubjectToRunoff": db_contest.is_subject_to_runoff,
     }
 
     # Initialize the choices in this contest and how many votes each received
@@ -44,6 +45,8 @@ class Contest:
     ballots: int  # The total number of ballots cast in this contest
     # Ballots that weren't tallied yet and thus not included in reported results (batch comparison only)
     pending_ballots: int
+    # Whether this contest is governed by majority-or-runoff law (batch comparison only)
+    is_subject_to_runoff: bool
     name: str  # The name of the contest
 
     winners: dict[str, int]  # list of all the winners
@@ -51,6 +54,8 @@ class Contest:
 
     diluted_margin: float  # The smallest diluted margin in this contest
     margins: dict[str, dict]  # dict of the margins for this contest
+    # Threshold pairs for runoff-subject contests (real candidate vs aggregate __not_X)
+    runoff_pairs: list[dict]
 
     def __init__(self, name: str, contest_info_dict: dict[str, int]):
         """
@@ -70,6 +75,9 @@ class Contest:
         self.num_winners = contest_info_dict["numWinners"]
         self.votes_allowed = contest_info_dict["votesAllowed"]
         self.pending_ballots = contest_info_dict.get("pendingBallots") or 0
+        self.is_subject_to_runoff = bool(
+            contest_info_dict.get("isSubjectToRunoff", False)
+        )
 
         self.candidates = {}
 
@@ -77,10 +85,25 @@ class Contest:
         self.losers = {}
 
         for cand in contest_info_dict:
-            if cand in ["ballots", "numWinners", "votesAllowed", "pendingBallots"]:
+            if cand in [
+                "ballots",
+                "numWinners",
+                "votesAllowed",
+                "pendingBallots",
+                "isSubjectToRunoff",
+            ]:
                 continue
 
             self.candidates[cand] = contest_info_dict[cand]
+
+        valid_votes = sum(self.candidates.values())
+        if self.is_subject_to_runoff:
+            top_votes = max(self.candidates.values())
+            # No-majority case (incl. exact 50/50): treat as 2-winner internally so
+            # the margin-population loop below promotes the runner-up into winners
+            # and produces R's pairwise margins against every non-advancing candidate.
+            if top_votes <= valid_votes - top_votes:
+                self.num_winners = 2
 
         """
         Initialize a dictionary of diluted margin info:
@@ -118,10 +141,7 @@ class Contest:
             reverse=True,
         )
 
-        v_wl = 0
-
         for i, choice in enumerate(cand_vec):
-            v_wl += choice[1]
             if i < self.num_winners:
                 self.winners[choice[0]] = choice[1]
 
@@ -131,13 +151,13 @@ class Contest:
         for loser in self.losers:
             self.margins["losers"][loser] = {
                 "p_l": self.losers[loser] / self.ballots,
-                "s_l": self.losers[loser] / v_wl,
+                "s_l": self.losers[loser] / valid_votes,
             }
 
         min_margin = self.ballots
 
         for winner in self.winners:
-            s_w = self.winners[winner] / v_wl
+            s_w = self.winners[winner] / valid_votes
 
             swl = {}
             for loser in self.losers:
@@ -158,6 +178,32 @@ class Contest:
             self.diluted_margin = float(min_margin) / self.ballots
         else:
             self.diluted_margin = -1.0
+
+        self.runoff_pairs = []
+        if self.is_subject_to_runoff:
+            for w_id, w_votes in self.winners.items():
+                not_id = f"__not_{w_id}"
+                not_votes = valid_votes - w_votes
+                if w_votes > not_votes:
+                    # Majority case for this winner: assert W > not-W.
+                    self.runoff_pairs.append(
+                        {
+                            "winner_id": w_id,
+                            "winner_votes": w_votes,
+                            "loser_id": not_id,
+                            "loser_votes": not_votes,
+                        }
+                    )
+                else:
+                    # No-majority case for this winner: assert not-W > W.
+                    self.runoff_pairs.append(
+                        {
+                            "winner_id": not_id,
+                            "winner_votes": not_votes,
+                            "loser_id": w_id,
+                            "loser_votes": w_votes,
+                        }
+                    )
 
     def __repr__(self) -> str:
         """

--- a/server/migrations/versions/fda464935ab0_contest_is_subject_to_runoff.py
+++ b/server/migrations/versions/fda464935ab0_contest_is_subject_to_runoff.py
@@ -1,0 +1,33 @@
+"""contest_is_subject_to_runoff
+
+Revision ID: fda464935ab0
+Revises: 4b1bf0241301
+Create Date: 2026-05-15 20:25:22.615362+00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "fda464935ab0"
+down_revision = "4b1bf0241301"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "contest",
+        sa.Column(
+            "is_subject_to_runoff",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -486,6 +486,14 @@ class Contest(BaseModel):
     # the losing candidates).
     pending_ballots = Column(Integer)
 
+    # When True, this contest is governed by majority-or-runoff law: a
+    # candidate wins outright if they receive a strict majority of valid
+    # votes, otherwise the top two advance to a runoff. The audit verifies
+    # the reported majority claim (and the runner-up's standing, in the
+    # no-majority case). Only valid for batch comparison audits with
+    # num_winners == 1.
+    is_subject_to_runoff = Column(Boolean, nullable=False, server_default="false")
+
     choices = relationship(
         "ContestChoice",
         back_populates="contest",

--- a/server/tests/api/test_contests.py
+++ b/server/tests/api/test_contests.py
@@ -1,3 +1,4 @@
+import io
 import json
 import uuid
 import pytest
@@ -6,7 +7,7 @@ from flask.testing import FlaskClient
 from ..helpers import *
 from ...database import db_session
 from ...models import *
-from ...api.contests import JSONDict
+from ...api.contests import JSONDict, should_reprocess_batch_tallies
 from ...auth import UserType
 
 
@@ -465,3 +466,96 @@ def test_audit_board_contests_list_order(
     assert contests[1]["name"] == db_contests[1].name
     assert contests[0]["choices"][0]["name"] == db_choices[0].name
     assert contests[0]["choices"][1]["name"] == db_choices[1].name
+
+
+def test_should_reprocess_batch_tallies_treats_missing_runoff_flag_as_false():
+    # serialize_contest emits isSubjectToRunoff for batch-comparison contests;
+    # the client conditionally omits it when false. Normalization must treat
+    # "missing" and "False" as equivalent so a no-op save doesn't trigger an
+    # unnecessary batch-tallies reprocess.
+    choice = {"id": "c1", "name": "candidate 1", "numVotes": 60}
+    base_contest = {
+        "id": "contest-1",
+        "name": "Contest 1",
+        "isTargeted": True,
+        "choices": [choice],
+        "numWinners": 1,
+        "votesAllowed": 1,
+        "jurisdictionIds": ["j1"],
+    }
+    previous = {**base_contest, "isSubjectToRunoff": False}
+    new_without = {**base_contest}
+
+    assert not should_reprocess_batch_tallies([previous], [new_without])
+
+
+def test_runoff_flag_rejected_for_non_batch_comparison(
+    client: FlaskClient,
+    org_id: str,
+    election_id: str,
+    jurisdiction_ids: list[str],
+):
+    expected_error = {
+        "errors": [
+            {
+                "message": "Runoff-subject contests are only supported for batch comparison audits",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+
+    # Ballot polling (default election_id fixture).
+    ballot_polling_contest = {
+        "id": str(uuid.uuid4()),
+        "name": "Contest 1",
+        "isTargeted": True,
+        "choices": [
+            {"id": str(uuid.uuid4()), "name": "Alice", "numVotes": 40},
+            {"id": str(uuid.uuid4()), "name": "Bob", "numVotes": 35},
+            {"id": str(uuid.uuid4()), "name": "Carla", "numVotes": 25},
+        ],
+        "totalBallotsCast": 100,
+        "numWinners": 1,
+        "votesAllowed": 1,
+        "jurisdictionIds": jurisdiction_ids,
+        "isSubjectToRunoff": True,
+    }
+    rv = put_json(
+        client, f"/api/election/{election_id}/contest", [ballot_polling_contest]
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == expected_error
+
+    # Ballot comparison uses a different (minimal) schema; verify the flag
+    # surfaces the same clean error rather than a generic schema rejection.
+    bc_election_id = create_election(
+        client,
+        audit_name="Test Audit ballot_comparison_runoff_rejection",
+        audit_type=AuditType.BALLOT_COMPARISON,
+        audit_math_type=AuditMathType.SUPERSIMPLE,
+        organization_id=org_id,
+    )
+    rv = upload_jurisdictions_file(
+        client,
+        io.BytesIO(
+            f"Jurisdiction,Admin Email\nJ1,j1-{bc_election_id}@example.com\n".encode()
+        ),
+        bc_election_id,
+    )
+    assert_ok(rv)
+    bc_jurisdiction_id = str(
+        Jurisdiction.query.filter_by(election_id=bc_election_id).one().id
+    )
+    ballot_comparison_contest = {
+        "id": str(uuid.uuid4()),
+        "name": "Contest 1",
+        "isTargeted": True,
+        "numWinners": 1,
+        "jurisdictionIds": [bc_jurisdiction_id],
+        "isSubjectToRunoff": True,
+    }
+    rv = put_json(
+        client, f"/api/election/{bc_election_id}/contest", [ballot_comparison_contest]
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == expected_error

--- a/server/tests/api/test_contests.py
+++ b/server/tests/api/test_contests.py
@@ -7,7 +7,7 @@ from flask.testing import FlaskClient
 from ..helpers import *
 from ...database import db_session
 from ...models import *
-from ...api.contests import JSONDict, should_reprocess_batch_tallies
+from ...api.contests import JSONDict
 from ...auth import UserType
 
 
@@ -468,27 +468,6 @@ def test_audit_board_contests_list_order(
     assert contests[0]["choices"][1]["name"] == db_choices[1].name
 
 
-def test_should_reprocess_batch_tallies_treats_missing_runoff_flag_as_false():
-    # serialize_contest emits isSubjectToRunoff for batch-comparison contests;
-    # the client conditionally omits it when false. Normalization must treat
-    # "missing" and "False" as equivalent so a no-op save doesn't trigger an
-    # unnecessary batch-tallies reprocess.
-    choice = {"id": "c1", "name": "candidate 1", "numVotes": 60}
-    base_contest = {
-        "id": "contest-1",
-        "name": "Contest 1",
-        "isTargeted": True,
-        "choices": [choice],
-        "numWinners": 1,
-        "votesAllowed": 1,
-        "jurisdictionIds": ["j1"],
-    }
-    previous = {**base_contest, "isSubjectToRunoff": False}
-    new_without = {**base_contest}
-
-    assert not should_reprocess_batch_tallies([previous], [new_without])
-
-
 def test_runoff_flag_rejected_for_non_batch_comparison(
     client: FlaskClient,
     org_id: str,
@@ -498,7 +477,7 @@ def test_runoff_flag_rejected_for_non_batch_comparison(
     expected_error = {
         "errors": [
             {
-                "message": "Runoff-subject contests are only supported for batch comparison audits",
+                "message": "isSubjectToRunoff is only supported for batch comparison audits",
                 "errorType": "Bad Request",
             }
         ]

--- a/server/tests/api/test_reports.py
+++ b/server/tests/api/test_reports.py
@@ -1,5 +1,8 @@
 from flask.testing import FlaskClient
 from .test_audit_boards import set_up_audit_board
+from ...api import reports
+from ...api.reports import reported_runoff_results_label
+from ...database import db_session
 from ...models import *
 from ..helpers import *
 from ...auth import UserType
@@ -139,3 +142,85 @@ def test_discrepancy_report_wrong_audit_type(
             }
         ]
     }
+
+
+def test_reported_runoff_results_majority():
+    # Leader has 55% of valid votes — strict majority.
+    assert (
+        reported_runoff_results_label(choice_votes=[55, 25, 15, 5])
+        == "Majority received, no runoff required"
+    )
+
+
+def test_reported_runoff_results_no_majority():
+    # Leader has 40% — below 50%.
+    assert (
+        reported_runoff_results_label(choice_votes=[40, 35, 15, 10])
+        == "No majority, runoff required"
+    )
+
+
+def test_reported_runoff_results_exact_50_is_not_majority():
+    # 50% is NOT a strict majority (Ga. Code § 21-2-501 requires > 50%).
+    assert (
+        reported_runoff_results_label(choice_votes=[50, 30, 20])
+        == "No majority, runoff required"
+    )
+
+
+def test_contest_rows_runoff_columns(org_id: str):
+    # Two contests, one flagged and one unflagged. Asserts contest_rows emits
+    # both runoff columns and populates both branches.
+    election = Election(
+        id=str(uuid.uuid4()),
+        audit_name="Test Audit contest_rows_runoff_columns",
+        audit_type=AuditType.BATCH_COMPARISON,
+        audit_math_type=AuditMathType.MACRO,
+        organization_id=org_id,
+        online=False,
+    )
+    flagged = Contest(
+        id=str(uuid.uuid4()),
+        election_id=election.id,
+        name="Flagged Contest",
+        is_targeted=True,
+        num_winners=1,
+        votes_allowed=1,
+        total_ballots_cast=100,
+        is_subject_to_runoff=True,
+    )
+    flagged.choices = [
+        ContestChoice(id=str(uuid.uuid4()), name="Alice", num_votes=55),
+        ContestChoice(id=str(uuid.uuid4()), name="Bob", num_votes=25),
+        ContestChoice(id=str(uuid.uuid4()), name="Carla", num_votes=20),
+    ]
+    unflagged = Contest(
+        id=str(uuid.uuid4()),
+        election_id=election.id,
+        name="Unflagged Contest",
+        is_targeted=True,
+        num_winners=1,
+        votes_allowed=1,
+        total_ballots_cast=100,
+        is_subject_to_runoff=False,
+    )
+    unflagged.choices = [
+        ContestChoice(id=str(uuid.uuid4()), name="X", num_votes=60),
+        ContestChoice(id=str(uuid.uuid4()), name="Y", num_votes=40),
+    ]
+    election.contests = [flagged, unflagged]
+    db_session.add(election)
+    db_session.commit()
+
+    rows = reports.contest_rows(election)
+    header = rows[1]
+    assert header[-2:] == ["Runoff Law", "Reported Runoff Results"]
+
+    flagged_row = next(row for row in rows[2:] if row[0] == "Flagged Contest")
+    assert flagged_row[-2:] == [
+        "Subject to runoff law",
+        "Majority received, no runoff required",
+    ]
+
+    unflagged_row = next(row for row in rows[2:] if row[0] == "Unflagged Contest")
+    assert unflagged_row[-2:] == ["Not subject to runoff law", ""]

--- a/server/tests/api/test_reports.py
+++ b/server/tests/api/test_reports.py
@@ -223,4 +223,4 @@ def test_contest_rows_runoff_columns(org_id: str):
     ]
 
     unflagged_row = next(row for row in rows[2:] if row[0] == "Unflagged Contest")
-    assert unflagged_row[-2:] == ["Not subject to runoff law", ""]
+    assert unflagged_row[-2:] == ["", ""]

--- a/server/tests/audit_math/test_macro.py
+++ b/server/tests/audit_math/test_macro.py
@@ -1266,3 +1266,18 @@ def test_runoff_discrepancy_flips_majority():
     )
 
     assert not terminated, "Audit should NOT clear when discrepancies flip majority"
+
+
+def test_runoff_exact_tie_threshold_returns_infinite_max_error():
+    # Exact 50/50 reported: the threshold pair has V_wl = 0, so the threshold
+    # leg of compute_max_error must short-circuit to Decimal("inf") (which
+    # propagates to U=inf, forcing a full hand recount).
+    contest, batches = _runoff_fixtures(
+        {"alice": 50, "bob": 30, "carla": 15, "dan": 5}, num_batches=1
+    )
+
+    max_err = macro.compute_max_error(
+        batches["Batch 0"], contest, unauditable_ballots=0
+    )
+
+    assert max_err == Decimal("inf")

--- a/server/tests/audit_math/test_macro.py
+++ b/server/tests/audit_math/test_macro.py
@@ -1126,3 +1126,143 @@ def test_unauditable_ballots(snapshot):
             computed_p_without_unauditable_ballots=computed_p_without_unauditable_ballots,
         )
     )
+
+
+def _runoff_fixtures(
+    per_batch_tallies: dict[str, int],
+    num_batches: int = 100,
+    is_subject_to_runoff: bool = True,
+):
+    """Build a Contest + reported batches for a 4-candidate runoff-subject test.
+
+    per_batch_tallies: dict like {"alice": 40, "bob": 35, "carla": 15, "dan": 10}.
+    Reported tallies are these values times num_batches. Each batch contributes
+    the same per-batch tallies.
+    """
+    ballots_per_batch = sum(per_batch_tallies.values())
+    info_dict = {
+        candidate: votes * num_batches for candidate, votes in per_batch_tallies.items()
+    }
+    info_dict.update(
+        {
+            "ballots": ballots_per_batch * num_batches,
+            "numWinners": 1,
+            "votesAllowed": 1,
+            "isSubjectToRunoff": is_subject_to_runoff,
+        }
+    )
+    contest = Contest("runoff_contest", info_dict)
+
+    batches = {
+        f"Batch {i}": {
+            "runoff_contest": {**per_batch_tallies, "ballots": ballots_per_batch}
+        }
+        for i in range(num_batches)
+    }
+    return contest, batches
+
+
+def _discrepancy_free_sample_minus_one(batches):
+    """Builds a sample dict + ticket-numbers dict covering every batch except 'Batch 0'.
+
+    Mirrors reported tallies exactly (no discrepancies). Leaving one batch
+    unsampled exercises the per-batch risk math instead of the full-recount
+    early-return.
+    """
+    sample = {
+        batch_key: {"runoff_contest": {**batch_results["runoff_contest"]}}
+        for batch_key, batch_results in batches.items()
+        if batch_key != "Batch 0"
+    }
+    sample_ticket_numbers = {str(i): f"Batch {i}" for i in range(1, len(batches))}
+    return sample, sample_ticket_numbers
+
+
+def test_runoff_no_majority_happy_path():
+    # Reported 40/35/15/10 (no majority): flag promotes Bob into winners, so
+    # the existing pairwise math validates Alice/Bob vs Carla/Dan, and the
+    # threshold pairs (__not_alice > alice, __not_bob > bob) cover the
+    # majority claim. Discrepancy-free sample clears the audit.
+    contest, batches = _runoff_fixtures(
+        {"alice": 40, "bob": 35, "carla": 15, "dan": 10}
+    )
+    sample, sample_ticket_numbers = _discrepancy_free_sample_minus_one(batches)
+
+    computed_p, terminated = macro.compute_risk(
+        RISK_LIMIT, contest, batches, sample, sample_ticket_numbers, []
+    )
+
+    assert terminated, f"Audit should clear with zero discrepancies, p={computed_p}"
+
+
+def test_runoff_majority_happy_path():
+    # Reported 55/25/15/5 (clean majority): num_winners stays 1, threshold pair
+    # is alice > __not_alice (V_wl = 1000). Existing pairwise pairs and the
+    # threshold pair both clear with a discrepancy-free sample.
+    contest, batches = _runoff_fixtures({"alice": 55, "bob": 25, "carla": 15, "dan": 5})
+    sample, sample_ticket_numbers = _discrepancy_free_sample_minus_one(batches)
+
+    computed_p, terminated = macro.compute_risk(
+        RISK_LIMIT, contest, batches, sample, sample_ticket_numbers, []
+    )
+
+    assert terminated, f"Audit should clear with zero discrepancies, p={computed_p}"
+
+
+def test_runoff_threshold_dominates_sample_size():
+    # Reported 48/25/15/12: leader is below 50%, threshold pair (__not_alice 52
+    # vs alice 48) has V_wl=400 — much tighter than the pairwise alice/carla
+    # (V_wl=3300) or alice/dan (V_wl=3600). With the flag on, the threshold
+    # pair dominates and sample size is materially larger than the flag-off
+    # baseline.
+    per_batch = {"alice": 48, "bob": 25, "carla": 15, "dan": 12}
+
+    contest_flag_on, batches_flag_on = _runoff_fixtures(per_batch)
+    # Multi-jurisdiction case: not every batch has this contest's tallies.
+    batches_flag_on["Other-contest batch"] = {
+        "other_contest": {"x": 50, "y": 50, "ballots": 100},
+    }
+
+    contest_flag_off, batches_flag_off = _runoff_fixtures(
+        per_batch, is_subject_to_runoff=False
+    )
+
+    size_flag_on = macro.get_sample_sizes(
+        RISK_LIMIT, contest_flag_on, batches_flag_on, {}, {}, []
+    )
+    size_flag_off = macro.get_sample_sizes(
+        RISK_LIMIT, contest_flag_off, batches_flag_off, {}, {}, []
+    )
+
+    assert size_flag_on > size_flag_off, (
+        f"Threshold pair should dominate: flag-on={size_flag_on} "
+        f"flag-off={size_flag_off}"
+    )
+
+
+def test_runoff_discrepancy_flips_majority():
+    # Reported 51/30/15/4: alice just clears 50%. Threshold pair is alice 5100
+    # vs __not_alice 4900 (V_wl=200). Sample includes discrepancies where
+    # alice loses 2 votes per batch to bob — scaled up, this would put alice
+    # below 50%. Risk should not clear.
+    contest, batches = _runoff_fixtures({"alice": 51, "bob": 30, "carla": 15, "dan": 4})
+
+    sample = {}
+    sample_ticket_numbers = {}
+    for i in range(50):
+        sample[f"Batch {i}"] = {
+            "runoff_contest": {
+                "alice": 49,  # 2 fewer than reported
+                "bob": 32,  # 2 more than reported
+                "carla": 15,
+                "dan": 4,
+                "ballots": 100,
+            }
+        }
+        sample_ticket_numbers[str(i)] = f"Batch {i}"
+
+    _, terminated = macro.compute_risk(
+        RISK_LIMIT, contest, batches, sample, sample_ticket_numbers, []
+    )
+
+    assert not terminated, "Audit should NOT clear when discrepancies flip majority"

--- a/server/tests/audit_math/test_sampler_contest.py
+++ b/server/tests/audit_math/test_sampler_contest.py
@@ -244,3 +244,90 @@ true_dms = {
     "test9": -1,
     "test10": 0.2,
 }
+
+
+def test_runoff_no_majority_pairs():
+    contest = Contest(
+        "runoff_no_majority",
+        {
+            "alice": 40,
+            "bob": 35,
+            "carla": 15,
+            "dan": 10,
+            "ballots": 100,
+            "numWinners": 1,
+            "votesAllowed": 1,
+            "isSubjectToRunoff": True,
+        },
+    )
+
+    # Runner-up promoted into winners so the existing pairwise math validates R
+    # against every non-advancing candidate.
+    assert contest.num_winners == 2
+    assert contest.winners == {"alice": 40, "bob": 35}
+    assert contest.losers == {"carla": 15, "dan": 10}
+
+    # Exactly two threshold pairs: not_W > W and not_R > R.
+    assert contest.runoff_pairs == [
+        {
+            "winner_id": "__not_alice",
+            "winner_votes": 60,
+            "loser_id": "alice",
+            "loser_votes": 40,
+        },
+        {
+            "winner_id": "__not_bob",
+            "winner_votes": 65,
+            "loser_id": "bob",
+            "loser_votes": 35,
+        },
+    ]
+
+
+def test_runoff_majority_pairs():
+    contest = Contest(
+        "runoff_majority",
+        {
+            "alice": 55,
+            "bob": 25,
+            "carla": 15,
+            "dan": 5,
+            "ballots": 100,
+            "numWinners": 1,
+            "votesAllowed": 1,
+            "isSubjectToRunoff": True,
+        },
+    )
+
+    # Majority case: num_winners stays 1, no runner-up promotion.
+    assert contest.num_winners == 1
+    assert contest.winners == {"alice": 55}
+    assert contest.losers == {"bob": 25, "carla": 15, "dan": 5}
+
+    # One threshold pair: W > not_W.
+    assert contest.runoff_pairs == [
+        {
+            "winner_id": "alice",
+            "winner_votes": 55,
+            "loser_id": "__not_alice",
+            "loser_votes": 45,
+        },
+    ]
+
+
+def test_runoff_flag_off_leaves_pairs_empty():
+    contest = Contest(
+        "no_flag",
+        {
+            "alice": 40,
+            "bob": 35,
+            "carla": 25,
+            "ballots": 100,
+            "numWinners": 1,
+            "votesAllowed": 1,
+        },
+    )
+
+    assert contest.is_subject_to_runoff is False
+    assert contest.num_winners == 1
+    assert contest.runoff_pairs == []

--- a/server/tests/audit_math/test_sampler_contest.py
+++ b/server/tests/audit_math/test_sampler_contest.py
@@ -246,7 +246,7 @@ true_dms = {
 }
 
 
-def test_runoff_no_majority_pairs():
+def test_runoff_no_majority_promotes_runner_up():
     contest = Contest(
         "runoff_no_majority",
         {
@@ -267,24 +267,8 @@ def test_runoff_no_majority_pairs():
     assert contest.winners == {"alice": 40, "bob": 35}
     assert contest.losers == {"carla": 15, "dan": 10}
 
-    # Exactly two threshold pairs: not_W > W and not_R > R.
-    assert contest.runoff_pairs == [
-        {
-            "winner_id": "__not_alice",
-            "winner_votes": 60,
-            "loser_id": "alice",
-            "loser_votes": 40,
-        },
-        {
-            "winner_id": "__not_bob",
-            "winner_votes": 65,
-            "loser_id": "bob",
-            "loser_votes": 35,
-        },
-    ]
 
-
-def test_runoff_majority_pairs():
+def test_runoff_majority_keeps_single_winner():
     contest = Contest(
         "runoff_majority",
         {
@@ -303,31 +287,3 @@ def test_runoff_majority_pairs():
     assert contest.num_winners == 1
     assert contest.winners == {"alice": 55}
     assert contest.losers == {"bob": 25, "carla": 15, "dan": 5}
-
-    # One threshold pair: W > not_W.
-    assert contest.runoff_pairs == [
-        {
-            "winner_id": "alice",
-            "winner_votes": 55,
-            "loser_id": "__not_alice",
-            "loser_votes": 45,
-        },
-    ]
-
-
-def test_runoff_flag_off_leaves_pairs_empty():
-    contest = Contest(
-        "no_flag",
-        {
-            "alice": 40,
-            "bob": 35,
-            "carla": 25,
-            "ballots": 100,
-            "numWinners": 1,
-            "votesAllowed": 1,
-        },
-    )
-
-    assert contest.is_subject_to_runoff is False
-    assert contest.num_winners == 1
-    assert contest.runoff_pairs == []

--- a/server/tests/batch_comparison/test_runoff_contests.py
+++ b/server/tests/batch_comparison/test_runoff_contests.py
@@ -67,7 +67,7 @@ def test_runoff_flag_rejects_num_winners_not_one(
     assert json.loads(rv.data) == {
         "errors": [
             {
-                "message": "Runoff-subject contests must have num_winners=1",
+                "message": "isSubjectToRunoff can only be true for contests with num_winners=1",
                 "errorType": "Bad Request",
             }
         ]
@@ -91,7 +91,7 @@ def test_runoff_flag_requires_three_or_more_choices(
     assert json.loads(rv.data) == {
         "errors": [
             {
-                "message": "Runoff-subject contests must have at least 3 choices",
+                "message": "isSubjectToRunoff can only be true for contests with at least 3 choices",
                 "errorType": "Bad Request",
             }
         ]

--- a/server/tests/batch_comparison/test_runoff_contests.py
+++ b/server/tests/batch_comparison/test_runoff_contests.py
@@ -1,0 +1,98 @@
+import json
+import uuid
+from flask.testing import FlaskClient
+
+from ...models import *
+from ..helpers import *
+
+
+def _runoff_contest(jurisdiction_ids: list[str], **overrides) -> dict:
+    contest = {
+        "id": str(uuid.uuid4()),
+        "name": "Runoff Contest",
+        "isTargeted": True,
+        "choices": [
+            {"id": str(uuid.uuid4()), "name": "Alice", "numVotes": 4000},
+            {"id": str(uuid.uuid4()), "name": "Bob", "numVotes": 3500},
+            {"id": str(uuid.uuid4()), "name": "Carla", "numVotes": 1500},
+            {"id": str(uuid.uuid4()), "name": "Dan", "numVotes": 1000},
+        ],
+        "numWinners": 1,
+        "votesAllowed": 1,
+        "jurisdictionIds": jurisdiction_ids,
+        "isSubjectToRunoff": True,
+    }
+    contest.update(overrides)
+    return contest
+
+
+def test_runoff_flag_serialized_for_batch_comparison(
+    client: FlaskClient, election_id: str, jurisdiction_ids: list[str]
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    contest = _runoff_contest(jurisdiction_ids)
+
+    rv = put_json(client, f"/api/election/{election_id}/contest", [contest])
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/contest")
+    contests = json.loads(rv.data)["contests"]
+    assert len(contests) == 1
+    assert contests[0]["isSubjectToRunoff"] is True
+
+
+def test_runoff_flag_defaults_to_false_when_omitted(
+    client: FlaskClient, election_id: str, jurisdiction_ids: list[str]
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    contest = _runoff_contest(jurisdiction_ids)
+    del contest["isSubjectToRunoff"]
+
+    rv = put_json(client, f"/api/election/{election_id}/contest", [contest])
+    assert_ok(rv)
+
+    rv = client.get(f"/api/election/{election_id}/contest")
+    contests = json.loads(rv.data)["contests"]
+    assert contests[0]["isSubjectToRunoff"] is False
+
+
+def test_runoff_flag_rejects_num_winners_not_one(
+    client: FlaskClient, election_id: str, jurisdiction_ids: list[str]
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    contest = _runoff_contest(jurisdiction_ids, numWinners=2)
+
+    rv = put_json(client, f"/api/election/{election_id}/contest", [contest])
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "Runoff-subject contests must have num_winners=1",
+                "errorType": "Bad Request",
+            }
+        ]
+    }
+
+
+def test_runoff_flag_requires_three_or_more_choices(
+    client: FlaskClient, election_id: str, jurisdiction_ids: list[str]
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    contest = _runoff_contest(
+        jurisdiction_ids,
+        choices=[
+            {"id": str(uuid.uuid4()), "name": "Alice", "numVotes": 4000},
+            {"id": str(uuid.uuid4()), "name": "Bob", "numVotes": 3500},
+        ],
+    )
+
+    rv = put_json(client, f"/api/election/{election_id}/contest", [contest])
+    assert rv.status_code == 400
+    assert json.loads(rv.data) == {
+        "errors": [
+            {
+                "message": "Runoff-subject contests must have at least 3 choices",
+                "errorType": "Bad Request",
+            }
+        ]
+    }

--- a/server/tests/batch_comparison/test_runoff_contests.py
+++ b/server/tests/batch_comparison/test_runoff_contests.py
@@ -1,3 +1,4 @@
+import io
 import json
 import uuid
 from flask.testing import FlaskClient
@@ -96,3 +97,298 @@ def test_runoff_flag_requires_three_or_more_choices(
             }
         ]
     }
+
+
+def test_end_to_end_runoff_no_majority_audit(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: list[str],
+):
+    # Full audit cycle for a Georgia batch comparison audit with a
+    # runoff-subject contest in the no-majority case: Alice 40 / Bob 35 /
+    # Carla 15 / Dan 10 per batch, 10 batches, 1000 ballots total. Sample
+    # results match reported exactly (no discrepancies) — the audit should
+    # clear and the report should surface the runoff outcome.
+
+    # 1. Set state=GA + base audit settings.
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/settings",
+        {
+            "electionName": "Test Election",
+            "online": False,
+            "randomSeed": "1234567890",
+            "riskLimit": 10,
+            "state": USState.Georgia,
+        },
+    )
+    assert_ok(rv)
+
+    # 2. Configure a runoff-subject contest scoped to J1 only.
+    contest = {
+        "id": str(uuid.uuid4()),
+        "name": "Runoff Contest",
+        "isTargeted": True,
+        "choices": [
+            {"id": str(uuid.uuid4()), "name": "Alice", "numVotes": 400},
+            {"id": str(uuid.uuid4()), "name": "Bob", "numVotes": 350},
+            {"id": str(uuid.uuid4()), "name": "Carla", "numVotes": 150},
+            {"id": str(uuid.uuid4()), "name": "Dan", "numVotes": 100},
+        ],
+        "numWinners": 1,
+        "votesAllowed": 1,
+        "jurisdictionIds": [jurisdiction_ids[0]],
+        "isSubjectToRunoff": True,
+    }
+    rv = put_json(client, f"/api/election/{election_id}/contest", [contest])
+    assert_ok(rv)
+
+    # 3. Upload manifest + matching batch tallies on J1.
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    manifest_csv = b"Batch Name,Number of Ballots\n" + b"".join(
+        f"Batch {i},100\n".encode() for i in range(1, 11)
+    )
+    rv = upload_ballot_manifest(
+        client, io.BytesIO(manifest_csv), election_id, jurisdiction_ids[0]
+    )
+    assert_ok(rv)
+
+    tallies_csv = b"Batch Name,Alice,Bob,Carla,Dan\n" + b"".join(
+        f"Batch {i},40,35,15,10\n".encode() for i in range(1, 11)
+    )
+    rv = upload_batch_tallies(
+        client, io.BytesIO(tallies_csv), election_id, jurisdiction_ids[0]
+    )
+    assert_ok(rv)
+
+    # 4. Start round 1 with the first suggested sample size.
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
+    assert rv.status_code == 200
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 1,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
+    assert_ok(rv)
+    round_id = json.loads(client.get(f"/api/election/{election_id}/round").data)[
+        "rounds"
+    ][0]["id"]
+
+    # 5. As JA, fetch sampled batches and submit results matching reported
+    #    (zero discrepancies).
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/batches"
+    )
+    assert rv.status_code == 200
+    batches = json.loads(rv.data)["batches"]
+    assert len(batches) > 0, "Expected at least one sampled batch"
+
+    choice_ids = [choice["id"] for choice in contest["choices"]]
+    for batch in batches:
+        rv = put_json(
+            client,
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/batches/{batch['id']}/results",
+            [
+                {
+                    "name": "Tally Sheet #1",
+                    "results": {
+                        choice_ids[0]: 40,
+                        choice_ids[1]: 35,
+                        choice_ids[2]: 15,
+                        choice_ids[3]: 10,
+                    },
+                }
+            ],
+        )
+        assert_ok(rv)
+
+    rv = client.post(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/batches/finalize"
+    )
+    assert_ok(rv)
+
+    # 6. End the round; with zero discrepancies the runoff-subject contest
+    #    should reach the risk limit and be marked complete.
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.post(f"/api/election/{election_id}/round/current/finish")
+    assert_ok(rv)
+
+    round_contest = RoundContest.query.filter_by(round_id=round_id).one()
+    assert round_contest.is_complete is True
+
+    # 7. Download the audit report and assert the new runoff columns appear
+    #    in the CONTESTS section with the expected outcome.
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert rv.status_code == 200
+    report_csv = rv.data.decode("utf-8")
+    assert "Runoff Law" in report_csv
+    assert "Reported Runoff Results" in report_csv
+    assert "Subject to runoff law" in report_csv
+    assert "No majority, runoff required" in report_csv
+
+
+def test_end_to_end_runoff_majority_threshold_drives_round_1_failure(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: list[str],
+):
+    # Majority case where the threshold pair (V_wl=600) is uniquely tight
+    # compared to the pairwise pairs (Alice-Bob V_wl=650, Alice-Carla=770,
+    # Alice-Dan=780). Round 1 submits Alice→Bob shift discrepancies on every
+    # sampled batch — small in absolute terms but disproportionate against
+    # the threshold pair's small margin. Round 1 fails; round 2 samples the
+    # remaining batches with clean results and clears.
+
+    # 1. Audit settings.
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/settings",
+        {
+            "electionName": "Test Election",
+            "online": False,
+            "randomSeed": "1234567890",
+            "riskLimit": 10,
+            "state": USState.Georgia,
+        },
+    )
+    assert_ok(rv)
+
+    # 2. Runoff-subject contest. Alice clears majority globally (80%).
+    contest = {
+        "id": str(uuid.uuid4()),
+        "name": "Runoff Contest",
+        "isTargeted": True,
+        "choices": [
+            {"id": str(uuid.uuid4()), "name": "Alice", "numVotes": 800},
+            {"id": str(uuid.uuid4()), "name": "Bob", "numVotes": 150},
+            {"id": str(uuid.uuid4()), "name": "Carla", "numVotes": 30},
+            {"id": str(uuid.uuid4()), "name": "Dan", "numVotes": 20},
+        ],
+        "numWinners": 1,
+        "votesAllowed": 1,
+        "jurisdictionIds": [jurisdiction_ids[0]],
+        "isSubjectToRunoff": True,
+    }
+    rv = put_json(client, f"/api/election/{election_id}/contest", [contest])
+    assert_ok(rv)
+
+    # 3. Manifest + matching batch tallies on J1.
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    manifest_csv = b"Batch Name,Number of Ballots\n" + b"".join(
+        f"Batch {i},100\n".encode() for i in range(1, 11)
+    )
+    rv = upload_ballot_manifest(
+        client, io.BytesIO(manifest_csv), election_id, jurisdiction_ids[0]
+    )
+    assert_ok(rv)
+
+    tallies_csv = b"Batch Name,Alice,Bob,Carla,Dan\n" + b"".join(
+        f"Batch {i},80,15,3,2\n".encode() for i in range(1, 11)
+    )
+    rv = upload_batch_tallies(
+        client, io.BytesIO(tallies_csv), election_id, jurisdiction_ids[0]
+    )
+    assert_ok(rv)
+
+    choice_ids = [choice["id"] for choice in contest["choices"]]
+
+    def submit_batch_results(round_id: str, results_by_batch: dict):
+        set_logged_in_user(
+            client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+        )
+        rv = client.get(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/batches"
+        )
+        assert rv.status_code == 200
+        batches = json.loads(rv.data)["batches"]
+        for batch in batches:
+            rv = put_json(
+                client,
+                f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/batches/{batch['id']}/results",
+                [{"name": "Tally Sheet #1", "results": results_by_batch}],
+            )
+            assert_ok(rv)
+        rv = client.post(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_id}/batches/finalize"
+        )
+        assert_ok(rv)
+
+    def start_round(round_num: int) -> str:
+        set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+        rv = client.get(f"/api/election/{election_id}/sample-sizes/{round_num}")
+        assert rv.status_code == 200
+        sample_size_options = json.loads(rv.data)["sampleSizes"]
+        rv = post_json(
+            client,
+            f"/api/election/{election_id}/round",
+            {
+                "roundNum": round_num,
+                "sampleSizes": {
+                    contest_id: options[0]
+                    for contest_id, options in sample_size_options.items()
+                },
+            },
+        )
+        assert_ok(rv)
+        rounds = json.loads(client.get(f"/api/election/{election_id}/round").data)[
+            "rounds"
+        ]
+        return rounds[-1]["id"]
+
+    # 4. Round 1: submit Alice→Bob shift (Alice 70/Bob 25 instead of 80/15)
+    #    on every sampled batch.
+    round_1_id = start_round(1)
+    submit_batch_results(
+        round_1_id,
+        {choice_ids[0]: 70, choice_ids[1]: 25, choice_ids[2]: 3, choice_ids[3]: 2},
+    )
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.post(f"/api/election/{election_id}/round/current/finish")
+    assert_ok(rv)
+
+    round_1_contest = RoundContest.query.filter_by(round_id=round_1_id).one()
+    assert round_1_contest.is_complete is False, (
+        f"Round 1 should fail because the threshold pair can't absorb the "
+        f"Alice→Bob discrepancies (p-value: {round_1_contest.end_p_value})"
+    )
+
+    # 5. Round 2: submit clean results on the newly sampled batches.
+    round_2_id = start_round(2)
+    submit_batch_results(
+        round_2_id,
+        {choice_ids[0]: 80, choice_ids[1]: 15, choice_ids[2]: 3, choice_ids[3]: 2},
+    )
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.post(f"/api/election/{election_id}/round/current/finish")
+    assert_ok(rv)
+
+    round_2_contest = RoundContest.query.filter_by(round_id=round_2_id).one()
+    assert round_2_contest.is_complete is True, (
+        f"Round 2 should clear once additional clean batches are sampled "
+        f"(p-value: {round_2_contest.end_p_value})"
+    )
+
+    # 6. Report: completed audit shows Majority received (the reported tallies
+    #    say so; the audit confirmed it via round 2).
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert rv.status_code == 200
+    report_csv = rv.data.decode("utf-8")
+    assert "Subject to runoff law" in report_csv
+    assert "Majority received, no runoff required" in report_csv

--- a/specs/0001-runoff-subject-contests.md
+++ b/specs/0001-runoff-subject-contests.md
@@ -43,7 +43,7 @@ These additional assertions will also be used in `compute_max_error` along with 
 
 _AI-speak technical version_ -
 
-Threshold assertions (real candidate vs aggregate candidate) are represented as **explicit, self-contained pair entries** in a new `contest.margins["runoff_assertions"]` collection. The aggregate side of a threshold pair (`__not_W`) has its per-batch tally pre-computed (sum of all real-candidate tallies in that batch, minus W's tally) before MACRO iterates. In the no-majority case, the runner-up R is additionally promoted into `self.winners` (with `self.num_winners` set to 2) so the existing pairwise winner×loser iteration validates R's standing against every non-advancing candidate — no extra entries needed for those pairs. MACRO iterates the threshold entries with the same arithmetic and produces a single p-value covering everything. Implementation details — including the structural-winner direction rule and the `V_wl ≥ 0` invariant — are in Section 2.
+Threshold assertions (real candidate vs aggregate candidate) are represented as **explicit, self-contained pair entries** in a new `contest.runoff_pairs` collection. The aggregate side of a threshold pair (`__not_W`) has its per-batch tally pre-computed (sum of all real-candidate tallies in that batch, minus W's tally) before MACRO iterates. In the no-majority case, the runner-up R is additionally promoted into `self.winners` (with `self.num_winners` set to 2) so the existing pairwise winner×loser iteration validates R's standing against every non-advancing candidate — no extra entries needed for those pairs. MACRO iterates the threshold entries with the same arithmetic and produces a single p-value covering everything. Implementation details — including the structural-winner direction rule and the `V_wl ≥ 0` invariant — are in Section 2.
 
 ### Design decisions
 
@@ -106,7 +106,7 @@ The entire "two winners advance in the no-majority case" treatment lives here. T
 
    The first block, **before** margin-population, decides direction: if `self.is_subject_to_runoff` and no candidate has a strict majority, set `self.num_winners = 2` so the existing winner-detection loop puts both top candidates into `self.winners` (and their pairwise margins fall out of the margin-population block automatically).
 
-   The second block, **after** margin-population, builds `self.margins["runoff_assertions"]` — a `list[dict]` with shape `{"winner_id", "winner_votes", "loser_id", "loser_votes"}` — by emitting one threshold pair per entry in `self.winners`:
+   The second block, **after** margin-population, builds `self.runoff_pairs` — a `list[dict]` with shape `{"winner_id", "winner_votes", "loser_id", "loser_votes"}` — by emitting one threshold pair per entry in `self.winners`:
 
    ```python
    # Before the existing margin-population block:
@@ -122,39 +122,39 @@ The entire "two winners advance in the no-majority case" treatment lives here. T
    # After the existing margin-population block:
    if self.is_subject_to_runoff:
        total_valid = sum(self.candidates.values())
-       runoff_assertions: list[dict] = []
+       runoff_pairs: list[dict] = []
        for w_id, w_votes in self.winners.items():
            not_id = f"__not_{w_id}"
            not_votes = total_valid - w_votes
            if w_votes > not_votes:
                # Majority case for this winner: assert W > not-W.
-               runoff_assertions.append({
+               runoff_pairs.append({
                    "winner_id": w_id, "winner_votes": w_votes,
                    "loser_id":  not_id, "loser_votes": not_votes,
                })
            else:
                # No-majority case for this winner: assert not-W > W.
-               runoff_assertions.append({
+               runoff_pairs.append({
                    "winner_id": not_id, "winner_votes": not_votes,
                    "loser_id":  w_id, "loser_votes": w_votes,
                })
-       self.margins["runoff_assertions"] = runoff_assertions
+       self.runoff_pairs = runoff_pairs
    ```
 
-   Direction rule for threshold pairs: the structural "winner" is whichever side has more reported votes, ensuring `V_wl ≥ 0`. At exact 50/50, `V_wl = 0` and MACRO's existing guard forces a hand recount — the correct fallback (zero reported margin cannot be statistically distinguished from a true majority or shortfall). Aggregate candidates (`__not_W`, `__not_R`) live exclusively in `self.margins["runoff_assertions"]` — they are not added to `self.winners` or `self.losers`.
+   Direction rule for threshold pairs: the structural "winner" is whichever side has more reported votes, ensuring `V_wl ≥ 0`. At exact 50/50, `V_wl = 0` and MACRO's existing guard forces a hand recount — the correct fallback (zero reported margin cannot be statistically distinguished from a true majority or shortfall). Aggregate candidates (`__not_W`, `__not_R`) live exclusively in `self.runoff_pairs` — they are not added to `self.winners` or `self.losers`.
 
 **[server/audit_math/macro.py](../server/audit_math/macro.py)** — changes:
 
-1. Add a helper `add_aggregate_tallies(contest, results_by_batch)` that mutates the input dict: for each batch's per-contest entry, adds a `__not_<X>` key for every aggregate ID referenced in `contest.margins["runoff_assertions"]`, with value `sum_of_real_candidates_in_batch − X_votes_in_batch`. Skip any batch where `contest.name` is not present (mirrors the existing `if contest.name not in sample_results[batch]: continue` check at [macro.py:345](../server/audit_math/macro.py#L345)). Assignment-based (idempotent) so that double-augmentation through `get_sample_sizes → compute_risk` is harmless — only mutates if `contest.is_subject_to_runoff`.
+1. Add a helper `add_aggregate_tallies(contest, results_by_batch)` that mutates the input dict: for each batch's per-contest entry, adds a `__not_<X>` key for every aggregate ID referenced in `contest.runoff_pairs`, with value `sum_of_real_candidates_in_batch − X_votes_in_batch`. Skip any batch where `contest.name` is not present (mirrors the existing `if contest.name not in sample_results[batch]: continue` check at [macro.py:345](../server/audit_math/macro.py#L345)). Assignment-based (idempotent) so that double-augmentation through `get_sample_sizes → compute_risk` is harmless — only mutates if `contest.is_subject_to_runoff`.
 2. Call `add_aggregate_tallies` at the top of MACRO's two public entry points — `get_sample_sizes` ([macro.py:209](../server/audit_math/macro.py#L209)) on `reported_results`, and `compute_risk` ([macro.py:287](../server/audit_math/macro.py#L287)) on both `reported_results` and `sample_results`. After these calls, every downstream lookup of `batch_results[contest.name][__not_<X>]` resolves to a real number.
 3. In `compute_error` at [macro.py:106-114](../server/audit_math/macro.py#L106-L114), after the existing `error_for_candidate_pair` list comprehension, append errors from each runoff assertion:
    ```python
    maybe_errors += [
-       error_for_runoff_assertion(a) for a in contest.margins.get("runoff_assertions", [])
+       error_for_runoff_pair(p) for p in contest.runoff_pairs
    ]
    ```
-4. Add `error_for_runoff_assertion(assertion)` next to [`error_for_candidate_pair`](../server/audit_math/macro.py#L82). Same arithmetic, but `V_wl` is read from `assertion["winner_votes"] - assertion["loser_votes"]` rather than from `contest.candidates`. Returns the same `BatchError` shape so the surrounding `max(...)` aggregation just works. (May be simpler to refactor `error_for_candidate_pair` to accept `(winner_id, loser_id, V_wl)` directly and drive both iterations through it.)
-5. In `compute_max_error` at [macro.py:147-172](../server/audit_math/macro.py#L147-L172), same change: add a parallel inner loop over `contest.margins["runoff_assertions"]` calling a sibling `max_error_for_runoff_assertion(assertion)` (same `((v_wp − v_lp) + b_cp) / V_wl` shape, where `b_cp` is the total **b**allot count for the **c**ontest in batch **p**, read from `batch_results[contest.name]["ballots"]`).
+4. Add `error_for_runoff_pair(pair)` next to [`error_for_candidate_pair`](../server/audit_math/macro.py#L82). Same arithmetic, but `V_wl` is read from `pair["winner_votes"] - pair["loser_votes"]` rather than from `contest.candidates`. Returns the same `BatchError` shape so the surrounding `max(...)` aggregation just works. (May be simpler to refactor `error_for_candidate_pair` to accept `(winner_id, loser_id, V_wl)` directly and drive both iterations through it.)
+5. In `compute_max_error` at [macro.py:147-172](../server/audit_math/macro.py#L147-L172), same change: add a parallel inner loop over `contest.runoff_pairs` calling a sibling `max_error_for_runoff_pair(pair)` (same `((v_wp − v_lp) + b_cp) / V_wl` shape, where `b_cp` is the total **b**allot count for the **c**ontest in batch **p**, read from `batch_results[contest.name]["ballots"]`).
 
 The `__not_` prefix is purely an ID-naming convention — correctness comes from the assertion list being closed over its own `(winner_id, loser_id, V_wl)` tuples, not from any string matching. Aggregate candidates are a math-module concern and stay inside `macro.py` + `sampler_contest.py`.
 
@@ -199,10 +199,10 @@ The audit admin's CSV report ([server/api/reports.py:400](../server/api/reports.
 
 **[server/tests/audit_math/test_sampler_contest.py](../server/tests/audit_math/test_sampler_contest.py)** — new tests:
 
-- `test_runoff_no_majority_assertions`: 4-candidate contest 40/35/15/10 with `isSubjectToRunoff=True` and `numWinners=1`. Asserts:
+- `test_runoff_no_majority_pairs`: 4-candidate contest 40/35/15/10 with `isSubjectToRunoff=True` and `numWinners=1`. Asserts:
   - `contest.num_winners == 2` and `contest.winners` contains both Alice and Bob (runner-up promoted), `contest.losers` contains only Carla and Dan.
-  - `contest.margins["runoff_assertions"]` has exactly two entries — `not_W > W` and `not_R > R` — both with `winner_votes > loser_votes`. (R-vs-non-advancing pairs are validated by the existing winner×loser iteration, not via this list.)
-- `test_runoff_majority_assertions`: 4-candidate contest 55/25/15/5 with the flag on and `numWinners=1`. Asserts `runoff_assertions` has one entry: `W > not_W` with `winner_votes > loser_votes`.
+  - `contest.runoff_pairs` has exactly two entries — `not_W > W` and `not_R > R` — both with `winner_votes > loser_votes`. (R-vs-non-advancing pairs are validated by the existing winner×loser iteration, not via this list.)
+- `test_runoff_majority_pairs`: 4-candidate contest 55/25/15/5 with the flag on and `numWinners=1`. Asserts `runoff_pairs` has one entry: `W > not_W` with `winner_votes > loser_votes`.
 
 **[server/tests/audit_math/test_macro.py](../server/tests/audit_math/test_macro.py)** — new tests, follow the existing fixture style at [test_macro.py:12-101](../server/tests/audit_math/test_macro.py#L12):
 

--- a/specs/0001-runoff-subject-contests.md
+++ b/specs/0001-runoff-subject-contests.md
@@ -164,9 +164,9 @@ The `__not_` prefix is purely an ID-naming convention — correctness comes from
 
 1. `CONTEST_SCHEMA` ([contests.py:28](../server/api/contests.py#L28)): add `"isSubjectToRunoff": {"type": "boolean"}` to properties. Not required (defaults to false).
 2. `validate_contests` ([contests.py:237](../server/api/contests.py#L237)): add a check — for each contest with `isSubjectToRunoff == True`:
-   - Election audit type must be `BATCH_COMPARISON` → else `BadRequest("Runoff-subject contests are only supported for batch comparison audits")`.
-   - `numWinners` must be `1` → else `BadRequest("Runoff-subject contests must have num_winners=1")`.
-   - At least 3 choices. With only 2 choices the contest is already a head-to-head race and the threshold pair degenerates to the head-to-head pair.
+   - Election audit type must be `BATCH_COMPARISON` → else `BadRequest("isSubjectToRunoff is only supported for batch comparison audits")`.
+   - `numWinners` must be `1` → else `BadRequest("isSubjectToRunoff can only be true for contests with num_winners=1")`.
+   - At least 3 choices → else `BadRequest("isSubjectToRunoff can only be true for contests with at least 3 choices")`. With only 2 choices the contest is already a head-to-head race and the threshold pair degenerates to the head-to-head pair.
 3. `serialize_contest` ([contests.py:127](../server/api/contests.py#L127)): include `"isSubjectToRunoff": contest.is_subject_to_runoff` only when `audit_type == BATCH_COMPARISON` (mirroring how `pendingBallots` is conditionally serialized at line 138).
 4. `deserialize_contest` ([contests.py:222](../server/api/contests.py#L222)): pass through `is_subject_to_runoff=contest.get("isSubjectToRunoff", False)`.
 
@@ -192,7 +192,7 @@ The audit admin's CSV report ([server/api/reports.py](../server/api/reports.py))
 - **Populate the cells** per contest:
   - **Runoff Law**:
     - `"Subject to runoff law"` if the contest's flag is set (matches the form checkbox label).
-    - `"Not subject to runoff law"` otherwise.
+    - `""` otherwise — leaving unflagged contests blank makes the flagged ones stand out visually.
   - **Reported Runoff Results** (based purely on the contest's reported choice tallies — independent of audit progress):
     - `"Majority received, no runoff required"` if the declared winner's reported tally is a strict majority of valid votes.
     - `"No majority, runoff required"` otherwise.

--- a/specs/0001-runoff-subject-contests.md
+++ b/specs/0001-runoff-subject-contests.md
@@ -1,0 +1,273 @@
+# Plan: Audit the Majority Claim for Runoff-Subject Contests (Batch Comparison)
+
+## Context
+
+Georgia is Arlo's only customer that conducts batch comparison audits (MACRO) of primary contests subject to **majority-or-runoff** law: if a candidate receives a majority of valid votes they win the primary outright; otherwise the top two advance to a runoff. Arlo today only audits the pairwise margins (the declared winner beats every other candidate). It does _not_ statistically verify the majority claim — i.e., whether the reported leader's share actually does or does not cross 50%.
+
+That leaves a gap in both directions:
+
+- If the reported leader is under 50% (runoff stands), Arlo doesn't confirm "no one actually hit a majority." A miscount could mean a candidate truly won outright and a runoff is being held that shouldn't be.
+- If the reported leader is at or over 50% (no runoff), Arlo doesn't confirm "they really did reach a majority." A miscount could mean the announced winner doesn't actually have a majority, and a runoff _is_ legally required.
+
+This plan adds the missing verification. From the user's perspective, the contest is always a single-winner contest; a checkbox marks it as subject to runoff law. The math module internally handles both the "primary winner declared" and the "top-2 advance to runoff" cases based on the reported tallies.
+
+- **No reported majority** (top two advance to a runoff): audit that **each** of the two reported top candidates received under 50% of valid votes, _and_ that the reported runner-up R genuinely beats every non-advancing candidate. The existing pairwise math only pairs the declared winner W against the rest — so without extra assertions, R's standing as runner-up isn't audited.
+- **Reported majority** (single primary winner, no runoff): audit that the reported leader did in fact receive at least 50% of valid votes.
+
+### Notation
+
+Notation matches the existing function and the MACRO paper:
+
+- `v_wp` = reported votes for the **w**inner in batch **p**.
+- `v_lp` = reported votes for the **l**oser in batch **p**.
+- `a_wp`, `a_lp` = the same as above but for **a**udited votes (from `sampled_results`).
+- `V_wl` = global reported margin between **w**inner and **l**oser across the whole contest.
+
+### Math reframe (the key insight)
+
+_Human-speak version_ -
+
+Right now we `compute_error` for batch comparison contests [here](https://github.com/votingworks/arlo/blob/main/server/audit_math/macro.py#L54) in the macro module. The core of the process is that we have a list of winners and a list of losers. For each winner-loser pair, we calculate a batch error. We then return the max error across each winner-loser pair to determine the error for that batch. We then use that error to determine the taint, which is the main contributor to calculating that batch's contribution to risk. Finally, we multiply the per-batch risk contributions to get the combined risk, the p-value.
+
+To add support for validating a contest that is subject to runoff rules, we need to validate 1 or 2 additional assertions.
+
+If the votes indicate one candidate received >50% of the votes, we need to validate that a runoff is not needed by adding that as an additional assertion. A clever way to add this assertion that fits relatively neatly into our existing model in the macro module is to model this threshold assertion as follows: assert the winner `W` has more votes than all other candidates, i.e. `not-W`, as this would assert the winner had more than 50% of votes.
+
+If the votes indicate no candidate received >50% of the votes, we need to validate the runoff is indeed required. First, we model this contest as having two winners, as the existing audit math will validate that top_vote_getter and second_vote_getter are indeed the two candidates that should be going to the runoff. In essence, there are two winners. Next, we need 2 additional assertions - that neither of these two candidates received more than 50% of the votes. We can use the same clever modeling described in the previous paragraph, just reversed. We assert these threshold assertions by asserting that `not-W` had more votes than `W` for each of the two top vote getters.
+
+Now, the max error of the existing candidate pair assertions and these new threshold assertions is selected in calculating each batch's error, which is how they will contribute to the audit's `p-value`.
+
+Note: An interesting consequence of adding these threshold assertions is that we may see them be the driving factor of sample size if the top candidate is close to having 50% of the total vote. Previously if the main contribution to risk was a candidate that had 51% of the vote having 31% more than the second candidate having 20% of the vote, that risk will now be dominated by the assertion that the winner had 51% of the vote compared to the not-winners having 49% of the vote, clearly a much tighter margin.
+
+These additional assertions will also be used in `compute_max_error` along with the existing candidate pair assertions to determine the upper bound of overstatement that a batch could contribute, used to drive sampling.
+
+_AI-speak technical version_ -
+
+Threshold assertions (real candidate vs aggregate candidate) are represented as **explicit, self-contained pair entries** in a new `contest.margins["runoff_assertions"]` collection. The aggregate side of a threshold pair (`__not_W`) has its per-batch tally pre-computed (sum of all real-candidate tallies in that batch, minus W's tally) before MACRO iterates. In the no-majority case, the runner-up R is additionally promoted into `self.winners` (with `self.num_winners` set to 2) so the existing pairwise winner×loser iteration validates R's standing against every non-advancing candidate — no extra entries needed for those pairs. MACRO iterates the threshold entries with the same arithmetic and produces a single p-value covering everything. Implementation details — including the structural-winner direction rule and the `V_wl ≥ 0` invariant — are in Section 2.
+
+### Design decisions
+
+- **Field name**: `is_subject_to_runoff` (boolean) on `Contest`. Captures the domain reality: this contest is governed by majority-or-runoff law. When on, the audit verifies the majority claim and (in the no-majority case) the runner-up's standing.
+- **`num_winners` constraint**: the flag is only valid when `num_winners == 1`. From the user's perspective a primary subject to runoff law is conceptually a single-winner race (one candidate wins outright if they hit majority; otherwise a runoff later decides between the top two). The "two winners advance to a runoff" framing is a math-internal concern in the no-majority case — it doesn't surface in the DB, API, form, or report.
+- **Audit type scope**: `BATCH_COMPARISON` only for v1. Other audit types raise a validation error if the flag is set.
+- **UI surfacing**: Checkbox appears on the contest form whenever `Election.state == "GA"` and `audit_type == BATCH_COMPARISON`. It is disabled (and forced off) when `numWinners != 1`, so the relationship between the flag and the `num_winners` constraint is visible to the user rather than hidden. Defaults to off.
+- **Both majority and no-majority directions are valid audit configurations.** The math handles either; the audit doesn't reject contests based on which side of 50% the reported leader is on. The direction is derived inside the math module from `contest.candidates`.
+
+### Open questions to confirm before implementation
+
+**MACRO conservative-adjustment composability with aggregate candidates** (math review needed):
+
+The threshold check is modeled as a pairwise pair between a real candidate W and an aggregate candidate `not-W` (whose reported tally = sum of all other real candidates' tallies). The structural "winner" of the pair is whichever side has more reported votes, so `V_wl ≥ 0` by construction (exact tie will degrade to a hand recount via MACRO's existing `V_wl ≤ 0` guard). The per-batch error and max-error arithmetic is identical to MACRO's existing pairwise math, except `V_wl` is sourced from the assertion's own tallies rather than from `contest.candidates`.
+
+- Does MACRO's existing single-subtract of `pending_ballots` and `unauditable_ballots` from `V_wl` still hold when one side of the pair is a sum-of-others rather than a single real candidate — in both directions (majority case: real candidate is the winner, `not-W` is the loser; no-majority case: `not-W` is the winner, real candidate is the loser)?
+- Does the presence of undervoted ballots — which appear in batch ballot counts but in no candidate's tally, and therefore aren't in `not-W` either — require any additional adjustment specifically to the threshold-pair math?
+
+### Reference: Georgia majority definition
+
+Ga. Code § 21-2-501: a runoff is required if no candidate receives **more than 50%** of the vote. The comparison throughout the plan (math direction, backend validation) uses strict `> 0.5` accordingly.
+
+---
+
+## Implementation
+
+### 1. Database — add the flag
+
+**[server/models.py:468](../server/models.py#L468)** — add to `Contest`:
+
+```python
+# When True, this contest is governed by majority-or-runoff law: a
+# candidate wins outright if they receive a strict majority of valid
+# votes, otherwise the top two advance to a runoff. The audit verifies
+# the reported majority claim (and the runner-up's standing, in the
+# no-majority case). Only valid for batch comparison audits with
+# num_winners == 1.
+is_subject_to_runoff = Column(Boolean, nullable=False, server_default="false")
+```
+
+**New migration** in [server/migrations/versions/](../server/migrations/versions/) — follow [7ca7a4b0bcc0_contest_pending_ballots.py](../server/migrations/versions/7ca7a4b0bcc0_contest_pending_ballots.py):
+
+```python
+def upgrade():
+    op.add_column(
+        "contest",
+        sa.Column("is_subject_to_runoff", sa.Boolean(), nullable=False, server_default="false"),
+    )
+```
+
+### 2. Math — synthesize threshold and runner-up assertions inside the math module
+
+The entire "two winners advance in the no-majority case" treatment lives here. The DB, API, and form all see `num_winners=1`; the math module privately derives the appropriate assertions from `contest.candidates`.
+
+**[server/audit_math/sampler_contest.py](../server/audit_math/sampler_contest.py)** — changes:
+
+1. `from_db_contest` (line 21): add `"isSubjectToRunoff": db_contest.is_subject_to_runoff` to `info_dict`.
+2. `Contest.__init__` (line 70): read `self.is_subject_to_runoff = contest_info_dict.get("isSubjectToRunoff", False)`; add the key to the skip-keys list at line 80.
+3. Inside `Contest.__init__`, add two blocks around the existing margin-population block ([sampler_contest.py:113-160](../server/audit_math/sampler_contest.py#L113-L160)).
+
+   The first block, **before** margin-population, decides direction: if `self.is_subject_to_runoff` and no candidate has a strict majority, set `self.num_winners = 2` so the existing winner-detection loop puts both top candidates into `self.winners` (and their pairwise margins fall out of the margin-population block automatically).
+
+   The second block, **after** margin-population, builds `self.margins["runoff_assertions"]` — a `list[dict]` with shape `{"winner_id", "winner_votes", "loser_id", "loser_votes"}` — by emitting one threshold pair per entry in `self.winners`:
+
+   ```python
+   # Before the existing margin-population block:
+   if self.is_subject_to_runoff:
+       total_valid = sum(self.candidates.values())
+       top_votes = max(self.candidates.values())
+       if top_votes <= total_valid - top_votes:
+           # No-majority case (incl. exact 50/50): treat as 2-winner internally.
+           self.num_winners = 2
+
+   # ... existing margin-population block runs unchanged ...
+
+   # After the existing margin-population block:
+   if self.is_subject_to_runoff:
+       total_valid = sum(self.candidates.values())
+       runoff_assertions: list[dict] = []
+       for w_id, w_votes in self.winners.items():
+           not_id = f"__not_{w_id}"
+           not_votes = total_valid - w_votes
+           if w_votes > not_votes:
+               # Majority case for this winner: assert W > not-W.
+               runoff_assertions.append({
+                   "winner_id": w_id, "winner_votes": w_votes,
+                   "loser_id":  not_id, "loser_votes": not_votes,
+               })
+           else:
+               # No-majority case for this winner: assert not-W > W.
+               runoff_assertions.append({
+                   "winner_id": not_id, "winner_votes": not_votes,
+                   "loser_id":  w_id, "loser_votes": w_votes,
+               })
+       self.margins["runoff_assertions"] = runoff_assertions
+   ```
+
+   Direction rule for threshold pairs: the structural "winner" is whichever side has more reported votes, ensuring `V_wl ≥ 0`. At exact 50/50, `V_wl = 0` and MACRO's existing guard forces a hand recount — the correct fallback (zero reported margin cannot be statistically distinguished from a true majority or shortfall). Aggregate candidates (`__not_W`, `__not_R`) live exclusively in `self.margins["runoff_assertions"]` — they are not added to `self.winners` or `self.losers`.
+
+**[server/audit_math/macro.py](../server/audit_math/macro.py)** — changes:
+
+1. Add a helper `add_aggregate_tallies(contest, results_by_batch)` that mutates the input dict: for each batch's per-contest entry, adds a `__not_<X>` key for every aggregate ID referenced in `contest.margins["runoff_assertions"]`, with value `sum_of_real_candidates_in_batch − X_votes_in_batch`. Skip any batch where `contest.name` is not present (mirrors the existing `if contest.name not in sample_results[batch]: continue` check at [macro.py:345](../server/audit_math/macro.py#L345)). Assignment-based (idempotent) so that double-augmentation through `get_sample_sizes → compute_risk` is harmless — only mutates if `contest.is_subject_to_runoff`.
+2. Call `add_aggregate_tallies` at the top of MACRO's two public entry points — `get_sample_sizes` ([macro.py:209](../server/audit_math/macro.py#L209)) on `reported_results`, and `compute_risk` ([macro.py:287](../server/audit_math/macro.py#L287)) on both `reported_results` and `sample_results`. After these calls, every downstream lookup of `batch_results[contest.name][__not_<X>]` resolves to a real number.
+3. In `compute_error` at [macro.py:106-114](../server/audit_math/macro.py#L106-L114), after the existing `error_for_candidate_pair` list comprehension, append errors from each runoff assertion:
+   ```python
+   maybe_errors += [
+       error_for_runoff_assertion(a) for a in contest.margins.get("runoff_assertions", [])
+   ]
+   ```
+4. Add `error_for_runoff_assertion(assertion)` next to [`error_for_candidate_pair`](../server/audit_math/macro.py#L82). Same arithmetic, but `V_wl` is read from `assertion["winner_votes"] - assertion["loser_votes"]` rather than from `contest.candidates`. Returns the same `BatchError` shape so the surrounding `max(...)` aggregation just works. (May be simpler to refactor `error_for_candidate_pair` to accept `(winner_id, loser_id, V_wl)` directly and drive both iterations through it.)
+5. In `compute_max_error` at [macro.py:147-172](../server/audit_math/macro.py#L147-L172), same change: add a parallel inner loop over `contest.margins["runoff_assertions"]` calling a sibling `max_error_for_runoff_assertion(assertion)` (same `((v_wp − v_lp) + b_cp) / V_wl` shape, where `b_cp` is the total **b**allot count for the **c**ontest in batch **p**, read from `batch_results[contest.name]["ballots"]`).
+
+The `__not_` prefix is purely an ID-naming convention — correctness comes from the assertion list being closed over its own `(winner_id, loser_id, V_wl)` tuples, not from any string matching. Aggregate candidates are a math-module concern and stay inside `macro.py` + `sampler_contest.py`.
+
+### 3. API ingest — schema, validation, serialization
+
+**[server/api/contests.py](../server/api/contests.py)**:
+
+1. `CONTEST_SCHEMA` ([contests.py:28](../server/api/contests.py#L28)): add `"isSubjectToRunoff": {"type": "boolean"}` to properties. Not required (defaults to false).
+2. `validate_contests` ([contests.py:237](../server/api/contests.py#L237)): add a check — for each contest with `isSubjectToRunoff == True`:
+   - Election audit type must be `BATCH_COMPARISON` → else `BadRequest("Runoff-subject contests are only supported for batch comparison audits")`.
+   - `numWinners` must be `1` → else `BadRequest("Runoff-subject contests must have num_winners=1")`.
+   - At least 3 choices. With only 2 choices the contest is already a head-to-head race and the threshold pair degenerates to the head-to-head pair.
+3. `serialize_contest` ([contests.py:127](../server/api/contests.py#L127)): include `"isSubjectToRunoff": contest.is_subject_to_runoff` only when `audit_type == BATCH_COMPARISON` (mirroring how `pendingBallots` is conditionally serialized at line 138).
+4. `deserialize_contest` ([contests.py:222](../server/api/contests.py#L222)): pass through `is_subject_to_runoff=contest.get("isSubjectToRunoff", False)`.
+
+### 4. UI — contest form
+
+**[client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx](../client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx)**:
+
+- Add `isSubjectToRunoff: boolean` to `IContestValues` (around line 190).
+- Render a Blueprint `Checkbox` labeled e.g. "Subject to runoff law" — shown whenever the audit's state is `"GA"` and the audit type is `BATCH_COMPARISON`. Place it near the `numWinners` field. The audit state is available from the election context already used in the form.
+- Disable the checkbox (and force its value to `false`) when `numWinners != 1`. Add a short helper line in that disabled state explaining why, e.g. _"Only available for single-winner contests."_ This keeps the constraint discoverable rather than hidden.
+- When the checkbox is on, display a short contextual line under it describing what the audit will verify, derived from the candidate vote inputs already on the same form:
+  - Compute `totalValid = sum(numVotes for each choice)` and `leaderShare = max(numVotes) / totalValid`. Recompute on blur of any candidate-vote input, and only when every choice row has both a name and a vote total filled in.
+  - If `leaderShare > 0.5` (strict majority, per Ga. Code § 21-2-501): `"Audit will verify {leader.name} received a majority."`
+  - Otherwise: `"Audit will verify {leader.name} and {runner_up.name} are the correct top two and that neither received a majority."`
+  - Blank before the first successful computation.
+- Add `isSubjectToRunoff: Yup.boolean()` to [schema.ts](../client/src/components/AuditAdmin/Setup/Contests/schema.ts).
+
+### 5. Audit report CSV — surface the outcome
+
+The audit admin's CSV report ([server/api/reports.py:400](../server/api/reports.py#L400)) is the canonical place audit results land. Per-contest p-values and `is_complete` already appear in the "ROUNDS" section; we extend that section with a single outcome column for flagged contests.
+
+- **Conditionally add a "Runoff Outcome" column** to the `ROUNDS` header alongside the existing batch-comparison-only columns at [reports.py:419-422](../server/api/reports.py#L419). The column appears only when `any(contest.is_subject_to_runoff for contest in election.contests)`. For audits with no flagged contests (the common case), the CSV looks identical to today.
+- **Populate the cell** in `round_rows` at [reports.py:534-563](../server/api/reports.py#L534) based on the reported tallies (since `num_winners` is always 1 for flagged contests, the direction is derived from `contest.candidates`):
+  - `""` if the contest doesn't have the flag set (but the audit has other contests that do, so the column exists).
+  - `"Majority confirmed"` if `is_complete` is True and the declared winner's reported tally is a strict majority of valid votes.
+  - `"No majority — runoff required"` if `is_complete` is True and the declared winner's reported tally is not a strict majority.
+  - `""` if `is_complete` is False — the existing "Risk Limit Met?" column already says No, and no outcome can be claimed.
+
+### 6. Tests
+
+**[server/tests/audit_math/test_sampler_contest.py](../server/tests/audit_math/test_sampler_contest.py)** — new tests:
+
+- `test_runoff_no_majority_assertions`: 4-candidate contest 40/35/15/10 with `isSubjectToRunoff=True` and `numWinners=1`. Asserts:
+  - `contest.num_winners == 2` and `contest.winners` contains both Alice and Bob (runner-up promoted), `contest.losers` contains only Carla and Dan.
+  - `contest.margins["runoff_assertions"]` has exactly two entries — `not_W > W` and `not_R > R` — both with `winner_votes > loser_votes`. (R-vs-non-advancing pairs are validated by the existing winner×loser iteration, not via this list.)
+- `test_runoff_majority_assertions`: 4-candidate contest 55/25/15/5 with the flag on and `numWinners=1`. Asserts `runoff_assertions` has one entry: `W > not_W` with `winner_votes > loser_votes`.
+
+**[server/tests/audit_math/test_macro.py](../server/tests/audit_math/test_macro.py)** — new tests, follow the existing fixture style at [test_macro.py:12-101](../server/tests/audit_math/test_macro.py#L12):
+
+- `test_runoff_no_majority_happy_path`: 4-candidate contest, reported 40/35/15/10, batches consistent with reported. All assertions clear — W and R each vs every non-advancing loser (existing pairwise math with the internal `num_winners=2` promotion), plus the `not_W > W` and `not_R > R` threshold pairs. Audit terminates.
+- `test_runoff_majority_happy_path`: 4-candidate contest, reported 55/25/15/5, batches consistent. Existing pairs (leader vs every other candidate) plus the `W > not-W` threshold pair clear. Audit terminates.
+- `test_runoff_threshold_dominates_sample_size`: reported leader at 48% — confirm sample size is materially larger than with the flag off (threshold pair becomes binding).
+- `test_runoff_discrepancy_flips_majority`: reported leader at 51%, but introduce sampled batch discrepancies that, scaled up, would put the leader under 50%. Risk fails to clear and the audit doesn't terminate (escalation/full hand-count expected).
+
+**[server/tests/api/test_contests.py](../server/tests/api/test_contests.py)** — new tests:
+
+- `test_runoff_flag_serialized_for_batch_comparison`: PUT-then-GET round trip preserves the flag.
+- `test_runoff_flag_rejected_for_non_batch_comparison`: 400 with a clear message for ballot polling, ballot comparison, hybrid.
+- `test_runoff_flag_rejects_num_winners_not_one`: 400 if `numWinners != 1`.
+- `test_runoff_flag_requires_three_or_more_choices`: 400 with 2 choices.
+
+**[server/tests/api/test_reports.py](../server/tests/api/test_reports.py)** — new tests (confirm the existing report-test file location before adding):
+
+- `test_audit_report_runoff_outcome_no_majority`: completed flagged contest, reported tallies Alice 40 / Bob 35 / Carla 15 / Dan 10 — CSV's "Runoff Outcome" cell reads `"No majority — runoff required"`.
+- `test_audit_report_runoff_outcome_majority`: completed flagged contest, reported tallies Alice 55 / Bob 25 / Carla 15 / Dan 5 — cell reads `"Majority confirmed"`.
+- `test_audit_report_runoff_outcome_blank_for_non_flagged_in_same_audit`: an audit with at least one flagged contest and one non-flagged contest — the column is present, the flagged contest's cell is populated, the non-flagged contest's cell is empty.
+- `test_audit_report_runoff_outcome_column_absent_when_no_contest_flagged`: an audit with no flagged contests — the "Runoff Outcome" column does not appear in the CSV at all.
+- `test_audit_report_runoff_outcome_blank_when_incomplete`: flagged contest, `is_complete=False` — cell is empty (the existing "Risk Limit Met?" column says No).
+
+---
+
+## Verification
+
+1. **Run the math tests**:
+   ```
+   pytest server/tests/audit_math/test_sampler_contest.py server/tests/audit_math/test_macro.py -v
+   ```
+2. **Run the API tests**:
+   ```
+   pytest server/tests/api/test_contests.py -v -k runoff
+   ```
+3. **Migration**:
+   ```
+   make resetdb && alembic upgrade head
+   ```
+   Then inspect that `contest.is_subject_to_runoff` exists and defaults to false.
+4. **Manual end-to-end** (frontend dev server + backend):
+   - Create a new audit, state=Georgia, type=Batch Comparison.
+   - Confirm the new checkbox appears on the contest form for Georgia batch comparison audits. It should not appear for other states or non-batch-comparison audit types. When `numWinners != 1`, it should be disabled with a helper line explaining the constraint.
+   - Configure a contest with 4 candidates, `numWinners=1`, reported tallies summing such that the leader is at 40%. Check the box. Contextual line should read e.g. _"Audit will verify Alice and Bob are the correct top two and that neither received a majority."_ Submit — succeed.
+   - Without unchecking the box, change one candidate's votes so the leader is now at 55%. Contextual line should flip to _"Audit will verify Alice received a majority."_ Submit — also succeed.
+   - Upload batch tallies and launch the audit.
+   - Run a round, enter audit-board results consistent with the reported tallies, confirm the round closes successfully and the displayed p-value covers all assertions.
+   - **Download the audit report CSV** and verify the new "Runoff Outcome" column reads `"No majority — runoff required"` or `"Majority confirmed"` depending on the reported tallies.
+5. **Negative manual cases** — verify that the API rejects (400 with clear message):
+   - Submitting a non-batch-comparison audit with the flag.
+   - Submitting a contest with `numWinners=2` and the flag.
+
+---
+
+## Files touched (summary)
+
+| Layer                         | Path                                                                                                                                                                                               |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DB model                      | [server/models.py:468](../server/models.py#L468)                                                                                                                                                   |
+| Migration                     | `server/migrations/versions/<new_id>_contest_is_subject_to_runoff.py`                                                                                                                              |
+| Math (contest object)         | [server/audit_math/sampler_contest.py](../server/audit_math/sampler_contest.py)                                                                                                                    |
+| Math (MACRO runoff iteration) | [server/audit_math/macro.py:106-114](../server/audit_math/macro.py#L106-L114), [macro.py:147-172](../server/audit_math/macro.py#L147-L172)                                                         |
+| API schema / validation       | [server/api/contests.py:28](../server/api/contests.py#L28), [contests.py:237](../server/api/contests.py#L237)                                                                                      |
+| API (de)serialization         | [server/api/contests.py:127](../server/api/contests.py#L127), [contests.py:222](../server/api/contests.py#L222)                                                                                    |
+| Audit report CSV              | [server/api/reports.py:400](../server/api/reports.py#L400), [reports.py:534-563](../server/api/reports.py#L534-L563)                                                                               |
+| UI form                       | [client/.../ContestForm.tsx](../client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx)                                                                                                   |
+| UI schema                     | [client/.../schema.ts](../client/src/components/AuditAdmin/Setup/Contests/schema.ts)                                                                                                               |
+| Tests                         | [test_sampler_contest.py](../server/tests/audit_math/test_sampler_contest.py), [test_macro.py](../server/tests/audit_math/test_macro.py), [test_contests.py](../server/tests/api/test_contests.py) |

--- a/specs/0001-runoff-subject-contests.md
+++ b/specs/0001-runoff-subject-contests.md
@@ -184,16 +184,19 @@ The `__not_` prefix is purely an ID-naming convention — correctness comes from
   - Blank before the first successful computation.
 - Add `isSubjectToRunoff: Yup.boolean()` to [schema.ts](../client/src/components/AuditAdmin/Setup/Contests/schema.ts).
 
-### 5. Audit report CSV — surface the outcome
+### 5. Audit report CSV — surface the contest's runoff configuration
 
-The audit admin's CSV report ([server/api/reports.py:400](../server/api/reports.py#L400)) is the canonical place audit results land. Per-contest p-values and `is_complete` already appear in the "ROUNDS" section; we extend that section with a single outcome column for flagged contests.
+The audit admin's CSV report ([server/api/reports.py](../server/api/reports.py)) has a `CONTESTS` section that describes each contest. We extend that section with two columns for flagged contests, mirroring the audit-setup form (one column for the configuration flag, one for the reported-tallies outcome it implies).
 
-- **Conditionally add a "Runoff Outcome" column** to the `ROUNDS` header alongside the existing batch-comparison-only columns at [reports.py:419-422](../server/api/reports.py#L419). The column appears only when `any(contest.is_subject_to_runoff for contest in election.contests)`. For audits with no flagged contests (the common case), the CSV looks identical to today.
-- **Populate the cell** in `round_rows` at [reports.py:534-563](../server/api/reports.py#L534) based on the reported tallies (since `num_winners` is always 1 for flagged contests, the direction is derived from `contest.candidates`):
-  - `""` if the contest doesn't have the flag set (but the audit has other contests that do, so the column exists).
-  - `"Majority confirmed"` if `is_complete` is True and the declared winner's reported tally is a strict majority of valid votes.
-  - `"No majority — runoff required"` if `is_complete` is True and the declared winner's reported tally is not a strict majority.
-  - `""` if `is_complete` is False — the existing "Risk Limit Met?" column already says No, and no outcome can be claimed.
+- **Conditionally add `"Runoff Law"` and `"Reported Runoff Results"` columns** to the `CONTESTS` header in `contest_rows`. Both columns appear together when `any(contest.is_subject_to_runoff for contest in election.contests)`. For audits with no flagged contests (the common case), the CSV looks identical to today.
+- **Populate the cells** per contest:
+  - **Runoff Law**:
+    - `"Subject to runoff law"` if the contest's flag is set (matches the form checkbox label).
+    - `"Not subject to runoff law"` otherwise.
+  - **Reported Runoff Results** (based purely on the contest's reported choice tallies — independent of audit progress):
+    - `"Majority received, no runoff required"` if the declared winner's reported tally is a strict majority of valid votes.
+    - `"No majority, runoff required"` otherwise.
+    - `""` for unflagged contests (the column exists because some other contest is flagged).
 
 ### 6. Tests
 
@@ -218,13 +221,11 @@ The audit admin's CSV report ([server/api/reports.py:400](../server/api/reports.
 - `test_runoff_flag_rejects_num_winners_not_one`: 400 if `numWinners != 1`.
 - `test_runoff_flag_requires_three_or_more_choices`: 400 with 2 choices.
 
-**[server/tests/api/test_reports.py](../server/tests/api/test_reports.py)** — new tests (confirm the existing report-test file location before adding):
+**[server/tests/api/test_reports.py](../server/tests/api/test_reports.py)** — new tests for the `reported_runoff_results_label` helper:
 
-- `test_audit_report_runoff_outcome_no_majority`: completed flagged contest, reported tallies Alice 40 / Bob 35 / Carla 15 / Dan 10 — CSV's "Runoff Outcome" cell reads `"No majority — runoff required"`.
-- `test_audit_report_runoff_outcome_majority`: completed flagged contest, reported tallies Alice 55 / Bob 25 / Carla 15 / Dan 5 — cell reads `"Majority confirmed"`.
-- `test_audit_report_runoff_outcome_blank_for_non_flagged_in_same_audit`: an audit with at least one flagged contest and one non-flagged contest — the column is present, the flagged contest's cell is populated, the non-flagged contest's cell is empty.
-- `test_audit_report_runoff_outcome_column_absent_when_no_contest_flagged`: an audit with no flagged contests — the "Runoff Outcome" column does not appear in the CSV at all.
-- `test_audit_report_runoff_outcome_blank_when_incomplete`: flagged contest, `is_complete=False` — cell is empty (the existing "Risk Limit Met?" column says No).
+- `test_reported_runoff_results_majority`: reported tallies 55 / 25 / 15 / 5 → `"Majority received, no runoff required"`.
+- `test_reported_runoff_results_no_majority`: reported tallies 40 / 35 / 15 / 10 → `"No majority, runoff required"`.
+- `test_reported_runoff_results_exact_50_is_not_majority`: reported tallies 50 / 30 / 20 → `"No majority, runoff required"` (Ga. Code § 21-2-501 requires strict majority).
 
 ---
 
@@ -250,7 +251,7 @@ The audit admin's CSV report ([server/api/reports.py:400](../server/api/reports.
    - Without unchecking the box, change one candidate's votes so the leader is now at 55%. Contextual line should flip to _"Reported results: Alice received a majority, no runoff required."_ Submit — also succeed.
    - Upload batch tallies and launch the audit.
    - Run a round, enter audit-board results consistent with the reported tallies, confirm the round closes successfully and the displayed p-value covers all assertions.
-   - **Download the audit report CSV** and verify the new "Runoff Outcome" column reads `"No majority — runoff required"` or `"Majority confirmed"` depending on the reported tallies.
+   - **Download the audit report CSV** and verify the `CONTESTS` section has new `"Runoff Law"` and `"Reported Runoff Results"` columns. The flagged contest's cells should read `"Subject to runoff law"` and either `"Majority received, no runoff required"` or `"No majority, runoff required"` depending on the reported tallies.
 5. **Negative manual cases** — verify that the API rejects (400 with clear message):
    - Submitting a non-batch-comparison audit with the flag.
    - Submitting a contest with `numWinners=2` and the flag.

--- a/specs/0001-runoff-subject-contests.md
+++ b/specs/0001-runoff-subject-contests.md
@@ -179,8 +179,8 @@ The `__not_` prefix is purely an ID-naming convention — correctness comes from
 - Disable the checkbox (and force its value to `false`) when `numWinners != 1`. Add a short helper line in that disabled state explaining why, e.g. _"Only available for single-winner contests."_ This keeps the constraint discoverable rather than hidden.
 - When the checkbox is on, display a short contextual line under it describing what the audit will verify, derived from the candidate vote inputs already on the same form:
   - Compute `totalValid = sum(numVotes for each choice)` and `leaderShare = max(numVotes) / totalValid`. Recompute on blur of any candidate-vote input, and only when every choice row has both a name and a vote total filled in.
-  - If `leaderShare > 0.5` (strict majority, per Ga. Code § 21-2-501): `"Audit will verify {leader.name} received a majority."`
-  - Otherwise: `"Audit will verify {leader.name} and {runner_up.name} are the correct top two and that neither received a majority."`
+  - If `leaderShare > 0.5` (strict majority, per Ga. Code § 21-2-501): `"Reported results: {leader.name} received a majority, no runoff required."`
+  - Otherwise: `"Reported results: {leader.name} and {runner_up.name} are the top two vote-getters and neither received a majority, runoff required."`
   - Blank before the first successful computation.
 - Add `isSubjectToRunoff: Yup.boolean()` to [schema.ts](../client/src/components/AuditAdmin/Setup/Contests/schema.ts).
 
@@ -246,8 +246,8 @@ The audit admin's CSV report ([server/api/reports.py:400](../server/api/reports.
 4. **Manual end-to-end** (frontend dev server + backend):
    - Create a new audit, state=Georgia, type=Batch Comparison.
    - Confirm the new checkbox appears on the contest form for Georgia batch comparison audits. It should not appear for other states or non-batch-comparison audit types. When `numWinners != 1`, it should be disabled with a helper line explaining the constraint.
-   - Configure a contest with 4 candidates, `numWinners=1`, reported tallies summing such that the leader is at 40%. Check the box. Contextual line should read e.g. _"Audit will verify Alice and Bob are the correct top two and that neither received a majority."_ Submit — succeed.
-   - Without unchecking the box, change one candidate's votes so the leader is now at 55%. Contextual line should flip to _"Audit will verify Alice received a majority."_ Submit — also succeed.
+   - Configure a contest with 4 candidates, `numWinners=1`, reported tallies summing such that the leader is at 40%. Check the box. Contextual line should read e.g. _"Reported results: Alice and Bob are the top two vote-getters and neither received a majority, runoff required."_ Submit — succeed.
+   - Without unchecking the box, change one candidate's votes so the leader is now at 55%. Contextual line should flip to _"Reported results: Alice received a majority, no runoff required."_ Submit — also succeed.
    - Upload batch tallies and launch the audit.
    - Run a round, enter audit-board results consistent with the reported tallies, confirm the round closes successfully and the displayed p-value covers all assertions.
    - **Download the audit report CSV** and verify the new "Runoff Outcome" column reads `"No majority — runoff required"` or `"Majority confirmed"` depending on the reported tallies.


### PR DESCRIPTION
Georgia is Arlo's only customer that conducts batch comparison audits (MACRO) of primary contests subject to **majority-or-runoff** law: if a candidate receives a majority of valid votes they win the primary outright; otherwise the top two advance to a runoff. 

Arlo today only audits the pairwise margins (e.g. with `num_winners=2`, that each reported top-2 candidate beats every other candidate). It does _not_ statistically verify the majority claim — i.e., whether the reported leader's share actually does or does not cross 50%.

This PR adds:
1. The missing mathematical assertions that the winning candidate received a majority, or that the top two vote-getters did not.
2. Updates the setup form to indicate the Runoff Law applies
3. Updates the audit report to indicate the runoff rules applied to the audit
4. Tests

Testing:
- Automated tests added
- I've done one end-to-end test, but I plan to do more to test the different permutations.

**Form updates:**

https://github.com/user-attachments/assets/4af008a3-a8ef-4300-82bb-8c07b0b2f5ad

**Audit report updates:**

<img width="998" height="288" alt="Screenshot 2026-05-19 at 5 03 49 PM" src="https://github.com/user-attachments/assets/6441c49c-6600-45df-b0da-2e976fdeb03c" />

