### PR TITLE
Set GA default system type to Liberty Vote; rename Dominion

### DIFF
--- a/client/src/components/Atoms/CSVForm.tsx
+++ b/client/src/components/Atoms/CSVForm.tsx
@@ -109,7 +109,9 @@ const CSVFile: React.FC<IProps> = ({
                     disabled={!enabled || !(isEditing || !file)}
                     onChange={e => setFieldValue('cvrFileType', e.target.value)}
                   >
-                    <option value={CvrFileType.DOMINION}>Dominion</option>
+                    <option value={CvrFileType.DOMINION}>
+                      Liberty Vote (Dominion)
+                    </option>
                     <option value={CvrFileType.CLEARBALLOT}>ClearBallot</option>
                     <option value={CvrFileType.ESS}>ES&amp;S</option>
                     <option value={CvrFileType.HART}>Hart</option>

--- a/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
+++ b/client/src/components/AuditAdmin/Progress/JurisdictionDetail.tsx
@@ -198,7 +198,9 @@ const CvrsFileUpload = ({
               style={{ width: '195px', marginLeft: '10px' }}
             >
               <option></option>
-              <option value={CvrFileType.DOMINION}>Dominion</option>
+              <option value={CvrFileType.DOMINION}>
+                Liberty Vote (Dominion)
+              </option>
               <option value={CvrFileType.CLEARBALLOT}>ClearBallot</option>
               <option value={CvrFileType.ESS}>ES&amp;S</option>
               <option value={CvrFileType.HART}>Hart</option>

--- a/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import React from 'react'
 import { screen, within, waitFor } from '@testing-library/react'
 import { QueryClientProvider } from 'react-query'
@@ -16,11 +16,12 @@ import {
   getMockFormDataForFileUpload,
   getMockJsonDataForUploadComplete,
 } from '../_mocks'
+import { useBatchInventoryFeatureFlag } from '../useFeatureFlag'
 
 vi.mock(import('axios'))
 vi.mock(import('../useFeatureFlag'), async importActual => ({
   ...(await importActual()),
-  useBatchInventoryFeatureFlag: vi.fn(() => ({ showBallotManifest: true })),
+  useBatchInventoryFeatureFlag: vi.fn(),
 }))
 
 const testCvrFile = new File([''], 'test-cvr.csv', {
@@ -176,6 +177,62 @@ const expectToBeOnStep = async (name: string) => {
 // returns to the batch inventory flow after leaving on a certain step, they
 // will be returned to that step based on the saved data from the previous step.
 describe('BatchInventory', () => {
+  beforeEach(() => {
+    vi.mocked(useBatchInventoryFeatureFlag).mockReturnValue({
+      showBallotManifest: true,
+    })
+  })
+
+  it('auto-selects the configured default system type on first visit', async () => {
+    vi.mocked(useBatchInventoryFeatureFlag).mockReturnValue({
+      showBallotManifest: true,
+      defaultSystemType: CvrFileType.DOMINION,
+    })
+
+    const expectedCalls = [
+      apiCalls.getSystemType(null),
+      apiCalls.getCvr(fileInfoMocks.empty),
+      apiCalls.getTabulatorStatus(fileInfoMocks.empty),
+      apiCalls.getSignOff(null),
+      // useEffect persists the configured default on mount
+      apiCalls.putSystemType(CvrFileType.DOMINION),
+      // The mutation invalidates all batch-inventory queries, triggering refetches.
+      // The cvr and tabulator-status refetches then fire their onFileChange
+      // handlers, which re-invalidate downstream queries.
+      apiCalls.getSystemType(CvrFileType.DOMINION),
+      apiCalls.getCvr(fileInfoMocks.empty),
+      apiCalls.getTabulatorStatus(fileInfoMocks.empty),
+      apiCalls.getSignOff(null),
+      apiCalls.getTabulatorStatus(fileInfoMocks.empty),
+      apiCalls.getSignOff(null),
+      apiCalls.getSignOff(null),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render()
+      await expectToBeOnStep('Select System Type')
+
+      const continueButton = screen.getByRole('button', { name: /Continue/ })
+      await waitFor(() => expect(continueButton).toBeEnabled())
+      expect(screen.getByRole('combobox')).toHaveValue(CvrFileType.DOMINION)
+    })
+  })
+
+  it('does not auto-select a system type when no default is configured', async () => {
+    const expectedCalls = [
+      apiCalls.getSystemType(null),
+      apiCalls.getCvr(fileInfoMocks.empty),
+      apiCalls.getTabulatorStatus(fileInfoMocks.empty),
+      apiCalls.getSignOff(null),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      render()
+      await expectToBeOnStep('Select System Type')
+
+      expect(screen.getByRole('button', { name: /Continue/ })).toBeDisabled()
+      expect(screen.getByRole('combobox')).toHaveValue('')
+    })
+  })
+
   it('continues to Upload Election Results step', async () => {
     const expectedCalls = [
       apiCalls.getSystemType(CvrFileType.DOMINION),

--- a/client/src/components/JurisdictionAdmin/BatchInventory.tsx
+++ b/client/src/components/JurisdictionAdmin/BatchInventory.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { H2, Button, H4, Checkbox, HTMLSelect } from '@blueprintjs/core'
 import {
   useQueryClient,
@@ -212,13 +212,21 @@ const useBatchInventorySignOff = (
 
 const SelectSystemStep: React.FC<{
   systemTypeQueries: ISystemTypeQueries
+  defaultSystemType?: CvrFileType
   nextStep: () => void
-}> = ({ systemTypeQueries, nextStep }) => {
+}> = ({ systemTypeQueries, defaultSystemType, nextStep }) => {
+  const systemType = systemTypeQueries.systemType.data
+  const setSystemTypeMutate = systemTypeQueries.setSystemType.mutate
+
+  useEffect(() => {
+    if (systemType === null && defaultSystemType) {
+      setSystemTypeMutate(defaultSystemType)
+    }
+  }, [systemType, defaultSystemType, setSystemTypeMutate])
+
   if (!systemTypeQueries.systemType.isSuccess) {
     return null
   }
-
-  const systemType = systemTypeQueries.systemType.data
 
   const setSystemType = async (event: React.ChangeEvent<HTMLSelectElement>) => {
     const newSystemType = event.target.value as CvrFileType
@@ -236,7 +244,9 @@ const SelectSystemStep: React.FC<{
             value={systemType || undefined}
           >
             {!systemType && <option value={undefined}></option>}
-            <option value={CvrFileType.DOMINION}>Dominion</option>
+            <option value={CvrFileType.DOMINION}>
+              Liberty Vote (Dominion)
+            </option>
             <option value={CvrFileType.ESS}>ES&S</option>
             <option value={CvrFileType.ESS_MD}>ES&S (MD)</option>
             <option value={CvrFileType.HART}>Hart</option>
@@ -573,6 +583,7 @@ const BatchInventorySteps: React.FC<{
                 return (
                   <SelectSystemStep
                     systemTypeQueries={systemTypeQueries}
+                    defaultSystemType={batchInventoryConfig.defaultSystemType}
                     nextStep={() => setCurrentStep('Upload Election Results')}
                   />
                 )

--- a/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
+++ b/client/src/components/JurisdictionAdmin/JurisdictionAdminView.test.tsx
@@ -247,7 +247,7 @@ describe('JA setup', () => {
       await screen.findByText('Audit Setup')
       const fileTypeSelect = screen.getByLabelText(/CVR File Type:/)
       within(fileTypeSelect).getByRole('option', {
-        name: 'Dominion',
+        name: 'Liberty Vote (Dominion)',
         selected: true,
       })
       userEvent.selectOptions(

--- a/client/src/components/useFeatureFlag.ts
+++ b/client/src/components/useFeatureFlag.ts
@@ -1,8 +1,10 @@
 import { useAuthDataContext } from './UserContext'
+import { CvrFileType } from './useCSV'
 import { assert } from './utilities'
 
 export interface BatchInventoryConfig {
   showBallotManifest: boolean
+  defaultSystemType?: CvrFileType
 }
 
 const BATCH_INVENTORY_CONFIGS: {
@@ -11,13 +13,14 @@ const BATCH_INVENTORY_CONFIGS: {
   // Georgia
   'b216ad0d-1481-44e4-a2c1-95da40175084': {
     showBallotManifest: true,
+    defaultSystemType: CvrFileType.DOMINION,
   },
   // Nevada
   'b6f34a14-1cb2-4d44-8f29-b4fe04fd2932': {
     showBallotManifest: false,
   },
   // Pennsylvania - CVR Upload
-  '82d9b42b-b21e-4ff6-a884-14a97da2f2f4' : {
+  '82d9b42b-b21e-4ff6-a884-14a97da2f2f4': {
     showBallotManifest: false,
   },
   // Rhode Island


### PR DESCRIPTION
Closes https://github.com/votingworks/arlo/issues/2292
Closes https://github.com/votingworks/arlo/issues/2192

This PR:
1. Renames **Domion** to **Libery Vote (Dominion)** on user facing screens.
2. Sets Liberty Vote to be the default system type for GA in the batch inventory tool


https://github.com/user-attachments/assets/8325d160-928e-4f6a-987e-6b653cd91fa4

