### PR TITLE
Fix spacing of candidate labels/buttons

### DIFF
--- a/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
+++ b/client/src/components/AuditAdmin/Setup/Contests/ContestForm.tsx
@@ -445,15 +445,19 @@ const ContestForm: React.FC<IProps> = ({
                                   (choice: IChoiceValues, j: number) => (
                                     /* eslint-disable react/no-array-index-key */
                                     <React.Fragment key={j}>
-                                      <InputFieldRow>
-                                        <InputLabel>
+                                      <InputFieldRow
+                                        style={
+                                          j === 0 ? {} : { marginTop: '15px' }
+                                        }
+                                      >
+                                        <InputLabel style={{ marginBottom: 0 }}>
                                           Name of Candidate/Choice {j + 1}
                                           <Field
                                             name={`contests[${i}].choices[${j}].name`}
                                             component={FlexField}
                                           />
                                         </InputLabel>
-                                        <InputLabel>
+                                        <InputLabel style={{ marginBottom: 0 }}>
                                           Votes for Candidate/Choice {j + 1}
                                           <Field
                                             name={`contests[${i}].choices[${j}].numVotes`}

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
@@ -130,6 +130,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
             >
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 1
@@ -150,6 +151,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
               </label>
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 1
@@ -171,9 +173,11 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
             </div>
             <div
               class="sc-esjQYD fijUfG"
+              style="margin-top: 15px;"
             >
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 2
@@ -194,6 +198,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
               </label>
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 2
@@ -532,6 +537,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
             >
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 1
@@ -552,6 +558,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
               </label>
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 1
@@ -573,9 +580,11 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
             </div>
             <div
               class="sc-esjQYD fijUfG"
+              style="margin-top: 15px;"
             >
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 2
@@ -596,6 +605,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
               </label>
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 2
@@ -934,6 +944,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
             >
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 1
@@ -954,6 +965,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
               </label>
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 1
@@ -975,9 +987,11 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
             </div>
             <div
               class="sc-esjQYD fijUfG"
+              style="margin-top: 15px;"
             >
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 2
@@ -998,6 +1012,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
               </label>
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 2
@@ -1336,6 +1351,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
             >
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 1
@@ -1356,6 +1372,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
               </label>
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 1
@@ -1377,9 +1394,11 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
             </div>
             <div
               class="sc-esjQYD fijUfG"
+              style="margin-top: 15px;"
             >
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 2
@@ -1400,6 +1419,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
               </label>
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 2

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
@@ -166,6 +166,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
             >
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 1
@@ -186,6 +187,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
               </label>
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 1
@@ -207,9 +209,11 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
             </div>
             <div
               class="sc-esjQYD fijUfG"
+              style="margin-top: 15px;"
             >
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 2
@@ -230,6 +234,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
               </label>
               <label
                 class="bp3-label sc-eXEjpC hSzFPc"
+                style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 2


### PR DESCRIPTION
Low lift change to align the spacing of the "Remove.." buttons with their candidate rows. I just overrode styling so I didn't need to consider side effects of editing the shared components, as the initial styling is coming from the `bp3` package.

Before:
<img width="533" height="329" alt="Screenshot 2026-05-19 at 5 40 09 PM" src="https://github.com/user-attachments/assets/f15bd698-af93-4fee-bedd-0a8ebcede401" />

After:
<img width="549" height="358" alt="Screenshot 2026-05-19 at 5 33 03 PM" src="https://github.com/user-attachments/assets/c375e262-e425-4e4b-aada-da3681ae2f99" />
