### PR TITLE
docs: Arlo comparison audit transparency report and guide

### DIFF
--- a/docs/cloud-testing-deployment-plan.md
+++ b/docs/cloud-testing-deployment-plan.md
@@ -1,0 +1,225 @@
+# Arlo Cloud Testing Deployment Plan
+
+_Written 2026-06-20 based on exploration of the gwexploratoryaudits/arlo fork._
+
+---
+
+## Summary
+
+| Option | Status | Effort |
+|--------|--------|--------|
+| **Heroku** (new app) | First-class, fully configured | Low |
+| **Heroku Review Apps** | Built-in support via `FLASK_ENV=staging` | Low |
+| **Docker** | Not present in repo | High (write from scratch) |
+| **VPS / "Sprite"** | Undocumented but feasible | Medium |
+| **Cypress E2E** | Implemented, runs locally or against a deployed instance | Low |
+| **Artillery load test** | Documented but not yet scripted | Medium |
+
+**Fastest path:** Deploy to a new Heroku app using `FLASK_ENV=development` + nOAuth (the built-in pass-through auth) so you skip Auth0 setup entirely.
+
+---
+
+## What the Repo Provides
+
+### Processes (Procfile)
+
+```
+release:      ./heroku-release-phase.sh      # alembic upgrade head on every deploy
+web:          gunicorn server.app:app --preload --max-requests 1000 ...
+worker:       python -m server.worker.worker  # background task processor
+slack_worker: python -m server.activity_log.slack_worker
+```
+
+For a minimal test instance, only `web` is needed if you set `RUN_BACKGROUND_TASKS_IMMEDIATELY=true`.
+
+### Stack
+
+- **Python 3.11**, **Poetry**, **Flask 3**, **Gunicorn 23**
+- **React/TypeScript** frontend built with Vite → `client/build/` served as static files
+- **PostgreSQL only** (no SQLite option); Alembic for migrations
+- **nOAuth** — a stub OAuth server bundled in the repo; used by `FLASK_ENV=development` and `FLASK_ENV=test` to bypass real Auth0
+
+---
+
+## Option 1: Heroku (Recommended — Easiest)
+
+### What's already there
+
+- `app.json` — defines buildpacks, addons, formation, auto-generates `ARLO_SESSION_SECRET`
+- `Procfile` — web + worker + slack_worker + release (migrations)
+- `server/config.py` — detects `FLASK_ENV=staging` and derives `HTTP_ORIGIN` from `HEROKU_APP_NAME` (Heroku Review Apps support built-in)
+- Build: `heroku-postbuild` in `package.json` runs `yarn build` to compile the React app
+
+### Fix needed in app.json
+
+The addon `heroku-postgresql:hobby-free` was discontinued. Change it to:
+
+```json
+"heroku-postgresql:mini"
+```
+
+### Steps for a new test app
+
+```bash
+heroku create arlo-test-YOURNAME
+heroku addons:create heroku-postgresql:mini
+
+# Required env vars
+heroku config:set \
+  FLASK_ENV=development \
+  ARLO_SESSION_SECRET=$(openssl rand -hex 32) \
+  ARLO_HTTP_ORIGIN=https://arlo-test-YOURNAME.herokuapp.com \
+  RUN_BACKGROUND_TASKS_IMMEDIATELY=true \
+  ARLO_FILE_UPLOAD_STORAGE_PATH=/tmp/arlo-uploads
+
+# Skip worker dyno for minimal test
+heroku ps:scale worker=0 slack_worker=0
+
+git push heroku main
+```
+
+With `FLASK_ENV=development`, nOAuth is activated — no Auth0 credentials needed. The release phase runs `alembic upgrade head` automatically.
+
+### Heroku Review Apps (per-PR staging)
+
+`server/config.py` already handles this:
+
+```python
+if os.environ.get("FLASK_ENV") == "staging":
+    HTTP_ORIGIN = f"https://{os.environ['HEROKU_APP_NAME']}.herokuapp.com"
+```
+
+Enable in the Heroku Dashboard: connect the GitHub repo, create a pipeline, enable Review Apps. Each PR gets its own ephemeral app with its own DB. Fix the `hobby-free` → `mini` addon in `app.json` first.
+
+---
+
+## Option 2: VPS / "Sprite" (e.g., DigitalOcean Droplet, Hetzner)
+
+No systemd units or nginx config exist in the repo, but the path is straightforward on **Ubuntu 24**.
+
+### Setup
+
+```bash
+# 1. Install system deps (requires Ubuntu 24)
+make dev-environment      # installs Python 3.11, Node 22, Poetry, Yarn, postgres
+
+# 2. Install app deps
+make install              # poetry install + yarn --cwd client install
+
+# 3. Set up databases
+make dev-dbs              # creates postgres user 'arlo', runs resetdb
+
+# 4. Build frontend
+yarn --cwd client build
+
+# 5. Set env vars (in a .env file or systemd EnvironmentFile)
+export FLASK_ENV=development
+export DATABASE_URL=postgresql://arlo:arlo@localhost:5432/arlo
+export ARLO_SESSION_SECRET=$(openssl rand -hex 32)
+export ARLO_HTTP_ORIGIN=https://YOUR_DOMAIN
+export RUN_BACKGROUND_TASKS_IMMEDIATELY=true
+export ARLO_FILE_UPLOAD_STORAGE_PATH=/var/lib/arlo/uploads
+
+# 6. Run migrations
+poetry run alembic upgrade head
+
+# 7. Start app
+poetry run gunicorn server.app:app --bind 0.0.0.0:5000 --preload
+```
+
+### Still needed (not in repo)
+
+- **nginx/Caddy** as reverse proxy (TLS termination, static file serving)
+- **systemd units** for gunicorn, worker (if needed), and nOAuth
+- **Firewall rules** (ufw)
+
+A minimal Caddy config would proxy `localhost:5000` and handle Let's Encrypt automatically. Estimated ~2 hours to hand-roll.
+
+---
+
+## Option 3: Docker (Not Yet Available)
+
+No `Dockerfile` or `docker-compose.yml` exists. Writing one from scratch would require:
+
+- Multi-stage build (Node build stage → Python runtime stage)
+- Postgres service in compose
+- Volume for file uploads
+- Health checks
+
+This is a medium-effort task (~1 day). The Heroku path is strictly easier for cloud testing.
+
+---
+
+## Testing Tooling
+
+### Unit / Integration Tests (server)
+
+```bash
+make test
+# → pytest -n auto --ignore=server/tests/arlo-extra-tests
+```
+
+Uses `pytest-xdist` for parallel execution against a local `arlotest` PostgreSQL DB. Includes `pytest-alembic` for migration correctness.
+
+```bash
+make -C client test
+# → vitest (frontend unit tests)
+```
+
+### End-to-End Tests (Cypress)
+
+```bash
+./client/run-cypress-tests.sh
+```
+
+Starts the full dev stack (`run-dev.sh`: nOAuth + Flask + Vite), waits for port 3000, then runs Cypress. Can also point Cypress at a deployed instance by setting the base URL.
+
+To run E2E against a cloud instance:
+
+```bash
+CYPRESS_BASE_URL=https://arlo-test-YOURNAME.herokuapp.com \
+  yarn --cwd client cypress run
+```
+
+### Load Testing (Artillery — Planned, Not Implemented)
+
+`docs/loadtesting.md` documents an **Artillery** / **Serverless Artillery** (AWS Lambda) approach designed to bypass Auth0 using nOAuth. No scripts are committed yet. Key design points from the doc:
+
+- Use `FLASK_ENV=development` (nOAuth) so load tests don't hit real OAuth
+- `scripts/seed-probely-db.sh` + `probely-data/` show a pattern for seeding a DB with test data before a test run
+- Serverless Artillery runs load generation from Lambda to avoid client-side bottlenecks
+
+Estimated ~1 day to write a basic Artillery script suite against a Heroku test instance.
+
+### Security / DAST (Probely)
+
+`scripts/seed-probely-db.sh` and `probely-data/probely-arlo.db` suggest **Probely** (a DAST scanner) has been run against a seeded Arlo instance. The seed script populates a known-state DB for repeatable scans.
+
+---
+
+## Required Environment Variables
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `DATABASE_URL` | Always | PostgreSQL URL |
+| `ARLO_SESSION_SECRET` | Always | Cookie signing key |
+| `ARLO_HTTP_ORIGIN` | Always | Full origin (e.g. `https://arlo.example.com`) |
+| `FLASK_ENV` | Always | `development` uses nOAuth; `production` requires Auth0 |
+| `ARLO_FILE_UPLOAD_STORAGE_PATH` | Always | Local path or `s3://bucket/prefix` |
+| `ARLO_SUPPORT_AUTH0_*` | Production only | Skip with `FLASK_ENV=development` |
+| `ARLO_AUDITADMIN_AUTH0_*` | Production only | Skip with `FLASK_ENV=development` |
+| `ARLO_SMTP_*` | Production only | Email login codes for jurisdiction admins |
+| `RUN_BACKGROUND_TASKS_IMMEDIATELY` | Optional | `true` → skip worker dyno, run tasks inline |
+| `AWS_*` | Optional | Only if using S3 for file storage |
+
+---
+
+## Recommended Path for Quick Cloud Testing
+
+1. **Fix `app.json`** — change `heroku-postgresql:hobby-free` to `heroku-postgresql:mini`
+2. **Create Heroku app** — `heroku create arlo-test-YOURNAME`
+3. **Set env vars** — `FLASK_ENV=development`, `RUN_BACKGROUND_TASKS_IMMEDIATELY=true`, origin, session secret, local file path
+4. **Push** — `git push heroku main` (builds frontend, runs migrations, starts web dyno)
+5. **Run Cypress E2E** against the live URL to validate
+
+For per-PR automated testing, enable Heroku Review Apps in the pipeline (low config, already supported by the codebase).

--- a/docs/transparency-implementation-plan.md
+++ b/docs/transparency-implementation-plan.md
@@ -8,40 +8,39 @@ _Written 2026-06-20. Builds on `docs/transparency-report.md` and deep codebase r
 
 ### The software-independence problem
 
-The purpose of a risk-limiting audit is *software independence*: the ability to detect errors in the voting system — including its CVRs — without relying on the same software stack that produced them. The existing Track A (computer-verifying-computer) is necessary but not sufficient. Verifying the sample draw and p-value calculation independently is valuable, but it still leaves the most important link unchecked: **did the human audit boards correctly describe what they saw on the paper ballots, and did Arlo correctly record what the boards said?**
+The purpose of a risk-limiting audit is *software independence*: the ability to detect errors in the voting system — including its CVRs — without relying on the same software stack that produced them. Audit support software like Arlo helps us accomplish that, but it needs independent observers and verification. They check that the evidence is sufficient to support the audit conclusions. Do the manifests and CVRs match the reported results? Did the interpretations of the human audit boards and independent risk calculations match the Arlo reports?
 
-That link can only be checked by **human observers who are physically present during audit board sessions**, maintaining their own silent, independent record of each ballot interpretation. Their record is then compared — after the session, not during — against both the CVR and the Arlo audit report. This comparison can and should be doable entirely on paper, without any computer, so that the verification chain remains independent of every system controlled by the jurisdiction.
+It is important to have **human observers who are physically present during audit board sessions**, maintaining their own silent, independent record of ballot interpretations. Their record is then compared — after the session, not during — against the Arlo audit report. This comparison and verification chain should remain independent of every computer system and individual responsible for the initial reported results.
 
-**The blind-audit principle** is what makes this work: audit boards must interpret each ballot without seeing the CVR's interpretation. If anyone communicates the CVR result to the board — observers, officials, or a screen visible in the room — the board could be coached to match a fraudulent CVR instead of reading the paper. Observers must therefore be silent: recording what they hear, never reacting, never speaking to boards, never revealing whether a ballot looks like a discrepancy. Any intervention compromises the independence of the audit.
+**The blind-audit principle** is what makes this work: audit boards must interpret each ballot without seeing the voting system's interpretation. If anyone communicates the voting system's interpretation to the board — observers, officials, Arlo, or a screen visible in the room — the board could be coached to match a fraudulent CVR instead of reading the paper. Observers must be silent: recording what they hear, never reacting, never speaking to boards, never revealing whether a ballot looks like a discrepancy.
 
 ### Two classes of verification
 
 | Verification class | Who does it | When | Tools needed |
 |--------------------|------------|------|-------------|
 | **Mechanical** (sample draw, p-value) | Any observer with a computer | After artifacts are published | `replicate_sample.py`, `replicate_pvalue.py` |
-| **Human** (board vs. paper vs. CVR vs. Arlo record) | Observers physically present during audit | During each board session | Pre-generated transcript (paper), pen |
+| **Human** (board vs. paper vs. CVR vs. Arlo record) | Observers physically present during audit | During each board session | Redacted CVR and selection list, pen |
 
 Both classes are necessary. Neither is sufficient alone.
 
 ### How the human observer layer actually works
 
-Observers cannot write fast enough to transcribe what they hear, and they must not interfere with the board. What they can do is **follow along on a pre-generated transcript** and mark any deviation.
+Observers cannot write fast enough to transcribe what they hear, and they must not interfere with the board. What they can do is **follow along via an excerpt of selected ballots from the CVR** and mark any deviation.
 
-The transcript is produced by joining the retrieval list with the CVR: for each sampled ballot in physical retrieval order, it shows the ballot's imprinted ID and the voting system's recorded interpretation of each contest on that ballot. The observer holds this printout, listens as the board calls out each contest aloud (typically twice for double-checking), and marks any vote where what they hear differs from what is printed. In a zero-discrepancy audit, nothing gets marked. The format is right-justified by contest name so the eye can scan down a column of values quickly.
+The excerpt is produced by joining the retrieval list with the CVR: for each sampled ballot in physical retrieval order, it shows the ballot's imprinted ID and the voting system's recorded interpretation of each contest on that ballot. The observer holds this printout, listens as the board calls out each contest aloud (typically twice for double-checking), and marks any vote where what they hear differs from what is printed. In a zero-discrepancy audit, nothing gets marked. The format is right-justified by contest name so the eye can scan down a column of values quickly.
 
-The audit board **never sees the CVR** — in proper blind practice they have no access to it during the session. They examine only the physical paper ballot. The observer's transcript must likewise never be shown to the board; it would compromise the independence of the audit by revealing what the CVR says before the board states their own interpretation.
+The audit board **never sees the CVR** — in proper blind practice they have no access to it during the session. They examine only the physical paper ballot. The observer's excerpt must likewise never be shown to the board; it would compromise the independence of the audit by revealing what the CVR says before the board states their own interpretation.
 
 The observer's marked printout is then compared against the Arlo audit report's SAMPLED BALLOTS section. Discrepancies can be checked in two directions:
-1. **Observer marked ≠ transcript printed** → the board saw something different from the CVR (a real discrepancy, should appear in Arlo's discrepancy report)
+1. **Observer marked ≠ excerpt printed** → the board saw something different from the CVR (a discrepancy that should appear in Arlo's discrepancy report)
 2. **Observer's hearing ≠ Arlo's recorded audit result** → either the board misspoke, the observer mis-heard, or Arlo recorded something other than what the board said
 
 This final comparison can be done entirely on paper — no computer needed — which is what gives it independence from every system the jurisdiction controls.
 
 ### CVR anonymization
 
-Before any CVR is published, rare ballot styles (those with fewer than ~10 ballots in the jurisdiction) must be aggregated to prevent vote revelation — a voter with a unique combination of contest choices could be identified from their CVR row. See [loriinboulder/anonymize_cvr](https://github.com/loriinboulder/anonymize_cvr), which implements Colorado's requirement (C.R.S. 24-72-205.5) and the approach documented in [Branscomb et al., 2018](http://www.sos.state.co.us/pubs/rule_making/hearings/2018/20180309BranscombEtAl.pdf) (endorsed by McBurnett, Stark, Rivest et al.). Arlo does not currently apply this redaction; it is the jurisdiction's responsibility before publishing the CVR.
-
-The transcript generator uses the full (unredacted) CVR for sampled ballots, since the physical ballots are in hand and the comparison is to individual rows — not to the aggregated public CVR. The anonymized CVR is what goes on the public website; the per-ballot transcript is a derivative of the unredacted data used only during the audit session itself.
+Before any CVR is published, rare ballot styles (e.g. those with fewer than ~10 ballots in the jurisdiction) must be aggregated to prevent vote revelation — a voter with a unique combination of contest choices could be identified from their CVR row. See [Privacy violations in election results | Science Advances](https://www.science.org/doi/10.1126/sciadv.adt1512), along with
+[loriinboulder/anonymize_cvr](https://github.com/loriinboulder/anonymize_cvr), which implements Colorado's requirement (C.R.S. 24-72-205.5) and the approach documented in [Branscomb et al., 2018](http://www.sos.state.co.us/pubs/rule_making/hearings/2018/20180309BranscombEtAl.pdf) (endorsed by McBurnett, Stark, Rivest et al.). Arlo does not currently apply this redaction; it is the jurisdiction's responsibility before publishing the CVR.
 
 ### This plan has two tracks
 
@@ -70,7 +69,7 @@ Changes to Arlo's API and UI that make the Track A workflow easy for officials a
 | CVR Reveal sheet | Paper form used by observers *after* a session to compare their record against the CVR and Arlo report |
 | Blind audit | Audit boards never see the CVR at all — they interpret the paper ballot in isolation, then their interpretation is compared to the CVR by Arlo. This independence is what makes the audit meaningful: a board that sees the CVR could be coached to match a fraudulent one |
 | Rare style | A ballot style (combination of contest choices) appearing in fewer than ~10 ballots — must be aggregated in the public CVR to prevent vote revelation |
-| Observer transcript | Pre-generated printout joining retrieval list with CVR; observer follows along during the board session and marks deviations |
+| Observer excerpt | Pre-generated printout joining retrieval list with CVR; observer follows along during the board session and marks deviations |
 
 ---
 
@@ -370,11 +369,11 @@ All checks passed. The reported p-value is independently reproducible.
 
 ---
 
-### A5. Observer Transcript Generator
+### A5. Observer Excerpt Generator
 
-**Goal:** A script that joins the retrieval list with the CVR to produce a print-ready per-ballot transcript that observers bring into the audit room. The observer follows along as the board reads each contest aloud and marks any vote that differs from what is printed. No writing required — just listening and marking.
+**Goal:** A script that joins the retrieval list with the CVR to produce a print-ready per-ballot excerpt that observers bring into the audit room. The observer follows along as the board reads each contest aloud and marks any vote that differs from what is printed. No writing required — just listening and marking.
 
-**Location:** `scripts/transparency/observer/generate_transcript.py`
+**Location:** `scripts/transparency/observer/generate_excerpt.py`
 
 #### Format
 
@@ -403,11 +402,11 @@ The observer marks directly on this printout when they hear something different 
 #### Usage
 
 ```
-generate_transcript.py \
+generate_excerpt.py \
   --retrieval-list J1_round1_retrieval_list.csv \
   --cvr J1_cvrs.csv \
   --cvr-format dominion \
-  [--output transcript_J1_round1.txt]
+  [--output excerpt_J1_round1.txt]
 ```
 
 - `--retrieval-list`: The retrieval list CSV downloaded from Arlo (columns: Tabulator, Batch Name, Ballot Number, Imprinted ID, Ticket Numbers, Status)
@@ -430,10 +429,10 @@ generate_transcript.py \
 
 #### Blind-audit note in the script header
 
-The generated transcript includes a printed notice at the top:
+The generated excerpt includes a printed notice at the top:
 
 ```
-OBSERVER TRANSCRIPT — [Election Name] — [Jurisdiction] — Round [N]
+OBSERVER EXCERPT — [Election Name] — [Jurisdiction] — Round [N]
 Generated: [timestamp]  SHA-256: [hash of this file]
 
 IMPORTANT: This document shows what the voting system recorded for each ballot.
@@ -448,28 +447,28 @@ IMPORTANT: This document shows what the voting system recorded for each ballot.
   paper without any computer.
 ```
 
-The SHA-256 of the transcript file is printed so observers can confirm they have the same file as other observers and that it was generated from the published CVR.
+The SHA-256 of the excerpt file is printed so observers can confirm they have the same file as other observers and that it was generated from the published CVR.
 
 #### After the session: paper-based comparison
 
-No additional script is needed for the comparison step. An observer with a marked transcript does the following on paper:
+No additional script is needed for the comparison step. An observer with a marked excerpt does the following on paper:
 
 1. Print the SAMPLED BALLOTS section of the Arlo audit report
 2. For each ballot where you marked a deviation: find that ballot's row in the report
 3. Check the "Audit Result" column — does it match what you heard the board say?
-4. Check the "CVR Result" column — does it match what is printed on your transcript?
+4. Check the "CVR Result" column — does it match what is printed on your excerpt?
 5. Check the "Change in Margin" column — does the discrepancy score match the deviation you marked?
 
 Discrepancies between the observer's marks and the Arlo report are reported to the audit supervisor, not acted on unilaterally by the observer.
 
 #### Test coverage
 
-`server/tests/transparency/test_generate_transcript.py`:
+`server/tests/transparency/test_generate_excerpt.py`:
 - Use the existing `TEST_CVRS` fixture (Dominion format) and a synthetic retrieval list
 - Assert that every imprinted ID in the retrieval list appears in the output
 - Assert that contests are right-justified to the correct width
 - Assert that NO VOTE appears for undervotes
-- Assert that the transcript is in retrieval order (not CVR row order)
+- Assert that the excerpt is in retrieval order (not CVR row order)
 - Assert that the SHA-256 printed at the top matches `hashlib.sha256(output.encode()).hexdigest()`
 
 ---
@@ -710,7 +709,7 @@ Wire this into `generate_pre_seed_bundle()` and `generate_reproducibility_bundle
 Week 1-2:  A1 — Pytest transparency test suite (2-round, phase-by-phase)
 Week 3:    A2 — Official export scripts (export_phase.py, hash_and_sign.py)
 Week 4:    A3 — Observer mechanical verification (replicate_sample.py, replicate_pvalue.py)
-           A5 — Observer transcript generator (generate_transcript.py)
+           A5 — Observer excerpt generator (generate_excerpt.py)
 Week 5:    A4 — Tests for A3 and A5 scripts
 Week 6:    B1 — JSON audit report endpoint
 Week 7:    B2 — Opportunistic contest risk levels + universe ballot count
@@ -747,14 +746,12 @@ Week 11+:  B6 — UI transparency checklist (multi-week, involves React)
 
 ## Open Questions
 
-1. **CVR redaction:** Arlo does not redact rare-style ballots before export. For production, the pre-seed export script should warn if a jurisdiction's CVR has ballot styles appearing only once (potential vote revelation risk). Should Arlo compute and display a "redaction risk score" per CVR? Or just document the responsibility?
+1. **CVR redaction:** The timing and handling of redaction needs more attention. Ideally Arlo would do all necessary redaction up-front. Until then, jurisdictions need to do the redaction on their own. Jurisdictions also need to address what to do when a selected CVR row overlaps with a redaction.
 
 2. **Universe ordering:** The exact ordering of ballots in `compute_sample_ballots()` determines the sample. The observer script must replicate this precisely. Is the ordering stable and documented? (Currently it is deterministic but not explicitly specified.) Should it be formally documented as part of the audit protocol?
 
-3. **Opportunistic contest risk threshold:** When there are zero sampled ballots for an opportunistic contest, reporting 100% risk is technically correct but may be alarming. Should the UI explain this differently (e.g., "Not sampled — risk not calculated") or always use the mathematically correct 100%?
+3. **Opportunistic contest risk threshold:** When contests are not audited (either targeted or opportunitically) reporting 100% risk is technically correct but may be alarming. The UI should probably explain this by noting that risk for those contests needs to be addressed via another sort of auditing.
 
-4. **Auth for observer scripts:** The observer scripts need an Arlo session token. For testing, `FLASK_ENV=development` nOAuth accepts any email. For production, should Arlo add a read-only "observer" role with a long-lived API token for downloading public artifacts, rather than requiring a full audit-admin login?
+4. **Data access for observer scripts:** The observer scripts need access to the exported data. The proposed testing flow should include a design for how to do that, since observers and the public don't have access to the Arlo instance.
 
-5. **Transcript generation: official tool or observer tool?** The transcript generator uses the CVR — a file that, for rare styles, must be anonymized before public release. Should Arlo generate the observer transcript server-side (using the unredacted CVR) and make it available for download alongside the retrieval list? Or should it remain an observer-side tool that observers generate from the publicly-posted (anonymized) CVR? The latter preserves more software independence but requires observers to handle CVR parsing; the former is more convenient but means observers must trust Arlo's output.
-
-6. **Arlo UI and the blind audit:** Arlo's online audit board UI currently shows the audit board member what the CVR says alongside the ballot (or makes it easy to derive). This violates the blind-audit principle for online audits. Should the UI be audited for CVR leakage, and should the board data-entry screen be redesigned to show only the ballot image (if available) and the contest names — never the CVR interpretation?
+5. **Excerpt generation: official tool or observer tool?** The excerpt generator currently uses the CVR — a file that, for rare styles, must be anonymized before public release. The final approach will depend on the anonymization and data access choices noted above. Excerpt generation must come from an observer-side tool that observers generate from the publicly-posted (anonymized) CVR.

--- a/docs/transparency-implementation-plan.md
+++ b/docs/transparency-implementation-plan.md
@@ -1,0 +1,611 @@
+# Arlo Audit Transparency: Phased Implementation Plan
+
+_Written 2026-06-20. Builds on `docs/transparency-report.md` and deep codebase research._
+
+---
+
+## Overview
+
+A verifiable comparison audit requires that independent observers can, using only publicly-published artifacts, replicate every mechanically-determined step: sample draw, risk measurement, and discrepancy detection. Today all the math is in Arlo and all the data can be exported, but there is no workflow that ties it together, no scripts that demonstrate replication, and no machine-readable output format that makes replication easy.
+
+This plan has two tracks:
+
+**Track A — Observer Toolkit** (implement first, no Arlo changes required):
+Tests and scripts that walk through a complete 2-round ballot comparison audit, export artifacts phase by phase, and independently verify every calculation.
+
+**Track B — Arlo Improvements** (implement after Track A proves what's needed):
+Changes to Arlo's API and UI that make the Track A workflow easy for officials and observers to follow in production.
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| AA | Audit Admin (state-level) |
+| JA | Jurisdiction Admin (county-level) |
+| AB | Audit Board |
+| CVR | Cast Vote Record — machine record of every ballot |
+| Imprinted ID | Tabulator/Batch/Position identifier stamped on ballot |
+| Ticket number | Fractional decimal from `consistent_sampler` — determines selection |
+| Diluted margin | `margin_votes / total_universe_ballots` |
+| `counted_as` | Supersimple discrepancy score: −2,−1,0,+1,+2 |
+| SHA-256 bundle | ZIP with a companion `*-sha256-hash.txt` inside |
+
+---
+
+## Track A: Observer Toolkit
+
+### A1. Pytest Integration Test Suite
+
+**Goal:** A single pytest run that exercises a complete 2-round ballot comparison audit and, at each phase transition, calls every export endpoint and saves the artifacts to a temp directory with SHA-256 hashes recorded in a JSON manifest. This becomes both a regression test suite and a live demonstration of the audit trail.
+
+**Location:** `server/tests/ballot_comparison/test_transparency_workflow.py`
+
+#### A1.1 Test structure
+
+```
+test_transparency_full_2_round_audit
+    ├── setup_audit()         → JSON manifest with hashes of inputs
+    ├── pre_seed_exports()    → manifest CSVs, CVR CSVs, standardized contests
+    ├── seed_and_sample()     → seed recorded, round 1 retrieval lists
+    ├── round_1_audit()       → interpretations entered, round 1 finished
+    ├── round_1_exports()     → audit report through round 1
+    ├── round_2_sample()      → round 2 retrieval lists
+    ├── round_2_audit()       → round 2 finished
+    └── final_exports()       → final audit report, reproducibility bundle
+```
+
+**Each phase helper should:**
+1. Call the relevant API endpoints on the test client
+2. Write artifacts to `tmp_path/<phase>/` with original filenames
+3. Compute `sha256sum` of each file
+4. Append an entry to a `phase_manifest.json`:
+   ```json
+   {
+     "phase": "pre_seed",
+     "timestamp": "...",
+     "artifacts": [
+       {"filename": "J1_ballot_manifest.csv", "sha256": "...", "endpoint": "..."},
+       ...
+     ]
+   }
+   ```
+5. Assert that the artifact content matches expected shape (columns, row count)
+
+**Fixtures to build on:**
+- `conftest.py` in `server/tests/ballot_comparison/` already provides `org_id`, `election_id`, `jurisdiction_ids`, `contest_ids`, `election_settings`, `manifests`, `cvrs`, `round_1_id`
+- `run_audit_round()` in `server/tests/helpers.py` handles interpretation entry at a given vote ratio
+- The `round_2_id` fixture in existing conftest shows the full 2-round sequence
+
+#### A1.2 Phase-by-phase artifact exports
+
+**Phase 0 — Audit creation (no exports; assertions only)**
+- Assert election created with `AuditType.BALLOT_COMPARISON`
+- Assert settings: risk limit, seed, audit name, state
+
+**Phase 1 — Pre-seed (upload complete, before seed is fixed)**
+- `GET /election/<id>/jurisdiction/<jid>/ballot-manifest/csv` → `<jname>_ballot_manifest.csv`
+- `GET /election/<id>/jurisdiction/<jid>/cvrs/csv` → `<jname>_cvrs.csv`
+- `GET /election/<id>/jurisdiction/<jid>/standardized-contests/csv` (if it exists) → `<jname>_standardized_contests.csv`
+- `GET /election/<id>/standardized-contests/file` → `standardized_contests.csv`
+- Validate each manifest: columns present, batch counts > 0, ballot counts > 0, no negative numbers
+- Validate each CVR: ImprintedId present, BallotType present, one column per contest choice
+- Cross-validate manifest vs. CVR: every (Tabulator, Batch, RecordId) in CVR appears in manifest; batch ballot counts match
+- Record SHA-256 of each file in phase manifest
+
+**Phase 2 — Post-seed, pre-round-1**
+- Record seed from `GET /election/<id>/settings` (the `randomSeed` field)
+- `GET /election/<id>/sample-sizes/1` → `sample_sizes_round1.json`
+- `POST /election/<id>/round` (starts round 1)
+- `GET /election/<id>/jurisdiction/<jid>/round/<rid>/ballots/retrieval-list` → `<jname>_round1_retrieval_list.csv` (for each jurisdiction)
+- Validate retrieval list: columns (Tabulator, Batch Name, Ballot Number, Imprinted ID, Ticket Numbers, Status)
+- Assert retrieval list count ≤ sample size
+- Record SHA-256 of each retrieval list
+
+**Phase 3 — Round 1 audit complete**
+- (Simulate audit board entries via `run_audit_round`)
+- `POST /election/<id>/round/current/finish`
+- `GET /election/<id>/report` → `audit_report_round1.txt`
+- `GET /election/<id>/discrepancy-report` → `discrepancy_report_round1.csv`
+- Parse the pseudo-CSV audit report: extract ROUNDS section rows, assert p-value and `is_complete` fields
+- If audit not complete: proceed to Phase 4
+
+**Phase 4 — Round 2 setup**
+- `GET /election/<id>/sample-sizes/2` → `sample_sizes_round2.json`
+- `POST /election/<id>/round`
+- `GET /election/<id>/jurisdiction/<jid>/round/<rid>/ballots/retrieval-list` → `<jname>_round2_retrieval_list.csv`
+- Validate as in Phase 2; assert round 2 list is a superset of round 1 (same ballots plus new ones)
+- Record SHA-256
+
+**Phase 5 — Final**
+- `GET /election/<id>/report` → `audit_report_final.txt`
+- `GET /election/<id>/discrepancy-report` → `discrepancy_report_final.csv`
+- Assert at least one targeted contest has risk limit met in final report
+- Write `reproducibility_bundle.json` (see A1.3)
+
+#### A1.3 Reproducibility bundle
+
+At the end of Phase 5, the test generates a `reproducibility_bundle.json` that contains everything an independent observer needs to replay the audit from scratch:
+
+```json
+{
+  "election": {"name": "...", "state": "...", "risk_limit_pct": 10},
+  "contests": [
+    {
+      "name": "Contest 1",
+      "targeted": true,
+      "choices": {"Alice": 5000, "Bob": 4000},
+      "total_ballots_cast": 10000
+    }
+  ],
+  "random_seed": "1234567890",
+  "jurisdictions": [
+    {
+      "name": "J1",
+      "manifest_sha256": "...",
+      "cvr_sha256": "...",
+      "batches": [
+        {"tabulator": "TABULATOR1", "name": "BATCH1", "ballot_count": 20}
+      ]
+    }
+  ],
+  "rounds": [
+    {
+      "round_num": 1,
+      "sample_sizes": {"Contest 1": 45},
+      "retrieval_list_sha256s": {"J1": "...", "J2": "..."},
+      "p_values": {"Contest 1": 0.38},
+      "complete": false
+    },
+    {
+      "round_num": 2,
+      "sample_sizes": {"Contest 1": 90},
+      "retrieval_list_sha256s": {"J1": "...", "J2": "..."},
+      "p_values": {"Contest 1": 0.04},
+      "complete": true
+    }
+  ]
+}
+```
+
+---
+
+### A2. Official Export Scripts
+
+**Goal:** Standalone scripts (no Arlo source code required) that an election official runs against a live or test Arlo instance to export and hash artifacts at each phase. Output is a directory tree with artifacts and a signed JSON manifest ready for public posting.
+
+**Location:** `scripts/transparency/`
+
+#### `scripts/transparency/export_phase.py`
+
+```
+usage: export_phase.py --url ARLO_URL --election ELECTION_ID \
+       --phase {pre_seed,post_seed,post_round,final} \
+       --round ROUND_NUM \
+       --output-dir OUTPUT_DIR
+```
+
+Authentication: reads a session token from `--token` or `ARLO_SESSION_TOKEN` env var (obtained by logging in via browser and copying the cookie).
+
+**Behavior per phase:**
+
+`pre_seed`:
+- Downloads manifest CSV, CVR CSV per jurisdiction
+- Downloads standardized contests file
+- Downloads audit settings (via `GET /election/<id>` JSON response)
+- Writes all to `output_dir/pre_seed/`
+- Computes SHA-256 of each; writes `pre_seed_manifest.json`
+
+`post_seed`:
+- Downloads round N retrieval list per jurisdiction
+- Downloads sample sizes JSON
+- Writes `post_seed_round_<N>_manifest.json`
+
+`post_round`:
+- Downloads audit report
+- Downloads discrepancy report
+- Writes `post_round_<N>_manifest.json`
+
+`final`:
+- Downloads final audit report
+- Writes `final_manifest.json`
+- Optionally generates `reproducibility_bundle.json`
+
+#### `scripts/transparency/hash_and_sign.py`
+
+```
+usage: hash_and_sign.py manifest.json [--sign-with KEY_FILE]
+```
+
+Reads a phase manifest JSON, verifies SHA-256 of each listed file, and optionally produces a detached PGP signature of the manifest. Prints a summary table and a publication-ready statement:
+
+```
+Pre-seed artifact bundle verified — 2026-10-15T10:32:00Z
+Files:
+  J1_ballot_manifest.csv      sha256: abc123...
+  J1_cvrs.csv                 sha256: def456...
+  standardized_contests.csv   sha256: ghi789...
+
+Sign this manifest and publish it to your public repository
+BEFORE entering the random seed.
+```
+
+---
+
+### A3. Observer Verification Scripts
+
+**Goal:** Scripts that an independent observer runs, given only the publicly-posted artifacts, to replicate every mechanically-determined step.
+
+**Location:** `scripts/transparency/observer/`
+
+All scripts are standalone — they import only `consistent_sampler` (installable via `pip install consistent-sampler`) and standard library. No Arlo server code required.
+
+#### `observer/verify_manifests.py`
+
+```
+usage: verify_manifests.py --manifest-dir DIR
+```
+
+1. Reads all `*_ballot_manifest.csv` files
+2. Validates columns (Tabulator, Batch Name, Number of Ballots)
+3. Checks for duplicate (Tabulator, Batch) pairs
+4. Sums ballot counts per tabulator, per jurisdiction
+5. Reads the CVR file if present: verifies every (Tabulator, Batch, RecordId) in the CVR exists in the manifest with sufficient ballot count
+6. Reports discrepancies
+
+#### `observer/replicate_sample.py`
+
+```
+usage: replicate_sample.py \
+  --seed SEED \
+  --manifest-dir DIR \          # directory with jurisdiction manifest CSVs
+  --sample-sizes FILE \         # sample_sizes_round<N>.json from official export
+  --round ROUND_NUM \
+  [--expected-retrieval-list DIR]   # compare against official retrieval lists
+```
+
+**Algorithm:**
+1. Read all jurisdiction manifests; build the universe list: one entry per (jurisdiction, tabulator, batch, ballot_position) ordered by jurisdiction name, then tabulator, then batch, then ballot position
+2. Concatenate all entries into a single ordered list (consistent with how Arlo builds it in `compute_sample_ballots()`)
+3. Call `consistent_sampler.sample_by_index(universe, sample_size, seed, with_replacement=False)` for each contest
+4. Merge results across contests (union of sampled ballots)
+5. Format as a retrieval list: (Jurisdiction, Tabulator, Batch Name, Ballot Number, Imprinted ID — from CVR, Ticket Numbers)
+6. If `--expected-retrieval-list` is given, diff against official list line-by-line; report any discrepancies
+
+This is the core independent replication step. A successful match proves that the sample was drawn from the published seed and manifest without manipulation.
+
+**Key implementation detail:** Arlo's `draw_sample` task in `server/api/rounds.py` calls `sampler.draw_sample()` from `server/audit_math/sampler.py`. The universe ordering is deterministic given the manifest. The observer script must replicate this ordering exactly. The code for this is in `server/audit_math/sampler.py` and `server/api/rounds.py` (`compute_sample_ballots`). Document the exact ordering in a comment in the observer script.
+
+#### `observer/replicate_pvalue.py`
+
+```
+usage: replicate_pvalue.py \
+  --cvr FILE \                        # jurisdiction CVR CSVs (one or more)
+  --audit-report FILE \               # official audit report (pseudo-CSV)
+  --contest-name "Contest 1" \
+  --risk-limit 0.10 \
+  --round ROUND_NUM
+```
+
+**Algorithm:**
+1. Parse the SAMPLED BALLOTS section of the audit report to get:
+   - For each sampled ballot: Imprinted ID, CVR result, Audit result, `counted_as` discrepancy
+2. Parse the CVR file to build a lookup: Imprinted ID → CVR interpretation per contest
+3. For each sampled ballot: verify that the `CVR Result` column in the report matches what the CVR file says for that Imprinted ID; flag mismatches
+4. Build `sampled_cvrs` dict: Imprinted ID → `{contest: {choice: count, "sampled": 1}}`
+5. Build `cvrs` dict (all CVR ballots): same structure
+6. Call `server.audit_math.supersimple.compute_risk(risk_limit, contest, cvrs, sampled_cvrs)` → `(p_value, is_complete)`
+7. Compare computed p-value against the value in the ROUNDS section of the audit report
+8. Also call `supersimple.compute_discrepancies()` and compare `counted_as` values against the SAMPLED BALLOTS section
+
+**Note:** This script imports from `server.audit_math` — it requires a copy of the Arlo source. A fully standalone version would re-implement `supersimple.py`'s `nMin` and `compute_risk()` in ~50 lines, which is a good future step.
+
+#### `observer/end_to_end_verify.py`
+
+```
+usage: end_to_end_verify.py --artifact-dir DIR --round ROUND_NUM
+```
+
+Orchestrates the above scripts in sequence and prints a verification report:
+
+```
+=== Arlo Audit Independent Verification Report ===
+Election: General Election 2026
+Contest: Governor
+Round: 1
+
+[PASS] SHA-256 hashes match published manifest
+[PASS] Ballot manifests valid (3 jurisdictions, 12 batches, 6240 ballots)
+[PASS] CVR consistent with manifest (6240 ballots, all batches present)
+[PASS] Sample draw replicated (45 ballots match official retrieval list)
+[PASS] CVR results in audit report match CVR file
+[PASS] Discrepancy scores match (0 type-2, 1 type-1, 44 type-0)
+[PASS] P-value replicated: computed=0.38, reported=0.38
+      Risk limit (10%) NOT MET — round 2 required.
+
+=== Summary ===
+All checks passed. The reported p-value is independently reproducible.
+```
+
+---
+
+### A4. Test Coverage for Observer Scripts
+
+**Location:** `server/tests/transparency/`
+
+Three test files:
+
+`test_replicate_sample.py`:
+- Use the same fixtures as `test_ballot_comparison.py`
+- After `round_1_id` fixture, call the API to get retrieval list
+- Run `replicate_sample.py` main function with seed + manifest
+- Assert output matches retrieved list exactly
+
+`test_replicate_pvalue.py`:
+- After `round_1_id` fixture finishes and round is completed
+- Export audit report via API
+- Run `replicate_pvalue.py` with that report + CVR
+- Assert computed p-value matches `round_contest.end_p_value` in DB
+
+`test_end_to_end_verify.py`:
+- Drives a full 2-round audit using fixtures
+- Exports all phase artifacts to `tmp_path`
+- Writes phase manifests
+- Runs `end_to_end_verify.py` for round 1 and round 2
+- Asserts all checks `[PASS]`
+
+---
+
+## Track B: Arlo Improvements
+
+Ordered by priority. Each item names the server files to change and the API surface added.
+
+---
+
+### B1. Machine-Readable Audit Report (High Priority)
+
+**Problem:** `GET /election/<id>/report` returns pseudo-CSV with `######## SECTION ########` headers. It is not parseable by standard CSV tools. There is no JSON or HTML alternative.
+
+**Change:** Add `GET /election/<id>/report.json` (or add `Accept: application/json` content negotiation to the existing endpoint).
+
+**Response shape:**
+```json
+{
+  "election": {...},
+  "contests": [...],
+  "settings": {...},
+  "rounds": [
+    {
+      "round_num": 1,
+      "contests": [
+        {
+          "name": "Contest 1",
+          "targeted": true,
+          "sample_size": 45,
+          "p_value": 0.38,
+          "risk_limit_met": false,
+          "audited_votes": {"Alice": 22, "Bob": 21, "Undervote": 2}
+        }
+      ],
+      "started_at": "...",
+      "ended_at": "..."
+    }
+  ],
+  "sampled_ballots": [
+    {
+      "jurisdiction": "J1",
+      "tabulator": "TABULATOR1",
+      "batch_name": "BATCH1",
+      "ballot_position": 3,
+      "imprinted_id": "1-1-3",
+      "ticket_numbers": {"Contest 1": "0.234..."},
+      "audited": true,
+      "cvr_result": {"Contest 1": {"Alice": 1, "Bob": 0}},
+      "audit_result": {"Contest 1": {"Alice": 1, "Bob": 0}},
+      "discrepancy": {"Contest 1": 0}
+    }
+  ]
+}
+```
+
+**Files:** `server/api/reports.py` — add a new route or branch on `request.accept_mimetypes`. The data assembly is already done in `election_report()` and `sampled_ballots_rows()`.
+
+**Test:** `server/tests/api/test_reports.py` — add JSON report assertions alongside existing snapshot tests.
+
+---
+
+### B2. Opportunistic Contest Risk Levels (High Priority)
+
+**Problem:** Opportunistic contests receive no p-value at all. A contest with zero sampled ballots has a formal risk of 100%, but this is not reported anywhere — neither in the API response nor in the audit report.
+
+**Change 1:** In `calculate_risk_measurements()` (`server/api/rounds.py`), for opportunistic contests compute and store `end_p_value` even if it is 1.0 (or the value from the supersimple formula with zero sampled ballots).
+
+**Change 2:** Add a `universe_ballot_count` field per contest to the sample sizes response (`server/api/sample_sizes.py`) — the count of ballots in the sampling universe for that contest. This is the denominator for the diluted margin.
+
+**Change 3:** In the audit report (both CSV and new JSON), include opportunistic contest p-values with a note: `"Risk limit not met — no ballots sampled for this contest (formal risk: 100%)"` for zero-sample contests.
+
+**Files:** `server/api/rounds.py` (`calculate_risk_measurements`), `server/api/sample_sizes.py`, `server/api/reports.py`.
+
+---
+
+### B3. Sampler Inputs Artifact (Medium Priority)
+
+**Problem:** An observer wanting to replicate the sample draw must reconstruct the sampling universe from the individual manifest CSVs. There is no single "sampler inputs" artifact that packages everything needed.
+
+**Change:** Add `GET /election/<id>/round/<id>/sampler-inputs` — returns a JSON artifact that contains everything needed to replicate the sample draw without downloading individual manifest CSVs:
+
+```json
+{
+  "random_seed": "1234567890",
+  "round_num": 1,
+  "contests": [
+    {"name": "Contest 1", "sample_size": 45, "universe_ballot_count": 6240}
+  ],
+  "jurisdictions": [
+    {
+      "name": "J1",
+      "batches": [
+        {"tabulator": "TABULATOR1", "name": "BATCH1", "ballot_count": 20},
+        ...
+      ]
+    }
+  ]
+}
+```
+
+This artifact, together with the CVR files and audit report, is sufficient to independently replicate everything.
+
+**Files:** New route in `server/api/rounds.py` or a new `server/api/sampler_inputs.py`.
+
+---
+
+### B4. Pre-seed Hash-Index JSON Endpoint (Medium Priority)
+
+**Problem:** The canonical pre-seed transparency artifact should be a JSON file containing hashes of all uploaded input files. Currently officials must download each file separately and hash them manually. The batch comparison SHA-256 bundle endpoints show the pattern.
+
+**Change:** Add `GET /election/<id>/pre-seed-bundle` — assembles and hashes all uploaded input files (manifests, CVRs, standardized contests) and returns:
+
+```json
+{
+  "generated_at": "2026-10-15T10:32:00Z",
+  "election_id": "...",
+  "election_name": "General Election 2026",
+  "state": "WA",
+  "risk_limit_pct": 10,
+  "jurisdictions": [
+    {
+      "name": "J1",
+      "ballot_manifest": {"filename": "manifest.csv", "sha256": "...", "ballot_count": 120},
+      "cvr": {"filename": "cvrs.csv", "sha256": "...", "ballot_count": 120}
+    }
+  ],
+  "standardized_contests": {"filename": "standardized_contests.csv", "sha256": "..."},
+  "contests": [
+    {"name": "Contest 1", "choices": {"Alice": 5000, "Bob": 4000}, "total_ballots_cast": 10000}
+  ]
+}
+```
+
+Officials download this JSON, sign it with PGP or a digital certificate, and publish it before entering the seed. The SHA-256 values let observers verify they have the right files.
+
+**Files:** New `server/api/pre_seed_bundle.py`.
+
+---
+
+### B5. Per-Jurisdiction Phase Exports of New Data Only (High Priority)
+
+**Problem:** Each county-level JA only needs to export the *new* data for the current phase. There is no per-jurisdiction bundle per phase. CVRs and manifests are not re-bundled unnecessarily.
+
+**Change:** Add three per-jurisdiction bundle endpoints:
+- `GET /election/<id>/jurisdiction/<id>/phase-export/pre-seed` → ZIP of manifest + CVR + SHA-256 hashes JSON
+- `GET /election/<id>/jurisdiction/<id>/phase-export/post-seed?round=1` → ZIP of retrieval list + SHA-256 hashes
+- `GET /election/<id>/jurisdiction/<id>/phase-export/post-audit?round=1` → ZIP of jurisdiction audit report + SHA-256 hashes
+
+Each ZIP includes a `manifest.json` with filename and hash of each file.
+
+**Files:** New `server/api/jurisdiction_phase_exports.py`.
+
+---
+
+### B6. UI Guidance for Transparency Workflow (High Priority)
+
+**Problem:** Arlo provides no guidance to officials about when to export, hash, publish, and timestamp artifacts. The current UI flows directly from upload to seed entry with no transparency checkpoint.
+
+**Change:** Add a "Transparency Checklist" panel to the audit admin dashboard that appears at each phase transition:
+
+- **After all manifests and CVRs uploaded, before seed entry:**
+  > Before entering the random seed, download and publish the pre-seed bundle. Have your official sign the JSON manifest and post it publicly with a timestamp. [Download pre-seed bundle] [Mark as published]
+
+- **After seed entered, before round start:**
+  > Before retrieving ballots, publish the retrieval lists so observers can verify the sample. [Download round 1 retrieval lists] [Mark as published]
+
+- **After round complete:**
+  > Publish the updated audit report before starting the next round. [Download audit report] [Mark as published]
+
+The "Mark as published" button records a `published_at` timestamp in the DB (new column on `Election` or a new `PublicationRecord` table). This is a soft gate — it does not block the audit from proceeding — but makes the best-practice workflow explicit and auditable.
+
+**Files:** React components in `client/src/`, new DB migration in `server/migrations/`, new columns or table in `server/models.py`.
+
+---
+
+### B7. Reproducibility Bundle (Medium Priority)
+
+**Problem:** There is no single artifact that, together with the published CSVs, lets an observer replay the entire audit.
+
+**Change:** Add `GET /election/<id>/reproducibility-bundle` after the audit is complete. Returns a ZIP containing:
+- `reproducibility_bundle.json` (see A1.3 above)
+- `README.md` with instructions for running `observer/end_to_end_verify.py`
+- A copy of `scripts/transparency/observer/` (the verification scripts themselves)
+
+This makes the reproducibility bundle self-contained: an observer downloads one ZIP and can verify everything.
+
+**Files:** New `server/api/reproducibility_bundle.py`.
+
+---
+
+### B8. RFC 3161 Timestamping Support (Lower Priority)
+
+**Problem:** "Published at" timestamps are self-asserted. RFC 3161 trusted timestamps from a free TSA (e.g., freetsa.org) provide cryptographic proof of publication time, binding the artifact hash to a trusted time source.
+
+**Change:** Add a `timestamp_artifact(file_bytes, filename)` utility in `server/util/timestamp.py` that:
+1. Computes SHA-256 of the bytes
+2. Posts to a configured RFC 3161 TSA (`ARLO_TSA_URL`)
+3. Returns the DER-encoded timestamp token
+4. Stores it alongside the artifact (locally or in S3)
+
+Wire this into `generate_pre_seed_bundle()` and `generate_reproducibility_bundle()`.
+
+**Files:** `server/util/timestamp.py`, updated bundle endpoints.
+
+---
+
+## Implementation Sequence
+
+```
+Week 1-2:  A1 — Pytest transparency test suite (2-round, phase-by-phase)
+Week 3:    A2 — Official export scripts (export_phase.py, hash_and_sign.py)
+Week 4:    A3 — Observer verification scripts (replicate_sample.py, replicate_pvalue.py)
+Week 5:    A4 — Tests for observer scripts
+Week 6:    B1 — JSON audit report endpoint
+Week 7:    B2 — Opportunistic contest risk levels + universe ballot count
+Week 8:    B3 — Sampler inputs artifact
+Week 9:    B4 — Pre-seed hash-index JSON endpoint
+Week 10:   B5 — Per-jurisdiction phase exports
+Week 11+:  B6 — UI transparency checklist (multi-week, involves React)
+           B7 — Reproducibility bundle
+           B8 — RFC 3161 timestamping
+```
+
+---
+
+## Key Code Locations
+
+| Topic | File | Notes |
+|-------|------|-------|
+| Sample drawing | `server/api/rounds.py` `draw_sample()` | Background task; calls `compute_sample_ballots()` |
+| Sampler math | `server/audit_math/sampler.py` | Wraps `consistent_sampler` |
+| P-value computation | `server/audit_math/supersimple.py` | `compute_risk()`, `compute_discrepancies()` |
+| Discrepancy scores | `server/audit_math/supersimple.py` `compute_discrepancies()` | Returns `counted_as` per ballot |
+| Audit report | `server/api/reports.py` | `election_report()`, `sampled_ballots_rows()` |
+| Sample sizes | `server/api/sample_sizes.py` | Returns options for each round |
+| CVR parsing | `server/api/cvrs.py` | Handles Dominion, ESS, ClearBallot, Hart |
+| Retrieval list | `server/api/ballots.py` `ballot_retrieval_list()` | Columns: Tabulator, Batch, Ballot Number, Imprinted ID, Ticket Numbers, Status |
+| Existing 2-round test | `server/tests/ballot_comparison/test_ballot_comparison.py` | Template for A1 |
+| Test helpers | `server/tests/helpers.py` | `run_audit_round()`, `set_logged_in_user()` |
+| Test fixtures | `server/tests/ballot_comparison/conftest.py` | `round_1_id`, `round_2_id`, etc. |
+| nOAuth | `server/nOAuth/app.py` | Pass-through OAuth; used in dev/test |
+| File storage | `server/util/file.py` | `retrieve_file()`, local vs. S3 |
+| Background tasks | `server/worker/worker.py` | 2-sec polling loop |
+
+---
+
+## Open Questions
+
+1. **CVR redaction:** Arlo does not redact rare-style ballots before export. For production, the pre-seed export script should warn if a jurisdiction's CVR has ballot styles appearing only once (potential vote revelation risk). Should Arlo compute and display a "redaction risk score" per CVR? Or just document the responsibility?
+
+2. **Universe ordering:** The exact ordering of ballots in `compute_sample_ballots()` determines the sample. The observer script must replicate this precisely. Is the ordering stable and documented? (Currently it is deterministic but not explicitly specified.) Should it be formally documented as part of the audit protocol?
+
+3. **Opportunistic contest risk threshold:** When there are zero sampled ballots for an opportunistic contest, reporting 100% risk is technically correct but may be alarming. Should the UI explain this differently (e.g., "Not sampled — risk not calculated") or always use the mathematically correct 100%?
+
+4. **Auth for observer scripts:** The observer scripts need an Arlo session token. For testing, `FLASK_ENV=development` nOAuth accepts any email. For production, should Arlo add a read-only "observer" role with a long-lived API token for downloading public artifacts, rather than requiring a full audit-admin login?

--- a/docs/transparency-implementation-plan.md
+++ b/docs/transparency-implementation-plan.md
@@ -12,22 +12,22 @@ The purpose of a risk-limiting audit is *software independence*: the ability to 
 
 It is important to have **human observers who are physically present during audit board sessions**, maintaining their own silent, independent record of ballot interpretations. Their record is then compared — after the session, not during — against the Arlo audit report. This comparison and verification chain should remain independent of every computer system and individual responsible for the initial reported results.
 
-**The blind-audit principle** is what makes this work: audit boards must interpret each ballot without seeing the voting system's interpretation. If anyone communicates the voting system's interpretation to the board — observers, officials, Arlo, or a screen visible in the room — the board could be coached to match a fraudulent CVR instead of reading the paper. Observers must be silent: recording what they hear, never reacting, never speaking to boards, never revealing whether a ballot looks like a discrepancy.
+**The blind-audit principle** is what makes this work: audit boards must interpret each ballot without seeing the voting system's interpretation. If anyone communicates the voting system's interpretation to the board — observers, officials, Arlo, or a screen visible in the room — the board's interpretations could be tainted. Observers must be silent: recording what they hear, never reacting, never speaking to boards, never revealing whether a ballot looks like a discrepancy.
 
 ### Two classes of verification
 
 | Verification class | Who does it | When | Tools needed |
 |--------------------|------------|------|-------------|
-| **Mechanical** (sample draw, p-value) | Any observer with a computer | After artifacts are published | `replicate_sample.py`, `replicate_pvalue.py` |
+| **Mechanical** (sample draw, risk level) | Any observer with a computer | After artifacts are published | `replicate_sample.py`, `replicate_risk_level.py` |
 | **Human** (board vs. paper vs. CVR vs. Arlo record) | Observers physically present during audit | During each board session | Redacted CVR and selection list, pen |
 
 Both classes are necessary. Neither is sufficient alone.
 
 ### How the human observer layer actually works
 
-Observers cannot write fast enough to transcribe what they hear, and they must not interfere with the board. What they can do is **follow along via an excerpt of selected ballots from the CVR** and mark any deviation.
+Observers cannot write fast enough to transcribe what they hear, and they must not interfere with the board. What they can do is **follow along via an excerpt of selected ballots from the CVR** and mark any discrepancy.
 
-The excerpt is produced by joining the retrieval list with the CVR: for each sampled ballot in physical retrieval order, it shows the ballot's imprinted ID and the voting system's recorded interpretation of each contest on that ballot. The observer holds this printout, listens as the board calls out each contest aloud (typically twice for double-checking), and marks any vote where what they hear differs from what is printed. In a zero-discrepancy audit, nothing gets marked. The format is right-justified by contest name so the eye can scan down a column of values quickly.
+The excerpt is produced by joining the retrieval list with the CVR: for each sampled ballot in physical retrieval order, it shows the ballot's imprinted ID and the voting system's recorded interpretation of each contest on that ballot. The observer holds this printout, listens as the board calls out each contest aloud (typically twice for double-checking), and notes any vote where what they hear differs from what is printed.The format is right-justified by contest name so the eye can scan down a column of values quickly.
 
 The audit board **never sees the CVR** — in proper blind practice they have no access to it during the session. They examine only the physical paper ballot. The observer's excerpt must likewise never be shown to the board; it would compromise the independence of the audit by revealing what the CVR says before the board states their own interpretation.
 
@@ -47,7 +47,7 @@ Before any CVR is published, rare ballot styles (e.g. those with fewer than ~10 
 **Track A — Observer Toolkit** (implement first, no Arlo changes required):
 Tests and scripts covering both verification classes: mechanical replication of every calculation, and paper-based tools for human observers to independently record and compare audit board interpretations.
 
-**Track B — Arlo Improvements** (implement after Track A proves what's needed):
+**Track B — Arlo Improvements**:
 Changes to Arlo's API and UI that make the Track A workflow easy for officials and observers to follow in production.
 
 ---
@@ -65,11 +65,10 @@ Changes to Arlo's API and UI that make the Track A workflow easy for officials a
 | Diluted margin | `margin_votes / total_universe_ballots` |
 | `counted_as` | Supersimple discrepancy score: −2,−1,0,+1,+2 |
 | SHA-256 bundle | ZIP with a companion `*-sha256-hash.txt` inside |
-| Observation sheet | Paper form used by observers *during* a board session to record what boards say — no CVR content |
-| CVR Reveal sheet | Paper form used by observers *after* a session to compare their record against the CVR and Arlo report |
-| Blind audit | Audit boards never see the CVR at all — they interpret the paper ballot in isolation, then their interpretation is compared to the CVR by Arlo. This independence is what makes the audit meaningful: a board that sees the CVR could be coached to match a fraudulent one |
+| CVR Excerpt | Excerpt of the selected ballots from the CVR used by observers to take notes during an auditing session |
+| Blind audit | Audit boards never see the CVR at all — they interpret the paper ballot in isolation, and their interpretation is compared to the CVR by both Arlo and the observers . This independence is crucial |
 | Rare style | A ballot style (combination of contest choices) appearing in fewer than ~10 ballots — must be aggregated in the public CVR to prevent vote revelation |
-| Observer excerpt | Pre-generated printout joining retrieval list with CVR; observer follows along during the board session and marks deviations |
+| Observer excerpt | Pre-generated printout joining retrieval list with CVR; observer follows along during the board session and marks discrepancys |
 
 ---
 
@@ -147,7 +146,7 @@ test_transparency_full_2_round_audit
 - `POST /election/<id>/round/current/finish`
 - `GET /election/<id>/report` → `audit_report_round1.txt`
 - `GET /election/<id>/discrepancy-report` → `discrepancy_report_round1.csv`
-- Parse the pseudo-CSV audit report: extract ROUNDS section rows, assert p-value and `is_complete` fields
+- Parse the pseudo-CSV audit report: extract ROUNDS section rows, assert risk level and `is_complete` fields
 - If audit not complete: proceed to Phase 4
 
 **Phase 4 — Round 2 setup**
@@ -210,9 +209,9 @@ At the end of Phase 5, the test generates a `reproducibility_bundle.json` that c
 
 ---
 
-### A2. Official Export Scripts
+### A2. Official Export Functions
 
-**Goal:** Standalone scripts (no Arlo source code required) that an election official runs against a live or test Arlo instance to export and hash artifacts at each phase. Output is a directory tree with artifacts and a signed JSON manifest ready for public posting. Public posting is how observers access the data — they have no Arlo instance access — so publishing each phase bundle to a stable public URL (e.g., a state elections website or GitHub release) is a required step in the workflow, not optional.
+**Goal:** Arlo scripts (standalone for now, eventually standard functions) to export and hash artifacts at each phase. Output is a directory tree with artifacts and a signed JSON manifest ready for public posting. Public posting is how observers access the data — they have no Arlo instance access — so publishing each phase bundle to a stable public URL (e.g., a state elections website) is a required step in the workflow, not optional.
 
 **Location:** `scripts/transparency/`
 
@@ -225,7 +224,7 @@ usage: export_phase.py --url ARLO_URL --election ELECTION_ID \
        --output-dir OUTPUT_DIR
 ```
 
-Authentication: reads a session token from `--token` or `ARLO_SESSION_TOKEN` env var (obtained by logging in via browser and copying the cookie).
+Authentication: reads a session token from `ARLO_SESSION_TOKEN` env var (obtained by logging in via browser and copying the cookie).
 
 **Behavior per phase:**
 
@@ -278,7 +277,7 @@ BEFORE entering the random seed.
 
 **Location:** `scripts/transparency/observer/`
 
-All scripts are standalone — they import only `consistent_sampler` (installable via `pip install consistent-sampler`) and standard library. No Arlo server code required.
+All scripts are standalone.  Arlo server library code reuse is fine.
 
 #### `observer/verify_manifests.py`
 
@@ -316,10 +315,10 @@ This is the core independent replication step. A successful match proves that th
 
 **Key implementation detail:** Arlo's `draw_sample` task in `server/api/rounds.py` calls `sampler.draw_sample()` from `server/audit_math/sampler.py`. The universe ordering is deterministic given the manifest. The observer script must replicate this ordering exactly. The code for this is in `server/audit_math/sampler.py` and `server/api/rounds.py` (`compute_sample_ballots`). Document the exact ordering in a comment in the observer script.
 
-#### `observer/replicate_pvalue.py`
+#### `observer/replicate_risk_level.py`
 
 ```
-usage: replicate_pvalue.py \
+usage: replicate_risk_level.py \
   --cvr FILE \                        # jurisdiction CVR CSVs (one or more)
   --audit-report FILE \               # official audit report (pseudo-CSV)
   --contest-name "Contest 1" \
@@ -335,7 +334,7 @@ usage: replicate_pvalue.py \
 4. Build `sampled_cvrs` dict: Imprinted ID → `{contest: {choice: count, "sampled": 1}}`
 5. Build `cvrs` dict (all CVR ballots): same structure
 6. Call `server.audit_math.supersimple.compute_risk(risk_limit, contest, cvrs, sampled_cvrs)` → `(p_value, is_complete)`
-7. Compare computed p-value against the value in the ROUNDS section of the audit report
+7. Compare computed risk level against the value in the ROUNDS section of the audit report
 8. Also call `supersimple.compute_discrepancies()` and compare `counted_as` values against the SAMPLED BALLOTS section
 
 **Note:** This script imports from `server.audit_math` — it requires a copy of the Arlo source. A fully standalone version would re-implement `supersimple.py`'s `nMin` and `compute_risk()` in ~50 lines, which is a good future step.
@@ -360,44 +359,44 @@ Round: 1
 [PASS] Sample draw replicated (45 ballots match official retrieval list)
 [PASS] CVR results in audit report match CVR file
 [PASS] Discrepancy scores match (0 type-2, 1 type-1, 44 type-0)
-[PASS] P-value replicated: computed=0.38, reported=0.38
+[PASS] risk level replicated: computed=0.38, reported=0.38
       Risk limit (10%) NOT MET — round 2 required.
 
 === Summary ===
-All checks passed. The reported p-value is independently reproducible.
+All checks passed. The reported risk level is independently reproducible.
 ```
 
 ---
 
 ### A5. Observer Excerpt Generator
 
-**Goal:** A script that joins the retrieval list with the CVR to produce a print-ready per-ballot excerpt that observers bring into the audit room. The observer follows along as the board reads each contest aloud and marks any vote that differs from what is printed. No writing required — just listening and marking.
+**Goal:** A script that joins the retrieval list with the CVR to produce a print-ready per-ballot excerpt that observers bring into the audit room. The observer follows along as the board reads each contest aloud and documents any vote they hear that differs from what is printed.
 
 **Location:** `scripts/transparency/observer/generate_excerpt.py`
 
 #### Format
 
-The format matches `neal_ignore/rightJustifiedBallotList.pdf` — the reference implementation for a zero-discrepancy audit. Each ballot is separated by a header line containing the imprinted ID bracketed by `<><><><><><><><><>` decorations (visually unambiguous, impossible to confuse with text). Contest names are right-justified in a fixed-width column; the CVR interpretation is printed immediately to the right.
+The format makes following along easy. Each ballot is separated by a header line containing the imprinted ID bracketed by `<><><><><><><><><>` decorations. Contest names are right-justified in a fixed-width column; the CVR interpretation is printed immediately to the right.
 
 ```
-<><><><><><><><><>  104-19-48  <><><><><><><><><>
-                   Presidential Electors  Kamala D. Harris / Tim Walz
-  Representative to the US Congress - District 7  Brittany Pettersen
-                             Amendment G  Yes/For
-                             Amendment H  Yes/For
-                             Amendment K  NO VOTE
-                         Proposition 127  No/Against
+<><><><><><><><><><><><><><><><><>><><><><><><>  104-19-48  <><><><><><><><><>
+                           Presidential Electors _ Kamala D. Harris / Tim Walz
+  Representative to the US Congress - District 7 _ Brittany Pettersen
+                                     Amendment G _ Yes/For
+                                     Amendment H _ Yes/For
+                                     Amendment K _ NO VOTE
+                                 Proposition 127 _ No/Against
 
-<><><><><><><><><>  105-55-20  <><><><><><><><><>
-                   Presidential Electors  Donald J. Trump / JD Vance
-  Representative to the US Congress - District 7  Sergei Matveyuk
-                        District Attorney  NO VOTE
-                             Amendment G  No/Against
+<><><><><><><><><><><><><><><><><><><><><><><>   105-55-20  <><><><><><><><><>
+                           Presidential Electors _ Donald J. Trump / JD Vance
+  Representative to the US Congress - District 7 _ Sergei Matveyuk
+                               District Attorney _ NO VOTE
+                                     Amendment G _ No/Against
 ```
 
 Ballots appear in physical retrieval order (by tabulator, batch, ballot position within batch) to match the sequence in which the board will handle them. Each ballot shows all contests on its ballot style — not just the targeted audit contests — because the board reads every race. Undervotes appear as `NO VOTE`, not as a blank, to make them explicit and audible.
 
-The observer marks directly on this printout when they hear something different from what is printed. In a zero-discrepancy audit, nothing gets marked.
+The observer writes directly on this printout when they hear something different from what is printed. In a zero-discrepancy audit, nothing gets marked.
 
 #### Usage
 
@@ -424,7 +423,7 @@ generate_excerpt.py \
 2. Parse the retrieval list to get sampled ballots in order (sort by Tabulator, Batch Name, Ballot Number)
 3. For each sampled ballot, look up its imprinted ID in the CVR lookup
 4. Compute the display width: the longest contest name across all sampled ballots' styles
-5. For each ballot, output the `<><>` header, then each contest right-padded to the display width, followed by the interpretation
+5. For each ballot, output the `<><>` header, then each contest name right-padded to the display width, followed by an underscore "_" followed by the interpretation
 6. Warn (but do not skip) if an imprinted ID from the retrieval list is not found in the CVR — this may indicate the ballot was in a rare style redacted from the public CVR (see Q1); the jurisdiction must provide the CVR row for that ballot separately, and the gap is itself a finding to report
 
 #### Blind-audit note in the script header
@@ -439,25 +438,24 @@ IMPORTANT: This document shows what the voting system recorded for each ballot.
 - DO NOT show this document to the audit board.
 - DO NOT communicate with the audit board during the session.
 - Audit boards must form their own interpretation of each ballot WITHOUT
-  seeing or hearing the CVR. This is what makes the audit independent.
-- Follow along silently. Mark any vote where you hear something different
-  from what is printed. In a zero-discrepancy audit, nothing gets marked.
+  seeing or hearing the CVR. This improves audit integrity.
+- Follow along silently. Note any vote where you hear something different
+  from what is printed.
 - After the session, compare your marked discrepancies against the Arlo
-  audit report (SAMPLED BALLOTS section). You may do this comparison on
-  paper without any computer.
+  audit report (SAMPLED BALLOTS section).
 ```
 
-The SHA-256 of the excerpt file is printed so observers can confirm they have the same file as other observers and that it was generated from the published CVR.
+The SHA-256 hash of the excerpt file is printed so observers can confirm they have the same file as other observers and that it was generated from the published CVR.
 
 #### After the session: paper-based comparison
 
 No additional script is needed for the comparison step. An observer with a marked excerpt does the following on paper:
 
-1. Print the SAMPLED BALLOTS section of the Arlo audit report
-2. For each ballot where you marked a deviation: find that ballot's row in the report
+1. Review the SAMPLED BALLOTS section of the Arlo audit report
+2. For each ballot where you marked a discrepancy: find that ballot's row in the report
 3. Check the "Audit Result" column — does it match what you heard the board say?
 4. Check the "CVR Result" column — does it match what is printed on your excerpt?
-5. Check the "Change in Margin" column — does the discrepancy score match the deviation you marked?
+5. Check the "Change in Margin" column — does the discrepancy score match the discrepancy you marked?
 
 Discrepancies between the observer's marks and the Arlo report are reported to the audit supervisor, not acted on unilaterally by the observer.
 
@@ -485,11 +483,11 @@ Three test files:
 - Run `replicate_sample.py` main function with seed + manifest
 - Assert output matches retrieved list exactly
 
-`test_replicate_pvalue.py`:
+`test_replicate_risk_level.py`:
 - After `round_1_id` fixture finishes and round is completed
 - Export audit report via API
-- Run `replicate_pvalue.py` with that report + CVR
-- Assert computed p-value matches `round_contest.end_p_value` in DB
+- Run `replicate_risk_level.py` with that report + CVR
+- Assert computed risk level matches `round_contest.end_p_value` in DB
 
 `test_end_to_end_verify.py`:
 - Drives a full 2-round audit using fixtures
@@ -511,6 +509,8 @@ Ordered by priority. Each item names the server files to change and the API surf
 **Problem:** `GET /election/<id>/report` returns pseudo-CSV with `######## SECTION ########` headers. It is not parseable by standard CSV tools. There is no JSON or HTML alternative.
 
 **Change:** Add `GET /election/<id>/report.json` (or add `Accept: application/json` content negotiation to the existing endpoint).
+
+Note this may be worth implementing before some of Track A is implemented.
 
 **Response shape:**
 ```json
@@ -560,13 +560,13 @@ Ordered by priority. Each item names the server files to change and the API surf
 
 ### B2. Opportunistic Contest Risk Levels (High Priority)
 
-**Problem:** Opportunistic contests receive no p-value at all. A contest with zero sampled ballots has a formal risk of 100%, but this is not reported anywhere — neither in the API response nor in the audit report.
+**Problem:** Evidence is generated for opportunistic contests, but risk reduction is not quantified.
 
 **Change 1:** In `calculate_risk_measurements()` (`server/api/rounds.py`), for opportunistic contests compute and store `end_p_value` even if it is 1.0 (or the value from the supersimple formula with zero sampled ballots).
 
 **Change 2:** Add a `universe_ballot_count` field per contest to the sample sizes response (`server/api/sample_sizes.py`) — the count of ballots in the sampling universe for that contest. This is the denominator for the diluted margin.
 
-**Change 3:** In the audit report (both CSV and new JSON), include opportunistic contest p-values with a note: `"Risk limit not met — no ballots sampled for this contest (formal risk: 100%)"` for zero-sample contests.
+**Change 3:** In the audit report (both CSV and new JSON), include opportunistic contest risk levels.
 
 **Files:** `server/api/rounds.py` (`calculate_risk_measurements`), `server/api/sample_sizes.py`, `server/api/reports.py`.
 
@@ -672,30 +672,15 @@ The "Mark as published" button records a `published_at` timestamp in the DB (new
 
 ---
 
-### B7. Reproducibility Bundle (Medium Priority)
+### B8. Timestamping Support (Lower Priority)
 
-**Problem:** There is no single artifact that, together with the published CSVs, lets an observer replay the entire audit.
-
-**Change:** Add `GET /election/<id>/reproducibility-bundle` after the audit is complete. Returns a ZIP containing:
-- `reproducibility_bundle.json` (see A1.3 above)
-- `README.md` with instructions for running `observer/end_to_end_verify.py`
-- A copy of `scripts/transparency/observer/` (the verification scripts themselves)
-
-This makes the reproducibility bundle self-contained: an observer downloads one ZIP and can verify everything.
-
-**Files:** New `server/api/reproducibility_bundle.py`.
-
----
-
-### B8. RFC 3161 Timestamping Support (Lower Priority)
-
-**Problem:** "Published at" timestamps are self-asserted. RFC 3161 trusted timestamps from a free TSA (e.g., freetsa.org) provide cryptographic proof of publication time, binding the artifact hash to a trusted time source.
+**Problem:** It is crucial that the data to be audited be committed to before the dice roll, so independent timestamps that can be publicly trusted and verified are important. Exact approach TBD.
 
 **Change:** Add a `timestamp_artifact(file_bytes, filename)` utility in `server/util/timestamp.py` that:
 1. Computes SHA-256 of the bytes
-2. Posts to a configured RFC 3161 TSA (`ARLO_TSA_URL`)
-3. Returns the DER-encoded timestamp token
-4. Stores it alongside the artifact (locally or in S3)
+2. Posts to a suitable, reliable trusted timestamp source (`ARLO_TIMESTAMP_SERVICE`)
+3. Returns the timestamp evidence
+4. Stores it alongside the artifact
 
 Wire this into `generate_pre_seed_bundle()` and `generate_reproducibility_bundle()`.
 
@@ -708,7 +693,7 @@ Wire this into `generate_pre_seed_bundle()` and `generate_reproducibility_bundle
 ```
 Week 1-2:  A1 — Pytest transparency test suite (2-round, phase-by-phase)
 Week 3:    A2 — Official export scripts (export_phase.py, hash_and_sign.py)
-Week 4:    A3 — Observer mechanical verification (replicate_sample.py, replicate_pvalue.py)
+Week 4:    A3 — Observer mechanical verification (replicate_sample.py, replicate_risk_level.py)
            A5 — Observer excerpt generator (generate_excerpt.py)
 Week 5:    A4 — Tests for A3 and A5 scripts
 Week 6:    B1 — JSON audit report endpoint
@@ -717,8 +702,7 @@ Week 8:    B3 — Sampler inputs artifact
 Week 9:    B4 — Pre-seed hash-index JSON endpoint
 Week 10:   B5 — Per-jurisdiction phase exports
 Week 11+:  B6 — UI transparency checklist (multi-week, involves React)
-           B7 — Reproducibility bundle
-           B8 — RFC 3161 timestamping
+           B8 — Timestamping
 ```
 
 ---
@@ -729,7 +713,7 @@ Week 11+:  B6 — UI transparency checklist (multi-week, involves React)
 |-------|------|-------|
 | Sample drawing | `server/api/rounds.py` `draw_sample()` | Background task; calls `compute_sample_ballots()` |
 | Sampler math | `server/audit_math/sampler.py` | Wraps `consistent_sampler` |
-| P-value computation | `server/audit_math/supersimple.py` | `compute_risk()`, `compute_discrepancies()` |
+| risk level computation | `server/audit_math/supersimple.py` | `compute_risk()`, `compute_discrepancies()` |
 | Discrepancy scores | `server/audit_math/supersimple.py` `compute_discrepancies()` | Returns `counted_as` per ballot |
 | Audit report | `server/api/reports.py` | `election_report()`, `sampled_ballots_rows()` |
 | Sample sizes | `server/api/sample_sizes.py` | Returns options for each round |

--- a/docs/transparency-implementation-plan.md
+++ b/docs/transparency-implementation-plan.md
@@ -212,7 +212,7 @@ At the end of Phase 5, the test generates a `reproducibility_bundle.json` that c
 
 ### A2. Official Export Scripts
 
-**Goal:** Standalone scripts (no Arlo source code required) that an election official runs against a live or test Arlo instance to export and hash artifacts at each phase. Output is a directory tree with artifacts and a signed JSON manifest ready for public posting.
+**Goal:** Standalone scripts (no Arlo source code required) that an election official runs against a live or test Arlo instance to export and hash artifacts at each phase. Output is a directory tree with artifacts and a signed JSON manifest ready for public posting. Public posting is how observers access the data — they have no Arlo instance access — so publishing each phase bundle to a stable public URL (e.g., a state elections website or GitHub release) is a required step in the workflow, not optional.
 
 **Location:** `scripts/transparency/`
 
@@ -410,13 +410,13 @@ generate_excerpt.py \
 ```
 
 - `--retrieval-list`: The retrieval list CSV downloaded from Arlo (columns: Tabulator, Batch Name, Ballot Number, Imprinted ID, Ticket Numbers, Status)
-- `--cvr`: The CVR file for this jurisdiction (Dominion, ESS, ClearBallot, or Hart format)
+- `--cvr`: The publicly-posted (anonymized) CVR file for this jurisdiction (Dominion, ESS, ClearBallot, or Hart format) — must be the version published before the seed, not a raw Arlo export
 - `--cvr-format`: CVR vendor format (determines column parsing)
 - `--output`: Output text file; if omitted, prints to stdout for piping to a printer
 
 #### Algorithm
 
-1. Parse the CVR file to build a lookup: `imprinted_id → {contest_name → interpretation}`. For Dominion format:
+1. Parse the publicly-posted (anonymized) CVR file to build a lookup: `imprinted_id → {contest_name → interpretation}`. For Dominion format:
    - Header row contains contest columns like `"Contest Name (Choice Name)"` after the first 8 fixed columns
    - For each ballot row, collect all (contest, choice) columns where the value is `1`
    - Group by contest name; if no choice has value `1`, record `NO VOTE` for that contest
@@ -425,7 +425,7 @@ generate_excerpt.py \
 3. For each sampled ballot, look up its imprinted ID in the CVR lookup
 4. Compute the display width: the longest contest name across all sampled ballots' styles
 5. For each ballot, output the `<><>` header, then each contest right-padded to the display width, followed by the interpretation
-6. Warn (but do not skip) if an imprinted ID from the retrieval list is not found in the CVR — this is itself a finding
+6. Warn (but do not skip) if an imprinted ID from the retrieval list is not found in the CVR — this may indicate the ballot was in a rare style redacted from the public CVR (see Q1); the jurisdiction must provide the CVR row for that ballot separately, and the gap is itself a finding to report
 
 #### Blind-audit note in the script header
 

--- a/docs/transparency-implementation-plan.md
+++ b/docs/transparency-implementation-plan.md
@@ -6,12 +6,47 @@ _Written 2026-06-20. Builds on `docs/transparency-report.md` and deep codebase r
 
 ## Overview
 
-A verifiable comparison audit requires that independent observers can, using only publicly-published artifacts, replicate every mechanically-determined step: sample draw, risk measurement, and discrepancy detection. Today all the math is in Arlo and all the data can be exported, but there is no workflow that ties it together, no scripts that demonstrate replication, and no machine-readable output format that makes replication easy.
+### The software-independence problem
 
-This plan has two tracks:
+The purpose of a risk-limiting audit is *software independence*: the ability to detect errors in the voting system — including its CVRs — without relying on the same software stack that produced them. The existing Track A (computer-verifying-computer) is necessary but not sufficient. Verifying the sample draw and p-value calculation independently is valuable, but it still leaves the most important link unchecked: **did the human audit boards correctly describe what they saw on the paper ballots, and did Arlo correctly record what the boards said?**
+
+That link can only be checked by **human observers who are physically present during audit board sessions**, maintaining their own silent, independent record of each ballot interpretation. Their record is then compared — after the session, not during — against both the CVR and the Arlo audit report. This comparison can and should be doable entirely on paper, without any computer, so that the verification chain remains independent of every system controlled by the jurisdiction.
+
+**The blind-audit principle** is what makes this work: audit boards must interpret each ballot without seeing the CVR's interpretation. If anyone communicates the CVR result to the board — observers, officials, or a screen visible in the room — the board could be coached to match a fraudulent CVR instead of reading the paper. Observers must therefore be silent: recording what they hear, never reacting, never speaking to boards, never revealing whether a ballot looks like a discrepancy. Any intervention compromises the independence of the audit.
+
+### Two classes of verification
+
+| Verification class | Who does it | When | Tools needed |
+|--------------------|------------|------|-------------|
+| **Mechanical** (sample draw, p-value) | Any observer with a computer | After artifacts are published | `replicate_sample.py`, `replicate_pvalue.py` |
+| **Human** (board vs. paper vs. CVR vs. Arlo record) | Observers physically present during audit | During each board session | Pre-generated transcript (paper), pen |
+
+Both classes are necessary. Neither is sufficient alone.
+
+### How the human observer layer actually works
+
+Observers cannot write fast enough to transcribe what they hear, and they must not interfere with the board. What they can do is **follow along on a pre-generated transcript** and mark any deviation.
+
+The transcript is produced by joining the retrieval list with the CVR: for each sampled ballot in physical retrieval order, it shows the ballot's imprinted ID and the voting system's recorded interpretation of each contest on that ballot. The observer holds this printout, listens as the board calls out each contest aloud (typically twice for double-checking), and marks any vote where what they hear differs from what is printed. In a zero-discrepancy audit, nothing gets marked. The format is right-justified by contest name so the eye can scan down a column of values quickly.
+
+The audit board **never sees the CVR** — in proper blind practice they have no access to it during the session. They examine only the physical paper ballot. The observer's transcript must likewise never be shown to the board; it would compromise the independence of the audit by revealing what the CVR says before the board states their own interpretation.
+
+The observer's marked printout is then compared against the Arlo audit report's SAMPLED BALLOTS section. Discrepancies can be checked in two directions:
+1. **Observer marked ≠ transcript printed** → the board saw something different from the CVR (a real discrepancy, should appear in Arlo's discrepancy report)
+2. **Observer's hearing ≠ Arlo's recorded audit result** → either the board misspoke, the observer mis-heard, or Arlo recorded something other than what the board said
+
+This final comparison can be done entirely on paper — no computer needed — which is what gives it independence from every system the jurisdiction controls.
+
+### CVR anonymization
+
+Before any CVR is published, rare ballot styles (those with fewer than ~10 ballots in the jurisdiction) must be aggregated to prevent vote revelation — a voter with a unique combination of contest choices could be identified from their CVR row. See [loriinboulder/anonymize_cvr](https://github.com/loriinboulder/anonymize_cvr), which implements Colorado's requirement (C.R.S. 24-72-205.5) and the approach documented in [Branscomb et al., 2018](http://www.sos.state.co.us/pubs/rule_making/hearings/2018/20180309BranscombEtAl.pdf) (endorsed by McBurnett, Stark, Rivest et al.). Arlo does not currently apply this redaction; it is the jurisdiction's responsibility before publishing the CVR.
+
+The transcript generator uses the full (unredacted) CVR for sampled ballots, since the physical ballots are in hand and the comparison is to individual rows — not to the aggregated public CVR. The anonymized CVR is what goes on the public website; the per-ballot transcript is a derivative of the unredacted data used only during the audit session itself.
+
+### This plan has two tracks
 
 **Track A — Observer Toolkit** (implement first, no Arlo changes required):
-Tests and scripts that walk through a complete 2-round ballot comparison audit, export artifacts phase by phase, and independently verify every calculation.
+Tests and scripts covering both verification classes: mechanical replication of every calculation, and paper-based tools for human observers to independently record and compare audit board interpretations.
 
 **Track B — Arlo Improvements** (implement after Track A proves what's needed):
 Changes to Arlo's API and UI that make the Track A workflow easy for officials and observers to follow in production.
@@ -24,13 +59,18 @@ Changes to Arlo's API and UI that make the Track A workflow easy for officials a
 |------|---------|
 | AA | Audit Admin (state-level) |
 | JA | Jurisdiction Admin (county-level) |
-| AB | Audit Board |
+| AB | Audit Board — the team (typically 2 people) that physically examines ballots and records interpretations |
 | CVR | Cast Vote Record — machine record of every ballot |
 | Imprinted ID | Tabulator/Batch/Position identifier stamped on ballot |
 | Ticket number | Fractional decimal from `consistent_sampler` — determines selection |
 | Diluted margin | `margin_votes / total_universe_ballots` |
 | `counted_as` | Supersimple discrepancy score: −2,−1,0,+1,+2 |
 | SHA-256 bundle | ZIP with a companion `*-sha256-hash.txt` inside |
+| Observation sheet | Paper form used by observers *during* a board session to record what boards say — no CVR content |
+| CVR Reveal sheet | Paper form used by observers *after* a session to compare their record against the CVR and Arlo report |
+| Blind audit | Audit boards never see the CVR at all — they interpret the paper ballot in isolation, then their interpretation is compared to the CVR by Arlo. This independence is what makes the audit meaningful: a board that sees the CVR could be coached to match a fraudulent one |
+| Rare style | A ballot style (combination of contest choices) appearing in fewer than ~10 ballots — must be aggregated in the public CVR to prevent vote revelation |
+| Observer transcript | Pre-generated printout joining retrieval list with CVR; observer follows along during the board session and marks deviations |
 
 ---
 
@@ -330,6 +370,110 @@ All checks passed. The reported p-value is independently reproducible.
 
 ---
 
+### A5. Observer Transcript Generator
+
+**Goal:** A script that joins the retrieval list with the CVR to produce a print-ready per-ballot transcript that observers bring into the audit room. The observer follows along as the board reads each contest aloud and marks any vote that differs from what is printed. No writing required — just listening and marking.
+
+**Location:** `scripts/transparency/observer/generate_transcript.py`
+
+#### Format
+
+The format matches `neal_ignore/rightJustifiedBallotList.pdf` — the reference implementation for a zero-discrepancy audit. Each ballot is separated by a header line containing the imprinted ID bracketed by `<><><><><><><><><>` decorations (visually unambiguous, impossible to confuse with text). Contest names are right-justified in a fixed-width column; the CVR interpretation is printed immediately to the right.
+
+```
+<><><><><><><><><>  104-19-48  <><><><><><><><><>
+                   Presidential Electors  Kamala D. Harris / Tim Walz
+  Representative to the US Congress - District 7  Brittany Pettersen
+                             Amendment G  Yes/For
+                             Amendment H  Yes/For
+                             Amendment K  NO VOTE
+                         Proposition 127  No/Against
+
+<><><><><><><><><>  105-55-20  <><><><><><><><><>
+                   Presidential Electors  Donald J. Trump / JD Vance
+  Representative to the US Congress - District 7  Sergei Matveyuk
+                        District Attorney  NO VOTE
+                             Amendment G  No/Against
+```
+
+Ballots appear in physical retrieval order (by tabulator, batch, ballot position within batch) to match the sequence in which the board will handle them. Each ballot shows all contests on its ballot style — not just the targeted audit contests — because the board reads every race. Undervotes appear as `NO VOTE`, not as a blank, to make them explicit and audible.
+
+The observer marks directly on this printout when they hear something different from what is printed. In a zero-discrepancy audit, nothing gets marked.
+
+#### Usage
+
+```
+generate_transcript.py \
+  --retrieval-list J1_round1_retrieval_list.csv \
+  --cvr J1_cvrs.csv \
+  --cvr-format dominion \
+  [--output transcript_J1_round1.txt]
+```
+
+- `--retrieval-list`: The retrieval list CSV downloaded from Arlo (columns: Tabulator, Batch Name, Ballot Number, Imprinted ID, Ticket Numbers, Status)
+- `--cvr`: The CVR file for this jurisdiction (Dominion, ESS, ClearBallot, or Hart format)
+- `--cvr-format`: CVR vendor format (determines column parsing)
+- `--output`: Output text file; if omitted, prints to stdout for piping to a printer
+
+#### Algorithm
+
+1. Parse the CVR file to build a lookup: `imprinted_id → {contest_name → interpretation}`. For Dominion format:
+   - Header row contains contest columns like `"Contest Name (Choice Name)"` after the first 8 fixed columns
+   - For each ballot row, collect all (contest, choice) columns where the value is `1`
+   - Group by contest name; if no choice has value `1`, record `NO VOTE` for that contest
+   - The `BallotType` column determines which contests appear on this ballot style (not all contests appear on all ballot types)
+2. Parse the retrieval list to get sampled ballots in order (sort by Tabulator, Batch Name, Ballot Number)
+3. For each sampled ballot, look up its imprinted ID in the CVR lookup
+4. Compute the display width: the longest contest name across all sampled ballots' styles
+5. For each ballot, output the `<><>` header, then each contest right-padded to the display width, followed by the interpretation
+6. Warn (but do not skip) if an imprinted ID from the retrieval list is not found in the CVR — this is itself a finding
+
+#### Blind-audit note in the script header
+
+The generated transcript includes a printed notice at the top:
+
+```
+OBSERVER TRANSCRIPT — [Election Name] — [Jurisdiction] — Round [N]
+Generated: [timestamp]  SHA-256: [hash of this file]
+
+IMPORTANT: This document shows what the voting system recorded for each ballot.
+- DO NOT show this document to the audit board.
+- DO NOT communicate with the audit board during the session.
+- Audit boards must form their own interpretation of each ballot WITHOUT
+  seeing or hearing the CVR. This is what makes the audit independent.
+- Follow along silently. Mark any vote where you hear something different
+  from what is printed. In a zero-discrepancy audit, nothing gets marked.
+- After the session, compare your marked discrepancies against the Arlo
+  audit report (SAMPLED BALLOTS section). You may do this comparison on
+  paper without any computer.
+```
+
+The SHA-256 of the transcript file is printed so observers can confirm they have the same file as other observers and that it was generated from the published CVR.
+
+#### After the session: paper-based comparison
+
+No additional script is needed for the comparison step. An observer with a marked transcript does the following on paper:
+
+1. Print the SAMPLED BALLOTS section of the Arlo audit report
+2. For each ballot where you marked a deviation: find that ballot's row in the report
+3. Check the "Audit Result" column — does it match what you heard the board say?
+4. Check the "CVR Result" column — does it match what is printed on your transcript?
+5. Check the "Change in Margin" column — does the discrepancy score match the deviation you marked?
+
+Discrepancies between the observer's marks and the Arlo report are reported to the audit supervisor, not acted on unilaterally by the observer.
+
+#### Test coverage
+
+`server/tests/transparency/test_generate_transcript.py`:
+- Use the existing `TEST_CVRS` fixture (Dominion format) and a synthetic retrieval list
+- Assert that every imprinted ID in the retrieval list appears in the output
+- Assert that contests are right-justified to the correct width
+- Assert that NO VOTE appears for undervotes
+- Assert that the transcript is in retrieval order (not CVR row order)
+- Assert that the SHA-256 printed at the top matches `hashlib.sha256(output.encode()).hexdigest()`
+
+---
+
 ### A4. Test Coverage for Observer Scripts
 
 **Location:** `server/tests/transparency/`
@@ -565,8 +709,9 @@ Wire this into `generate_pre_seed_bundle()` and `generate_reproducibility_bundle
 ```
 Week 1-2:  A1 — Pytest transparency test suite (2-round, phase-by-phase)
 Week 3:    A2 — Official export scripts (export_phase.py, hash_and_sign.py)
-Week 4:    A3 — Observer verification scripts (replicate_sample.py, replicate_pvalue.py)
-Week 5:    A4 — Tests for observer scripts
+Week 4:    A3 — Observer mechanical verification (replicate_sample.py, replicate_pvalue.py)
+           A5 — Observer transcript generator (generate_transcript.py)
+Week 5:    A4 — Tests for A3 and A5 scripts
 Week 6:    B1 — JSON audit report endpoint
 Week 7:    B2 — Opportunistic contest risk levels + universe ballot count
 Week 8:    B3 — Sampler inputs artifact
@@ -609,3 +754,7 @@ Week 11+:  B6 — UI transparency checklist (multi-week, involves React)
 3. **Opportunistic contest risk threshold:** When there are zero sampled ballots for an opportunistic contest, reporting 100% risk is technically correct but may be alarming. Should the UI explain this differently (e.g., "Not sampled — risk not calculated") or always use the mathematically correct 100%?
 
 4. **Auth for observer scripts:** The observer scripts need an Arlo session token. For testing, `FLASK_ENV=development` nOAuth accepts any email. For production, should Arlo add a read-only "observer" role with a long-lived API token for downloading public artifacts, rather than requiring a full audit-admin login?
+
+5. **Transcript generation: official tool or observer tool?** The transcript generator uses the CVR — a file that, for rare styles, must be anonymized before public release. Should Arlo generate the observer transcript server-side (using the unredacted CVR) and make it available for download alongside the retrieval list? Or should it remain an observer-side tool that observers generate from the publicly-posted (anonymized) CVR? The latter preserves more software independence but requires observers to handle CVR parsing; the former is more convenient but means observers must trust Arlo's output.
+
+6. **Arlo UI and the blind audit:** Arlo's online audit board UI currently shows the audit board member what the CVR says alongside the ballot (or makes it easy to derive). This violates the blind-audit principle for online audits. Should the UI be audited for CVR leakage, and should the board data-entry screen be redesigned to show only the ballot image (if available) and the contest names — never the CVR interpretation?

--- a/docs/transparency-report.md
+++ b/docs/transparency-report.md
@@ -1,0 +1,204 @@
+# Arlo Comparison Audit Transparency: Report and Guide
+
+## Executive Summary
+
+Arlo supports sufficient transparency for independently verifiable comparison audits: all data needed for verification can be exported by election officials in a timely manner at each stage. Some exports are already convenient and well-structured. The main gap is not missing data, but missing guidance — Arlo does not yet steer jurisdictions through the best-practice workflow of exporting, hashing, signing, and publishing each phase's artifacts before moving to the next phase.
+
+Key design points that are correct as-is:
+- **Arlo does not produce auditor transcripts** (pre-filled records of what each sampled ballot is expected to show). This is correct: producing such transcripts inside the audit tool would invite violating the blind-audit principle and could be used to script human interpretations. The right approach is for a *separate* observer tool to join the published sample list with the published CVR file *after* both are public, generating verification materials only for observers — never for audit boards.
+- **Arlo runs on a jurisdiction's internal, firewalled network**, not as a public-facing service. Election officials are responsible for exporting audit artifacts and publishing them to a public site or repository. Adding public API endpoints to Arlo itself would expand its attack surface and is inappropriate for an air-gap-friendly audit tool.
+
+Concrete improvements — ordered by priority — are described at the end of this document.
+
+---
+
+## Stage 1: Before the Random Seed — Uploading Inputs
+
+### What Arlo Can Export Today
+
+**For ballot comparison audits**, the audit admin can download (via authenticated API endpoints — Arlo runs on a firewalled internal network, so these are only accessible to authorized officials):
+- **Jurisdictions file** (`GET /election/<id>/jurisdictions/file`) — the list of participating counties/jurisdictions
+- **Standardized contests file** (`GET /election/<id>/standardized-contests/file`) — the set of contests to be audited
+- **Ballot manifest per jurisdiction** (`GET /election/<id>/jurisdiction/<id>/ballot-manifest/csv`) — batch/tabulator structure and ballot counts
+- **CVR file per jurisdiction** (`GET /election/<id>/jurisdiction/<id>/cvrs/csv`) — the cast vote record for every ballot, with imprinted IDs. Note that many jurisdictions are required to redact CVRs before publication to prevent vote revelation from rare ballot styles (see [Kuriwaki et al., 2025](https://www.science.org/doi/10.1126/sciadv.adt1512)); Arlo's CVR export does not currently apply any redaction.
+
+**For batch comparison audits**, additionally:
+- **Batch tallies per jurisdiction** (`GET /election/<id>/jurisdiction/<id>/batch-tallies/csv`) — reported vote counts per batch
+- **Batch inventory worksheet, CVR, and ballot manifest** (generated from batch inventory sign-off flow)
+- **Bundle downloads**: Arlo recently added `POST /election/<id>/batch-files/manifests-bundle` and `POST /election/<id>/batch-files/candidate-totals-bundle` — these assemble all jurisdiction manifests or batch tallies into a single ZIP, compute a **SHA-256 hash** of the inner archive, and include a `*-sha256-hash.txt` file in the outer ZIP. This is the most significant transparency artifact for the pre-seed stage.
+
+**Audit settings** (risk limit, math type, contest definitions with vote totals) are entered before the seed and appear in the final audit report.
+
+### Gaps
+
+- **No per-jurisdiction export of new data for each phase** — most observation happens at the county level. Each phase (pre-seed, pre-round, final) should produce a per-jurisdiction export of the data *new to that phase* (e.g., manifests and redacted CVRs pre-seed; retrieval lists pre-round; interpretations post-audit). There is no need to re-bundle unchanged data such as CVRs in every phase export.
+- **No CVR redaction on export** — Arlo exports the full CVR without redaction. Jurisdictions that are required to redact rare-style ballots must do so manually before publication.
+- **No single "pre-seed inputs" bundle** — the canonical pre-seed artifact that officials should sign and publish is a JSON file containing hashes of all uploaded input files (manifests, redacted CVRs, settings) with pointers to where the files are published. Observers verify files by checking the hashes themselves; the JSON artifact is what officials timestamp and sign.
+- **No UI guidance for transparency best practices** — Arlo does not yet steer jurisdictions through the workflow of exporting, hashing, publishing, and timestamping each phase's artifacts before proceeding to the next.
+- **No formal "checkpoint" or UI gate** that enforces publishing and timestamping hashed inputs before the seed is entered.
+- **No Arlo-managed signing workflow** — sign-off tracking in `BatchInventoryData` stores a `signed_off_at` timestamp and `sign_off_user_id`, but this is an internal status flag, not a cryptographic signature or exported signed artifact.
+
+### Guide: What to Do Today (Pre-Seed)
+
+1. Once all jurisdictions have uploaded their manifests, CVRs (for ballot comparison), and batch tallies (for batch comparison), download them via the API — jurisdiction by jurisdiction, since observation happens primarily at the local (county) level. For batch comparison, use the manifests-bundle and candidate-totals-bundle endpoints to get the SHA-256-hashed ZIP bundles.
+2. For ballot comparison audits, download each jurisdiction's CVR file. Apply any redaction required by your jurisdiction to protect rare-style ballot privacy before publication (Arlo does not apply redaction automatically). Compute a SHA-256 hash of each jurisdiction's redacted CVR, manifest, and settings.
+3. Export the contest settings and standardized contests file.
+4. For each jurisdiction, assemble a per-jurisdiction pre-seed export of the *new* data for this phase (manifest, redacted CVR, relevant contest settings). Compute a SHA-256 hash of each file. Create a JSON index file recording the hashes and pointers to where each file will be published; have the responsible official sign this JSON index (e.g., with PGP or a digital certificate). Publish the data files and signed JSON index to your public website or repository before entering the random seed.
+5. Record the exact timestamp of the public publication.
+
+---
+
+## Stage 2: After the Seed, Before Comparisons — Publishing the Sample
+
+### What Arlo Can Export Today
+
+Once a round is started (seed entered, sample drawn), Arlo provides per-jurisdiction **ballot retrieval lists**:
+- `GET /election/<id>/jurisdiction/<id>/round/<id>/ballots/retrieval-list` — CSV with container, tabulator, batch name, ballot position, imprinted ID, ticket numbers, already-audited flag, and audit board assignment.
+
+For ballot comparison audits, the imprinted ID is included in the retrieval list. Since the CVR was published in Stage 1, an observer can look up the CVR interpretation for each sampled ballot using the imprinted ID as a key. Importantly, observers should do this join *after* the sample is public and *outside* of Arlo, so that audit boards never see pre-joined CVR interpretations that could script their judgments.
+
+The **sample preview** endpoints allow the audit admin to estimate the sample size distribution across jurisdictions *before* officially launching a round. `POST /election/<id>/sample-preview` triggers a background computation given a set of proposed sample sizes; `GET /election/<id>/sample-preview` retrieves the result once complete. The response lists, for each jurisdiction, the projected number of sample draws (`numSamples`) and the number of unique ballots (`numUnique`) that would be selected. This is useful for workload planning but does not produce a binding sample — the actual sample is drawn when the round is officially started.
+
+**The random seed** (`randomSeed`) is stored in `Election.random_seed` and is available via `GET /election/<id>/settings` once entered. It also appears in the final audit report header. The seed is typically a 20-digit number publicly drawn (e.g., from a live lottery). What is currently missing is a *structured bundle* that packages the seed together with the hashes of the pre-published inputs so observers can invoke `consistent_sampler` directly to verify the sample draw.
+
+### Gaps
+
+- **No combined cross-jurisdiction "all sampled ballots" export at round start time** — the retrieval list requires a separate download per jurisdiction.
+- **No structured sampler-inputs bundle** — while the random seed is available from `GET /election/<id>/settings` and from the audit report, there is no single export that packages the seed together with the manifest hashes and CVR hashes used for sampling, so independent reproduction of the sample requires re-running Arlo or careful manual reconstruction.
+- **Ticket numbers explain sampling but require the sampler algorithm to verify** — while `consistent_sampler` is open-source, no guided export walks observers through calling it with the exact inputs.
+
+### Guide: What to Do Today (Post-Seed, Pre-Comparisons)
+
+1. Immediately after starting the round, export the retrieval list for every jurisdiction (one download per jurisdiction, matching the local observation model).
+2. Publish the random seed — it is available immediately via `GET /election/<id>/settings` (field `randomSeed`) and will also appear in the final audit report. The seed can be published as a plain number; it is not sensitive.
+3. Publish each jurisdiction's retrieval list along with the seed and a timestamp. Observers can then independently join the retrieval list against the CVR file published in Stage 1 (using the imprinted ID as the key) to verify CVR interpretations — this join should happen externally, not inside Arlo.
+4. Add a signed timestamp to the published retrieval lists so observers can verify that the sample was not changed after the seed was entered.
+
+---
+
+## Stage 3: After the Audit — Publishing Comparisons and Conclusions
+
+### What Arlo Can Export Today
+
+The primary post-audit export is the **audit admin audit report** (`GET /election/<id>/report`):
+- **ELECTION INFO**: Organization, election name, state
+- **CONTESTS**: Contest names, targeted/opportunistic, vote totals, number of winners
+- **AUDIT SETTINGS**: Audit name, type, math type, risk limit, **random seed**, online/offline
+- **AUDIT BOARDS**: Member names and affiliations (for online audits)
+- **ROUNDS**: For each round and contest — sample size, risk limit met (Yes/No), **p-value**, start/end time, audited vote totals (CVR vs non-CVR for hybrid)
+- **SAMPLED BALLOTS** (for ballot comparison):
+  - Jurisdiction, container, tabulator, batch name, ballot position, imprinted ID
+  - Ticket numbers per targeted contest
+  - CVR result per contest
+  - Audit result per contest
+  - **Change in results** (vote delta)
+  - **Change in margin** (discrepancy score, i.e., `counted_as` in supersimple terms: −2, −1, 0, +1, +2)
+- **SAMPLED BATCHES** (for batch comparison):
+  - Jurisdiction, batch, ballots in batch, ticket numbers, audited flag, reported results, audit results, change in results/margin
+
+Additionally, a separate **discrepancy report** endpoint (`GET /election/<id>/discrepancy-report`) provides a focused view of the ballot or batch data without the summary header sections.
+
+The **jurisdiction admin report** provides a per-jurisdiction view of the same sampled ballot/batch data.
+
+### What's Included for Independent Reproducibility
+
+For ballot comparison (supersimple), an observer can in principle independently reproduce the p-value if they have:
+- The contest vote totals (in the report)
+- The random seed (in the report)
+- The ballot manifest and CVR files (published in Stage 1)
+- The auditor's interpretations for each sampled ballot (in the report)
+
+All of these are in the audit report or were published in earlier stages. The supersimple algorithm is open-source in Arlo's [`server/audit_math/supersimple.py`](../server/audit_math/supersimple.py).
+
+For batch comparison (MACRO), the same is true with batch tallies instead of CVRs.
+
+#### Sampling universe for each contest
+
+An important detail for independent risk computation is knowing the *sampling universe* for each contest — the set of ballots (or batches) that were eligible to be sampled for it. This depends on the sampling approach used:
+
+- For **targeted contests**, the universe is all ballots (or batches) in the contest's participating jurisdictions — those listed in the standardized contests file for that contest. The manifest for each jurisdiction defines how many ballots exist; the combined total is the denominator used in the risk calculation.
+- For **uniform sampling across jurisdictions**, the universe for any contest (targeted or opportunistic) is defined by the jurisdictions the contest appears in. Risk statistics may require calculating the *minimum uniform sampling rate* across those jurisdictions and discarding extra samples from jurisdictions sampled at a higher rate for other contests — only samples at or below that minimum rate are relevant to the risk calculation.
+- For **style-based sampling**, the universe for a contest is the set of ballots the contest appears on (determined from the CVR's ballot style data). This is a subset of all ballots in the contest's jurisdictions, and the risk calculation uses the ballot-style universe rather than the full jurisdiction ballot count.
+
+The size of the sampling universe and how it was constructed are critical inputs for verifying risk levels for all contests — targeted and opportunistic alike. For each contest, the participating jurisdictions are defined by the contest's entries in the standardized contests file, which is downloadable in Stage 1.
+
+#### How `sampled_ballot_interpretations_to_cvrs` works
+
+The internal function `sampled_ballot_interpretations_to_cvrs` (in `server/api/shared.py`) is the bridge between auditor input data and the risk computation. It converts each auditor's ballot interpretation into the `SAMPLECVRS` format expected by `supersimple.compute_risk`. For each sampled ballot it produces an entry with:
+- `times_sampled`: for targeted contests, the number of ticket numbers the ballot received; for opportunistic contests, always 1
+- `cvr`: a dict mapping each candidate/choice to 1 (voted) or 0 (not voted), or `None` if the ballot was `NOT_FOUND`, or `{}` if the contest was not on the ballot
+
+The audit report's "CVR Result" and "Audit Result" columns encode this same information in human-readable form; the "Change in Margin" column encodes the `counted_as` discrepancy category (−2 to +2) that supersimple uses directly in its risk formula. An observer reproducing the p-value should map the "Change in Margin" column entries to the `counted_as` values in the supersimple algorithm.
+
+### Gaps
+
+- **Opportunistic contests: risk levels not computed or reported**: The audit report lists the CVR and audit results for opportunistic contests in sampled ballot rows, but Arlo does not compute or export a risk level (p-value) for them. If no data is reported for a contest, the risk level is formally 100%.
+- **Sampling universe not explicitly exported**: The composition and size of each contest's sampling universe — including universe type (uniform jurisdiction-based vs. style-based), the minimum uniform sampling rate across relevant jurisdictions, and the set of samples included in the risk calculation — must currently be derived manually. These are not included in the audit report but are required to independently verify risk levels.
+- **No p-value history for intermediate rounds**: The report shows the final p-value per round, but if the audit ran multiple rounds, the progression of risk reduction is not shown in a way that is easy to extract.
+- **Audit report not in a proper machine-readable format**: The current "CSV" export mixes section headers and data rows, making it unsuitable for programmatic parsing. It should be offered in both HTML and structured JSON formats, with hashed references to the underlying CVR files for end-to-end traceability.
+- **No self-contained reproducibility bundle**: There is no single export that bundles (a) the audit inputs, (b) the sample, (c) the interpretations, and (d) the risk computation result with enough metadata for a third party to run the risk computation independently without any Arlo access.
+- **The "change in margin" column for ballot comparison shows the discrepancy category** (`counted_as`) not the raw vote delta: The values are −2, −1, 0, +1, +2 (supersimple categories), which is the right input for the risk formula, but an observer unfamiliar with the supersimple algorithm may not understand how to use these to reproduce the p-value.
+
+### Guide: What to Do Today (Post-Audit)
+
+1. Download the audit report CSV. This is the primary artifact.
+2. Verify the p-values using the `supersimple.py` or `macro.py` algorithms. The report contains all the inputs: contest totals, sample size, discrepancy counts (change in margin values: −2 to +2).
+3. For ballot comparison: cross-reference the "CVR Result" and "Audit Result" columns for each ballot with the original CVR files (published in Stage 1) to independently verify that the reported CVR interpretations match the CVR files.
+4. For opportunistic contests: Arlo does not currently compute or export their risk levels. To compute them manually: identify all sampled ballots in jurisdictions participating in the opportunistic contest (from the audit report), determine the total ballot universe for that contest (from the manifests published in Stage 1 filtered to the contest's jurisdictions), look up CVR and audit interpretations, and run `supersimple.compute_risk` independently.
+5. Publish per-jurisdiction post-audit exports: for each jurisdiction, bundle the *new* data for this phase (retrieval list, audit interpretations from the report) and publish them. Together with the pre-seed Stage 1 signed hash index and the random seed, these form a complete, reproducible audit record.
+
+---
+
+## Recommendations for Improving Transparency Support
+
+The following recommendations are ordered roughly by impact and implementation complexity.
+
+### High Priority
+
+1. **Guide jurisdictions through transparency and reproducibility best practices in the UI** — Arlo should steer officials through the workflow of exporting, hashing, signing, publishing, and timestamping each phase's artifacts before proceeding to the next step. This is the single highest-leverage improvement: all data already exists, but no guided path exists to get it into the public record correctly.
+
+2. **Compute and report risk levels for every contest in the audit report**, including opportunistic contests. If no audit data is available for a contest (e.g., it received no sampled ballots), the report should explicitly note that the risk level is formally 100% — meaning the audit provides no assurance for that contest without additional audits or a recount. Export the intermediate numbers needed to reproduce each risk calculation: universe composition and size, universe type (uniform jurisdiction-based vs. style-based), minimum uniform sampling rate across the universe jurisdictions, and the list of samples included in the risk computation.
+
+3. **Integrate pre-seed publication and verifiable timestamping as a gate before seed generation** — the UI should require officials to confirm that the pre-seed data has been exported, hashed, and published (with a timestamp) before the seed entry step is unlocked. The canonical pre-seed artifact is a signed JSON file containing hashes of all input files (manifests, redacted CVRs, settings) and pointers to where the files are published; observers verify files themselves by checking the hashes.
+
+4. **Provide the audit report in proper machine-readable formats** — the current "CSV" export mixes section headers and data rows and is not a valid CSV suitable for automated processing. The report should be offered in both HTML and structured JSON formats, with hashed references to the family of per-jurisdiction CVR files bundled for transport. JSON is the canonical format for programmatic reproducibility; HTML is the canonical format for human-readable publication.
+
+5. **Add per-jurisdiction phase exports** — at each phase (pre-seed, pre-round, post-audit) provide a convenience export for each jurisdiction containing *only the new data for that phase*: manifests and redacted CVRs pre-seed; retrieval lists pre-round; interpretations post-audit. There is no need to re-bundle data already published in earlier phases.
+
+### Medium Priority
+
+6. **Add a "pre-seed audit inputs" hash index** (`GET /election/<id>/pre-seed-inputs-index`) that produces a structured JSON containing: contest settings, risk limit, jurisdictions list, and SHA-256 hashes of all uploaded manifest and redacted CVR files, with pointers to their published locations. This is the artifact for officials to sign and publish as the pre-seed commitment.
+
+7. **Surface the sampler inputs as a published artifact**: After the sample is drawn, export a structured file containing the seed, the manifest hashes, the CVR hashes (for ballot comparison), and the `consistent_sampler` version used, so observers can call `consistent_sampler` directly to verify the sample draw.
+
+8. **Add a "reproducibility bundle"** post-audit that packages the audit report, the algorithm name and version, and a README explaining exactly how to reproduce the risk calculation (what inputs go into `supersimple.compute_risk` or `macro.compute_risk`, how to parse the relevant columns from the audit report, and which open-source code to use).
+
+### Lower Priority
+
+9. **Document the `CARD_STYLE_DATA` audit math type for public observers** — Arlo supports a card-style-data variant of ballot comparison that uses ballot style information from the CVR to compute contest-specific expected error rates (reducing sample sizes for contests that appear on only a subset of ballot styles). Currently this math type and its transparency implications are not documented for observers who need to replicate the risk computation.
+
+10. **Integrate timestamp-authority support**: Allow officials to submit a hash of the pre-seed inputs index to a public timestamp service (e.g., RFC 3161) and record the receipt in Arlo's database. This provides verifiable proof of when the data was committed.
+
+11. **Make the "change in margin" column in the audit report more transparent**: Add a companion column that explains the discrepancy in plain language (e.g., "2-vote overstatement") so that observers unfamiliar with the supersimple algorithm can understand the data.
+
+12. **Formalize the sign-off workflow for audit admins**: Currently, the batch inventory sign-off tracks timestamps (`signed_off_at`, `sign_off_user_id`), but there is no audit-admin-level sign-off gate between the "inputs uploaded" and "seed entered" stages, nor between "sample drawn" and "comparisons entered." Adding explicit sign-off checkpoints with exported, signed receipts at each stage would support a complete chain of custody.
+
+---
+
+## Summary Table
+
+| Transparency Need | Arlo Today | Gap / Note |
+|---|---|---|
+| Export all input data (manifests) | ✅ Per-jurisdiction CSV + bundle w/ SHA-256 (batch comparison) | ⚠️ Per-jurisdiction CSV for ballot comparison; no hash bundle |
+| Export all input data (redacted CVRs) | ✅ Per-jurisdiction CSV exportable | ❌ No built-in redaction for rare-style privacy; no SHA-256 hash index |
+| Pre-seed signature artifact | ⚠️ All raw data is exportable | ❌ No structured hash-index JSON; no UI gate before seed entry |
+| Post-seed: sample selection list | ✅ Per-jurisdiction retrieval list w/ imprinted ID | ❌ No combined list; observer CVR join must happen outside Arlo |
+| Random seed availability | ✅ Available via settings endpoint and in audit report | ❌ No structured sampler-inputs bundle (seed + hashes) for independent verification |
+| Post-audit: discrepancy/comparison export | ✅ Audit report + discrepancy report | ❌ Not proper CSV/JSON; sampling universe not explicit; no HTML version |
+| Sampling universe per contest | ⚠️ Derivable from manifest + standardized contests file | ❌ Universe type, minimum sampling rate, and included samples not exported |
+| Risk level for opportunistic contests | ❌ Not computed or exported | ❌ Significant gap; universe and p-value must be computed manually; 100% risk not noted |
+| CARD_STYLE_DATA (style-based selection) | ✅ Implemented in codebase | ❌ Not documented for observers; transparency implications unstated |
+| Reproducibility documentation | ❌ Not provided as a bundle | ❌ Algorithm is open-source; no guided README or bundle |
+| Public transparency endpoint | N/A — Arlo runs on a firewalled internal network | Officials export and publish data externally; no public endpoint needed or appropriate |
+| Cryptographic signing support | ❌ No Arlo-native support | Officials sign exported artifacts externally; RFC 3161 timestamping would help |
+| Activity/chain-of-custody log | ⚠️ Internal `ActivityLogRecord` table only | ❌ Not exportable |


### PR DESCRIPTION
Adds three planning documents for Arlo comparison audit transparency.

---

### `docs/transparency-report.md`

Analysis of what Arlo currently exports at each phase of a comparison audit, where the transparency gaps are, and prioritized recommendations for closing them. Covers pre-seed, post-seed, and post-audit phases; identifies gaps in machine-readable formats, opportunistic contest risk levels, pre-seed commitment workflow, and per-jurisdiction phase exports.

---

### `docs/transparency-implementation-plan.md`

Phased implementation plan grounded in two principles:

**Software independence** — the ability to detect voting system errors without relying on the same software stack that produced them. Requires both mechanical verification (anyone can replicate the sample draw and risk calculation from published artifacts) and human verification (physically present observers independently record board interpretations and compare against Arlo's record).

**The blind audit principle** — audit boards must interpret each ballot without seeing the CVR. Observers follow along silently using a pre-generated excerpt that joins the retrieval list with the CVR; they never show it to the board or speak during the session.

#### Track A — Observer Toolkit (no Arlo changes required)

- **A1** Pytest integration test suite: full 2-round audit, saving phase artifacts with SHA-256 hashes at each transition
- **A2** Official export functions: download and hash phase artifacts for public posting (public posting is required — observers have no Arlo instance access)
- **A3** Independent observer verification scripts: `replicate_sample.py`, `replicate_risk_level.py`, `end_to_end_verify.py` — replicates sample draw and risk level from published artifacts alone
- **A4** Test coverage for A3/A5 scripts
- **A5** Observer excerpt generator: joins retrieval list with CVR to produce a print-ready per-ballot sheet; includes a printed notice reminding observers not to show it to the board

#### Track B — Arlo Improvements

- **B1** Machine-readable audit report (JSON endpoint) — may be worth implementing before some Track A work
- **B2** Opportunistic contest risk levels: compute and export risk for contests that received ballots incidentally; add `universe_ballot_count` per contest to sample sizes response
- **B3** Per-contest, per-jurisdiction eligible ballot count endpoint: needed to verify opportunistic risk level denominators — the manifest CSVs give total ballot counts but not the count of ballots containing a given contest, which comes from CVR metadata
- **B4** Pre-seed hash-index JSON endpoint
- **B5** Per-jurisdiction phase exports (new data only per phase)
- **B6** UI transparency checklist panel at each phase transition (soft gate, not a hard block)
- **B8** Trusted timestamping support (approach TBD)

Also notes CVR anonymization requirements (rare ballot styles < ~10 must be aggregated before public CVR release) and why Arlo server library code reuse is appropriate for observer scripts.

---

### `docs/cloud-testing-deployment-plan.md`

Notes on cloud testing and deployment context for running Arlo in a test environment.

---

*Originally drafted with [Copilot](https://github.com/features/copilot). Developed with [Claude Code](https://claude.com/claude-code).*