### PR TITLE
Audit report: Account for combined batches in the Ballots in Batch total

### DIFF
--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -1138,8 +1138,16 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
                 f"Combines {', '.join(sub_batch.name for sub_batch in sorted(sub_batches, key=lambda batch: batch.name))}",
             ]
             rows.append(combined_batch_row)
-
-    totals_row = ["Totals", "", sum(batch.num_ballots for batch in batches)]
+    total_ballots = sum(
+        batch.num_ballots for batch in batches if batch.id not in combined_sub_batch_ids
+    )
+    if has_combined_batches:
+        total_ballots += sum(
+            sub_batch.num_ballots
+            for combined_batch in combined_batches
+            for sub_batch in combined_batch["sub_batches"]
+        )
+    totals_row = ["Totals", "", total_ballots]
     totals_row += ["" for _ in contests]  # Ticket number cols - not relevant to totals
     totals_row += [""]  # Audited flag - not relevant to totals
     for contest in contests:

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -78,7 +78,7 @@ J1,Batch 6,100,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 
 J1,Batch 8,100,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,\r
 J2,Batch 3,500,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,\r
 J1,Combined Batch,1500,,Yes,candidate 1: 1500; candidate 2: 750; candidate 3: 750,candidate 1: 1500; candidate 2: 745; candidate 3: 755,candidate 2: +5; candidate 3: -5,5,support@example.org,"Combines Batch 1, Batch 2, Batch 3"\r
-Totals,,2200,,,candidate 1: 2700; candidate 2: 1350; candidate 3: 1350,candidate 1: 2700; candidate 2: 1345; candidate 3: 1355,,\r
+Totals,,2700,,,candidate 1: 2700; candidate 2: 1350; candidate 3: 1350,candidate 1: 2700; candidate 2: 1345; candidate 3: 1355,,\r
 """
 
 snapshots["test_batch_comparison_pending_ballots 1"] = [
@@ -260,12 +260,6 @@ snapshots["test_batch_comparison_round_2 9"] = {
     "numUniqueAudited": 1,
     "status": "COMPLETE",
 }
-
-snapshots["test_batch_comparison_sample_preview 1"] = [
-    {"name": "J1", "numSamples": 5, "numUnique": 5},
-    {"name": "J2", "numSamples": 2, "numUnique": 1},
-    {"name": "J3", "numSamples": 0, "numUnique": 0},
-]
 
 snapshots["test_batch_comparison_sample_size 1"] = [
     {"key": "macro", "prob": None, "size": 7}

--- a/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
@@ -64,5 +64,5 @@ J2,Batch 3,500,Round 1: 0.368061935896261076,Yes,candidate 1: 500; candidate 2: 
 J2,Batch 6,250,Round 1: EXTRA,Yes,candidate 1: 200; candidate 2: 150; candidate 3: 150,,,,support@example.org,"Combined Batch - Sampled, Extra, Unsampled"\r
 J1,"Combined Batch - Extra, Unsampled",600,,Yes,candidate 1: 600; candidate 2: 300; candidate 3: 300,candidate 1: 600; candidate 2: 300; candidate 3: 300,,,support@example.org,"Combines Batch 1, Batch 7"\r
 J2,"Combined Batch - Sampled, Extra, Unsampled",1250,,Yes,candidate 1: 1200; candidate 2: 650; candidate 3: 650,candidate 1: 1200; candidate 2: 650; candidate 3: 650,,,support@example.org,"Combines Batch 1, Batch 3, Batch 6"\r
-Totals,,950,,,candidate 1: 1900; candidate 2: 1000; candidate 3: 1000,candidate 1: 1900; candidate 2: 1000; candidate 3: 1000,,\r
+Totals,,1950,,,candidate 1: 1900; candidate 2: 1000; candidate 3: 1000,candidate 1: 1900; candidate 2: 1000; candidate 3: 1000,,\r
 """


### PR DESCRIPTION
https://github.com/votingworks/arlo/issues/2291

The Ballots in Batch total was not considering additional batches that may have been added by being included in a combined batch. These additional batches may not have been included in the original batch selection, but once combined with a batch that was selected, they need to be accounted for in the totals.

Follow up:
- As noted in the ticket, should we remove the row entries for the batches that were selected but then combined from the audit report? Wanted to just get this merged, since it's actually an error. Thought it could be worth checking with Jonah/success if the original batch rows were maintained for a reason, though seems like they aren't worth keeping.

**After - Ballots in Batches total matches with Ballots Sampled**

<img width="2549" height="468" alt="Screenshot 2026-05-29 at 1 20 11 PM" src="https://github.com/user-attachments/assets/9849eca2-335d-45a2-91d0-fb472e9be1d8" />

**Before - Ballots in Batches total mismatches with Ballots Sampled**

<img width="1864" height="419" alt="Screenshot 2026-05-29 at 1 19 54 PM" src="https://github.com/user-attachments/assets/ebfc2f0c-355f-4c4f-8cfe-e7650f24085b" />
