### PR TITLE
Normalize names for batch prep tool

### DIFF
--- a/server/api/batch_inventory.py
+++ b/server/api/batch_inventory.py
@@ -121,12 +121,16 @@ def items_list_to_dict(items):
     }
 
 
+def collapse_whitespace(name: str) -> str:
+    return re.sub(r"\s+", " ", name).strip()
+
+
 def validate_choice_name_and_get_choice_id(
     contest: Contest, choice_name: str
 ) -> str | None:
     choice_id = None
     for choice in contest.choices:
-        if choice.name == choice_name:
+        if collapse_whitespace(choice.name) == collapse_whitespace(choice_name):
             choice_id = choice.id
             break
         # handle capitalization mismatches for the write in column
@@ -609,9 +613,12 @@ def process_batch_inventory_cvr_file(
             )  # Tabulator ID is not present in Hart CVRs
 
             ballot_count_by_batch[batch_key] += 1
-            contest_results = parse_contest_results(cvr_xml)
+            contest_results = {
+                collapse_whitespace(contest_name): choice_names
+                for contest_name, choice_names in parse_contest_results(cvr_xml).items()
+            }
             for contest in contests:
-                choices = contest_results.get(contest.name, set())
+                choices = contest_results.get(collapse_whitespace(contest.name), set())
                 validated_choice_ids = []
                 for choice_name in choices:
                     validated_choice_id = validate_choice_name_and_get_choice_id(

--- a/server/tests/batch_comparison/test_batch_inventory.py
+++ b/server/tests/batch_comparison/test_batch_inventory.py
@@ -2181,6 +2181,47 @@ def test_batch_inventory_hart_cvr_upload(
     )
 
 
+def test_batch_inventory_hart_cvr_upload_collapses_whitespace_in_names(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: list[str],
+    contest_id: str,
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/system-type",
+        {"systemType": CvrFileType.HART},
+    )
+    assert_ok(rv)
+
+    def with_whitespace(cvr_xml: str) -> str:
+        return cvr_xml.replace("Contest 1", "Contest \n 1").replace(
+            "Choice 1-1", "Choice   1-1"
+        )
+
+    hart_cvrs = [
+        with_whitespace(build_hart_cvr("BATCH1", "1", "1-1-1", "1,0,0,0,0")),
+        with_whitespace(build_hart_cvr("BATCH1", "2", "1-1-2", "0,1,0,0,0")),
+    ]
+    hart_zip = zip_hart_cvrs(hart_cvrs)
+
+    rv = upload_batch_inventory_cvr(
+        client, hart_zip, election_id, jurisdiction_ids[0], "application/zip"
+    )
+    assert_ok(rv)
+
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/batch-inventory/batch-tallies"
+    )
+    batch_tallies = rv.data.decode("utf-8")
+    assert batch_tallies == (
+        "Batch Name,Choice 1-1,Choice 1-2,Write-In\r\nBATCH1,1,1,0\r\n"
+    )
+
+
 def test_batch_inventory_hart_cvr_upload_multi_contest(
     client: FlaskClient,
     election_id: str,


### PR DESCRIPTION
https://votingworks.slack.com/archives/C0B5C56T15G/p1779916628631129?thread_ts=1779912698.727599&cid=C0B5C56T15G

<img width="1612" height="370" alt="Screenshot 2026-05-27 at 2 08 08 PM" src="https://github.com/user-attachments/assets/097a574d-83f1-4034-a6b9-6e9acd449e1a" />

Noticed with a PA county that their CVR upload was failing to produce CTBB that had any counts, and it was because the target contest for the audit was not matching any contests in the CVR. This is because the CVRs have newlines in the middle of the contest names. The same issue also affects choice names. 

This PR adds normalization of the contest names when getting contest/choice values from the CVR, and additionally adds normalization of choice names when assigning vote counts to choice IDs.