### PR TITLE
Fix combined batch selector

### DIFF
--- a/client/src/components/SupportTools/Jurisdiction.tsx
+++ b/client/src/components/SupportTools/Jurisdiction.tsx
@@ -12,7 +12,7 @@ import {
   MenuItem,
   Menu,
 } from '@blueprintjs/core'
-import { MultiSelect } from '@blueprintjs/select'
+import { MultiSelect, renderFilteredItems } from '@blueprintjs/select'
 import { useForm, Controller } from 'react-hook-form'
 import {
   useJurisdiction,
@@ -217,20 +217,22 @@ const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
                               value.filter((id: string) => id !== item.id)
                             )
                           }}
-                          itemListRenderer={({
-                            filteredItems,
-                            itemsParentRef,
-                            renderItem,
-                          }) => (
+                          itemListRenderer={itemListProps => (
                             <Menu
                               ulRef={
-                                itemsParentRef as (
+                                itemListProps.itemsParentRef as (
                                   ref: HTMLUListElement | null
                                 ) => void
                               }
                               style={{ maxHeight: 350, overflowY: 'auto' }}
                             >
-                              {filteredItems.map(renderItem)}
+                              {renderFilteredItems(
+                                itemListProps,
+                                <MenuItem
+                                  disabled
+                                  text="No matching batches."
+                                />
+                              )}
                             </Menu>
                           )}
                           itemRenderer={(item, { handleClick, modifiers }) => (

--- a/client/src/components/SupportTools/Jurisdiction.tsx
+++ b/client/src/components/SupportTools/Jurisdiction.tsx
@@ -10,6 +10,7 @@ import {
   Intent,
   Card,
   MenuItem,
+  Menu,
 } from '@blueprintjs/core'
 import { MultiSelect } from '@blueprintjs/select'
 import { useForm, Controller } from 'react-hook-form'
@@ -216,6 +217,22 @@ const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
                               value.filter((id: string) => id !== item.id)
                             )
                           }}
+                          itemListRenderer={({
+                            filteredItems,
+                            itemsParentRef,
+                            renderItem,
+                          }) => (
+                            <Menu
+                              ulRef={
+                                itemsParentRef as (
+                                  ref: HTMLUListElement | null
+                                ) => void
+                              }
+                              style={{ maxHeight: 350, overflowY: 'auto' }}
+                            >
+                              {filteredItems.map(renderItem)}
+                            </Menu>
+                          )}
                           itemRenderer={(item, { handleClick, modifiers }) => (
                             <MenuItem
                               key={item.id}
@@ -231,7 +248,7 @@ const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
                               .toLowerCase()
                               .includes(query.toLowerCase())
                           }
-                          placeholder="Select batches..."
+                          placeholder="Search by batch name..."
                           resetOnSelect
                           fill
                           popoverProps={{ minimal: true }}

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -1257,7 +1257,7 @@ describe('Support Tools', () => {
         screen.getByLabelText('Combined Batch Name:'),
         'Combined Batch 1'
       )
-      userEvent.click(screen.getByPlaceholderText('Select batches...'))
+      userEvent.click(screen.getByPlaceholderText('Search by batch name...'))
 
       // Find the dropdown menu - use the popover content container
       const popover = (await screen.findByText('Batch 3')).closest(


### PR DESCRIPTION
When there was a really long list, the select would take the full browser height, covering up the input area.

Future improvement under consideration:
- allow for selecting multiple batches based on input (don't clear input after selection)

Before:
<img width="890" height="823" alt="Screenshot 2026-06-08 at 9 50 51 PM" src="https://github.com/user-attachments/assets/0fa0877c-9108-40d3-a667-2d14c68fd450" />

After:

https://github.com/user-attachments/assets/3dd28874-1f99-4172-b38c-ddcb118f7dc1

