### PR TITLE
Audit setup: Await putContests response

### DIFF
--- a/client/cypress/end-to-end/ballot-comparison.cy.js
+++ b/client/cypress/end-to-end/ballot-comparison.cy.js
@@ -94,8 +94,6 @@ describe('Ballot Comparison Test Cases', () => {
     cy.findByText('Save & Next').click()
     cy.findAndCloseToast('Must have at least one targeted contest')
 
-    cy.findByText('Back').click()
-
     // select targeted contest
     cy.get('input[type="checkbox"]')
       .first()

--- a/client/src/components/useContestsBallotComparison.ts
+++ b/client/src/components/useContestsBallotComparison.ts
@@ -26,11 +26,11 @@ const putContests = async (
   electionId: string,
   newContests: INewContest[]
 ): Promise<boolean> =>
-  !!api(`/election/${electionId}/contest`, {
+  !!(await api(`/election/${electionId}/contest`, {
     method: 'PUT',
     body: JSON.stringify(newContests),
     headers: { 'Content-Type': 'application/json' },
-  })
+  }))
 
 const useContestsBallotComparison = (
   electionId: string


### PR DESCRIPTION
I couldn't reproduce the issue from this [ticket](https://github.com/votingworks/arlo/issues/2194), but I did notice a bug that might be the same cause. When updating target contests, and then navigating to opportunistic contests, the data showing on the opportunistic contests is always stale. 

It looks like there is a race condition from the `PutContests` that happens when setting target contests, so that's why it's hard to recreate on PUT creates. But on PUT updates, a bit more happens on the backend, so maybe that's why I can reliably recreate it.


Old

https://github.com/user-attachments/assets/8ee5618c-03d5-4340-890a-22e2164ec4af

New

https://github.com/user-attachments/assets/fcfa4e7e-58be-42a0-969f-87235eeeec26


