### PR TITLE
Combined batches: Fix updating combined batch tallies

### DIFF
--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -315,6 +315,11 @@ def record_batch_results(
             Batch.jurisdiction_id == jurisdiction.id,
             Batch.id != batch.id,
         )
+        BatchResultTallySheet.query.filter(
+            BatchResultTallySheet.batch_id.in_(
+                non_representative_sub_batches.with_entities(Batch.id)
+            )
+        ).delete(synchronize_session="fetch")
         for sub_batch in non_representative_sub_batches:
             sub_batch.result_tally_sheets = [
                 BatchResultTallySheet(

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -315,6 +315,7 @@ def record_batch_results(
             Batch.jurisdiction_id == jurisdiction.id,
             Batch.id != batch.id,
         )
+        # Delete existing sub batch tallies if any
         BatchResultTallySheet.query.filter(
             BatchResultTallySheet.batch_id.in_(
                 non_representative_sub_batches.with_entities(Batch.id)

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -1020,7 +1020,15 @@ def test_batch_comparison_combined_batches(
         ]
     }
 
-    # Audit the combined batch
+    # Make two requests: a first put request without discrepancies, and a second
+    # with them added, so we can test that the combined batch tallies can be updated
+    rv = put_json(
+        client,
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/round/{round_1_id}/batches/{combined_batch['id']}/results",
+        [{"name": "Tally Sheet #1", "results": reported_tallies}],
+    )
+    assert_ok(rv)
+
     candidate_2_discrepancy = 5
     candidate_3_discrepancy = -5
     rv = put_json(


### PR DESCRIPTION

<img width="316" height="436" alt="image (1)" src="https://github.com/user-attachments/assets/528e7270-5ac4-450d-9519-bfd46181a963" />

We saw an error when updating combined batch tallies, because the zero tally sheets we create for the non-representative batches were not deleted before we attempted to recreate them. This PR fixes this by deleting them first.