### PR TITLE
WIP Fix pytest-xdist race condition in test org creation with retry logic

### DIFF
--- a/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
@@ -9,8 +9,11 @@ from ..helpers import *
 def org_id(client: FlaskClient, request) -> str:
     # Allow specifying a custom test org via @pytest.mark.parametrize to toggle relevant feature
     # flags
-    org_id: str = str(request.param)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-    return get_or_create_org(org_id)
+    org_id = str(request.param)
+    org = Organization.query.get(org_id)
+    if not org:
+        create_org(org_id)
+    return org_id
 
 
 @pytest.fixture

--- a/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
@@ -1,7 +1,6 @@
 import pytest
 from flask.testing import FlaskClient
 
-from ...database import db_session
 from ...models import *
 from ..helpers import *
 
@@ -10,14 +9,8 @@ from ..helpers import *
 def org_id(client: FlaskClient, request) -> str:
     # Allow specifying a custom test org via @pytest.mark.parametrize to toggle relevant feature
     # flags
-    org_id = str(request.param)
-    org = Organization.query.get(org_id)
-    if not org:
-        org = Organization(id=org_id, name=org_id)
-        db_session.add(org)
-        add_admin_to_org(org_id, DEFAULT_AA_EMAIL)
-        db_session.commit()
-    return org_id
+    org_id: str = str(request.param)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+    return get_or_create_org(org_id)
 
 
 @pytest.fixture

--- a/server/tests/batch_comparison/test_sample_extra_batches_to_ensure_one_per_jurisdiction.py
+++ b/server/tests/batch_comparison/test_sample_extra_batches_to_ensure_one_per_jurisdiction.py
@@ -9,8 +9,11 @@ from ..helpers import *
 def org_id(client: FlaskClient, request) -> str:
     # Allow specifying a custom test org via @pytest.mark.parametrize to toggle relevant feature
     # flags
-    org_id: str = str(request.param)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-    return get_or_create_org(org_id)
+    org_id = str(request.param)
+    org = Organization.query.get(org_id)
+    if not org:
+        create_org(org_id)
+    return org_id
 
 
 @pytest.fixture

--- a/server/tests/batch_comparison/test_sample_extra_batches_to_ensure_one_per_jurisdiction.py
+++ b/server/tests/batch_comparison/test_sample_extra_batches_to_ensure_one_per_jurisdiction.py
@@ -1,7 +1,6 @@
 import pytest
 from flask.testing import FlaskClient
 
-from ...database import db_session
 from ...models import *
 from ..helpers import *
 
@@ -10,14 +9,8 @@ from ..helpers import *
 def org_id(client: FlaskClient, request) -> str:
     # Allow specifying a custom test org via @pytest.mark.parametrize to toggle relevant feature
     # flags
-    org_id = str(request.param)
-    org = Organization.query.get(org_id)
-    if not org:
-        org = Organization(id=org_id, name=org_id)
-        db_session.add(org)
-        add_admin_to_org(org_id, DEFAULT_AA_EMAIL)
-        db_session.commit()
-    return org_id
+    org_id: str = str(request.param)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+    return get_or_create_org(org_id)
 
 
 @pytest.fixture

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -116,27 +116,13 @@ def add_admin_to_org(org_id: str, user_email: str):
     return audit_admin.id
 
 
-def get_or_create_org(org_id: str, user_email: str = DEFAULT_AA_EMAIL) -> str:
-    """Get or create an organization, handling race conditions in concurrent tests.
-
-    With pytest-xdist, multiple workers can try to create the same org simultaneously.
-    This function is idempotent and retries if another worker creates the org first.
-    """
-    for attempt in range(3):
-        if Organization.query.get(org_id):  # pyright: ignore[reportUnknownMemberType]
-            return org_id
-
-        org: Organization = Organization(id=org_id, name=org_id)  # pyright: ignore[reportCallIssue]
-        db_session.add(org)  # pyright: ignore[reportUnknownMemberType]
-        try:
-            _ = add_admin_to_org(org.id, user_email)
-            db_session.commit()  # pyright: ignore[reportUnknownMemberType]
-            return org_id
-        except IntegrityError:
-            db_session.rollback()  # pyright: ignore[reportUnknownMemberType]
-            if attempt == 2:
-                raise
-    raise RuntimeError("unreachable")  # pragma: no cover
+def create_org(org_id: str, user_email: str = DEFAULT_AA_EMAIL) -> None:
+    try:
+        with db_session.begin_nested():
+            db_session.add(Organization(id=org_id, name=org_id))
+        add_admin_to_org(org_id, user_email)
+    except IntegrityError:
+        pass
 
 
 def create_jurisdiction_admin(jurisdiction_id: str, user_email: str) -> str:

--- a/server/tests/helpers.py
+++ b/server/tests/helpers.py
@@ -116,6 +116,29 @@ def add_admin_to_org(org_id: str, user_email: str):
     return audit_admin.id
 
 
+def get_or_create_org(org_id: str, user_email: str = DEFAULT_AA_EMAIL) -> str:
+    """Get or create an organization, handling race conditions in concurrent tests.
+
+    With pytest-xdist, multiple workers can try to create the same org simultaneously.
+    This function is idempotent and retries if another worker creates the org first.
+    """
+    for attempt in range(3):
+        if Organization.query.get(org_id):  # pyright: ignore[reportUnknownMemberType]
+            return org_id
+
+        org: Organization = Organization(id=org_id, name=org_id)  # pyright: ignore[reportCallIssue]
+        db_session.add(org)  # pyright: ignore[reportUnknownMemberType]
+        try:
+            _ = add_admin_to_org(org.id, user_email)
+            db_session.commit()  # pyright: ignore[reportUnknownMemberType]
+            return org_id
+        except IntegrityError:
+            db_session.rollback()  # pyright: ignore[reportUnknownMemberType]
+            if attempt == 2:
+                raise
+    raise RuntimeError("unreachable")  # pragma: no cover
+
+
 def create_jurisdiction_admin(jurisdiction_id: str, user_email: str) -> str:
     jurisdiction_admin = create_user(user_email)
     db_session.add(jurisdiction_admin)


### PR DESCRIPTION
Possibly fixes flaky test in https://app.circleci.com/pipelines/github/votingworks/arlo/8236/workflows/8810e198-aa50-480a-9fb4-c367479935c8/jobs/26039

Claude's analysis:

> The tests used hardcoded org IDs (e.g. "TEST-ORG/sample-extra-batches-by-counting-group") shared across multiple parametrized test cases. When pytest-xdist distributed those tests to parallel workers, two workers could simultaneously check whether the org existed, both find it absent, and both attempt to insert it — causing one to fail with a UniqueViolation on the primary key.

> The fix adds get_or_create_org() in helpers.py: it attempts the insert and catches IntegrityError, then retries. On retry, the org now exists (created by the other worker) and is returned successfully.

The fix itself seems low-risk enough to try without concretely reproing the issue, but I'm not sure why we needed so many changes to .basedpyright/baseline.json to pass commit hook linting.