### PR TITLE
Batch comparison: Count all extra batches when counting sampled batches

### DIFF
--- a/server/api/jurisdictions.py
+++ b/server/api/jurisdictions.py
@@ -6,7 +6,7 @@ import uuid
 import datetime
 import math
 from flask import jsonify, request
-from sqlalchemy import func
+from sqlalchemy import distinct, func, tuple_
 from sqlalchemy.orm import joinedload
 from werkzeug.exceptions import Conflict, BadRequest
 
@@ -454,7 +454,16 @@ def batch_round_status(election: Election, round: Round) -> dict[str, JSONDict]:
         .join(Batch)
         .group_by(Batch.jurisdiction_id)
         .values(
-            Batch.jurisdiction_id, func.count(SampledBatchDraw.ticket_number.distinct())
+            Batch.jurisdiction_id,
+            func.count(
+                distinct(
+                    tuple_(
+                        SampledBatchDraw.batch_id,
+                        SampledBatchDraw.contest_id,
+                        SampledBatchDraw.ticket_number,
+                    )
+                )
+            ),
         )
     )
     audited_sample_count_by_jurisdiction = dict(
@@ -464,7 +473,16 @@ def batch_round_status(election: Election, round: Round) -> dict[str, JSONDict]:
         .group_by(Batch.jurisdiction_id)
         .having(func.count(BatchResultTallySheet.id) > 0)
         .values(
-            Batch.jurisdiction_id, func.count(SampledBatchDraw.ticket_number.distinct())
+            Batch.jurisdiction_id,
+            func.count(
+                distinct(
+                    tuple_(
+                        SampledBatchDraw.batch_id,
+                        SampledBatchDraw.contest_id,
+                        SampledBatchDraw.ticket_number,
+                    )
+                )
+            ),
         )
     )
 

--- a/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/test_sample_extra_batches_by_counting_group.py
@@ -419,6 +419,16 @@ def test_sample_extra_batches_min_percentage_of_jurisdiction_ballots_selected(
     )  # Must be selected to hit the 2% selection threshold.
     # Also satisfies the BMD group expectation so we test that explicitly in another test.
 
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/jurisdiction")
+    assert rv.status_code == 200
+    jurisdictions = json.loads(rv.data)["jurisdictions"]
+    j1_status = next(j for j in jurisdictions if j["id"] == jurisdiction_ids[0])[
+        "currentRoundStatus"
+    ]
+    assert j1_status["numSamples"] == len(j1_batch_names)
+    assert j1_status["numUnique"] == len(j1_batch_names)
+
 
 @pytest.mark.parametrize(
     "org_id",


### PR DESCRIPTION
Ginny noticed recently that the unique sampled batch count was higher than when the toggle was off for some jurisdictions. A good example was Appling, which has only two Extra batches selected. Count was 2 when unique, and 1 when total. The non-unique/total case was off because the query was counting distinct ticket numbers, but the extra batches share a ticket number of "EXTRA".

Toggle on -
<img width="1084" height="1074" alt="Screenshot 2026-06-01 at 4 41 31 PM" src="https://github.com/user-attachments/assets/2f5e45c3-da63-42a8-a7f4-e4d5366eb922" />

Before patch - 
<img width="1225" height="1081" alt="Screenshot 2026-06-01 at 4 41 25 PM" src="https://github.com/user-attachments/assets/76d20c64-b287-441d-81ed-063e7b45a8f1" />

After patch - 
<img width="1141" height="1075" alt="Screenshot 2026-06-01 at 4 41 11 PM" src="https://github.com/user-attachments/assets/820e0c0f-3ee5-4bdc-85f5-5c6e874603bd" />
