### PR TITLE
Batch comparison: Improve combined batch rows handling in reports

### DIFF
--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -965,6 +965,9 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
     )
 
     for batch in batches:
+        if batch.id in combined_sub_batch_ids:
+            continue
+
         row = [
             batch.jurisdiction.name,
             batch.name,
@@ -980,21 +983,15 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
         is_audited = batch.id in audit_results_by_batch
         row += [pretty_boolean(is_audited)]
 
-        is_combined = batch.id in combined_sub_batch_ids
-
         for contest in contests:
             reported_results = batch.jurisdiction.batch_tallies[batch.name].get(
                 contest.id
             )
             if reported_results is not None:
-                # For combined batches, we need to add the combined batch
-                # reported results to the total, since it may include some
-                # unsampled batches. We add these below, so we skip them here.
-                if not is_combined:
-                    for choice in contest.choices:
-                        total_reported_results[contest.id][choice.id] += (
-                            reported_results[choice.id]
-                        )
+                for choice in contest.choices:
+                    total_reported_results[contest.id][choice.id] += reported_results[
+                        choice.id
+                    ]
 
             reported_results_by_name = reported_results and {
                 choice.name: reported_results[choice.id] for choice in contest.choices
@@ -1024,7 +1021,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
                     sampler_contest.from_db_contest(contest),
                     0,
                 )
-                if is_audited and audit_results and not is_combined
+                if is_audited and audit_results
                 else None
             )
 
@@ -1036,14 +1033,14 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
                 ),
                 (
                     pretty_choice_votes(audit_results_by_name)
-                    if audit_results_by_name and not is_combined
+                    if audit_results_by_name
                     else ""
                 ),
                 (
                     pretty_vote_deltas(
                         contest, batch_vote_deltas(reported_results, audit_results)
                     )
-                    if reported_results and audit_results and not is_combined
+                    if reported_results and audit_results
                     else ""
                 ),
                 error["counted_as"] if error else "",
@@ -1051,7 +1048,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
 
         row += [construct_batch_last_edited_by_string(batch)]
         if has_combined_batches:
-            row.append(batch.combined_batch_name or "")
+            row.append("")
 
         rows.append(row)
 
@@ -1059,14 +1056,24 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
         for combined_batch in combined_batches:
             representative_batch = combined_batch["representative_batch"]
             sub_batches = combined_batch["sub_batches"]
-            is_audited = representative_batch.id in audit_results_by_batch
+            combines_description = f"Combines {', '.join(sub_batch.name for sub_batch in sorted(sub_batches, key=lambda batch: batch.name))}"
             combined_batch_row = [
                 representative_batch.jurisdiction.name,
                 representative_batch.combined_batch_name,
                 sum(batch.num_ballots for batch in sub_batches),
                 "",  # Ticket number cols - not relevant to combined batches
-                pretty_boolean(is_audited),
             ]
+            if not show_discrepancies_by_jurisdiction[
+                representative_batch.jurisdiction.id
+            ]:
+                combined_batch_row += [pretty_boolean(False)]
+                combined_batch_row += [""] * (len(result_columns) + 1)
+                combined_batch_row += [combines_description]
+                rows.append(combined_batch_row)
+                continue
+
+            is_audited = representative_batch.id in audit_results_by_batch
+            combined_batch_row += [pretty_boolean(is_audited)]
             for contest in contests:
                 sub_batch_reported_results = list(
                     sub_batch.jurisdiction.batch_tallies[sub_batch.name].get(contest.id)  # type: ignore
@@ -1100,6 +1107,11 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
                     if is_audited
                     else None
                 )
+                if audit_results is not None:
+                    for choice in contest.choices:
+                        total_audit_results[contest.id][choice.id] += audit_results[
+                            choice.id
+                        ]
                 audit_results_by_name = audit_results and {
                     choice.name: audit_results[choice.id] for choice in contest.choices
                 }
@@ -1135,7 +1147,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
 
             combined_batch_row += [
                 construct_batch_last_edited_by_string(representative_batch),
-                f"Combines {', '.join(sub_batch.name for sub_batch in sorted(sub_batches, key=lambda batch: batch.name))}",
+                combines_description,
             ]
             rows.append(combined_batch_row)
     total_ballots = sum(

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -125,6 +125,22 @@ def pretty_batch_ticket_numbers(
     ]
 
 
+def pretty_combined_batch_ticket_numbers(
+    sub_batches: list[Batch], round_id_to_num: dict[str, int], contests: list[Contest]
+) -> list[str]:
+    ticket_numbers_for_contests = []
+    for contest in contests:
+        sub_batch_ticket_numbers = []
+        for sub_batch in sorted(sub_batches, key=lambda batch: batch.name):
+            ticket_numbers = pretty_batch_ticket_numbers_for_contest(
+                sub_batch, round_id_to_num, contest.id
+            )
+            if ticket_numbers:
+                sub_batch_ticket_numbers.append(f"{ticket_numbers} ({sub_batch.name})")
+        ticket_numbers_for_contests.append("; ".join(sub_batch_ticket_numbers))
+    return ticket_numbers_for_contests
+
+
 # (contest_id, interpretation, selected_choice_names, comment, is_overvote, has_invalid_write_in)
 InterpretationTuple = tuple[str, str, list[str], str, bool, bool]
 
@@ -1061,7 +1077,9 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
                 representative_batch.jurisdiction.name,
                 representative_batch.combined_batch_name,
                 sum(batch.num_ballots for batch in sub_batches),
-                "",  # Ticket number cols - not relevant to combined batches
+                *pretty_combined_batch_ticket_numbers(
+                    sub_batches, round_id_to_num, contests
+                ),
             ]
             if not show_discrepancies_by_jurisdiction[
                 representative_batch.jurisdiction.id

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -71,13 +71,11 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 \r
 ######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?,Reported Results: Contest 1,Audit Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By,Combined Batch\r
-J1,Batch 1,500,Round 1: 0.720194360819624066,Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,,support@example.org,Combined Batch\r
-J1,Batch 2,500,Round 1: 0.474971525750860236,Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,,support@example.org,Combined Batch\r
 J1,Batch 4,500,Round 1: 0.9553762217707628661,Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,\r
 J1,Batch 6,100,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,\r
 J1,Batch 8,100,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,\r
 J2,Batch 3,500,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,\r
-J1,Combined Batch,1500,,Yes,candidate 1: 1500; candidate 2: 750; candidate 3: 750,candidate 1: 1500; candidate 2: 745; candidate 3: 755,candidate 2: +5; candidate 3: -5,5,support@example.org,"Combines Batch 1, Batch 2, Batch 3"\r
+J1,Combined Batch,1500,Round 1: 0.720194360819624066 (Batch 1); Round 1: 0.474971525750860236 (Batch 2),Yes,candidate 1: 1500; candidate 2: 750; candidate 3: 750,candidate 1: 1500; candidate 2: 745; candidate 3: 755,candidate 2: +5; candidate 3: -5,5,support@example.org,"Combines Batch 1, Batch 2, Batch 3"\r
 Totals,,2700,,,candidate 1: 2700; candidate 2: 1350; candidate 3: 1350,candidate 1: 2700; candidate 2: 1345; candidate 3: 1355,,\r
 """
 

--- a/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_sample_extra_batches_by_counting_group.py
@@ -58,11 +58,8 @@ Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Ti
 \r
 ######## SAMPLED BATCHES ########\r
 Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?,Reported Results: Contest 1,Audit Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By,Combined Batch\r
-J1,Batch 7,100,Round 1: EXTRA,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,,support@example.org,"Combined Batch - Extra, Unsampled"\r
 J1,Batch 9,100,Round 1: EXTRA,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,\r
-J2,Batch 3,500,Round 1: 0.368061935896261076,Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,,support@example.org,"Combined Batch - Sampled, Extra, Unsampled"\r
-J2,Batch 6,250,Round 1: EXTRA,Yes,candidate 1: 200; candidate 2: 150; candidate 3: 150,,,,support@example.org,"Combined Batch - Sampled, Extra, Unsampled"\r
-J1,"Combined Batch - Extra, Unsampled",600,,Yes,candidate 1: 600; candidate 2: 300; candidate 3: 300,candidate 1: 600; candidate 2: 300; candidate 3: 300,,,support@example.org,"Combines Batch 1, Batch 7"\r
-J2,"Combined Batch - Sampled, Extra, Unsampled",1250,,Yes,candidate 1: 1200; candidate 2: 650; candidate 3: 650,candidate 1: 1200; candidate 2: 650; candidate 3: 650,,,support@example.org,"Combines Batch 1, Batch 3, Batch 6"\r
+J1,"Combined Batch - Extra, Unsampled",600,Round 1: EXTRA (Batch 7),Yes,candidate 1: 600; candidate 2: 300; candidate 3: 300,candidate 1: 600; candidate 2: 300; candidate 3: 300,,,support@example.org,"Combines Batch 1, Batch 7"\r
+J2,"Combined Batch - Sampled, Extra, Unsampled",1250,Round 1: 0.368061935896261076 (Batch 3); Round 1: EXTRA (Batch 6),Yes,candidate 1: 1200; candidate 2: 650; candidate 3: 650,candidate 1: 1200; candidate 2: 650; candidate 3: 650,,,support@example.org,"Combines Batch 1, Batch 3, Batch 6"\r
 Totals,,1950,,,candidate 1: 1900; candidate 2: 1000; candidate 3: 1000,candidate 1: 1900; candidate 2: 1000; candidate 3: 1000,,\r
 """

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -1070,6 +1070,24 @@ def test_batch_comparison_combined_batches(
         )
         assert_ok(rv)
 
+    # Before any jurisdiction finalizes its results, discrepancies are hidden,
+    # so the audit report shows combined batches with no reported or audited
+    # votes.
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert rv.status_code == 200
+    combined_batch_line = next(
+        line
+        for line in rv.data.decode("utf-8").splitlines()
+        if line.startswith("J1,Combined Batch,")
+    )
+    assert ",No," in combined_batch_line
+    assert "candidate" not in combined_batch_line
+    assert combined_batch_line.endswith('"Combines Batch 1, Batch 2, Batch 3"')
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
     # Finalize the results
     rv = post_json(
         client,


### PR DESCRIPTION
Closes https://github.com/votingworks/arlo/issues/2291
Closes https://github.com/votingworks/arlo/issues/2332
Closes https://github.com/votingworks/arlo/issues/2333

1. Removes sub-batch rows from Sampled Batches section
2. Adds sub-batch ticket numbers to combined batch rows
3. Because of 2, fixes column mis-ordering for multi-contest audits
4. No longer shows reported votes for combined batches when `show_discrepancies_by_jurisdiction` is false

**Updated - column shift fixed, ticket numbers added**
<img width="1062" height="238" alt="Screenshot 2026-06-02 at 2 53 38 PM" src="https://github.com/user-attachments/assets/47212c9d-0e2c-4896-ba4c-af95e953d04c" />

**Before**
<img width="962" height="251" alt="Screenshot 2026-06-02 at 3 38 41 PM" src="https://github.com/user-attachments/assets/b5c9bd45-3526-4564-888a-246b4b962de9" />

