### PR TITLE
Batch comparison: Sort combined batches within sampled batches in reports

### DIFF
--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -1,4 +1,5 @@
 import io
+import re
 import csv
 from typing import cast as typing_cast
 from collections import defaultdict, Counter
@@ -201,6 +202,15 @@ def pretty_cvr_interpretation(
         for choice_id, interpretation in cvrs_by_choice.items()
         if interpretation == "1"
     )
+
+
+def natural_sort_key(name: str) -> list:
+    # Mirror the human_sort Postgres function used to order batches in queries,
+    # so e.g. "Batch 2" sorts before "Batch 10".
+    return [
+        int(chunk) if chunk.isdigit() else chunk.lower()
+        for chunk in re.split(r"(\d+)", name)
+    ]
 
 
 def add_sign(value: int) -> str:
@@ -890,7 +900,7 @@ def sampled_ballot_rows(election: Election, jurisdiction: Jurisdiction | None = 
 
 
 def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = None):
-    rows = [heading("SAMPLED BATCHES")]
+    header_rows = [heading("SAMPLED BATCHES")]
 
     batches_query = (
         Batch.query.join(SampledBatchDraw)
@@ -967,7 +977,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
     ]
     if has_combined_batches:
         column_headers.append("Combined Batch")
-    rows.append(column_headers)
+    header_rows.append(column_headers)
 
     total_reported_results: dict = {
         contest.id: {choice.id: 0 for choice in contest.choices} for contest in contests
@@ -980,10 +990,15 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
         show_batch_comparison_discrepancies_by_jurisdiction(election)
     )
 
+    # Each entry is (min_round_num, row). We sort by min_round_num below so the
+    # rows (including combined batches) follow the same ordering as the batches
+    # query: round number, then jurisdiction name, then batch name.
+    sampled_batch_rows = []
     for batch in batches:
         if batch.id in combined_sub_batch_ids:
             continue
 
+        min_round_num = min(round_id_to_num[draw.round_id] for draw in batch.draws)
         row = [
             batch.jurisdiction.name,
             batch.name,
@@ -993,7 +1008,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
         if not show_discrepancies_by_jurisdiction[batch.jurisdiction.id]:
             row += [pretty_boolean(False)]
             row += [""] * (len(result_columns) + 1)
-            rows.append(row)
+            sampled_batch_rows.append((min_round_num, row))
             continue
 
         is_audited = batch.id in audit_results_by_batch
@@ -1066,12 +1081,17 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
         if has_combined_batches:
             row.append("")
 
-        rows.append(row)
+        sampled_batch_rows.append((min_round_num, row))
 
     if has_combined_batches:
         for combined_batch in combined_batches:
             representative_batch = combined_batch["representative_batch"]
             sub_batches = combined_batch["sub_batches"]
+            min_round_num = min(
+                round_id_to_num[draw.round_id]
+                for sub_batch in sub_batches
+                for draw in sub_batch.draws
+            )
             combines_description = f"Combines {', '.join(sub_batch.name for sub_batch in sorted(sub_batches, key=lambda batch: batch.name))}"
             combined_batch_row = [
                 representative_batch.jurisdiction.name,
@@ -1087,7 +1107,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
                 combined_batch_row += [pretty_boolean(False)]
                 combined_batch_row += [""] * (len(result_columns) + 1)
                 combined_batch_row += [combines_description]
-                rows.append(combined_batch_row)
+                sampled_batch_rows.append((min_round_num, combined_batch_row))
                 continue
 
             is_audited = representative_batch.id in audit_results_by_batch
@@ -1167,7 +1187,17 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
                 construct_batch_last_edited_by_string(representative_batch),
                 combines_description,
             ]
-            rows.append(combined_batch_row)
+            sampled_batch_rows.append((min_round_num, combined_batch_row))
+
+    sampled_batch_rows.sort(
+        key=lambda min_round_num_and_row: (
+            min_round_num_and_row[0],  # Round number
+            min_round_num_and_row[1][0],  # Jurisdiction Name
+            natural_sort_key(min_round_num_and_row[1][1]),  # Batch Name
+        )
+    )
+    sorted_rows = [row for _, row in sampled_batch_rows]
+
     total_ballots = sum(
         batch.num_ballots for batch in batches if batch.id not in combined_sub_batch_ids
     )
@@ -1196,8 +1226,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
             "",  # change in margin not calculated for totals
         ]
     totals_row += ""  # last edited col
-    rows.append(totals_row)
-    return rows
+    return header_rows + sorted_rows + [totals_row]
 
 
 @api.route("/election/<election_id>/report", methods=["GET"])

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -1,5 +1,4 @@
 import io
-import re
 import csv
 from typing import cast as typing_cast
 from collections import defaultdict, Counter
@@ -23,6 +22,7 @@ from .ballot_manifest import hybrid_contest_total_ballots
 from .cvrs import hybrid_contest_choice_vote_counts
 from .batches import construct_batch_last_edited_by_string
 from .shared import (
+    CombinedBatch,
     ContestVoteDeltas,
     ballot_vote_deltas,
     batch_tallies,
@@ -202,15 +202,6 @@ def pretty_cvr_interpretation(
         for choice_id, interpretation in cvrs_by_choice.items()
         if interpretation == "1"
     )
-
-
-def natural_sort_key(name: str) -> list:
-    # Mirror the human_sort Postgres function used to order batches in queries,
-    # so e.g. "Batch 2" sorts before "Batch 10".
-    return [
-        int(chunk) if chunk.isdigit() else chunk.lower()
-        for chunk in re.split(r"(\d+)", name)
-    ]
 
 
 def add_sign(value: int) -> str:
@@ -914,7 +905,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
     batches = batches_query.order_by(
         Round.round_num,
         Jurisdiction.name,
-        func.human_sort(Batch.name),
+        func.human_sort(func.coalesce(Batch.combined_batch_name, Batch.name)),
         SampledBatchDraw.ticket_number,
     ).all()
 
@@ -990,15 +981,121 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
         show_batch_comparison_discrepancies_by_jurisdiction(election)
     )
 
-    # Each entry is (min_round_num, row). We sort by min_round_num below so the
-    # rows (including combined batches) follow the same ordering as the batches
-    # query: round number, then jurisdiction name, then batch name.
-    sampled_batch_rows = []
+    sampled_batch_rows: list[list[str | int]] = []
+
+    def add_combined_batch_row(combined_batch: CombinedBatch):
+        sub_batches = combined_batch["sub_batches"]
+        combines_description = f"Combines {', '.join(sub_batch.name for sub_batch in sorted(sub_batches, key=lambda batch: batch.name))}"
+        representative_batch = combined_batch["representative_batch"]
+        combined_batch_row = [
+            representative_batch.jurisdiction.name,
+            representative_batch.combined_batch_name,
+            sum(batch.num_ballots for batch in sub_batches),
+            *pretty_combined_batch_ticket_numbers(
+                sub_batches, round_id_to_num, contests
+            ),
+        ]
+        if not show_discrepancies_by_jurisdiction[representative_batch.jurisdiction.id]:
+            combined_batch_row += [pretty_boolean(False)]
+            combined_batch_row += [""] * (len(result_columns) + 1)
+            combined_batch_row += [combines_description]
+            sampled_batch_rows.append(combined_batch_row)
+            return
+
+        is_audited = representative_batch.id in audit_results_by_batch
+        combined_batch_row += [pretty_boolean(is_audited)]
+        for contest in contests:
+            sub_batch_reported_results = list(
+                sub_batch.jurisdiction.batch_tallies[sub_batch.name].get(contest.id)  # type: ignore
+                for sub_batch in sub_batches
+            )
+            reported_results = {
+                choice.id: sum(
+                    reported_results[choice.id]
+                    for reported_results in sub_batch_reported_results
+                    if reported_results is not None
+                )
+                for choice in contest.choices
+            }
+            for choice in contest.choices:
+                total_reported_results[contest.id][choice.id] += reported_results[
+                    choice.id
+                ]
+
+            reported_results_by_name = {
+                choice.name: reported_results[choice.id] for choice in contest.choices
+            }
+
+            audit_results = (
+                {
+                    choice.id: audit_results_by_batch[representative_batch.id].get(
+                        choice.id, 0
+                    )
+                    for choice in contest.choices
+                }
+                if is_audited
+                else None
+            )
+            if audit_results is not None:
+                for choice in contest.choices:
+                    total_audit_results[contest.id][choice.id] += audit_results[
+                        choice.id
+                    ]
+            audit_results_by_name = audit_results and {
+                choice.name: audit_results[choice.id] for choice in contest.choices
+            }
+
+            error = (
+                macro.compute_error(
+                    {contest.id: reported_results},
+                    {contest.id: audit_results},
+                    sampler_contest.from_db_contest(contest),
+                    0,
+                )
+                if audit_results
+                else None
+            )
+
+            combined_batch_row += [
+                pretty_choice_votes(reported_results_by_name),
+                (
+                    pretty_choice_votes(audit_results_by_name)
+                    if audit_results_by_name
+                    else ""
+                ),
+                (
+                    pretty_vote_deltas(
+                        contest,
+                        batch_vote_deltas(reported_results, audit_results),
+                    )
+                    if audit_results
+                    else ""
+                ),
+                error["counted_as"] if error else "",
+            ]
+
+        combined_batch_row += [
+            construct_batch_last_edited_by_string(representative_batch),
+            combines_description,
+        ]
+        sampled_batch_rows.append(combined_batch_row)
+
+    seen_combined_batch_names: set[str] = set()
     for batch in batches:
-        if batch.id in combined_sub_batch_ids:
+        if batch.combined_batch_name:
+            if batch.combined_batch_name in seen_combined_batch_names:
+                continue
+            seen_combined_batch_names.add(batch.combined_batch_name)
+            combined_batch = next(
+                (
+                    cb
+                    for cb in combined_batches
+                    if cb["name"] == batch.combined_batch_name
+                )
+            )
+            add_combined_batch_row(combined_batch)
             continue
 
-        min_round_num = min(round_id_to_num[draw.round_id] for draw in batch.draws)
         row = [
             batch.jurisdiction.name,
             batch.name,
@@ -1008,7 +1105,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
         if not show_discrepancies_by_jurisdiction[batch.jurisdiction.id]:
             row += [pretty_boolean(False)]
             row += [""] * (len(result_columns) + 1)
-            sampled_batch_rows.append((min_round_num, row))
+            sampled_batch_rows.append(row)
             continue
 
         is_audited = batch.id in audit_results_by_batch
@@ -1081,122 +1178,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
         if has_combined_batches:
             row.append("")
 
-        sampled_batch_rows.append((min_round_num, row))
-
-    if has_combined_batches:
-        for combined_batch in combined_batches:
-            representative_batch = combined_batch["representative_batch"]
-            sub_batches = combined_batch["sub_batches"]
-            min_round_num = min(
-                round_id_to_num[draw.round_id]
-                for sub_batch in sub_batches
-                for draw in sub_batch.draws
-            )
-            combines_description = f"Combines {', '.join(sub_batch.name for sub_batch in sorted(sub_batches, key=lambda batch: batch.name))}"
-            combined_batch_row = [
-                representative_batch.jurisdiction.name,
-                representative_batch.combined_batch_name,
-                sum(batch.num_ballots for batch in sub_batches),
-                *pretty_combined_batch_ticket_numbers(
-                    sub_batches, round_id_to_num, contests
-                ),
-            ]
-            if not show_discrepancies_by_jurisdiction[
-                representative_batch.jurisdiction.id
-            ]:
-                combined_batch_row += [pretty_boolean(False)]
-                combined_batch_row += [""] * (len(result_columns) + 1)
-                combined_batch_row += [combines_description]
-                sampled_batch_rows.append((min_round_num, combined_batch_row))
-                continue
-
-            is_audited = representative_batch.id in audit_results_by_batch
-            combined_batch_row += [pretty_boolean(is_audited)]
-            for contest in contests:
-                sub_batch_reported_results = list(
-                    sub_batch.jurisdiction.batch_tallies[sub_batch.name].get(contest.id)  # type: ignore
-                    for sub_batch in sub_batches
-                )
-                reported_results = {
-                    choice.id: sum(
-                        reported_results[choice.id]
-                        for reported_results in sub_batch_reported_results
-                        if reported_results is not None
-                    )
-                    for choice in contest.choices
-                }
-                for choice in contest.choices:
-                    total_reported_results[contest.id][choice.id] += reported_results[
-                        choice.id
-                    ]
-
-                reported_results_by_name = {
-                    choice.name: reported_results[choice.id]
-                    for choice in contest.choices
-                }
-
-                audit_results = (
-                    {
-                        choice.id: audit_results_by_batch[representative_batch.id].get(
-                            choice.id, 0
-                        )
-                        for choice in contest.choices
-                    }
-                    if is_audited
-                    else None
-                )
-                if audit_results is not None:
-                    for choice in contest.choices:
-                        total_audit_results[contest.id][choice.id] += audit_results[
-                            choice.id
-                        ]
-                audit_results_by_name = audit_results and {
-                    choice.name: audit_results[choice.id] for choice in contest.choices
-                }
-
-                error = (
-                    macro.compute_error(
-                        {contest.id: reported_results},
-                        {contest.id: audit_results},
-                        sampler_contest.from_db_contest(contest),
-                        0,
-                    )
-                    if audit_results
-                    else None
-                )
-
-                combined_batch_row += [
-                    pretty_choice_votes(reported_results_by_name),
-                    (
-                        pretty_choice_votes(audit_results_by_name)
-                        if audit_results_by_name
-                        else ""
-                    ),
-                    (
-                        pretty_vote_deltas(
-                            contest,
-                            batch_vote_deltas(reported_results, audit_results),
-                        )
-                        if audit_results
-                        else ""
-                    ),
-                    error["counted_as"] if error else "",
-                ]
-
-            combined_batch_row += [
-                construct_batch_last_edited_by_string(representative_batch),
-                combines_description,
-            ]
-            sampled_batch_rows.append((min_round_num, combined_batch_row))
-
-    sampled_batch_rows.sort(
-        key=lambda min_round_num_and_row: (
-            min_round_num_and_row[0],  # Round number
-            min_round_num_and_row[1][0],  # Jurisdiction Name
-            natural_sort_key(min_round_num_and_row[1][1]),  # Batch Name
-        )
-    )
-    sorted_rows = [row for _, row in sampled_batch_rows]
+        sampled_batch_rows.append(row)
 
     total_ballots = sum(
         batch.num_ballots for batch in batches if batch.id not in combined_sub_batch_ids
@@ -1226,7 +1208,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
             "",  # change in margin not calculated for totals
         ]
     totals_row += ""  # last edited col
-    return header_rows + sorted_rows + [totals_row]
+    return header_rows + sampled_batch_rows + [totals_row]
 
 
 @api.route("/election/<election_id>/report", methods=["GET"])

--- a/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_batch_comparison.py
@@ -74,8 +74,8 @@ Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?
 J1,Batch 4,500,Round 1: 0.9553762217707628661,Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,\r
 J1,Batch 6,100,Round 1: 0.899217854763070950,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,\r
 J1,Batch 8,100,Round 1: 0.9723790677174592551,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,\r
-J2,Batch 3,500,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,\r
 J1,Combined Batch,1500,Round 1: 0.720194360819624066 (Batch 1); Round 1: 0.474971525750860236 (Batch 2),Yes,candidate 1: 1500; candidate 2: 750; candidate 3: 750,candidate 1: 1500; candidate 2: 745; candidate 3: 755,candidate 2: +5; candidate 3: -5,5,support@example.org,"Combines Batch 1, Batch 2, Batch 3"\r
+J2,Batch 3,500,"Round 1: 0.368061935896261076, 0.733615858338543383",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,\r
 Totals,,2700,,,candidate 1: 2700; candidate 2: 1350; candidate 3: 1350,candidate 1: 2700; candidate 2: 1345; candidate 3: 1355,,\r
 """
 
@@ -258,6 +258,12 @@ snapshots["test_batch_comparison_round_2 9"] = {
     "numUniqueAudited": 1,
     "status": "COMPLETE",
 }
+
+snapshots["test_batch_comparison_sample_preview 1"] = [
+    {"name": "J1", "numSamples": 5, "numUnique": 5},
+    {"name": "J2", "numSamples": 2, "numUnique": 1},
+    {"name": "J3", "numSamples": 0, "numUnique": 0},
+]
 
 snapshots["test_batch_comparison_sample_size 1"] = [
     {"key": "macro", "prob": None, "size": 7}


### PR DESCRIPTION
Closes https://github.com/votingworks/arlo/issues/2335

[Ginny](https://votingworks.slack.com/archives/C0B5C56T15G/p1780440748390289?thread_ts=1780438602.166029&cid=C0B5C56T15G) had to manually move combined batch rows in the audit report to sort them within sampled batch rows. This PR aims to automate that.

Screenshot showing combined batch interspersed with sampled batch rows:
<img width="977" height="797" alt="Screenshot 2026-06-03 at 4 54 23 PM" src="https://github.com/user-attachments/assets/4b89a5da-8189-4225-96e0-df68b2bc131f" />
