### PR TITLE
Allow manual selection of extra batches before audit launch

### DIFF
--- a/client/src/components/SupportTools/Jurisdiction.tsx
+++ b/client/src/components/SupportTools/Jurisdiction.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import styled from 'styled-components'
@@ -15,12 +15,15 @@ import {
 import { MultiSelect, renderFilteredItems } from '@blueprintjs/select'
 import { useForm, Controller } from 'react-hook-form'
 import {
+  IBatch,
+  ICombinedBatch,
   useJurisdiction,
   useClearAuditBoards,
   useClearOfflineResults,
   useJurisdictionBatches,
   useCreateCombinedBatch,
   useDeleteCombinedBatch,
+  useSetRequiredBatches,
 } from './support-api'
 import { useConfirm, Confirm } from '../Atoms/Confirm'
 import AuditBoardsTable from '../AuditAdmin/Progress/AuditBoardsTable'
@@ -28,7 +31,7 @@ import Breadcrumbs from './Breadcrumbs'
 import { Column, Row, Table } from './shared'
 import H2Title from '../Atoms/H2Title'
 
-const CombinedBatchForm = styled.form`
+const BatchForm = styled.form`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -40,19 +43,245 @@ const CombinedBatchForm = styled.form`
   }
 `
 
-const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
-  const jurisdiction = useJurisdiction(jurisdictionId)
-  const clearAuditBoards = useClearAuditBoards()
-  const clearOfflineResults = useClearOfflineResults()
-  const batches = useJurisdictionBatches(jurisdictionId)
+const BatchMultiSelect = ({
+  batches,
+  selectedBatchIds,
+  onChange,
+  placeholder = 'Search by batch name...',
+}: {
+  batches: IBatch[]
+  selectedBatchIds: string[]
+  onChange: (batchIds: string[]) => void
+  placeholder?: string
+}) => (
+  <MultiSelect
+    items={batches}
+    selectedItems={batches.filter(batch => selectedBatchIds.includes(batch.id))}
+    onItemSelect={item => {
+      onChange(
+        selectedBatchIds.includes(item.id)
+          ? selectedBatchIds.filter(id => id !== item.id)
+          : [...selectedBatchIds, item.id]
+      )
+    }}
+    onRemove={item => {
+      onChange(selectedBatchIds.filter((id: string) => id !== item.id))
+    }}
+    itemListRenderer={itemListProps => (
+      <Menu
+        ulRef={
+          itemListProps.itemsParentRef as (ref: HTMLUListElement | null) => void
+        }
+        style={{ maxHeight: 350, overflowY: 'auto' }}
+      >
+        {renderFilteredItems(
+          itemListProps,
+          <MenuItem disabled text="No matching batches." />
+        )}
+      </Menu>
+    )}
+    itemRenderer={(item, { handleClick, modifiers }) => (
+      <MenuItem
+        key={item.id}
+        text={item.name}
+        onClick={handleClick}
+        active={modifiers.active}
+        icon={selectedBatchIds.includes(item.id) ? 'tick' : 'blank'}
+      />
+    )}
+    tagRenderer={item => item.name}
+    itemPredicate={(query, item) =>
+      item.name.toLowerCase().includes(query.toLowerCase())
+    }
+    placeholder={placeholder}
+    resetOnSelect
+    fill
+    popoverProps={{ minimal: true }}
+    tagInputProps={{ tagProps: { minimal: true } }}
+  />
+)
+
+const RequiredBatchesForm = ({
+  jurisdictionId,
+  batches,
+}: {
+  jurisdictionId: string
+  batches: IBatch[]
+}) => {
+  const setRequiredBatches = useSetRequiredBatches()
+  const [requiredBatchIds, setRequiredBatchIds] = useState(() =>
+    batches.filter(batch => batch.required).map(batch => batch.id)
+  )
+
+  const onClickSave = async () => {
+    try {
+      await setRequiredBatches.mutateAsync({
+        jurisdictionId,
+        batchIds: requiredBatchIds,
+      })
+      toast.success('Saved required batches')
+    } catch (error) {
+      // Do nothing - errors toasted by queryClient
+    }
+  }
+
+  return (
+    <Card>
+      <BatchForm>
+        <div>
+          <label htmlFor="requiredBatchIds">Batches to Require:</label>
+          <BatchMultiSelect
+            batches={batches}
+            selectedBatchIds={requiredBatchIds}
+            onChange={setRequiredBatchIds}
+            placeholder="Search by batch name to require..."
+          />
+        </div>
+        <Button
+          icon="tick"
+          style={{ alignSelf: 'end' }}
+          loading={setRequiredBatches.isLoading}
+          onClick={onClickSave}
+        >
+          Save Required Batches
+        </Button>
+      </BatchForm>
+    </Card>
+  )
+}
+
+const CombinedBatchesForm = ({
+  jurisdictionId,
+  batches,
+  combinedBatches,
+}: {
+  jurisdictionId: string
+  batches: IBatch[]
+  combinedBatches: ICombinedBatch[]
+}) => {
   const createCombinedBatch = useCreateCombinedBatch()
   const deleteCombinedBatch = useDeleteCombinedBatch()
-  const { confirm, confirmProps } = useConfirm()
 
   const { register, handleSubmit, reset, control, formState } = useForm<{
     name: string
     subBatchIds: string[]
   }>()
+
+  const onSubmitCreateCombinedBatch = async ({
+    name,
+    subBatchIds,
+  }: {
+    name: string
+    subBatchIds: string[]
+  }) => {
+    try {
+      await createCombinedBatch.mutateAsync({
+        jurisdictionId,
+        name,
+        subBatchIds,
+      })
+      reset()
+    } catch (error) {
+      // Do nothing - errors toasted by queryClient
+    }
+  }
+
+  return (
+    <>
+      <Card>
+        <BatchForm>
+          <div>
+            <label htmlFor="combinedBatchName">Combined Batch Name:</label>
+            <input
+              type="text"
+              name="name"
+              id="combinedBatchName"
+              className={Classes.INPUT}
+              ref={register}
+              style={{ flexGrow: 1 }}
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="subBatchIds">Batches to Combine:</label>
+            <Controller
+              name="subBatchIds"
+              control={control}
+              defaultValue={[]}
+              render={({
+                value,
+                onChange,
+              }: {
+                value: string[] // eslint-disable-line react/no-unused-prop-types
+                onChange: (value: string[]) => void // eslint-disable-line react/no-unused-prop-types
+              }) => (
+                <BatchMultiSelect
+                  batches={batches}
+                  selectedBatchIds={value}
+                  onChange={onChange}
+                />
+              )}
+            />
+          </div>
+          <Button
+            icon="insert"
+            style={{ alignSelf: 'end' }}
+            loading={formState.isSubmitting}
+            onClick={handleSubmit(onSubmitCreateCombinedBatch)}
+          >
+            Create Combined Batch
+          </Button>
+        </BatchForm>
+      </Card>
+      {combinedBatches.length > 0 && (
+        <Table striped>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Batches</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {combinedBatches.map(combinedBatch => (
+              <tr key={combinedBatch.name}>
+                <td>{combinedBatch.name}</td>
+                <td style={{ textAlign: 'left' }}>
+                  {combinedBatch.subBatches
+                    .map(subBatch => subBatch.name)
+                    .join(', ')}
+                </td>
+                <td>
+                  <Button
+                    onClick={() =>
+                      deleteCombinedBatch.mutate({
+                        jurisdictionId,
+                        name: combinedBatch.name,
+                      })
+                    }
+                    loading={deleteCombinedBatch.isLoading}
+                    icon="delete"
+                    intent="danger"
+                    minimal
+                  >
+                    Delete
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      )}
+    </>
+  )
+}
+
+const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
+  const jurisdiction = useJurisdiction(jurisdictionId)
+  const clearAuditBoards = useClearAuditBoards()
+  const clearOfflineResults = useClearOfflineResults()
+  const batches = useJurisdictionBatches(jurisdictionId)
+  const { confirm, confirmProps } = useConfirm()
 
   if (!jurisdiction.isSuccess) return null
 
@@ -89,26 +318,6 @@ const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
         toast.success(`Cleared results for ${name}`)
       },
     })
-  }
-
-  const onSubmitCreateCombinedBatch = async ({
-    // eslint-disable-next-line no-shadow
-    name,
-    subBatchIds,
-  }: {
-    name: string
-    subBatchIds: string[]
-  }) => {
-    try {
-      await createCombinedBatch.mutateAsync({
-        jurisdictionId,
-        name,
-        subBatchIds,
-      })
-      reset()
-    } catch (error) {
-      // Do nothing - errors toasted by queryClient
-    }
   }
 
   return (
@@ -170,144 +379,19 @@ const Jurisdiction = ({ jurisdictionId }: { jurisdictionId: string }) => {
           )}
           {election.auditType === 'BATCH_COMPARISON' && batches.isSuccess && (
             <>
+              <H2Title>Required Batches</H2Title>
+              <RequiredBatchesForm
+                key={`required-batches-${jurisdictionId}`}
+                jurisdictionId={jurisdictionId}
+                batches={batches.data.batches}
+              />
               <H2Title>Combined Batches</H2Title>
-              <Card>
-                <CombinedBatchForm>
-                  <div>
-                    <label htmlFor="combinedBatchName">
-                      Combined Batch Name:
-                    </label>
-                    <input
-                      type="text"
-                      name="name"
-                      id="combinedBatchName"
-                      className={Classes.INPUT}
-                      ref={register}
-                      style={{ flexGrow: 1 }}
-                      required
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="subBatchIds">Batches to Combine:</label>
-                    <Controller
-                      name="subBatchIds"
-                      control={control}
-                      defaultValue={[]}
-                      render={({
-                        value,
-                        onChange,
-                      }: {
-                        value: string[]
-                        onChange: (value: string[]) => void
-                      }) => (
-                        <MultiSelect
-                          items={batches.data.batches}
-                          selectedItems={batches.data.batches.filter(batch =>
-                            value.includes(batch.id)
-                          )}
-                          onItemSelect={item => {
-                            onChange(
-                              value.includes(item.id)
-                                ? value.filter(id => id !== item.id)
-                                : [...value, item.id]
-                            )
-                          }}
-                          onRemove={item => {
-                            onChange(
-                              value.filter((id: string) => id !== item.id)
-                            )
-                          }}
-                          itemListRenderer={itemListProps => (
-                            <Menu
-                              ulRef={
-                                itemListProps.itemsParentRef as (
-                                  ref: HTMLUListElement | null
-                                ) => void
-                              }
-                              style={{ maxHeight: 350, overflowY: 'auto' }}
-                            >
-                              {renderFilteredItems(
-                                itemListProps,
-                                <MenuItem
-                                  disabled
-                                  text="No matching batches."
-                                />
-                              )}
-                            </Menu>
-                          )}
-                          itemRenderer={(item, { handleClick, modifiers }) => (
-                            <MenuItem
-                              key={item.id}
-                              text={item.name}
-                              onClick={handleClick}
-                              active={modifiers.active}
-                              icon={value.includes(item.id) ? 'tick' : 'blank'}
-                            />
-                          )}
-                          tagRenderer={item => item.name}
-                          itemPredicate={(query, item) =>
-                            item.name
-                              .toLowerCase()
-                              .includes(query.toLowerCase())
-                          }
-                          placeholder="Search by batch name..."
-                          resetOnSelect
-                          fill
-                          popoverProps={{ minimal: true }}
-                          tagInputProps={{ tagProps: { minimal: true } }}
-                        />
-                      )}
-                    />
-                  </div>
-                  <Button
-                    icon="insert"
-                    style={{ alignSelf: 'end' }}
-                    loading={formState.isSubmitting}
-                    onClick={handleSubmit(onSubmitCreateCombinedBatch)}
-                  >
-                    Create Combined Batch
-                  </Button>
-                </CombinedBatchForm>
-              </Card>
-              {batches.data.combinedBatches.length > 0 && (
-                <Table striped>
-                  <thead>
-                    <tr>
-                      <th>Name</th>
-                      <th>Batches</th>
-                      <th />
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {batches.data.combinedBatches.map(combinedBatch => (
-                      <tr key={combinedBatch.name}>
-                        <td>{combinedBatch.name}</td>
-                        <td style={{ textAlign: 'left' }}>
-                          {combinedBatch.subBatches
-                            .map(subBatch => subBatch.name)
-                            .join(', ')}
-                        </td>
-                        <td>
-                          <Button
-                            onClick={() =>
-                              deleteCombinedBatch.mutate({
-                                jurisdictionId,
-                                name: combinedBatch.name,
-                              })
-                            }
-                            loading={deleteCombinedBatch.isLoading}
-                            icon="delete"
-                            intent="danger"
-                            minimal
-                          >
-                            Delete
-                          </Button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </Table>
-              )}
+              <CombinedBatchesForm
+                key={`combined-batches-${jurisdictionId}`}
+                jurisdictionId={jurisdictionId}
+                batches={batches.data.batches}
+                combinedBatches={batches.data.combinedBatches}
+              />
             </>
           )}
         </Column>

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -142,10 +142,10 @@ const mockJurisdictionBatches: {
   combinedBatches: ICombinedBatch[]
 } = {
   batches: [
-    { id: 'batch-id-1', name: 'Batch 1' },
-    { id: 'batch-id-2', name: 'Batch 2' },
-    { id: 'batch-id-3', name: 'Batch 3' },
-    { id: 'batch-id-4', name: 'Batch 4' },
+    { id: 'batch-id-1', name: 'Batch 1', required: false },
+    { id: 'batch-id-2', name: 'Batch 2', required: false },
+    { id: 'batch-id-3', name: 'Batch 3', required: false },
+    { id: 'batch-id-4', name: 'Batch 4', required: false },
   ],
   combinedBatches: [],
 }
@@ -1236,10 +1236,12 @@ describe('Support Tools', () => {
               {
                 id: 'batch-id-1',
                 name: 'Batch 1',
+                required: false,
               },
               {
                 id: 'batch-id-2',
                 name: 'Batch 2',
+                required: false,
               },
             ],
           },

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -83,6 +83,7 @@ export interface IAuditBoard {
 export interface IBatch {
   id: string
   name: string
+  required: boolean
 }
 
 export interface ICombinedBatch {
@@ -341,6 +342,32 @@ export const useDeleteCombinedBatch = () => {
   const queryClient = useQueryClient()
 
   return useMutation(deleteCombinedBatch, {
+    onSuccess: (_data, variables) =>
+      queryClient.invalidateQueries([
+        'jurisdiction',
+        variables.jurisdictionId,
+        'batches',
+      ]),
+  })
+}
+
+export const useSetRequiredBatches = () => {
+  const setRequiredBatches = async ({
+    jurisdictionId,
+    batchIds,
+  }: {
+    jurisdictionId: string
+    batchIds: string[]
+  }) =>
+    fetchApi(`/api/support/jurisdictions/${jurisdictionId}/required-batches`, {
+      method: 'PUT',
+      body: JSON.stringify({ batchIds }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+  const queryClient = useQueryClient()
+
+  return useMutation(setRequiredBatches, {
     onSuccess: (_data, variables) =>
       queryClient.invalidateQueries([
         'jurisdiction',

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -942,6 +942,7 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
     combined_batches = group_combined_batches(combined_sub_batches)
     combined_sub_batch_ids = {batch.id for batch in combined_sub_batches}
     has_combined_batches = len(combined_batches) > 0
+    has_required_batches = any(batch.required for batch in batches)
 
     contests = list(
         election.contests if jurisdiction is None else jurisdiction.contests
@@ -968,6 +969,8 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
     ]
     if has_combined_batches:
         column_headers.append("Combined Batch")
+    if has_required_batches:
+        column_headers.append("Precinct Audit Batch")
     header_rows.append(column_headers)
 
     total_reported_results: dict = {
@@ -987,6 +990,16 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
         sub_batches = combined_batch["sub_batches"]
         combines_description = f"Combines {', '.join(sub_batch.name for sub_batch in sorted(sub_batches, key=lambda batch: batch.name))}"
         representative_batch = combined_batch["representative_batch"]
+        required_sub_batch_names = [
+            sub_batch.name
+            for sub_batch in sorted(sub_batches, key=lambda batch: batch.name)
+            if sub_batch.required
+        ]
+        required_label = (
+            f"Yes ({', '.join(required_sub_batch_names)})"
+            if required_sub_batch_names
+            else ""
+        )
         combined_batch_row = [
             representative_batch.jurisdiction.name,
             representative_batch.combined_batch_name,
@@ -999,6 +1012,8 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
             combined_batch_row += [pretty_boolean(False)]
             combined_batch_row += [""] * (len(result_columns) + 1)
             combined_batch_row += [combines_description]
+            if has_required_batches:
+                combined_batch_row.append(required_label)
             sampled_batch_rows.append(combined_batch_row)
             return
 
@@ -1078,6 +1093,8 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
             construct_batch_last_edited_by_string(representative_batch),
             combines_description,
         ]
+        if has_required_batches:
+            combined_batch_row.append(required_label)
         sampled_batch_rows.append(combined_batch_row)
 
     seen_combined_batch_names: set[str] = set()
@@ -1105,6 +1122,10 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
         if not show_discrepancies_by_jurisdiction[batch.jurisdiction.id]:
             row += [pretty_boolean(False)]
             row += [""] * (len(result_columns) + 1)
+            if has_combined_batches:
+                row.append("")
+            if has_required_batches:
+                row.append("Yes" if batch.required else "")
             sampled_batch_rows.append(row)
             continue
 
@@ -1177,6 +1198,8 @@ def sampled_batch_rows(election: Election, jurisdiction: Jurisdiction | None = N
         row += [construct_batch_last_edited_by_string(batch)]
         if has_combined_batches:
             row.append("")
+        if has_required_batches:
+            row.append("Yes" if batch.required else "")
 
         sampled_batch_rows.append(row)
 

--- a/server/api/shared.py
+++ b/server/api/shared.py
@@ -20,7 +20,7 @@ from .cvrs import cvr_contests_metadata, hybrid_contest_choice_vote_counts
 from ..feature_flags import (
     is_enabled_sample_extra_batches_by_counting_group,
     is_enabled_sample_extra_batches_to_ensure_one_per_jurisdiction,
-    is_enabled_specific_batch_inclusion,
+    is_enabled_required_batches,
 )
 
 
@@ -826,7 +826,7 @@ def compute_extra_batches_for_round(
                     )
                 )
 
-    if is_enabled_specific_batch_inclusion(election) and round_num == 1:
+    if is_enabled_required_batches(election) and round_num == 1:
         sampled_batch_ids = {batch["batch_id"] for batch in sampled_batches}
         for jurisdiction in jurisdictions:
             representative_contest_id = jurisdiction_id_to_contest_id[jurisdiction.id]

--- a/server/api/shared.py
+++ b/server/api/shared.py
@@ -20,6 +20,7 @@ from .cvrs import cvr_contests_metadata, hybrid_contest_choice_vote_counts
 from ..feature_flags import (
     is_enabled_sample_extra_batches_by_counting_group,
     is_enabled_sample_extra_batches_to_ensure_one_per_jurisdiction,
+    is_enabled_specific_batch_inclusion,
 )
 
 
@@ -825,17 +826,34 @@ def compute_extra_batches_for_round(
                     )
                 )
 
+    if is_enabled_specific_batch_inclusion(election) and round_num == 1:
+        sampled_batch_ids = {batch["batch_id"] for batch in sampled_batches}
+        for jurisdiction in jurisdictions:
+            representative_contest_id = jurisdiction_id_to_contest_id[jurisdiction.id]
+            for batch in jurisdiction.batches:
+                # If a required batch was already sampled, it will be audited
+                # and count towards the risk measurement, so we don't need to
+                # add it as an extra batch
+                if batch.required and batch.id not in sampled_batch_ids:
+                    extra_batches.append(
+                        BatchDraw(
+                            batch_id=batch.id,
+                            contest_id=representative_contest_id,
+                            ticket_number=EXTRA_TICKET_NUMBER,
+                        )
+                    )
+
     if is_enabled_sample_extra_batches_to_ensure_one_per_jurisdiction(election):
         rand = random.Random(str(election.random_seed))
         for jurisdiction in jurisdictions:
             representative_contest_id = jurisdiction_id_to_contest_id[jurisdiction.id]
-            sampled_batch_keys_from_jurisdiction = {
+            selected_batch_keys_from_jurisdiction = {
                 batch_id_to_key[batch["batch_id"]]
-                for batch in sampled_batches
+                for batch in sampled_batches + extra_batches
                 if batch_id_to_key[batch["batch_id"]][0] == jurisdiction.name
             }
-            # If we didn't sample any batches from this jurisdiction, add one
-            if len(sampled_batch_keys_from_jurisdiction) == 0:
+            # If we didn't select any batches from this jurisdiction, add one
+            if len(selected_batch_keys_from_jurisdiction) == 0:
                 jurisdiction_batch_keys = {
                     (jurisdiction.name, batch.name) for batch in jurisdiction.batches
                 }

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -16,7 +16,7 @@ from server.util.csv_download import csv_response
 from . import api
 from ..models import *
 from ..database import db_session
-from ..feature_flags import is_enabled_specific_batch_inclusion
+from ..feature_flags import is_enabled_required_batches
 from ..auth import (
     restrict_access_support,
     set_loggedin_user,
@@ -683,8 +683,8 @@ def set_required_batches(jurisdiction_id: str):
         raise Conflict(
             "Required batches are only supported for batch comparison audits"
         )
-    if not is_enabled_specific_batch_inclusion(election):
-        raise Conflict("Specific batch inclusion is not enabled for this organization")
+    if not is_enabled_required_batches(election):
+        raise Conflict("Required batches are not enabled for this organization")
     if get_current_round(election) is not None:
         raise Conflict(
             "Batches cannot be marked as required after the audit has launched"

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -638,6 +638,7 @@ def list_jurisdiction_batches(jurisdiction_id: str):
         return dict(
             id=batch.id,
             name=batch.name,
+            required=batch.required,
         )
 
     return jsonify(

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -16,6 +16,7 @@ from server.util.csv_download import csv_response
 from . import api
 from ..models import *
 from ..database import db_session
+from ..feature_flags import is_enabled_specific_batch_inclusion
 from ..auth import (
     restrict_access_support,
     set_loggedin_user,
@@ -656,6 +657,52 @@ def list_jurisdiction_batches(jurisdiction_id: str):
             )
         ],
     )
+
+
+REQUIRED_BATCHES_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "batchIds": {"type": "array", "items": {"type": "string"}},
+    },
+    "additionalProperties": False,
+    "required": ["batchIds"],
+}
+
+
+@api.route(
+    "/support/jurisdictions/<jurisdiction_id>/required-batches",
+    methods=["PUT"],
+)
+@restrict_access_support
+def set_required_batches(jurisdiction_id: str):
+    jurisdiction = get_or_404(Jurisdiction, jurisdiction_id)
+    election = jurisdiction.election
+
+    if election.audit_type != AuditType.BATCH_COMPARISON:
+        raise Conflict(
+            "Required batches are only supported for batch comparison audits"
+        )
+    if not is_enabled_specific_batch_inclusion(election):
+        raise Conflict("Specific batch inclusion is not enabled for this organization")
+    if get_current_round(election) is not None:
+        raise Conflict(
+            "Batches cannot be marked as required after the audit has launched"
+        )
+
+    body = safe_get_json_dict(request)
+    validate(body, REQUIRED_BATCHES_SCHEMA)
+    required_batch_ids = set(body["batchIds"])
+
+    jurisdiction_batches = Batch.query.filter_by(jurisdiction_id=jurisdiction.id).all()
+    if not required_batch_ids.issubset({batch.id for batch in jurisdiction_batches}):
+        raise BadRequest("Invalid batch ids")
+
+    for batch in jurisdiction_batches:
+        batch.required = batch.id in required_batch_ids
+
+    db_session.commit()
+
+    return jsonify(status="ok")
 
 
 COMBINED_BATCH_SCHEMA = {

--- a/server/feature_flags.py
+++ b/server/feature_flags.py
@@ -20,10 +20,10 @@ def is_enabled_sample_extra_batches_to_ensure_one_per_jurisdiction(election: Ele
     ]
 
 
-def is_enabled_specific_batch_inclusion(election: Election):
+def is_enabled_required_batches(election: Election):
     return election.organization_id in [
         "d563f551-0d7a-4a89-aa45-2f60147d0337",  # Maryland
-        "TEST-ORG/specific-batch-inclusion",  # For tests
+        "TEST-ORG/required-batches",  # For tests
     ]
 
 

--- a/server/feature_flags.py
+++ b/server/feature_flags.py
@@ -20,6 +20,13 @@ def is_enabled_sample_extra_batches_to_ensure_one_per_jurisdiction(election: Ele
     ]
 
 
+def is_enabled_specific_batch_inclusion(election: Election):
+    return election.organization_id in [
+        "d563f551-0d7a-4a89-aa45-2f60147d0337",  # Maryland
+        "TEST-ORG/specific-batch-inclusion",  # For tests
+    ]
+
+
 def is_enabled_automatically_end_audit_after_one_round(election: Election):
     return (
         election.organization_id

--- a/server/feature_flags.py
+++ b/server/feature_flags.py
@@ -17,6 +17,7 @@ def is_enabled_sample_extra_batches_to_ensure_one_per_jurisdiction(election: Ele
     return election.organization_id in [
         "d563f551-0d7a-4a89-aa45-2f60147d0337",  # Maryland
         "TEST-ORG/sample-extra-batches-to-ensure-one-per-jurisdiction",  # For tests
+        "TEST-ORG/required-batches",  # For tests
     ]
 
 

--- a/server/migrations/versions/233f4348c3bc_batch_required.py
+++ b/server/migrations/versions/233f4348c3bc_batch_required.py
@@ -1,0 +1,33 @@
+"""Batch.required
+
+Revision ID: 233f4348c3bc
+Revises: fda464935ab0
+Create Date: 2026-07-07 00:00:00.000000+00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "233f4348c3bc"
+down_revision = "fda464935ab0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "batch",
+        sa.Column(
+            "required",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -430,6 +430,11 @@ class Batch(BaseModel):
     # those batches together by labeling them with a combined batch name.
     combined_batch_name = Column(String(200))
 
+    # For batch comparison audits with specific batch inclusion enabled,
+    # users can flag batches to be guaranteed inclusion in the audit sample,
+    # though they will only count towards the RLA if randomly sampled as well.
+    required = Column(Boolean, nullable=False, server_default="false")
+
     draws = relationship(
         "SampledBatchDraw",
         uselist=True,

--- a/server/models.py
+++ b/server/models.py
@@ -430,7 +430,7 @@ class Batch(BaseModel):
     # those batches together by labeling them with a combined batch name.
     combined_batch_name = Column(String(200))
 
-    # For batch comparison audits with specific batch inclusion enabled,
+    # For batch comparison audits with required batches enabled,
     # users can flag batches to be guaranteed inclusion in the audit sample,
     # though they will only count towards the RLA if randomly sampled as well.
     required = Column(Boolean, nullable=False, server_default="false")

--- a/server/tests/batch_comparison/snapshots/snap_test_required_batches.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_required_batches.py
@@ -37,3 +37,33 @@ J2,Batch 02,100,Round 1: EXTRA,Yes,candidate 1: 100; candidate 2: 50; candidate 
 J3,Batch 02,100,Round 1: EXTRA,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,\r
 Totals,,2400,,,candidate 1: 2400; candidate 2: 1200; candidate 3: 1200,candidate 1: 2400; candidate 2: 1200; candidate 3: 1200,,\r
 """
+
+snapshots[
+    "test_required_batches_with_combined_batches[TEST-ORG/required-batches] 1"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+TEST-ORG/required-batches,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Vote Totals,Vote Totals from Batches,Pending Ballots\r
+Contest 1,Targeted,1,2,4600,candidate 1: 4600; candidate 2: 2300; candidate 3: 2300,candidate 1: 4600; candidate 2: 2300; candidate 3: 2300,0\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_required_batches_with_combined_batches[TEST-ORG/required-batches],BATCH_COMPARISON,MACRO,10%,1234567890,No\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
+1,Contest 1,Targeted,7,Yes,0.0585276635,DATETIME,DATETIME,candidate 1: 2200; candidate 2: 1100; candidate 3: 1100,5,2200,candidate 1: 2200; candidate 2: 1100; candidate 3: 1100\r
+\r
+######## SAMPLED BATCHES ########\r
+Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?,Reported Results: Contest 1,Audit Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By,Combined Batch,Precinct Audit Batch\r
+J1,Batch 01,500,"Round 1: 0.302716308664955135, 0.336361592874418453",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,,\r
+J1,Batch 03,500,Round 1: 0.460991031946439599,Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,,\r
+J1,Batch 07,100,Round 1: 0.644005359033749581,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,,\r
+J1,Batch 11,500,"Round 1: 0.9831918631389931679, 0.9890301455414025321",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,,\r
+J1,Combined Batch 1,600,Round 1: 0.9841272498736112234 (Batch 04); Round 1: EXTRA (Batch 05),Yes,candidate 1: 600; candidate 2: 300; candidate 3: 300,candidate 1: 600; candidate 2: 300; candidate 3: 300,,,support@example.org,"Combines Batch 04, Batch 05",Yes (Batch 05)\r
+J2,Batch 02,100,Round 1: EXTRA,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,,\r
+J3,Batch 02,100,Round 1: EXTRA,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,,\r
+Totals,,2400,,,candidate 1: 2400; candidate 2: 1200; candidate 3: 1200,candidate 1: 2400; candidate 2: 1200; candidate 3: 1200,,\r
+"""

--- a/server/tests/batch_comparison/snapshots/snap_test_required_batches.py
+++ b/server/tests/batch_comparison/snapshots/snap_test_required_batches.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots[
+    "test_required_batches[TEST-ORG/required-batches] 1"
+] = """######## ELECTION INFO ########\r
+Organization,Election Name,State\r
+TEST-ORG/required-batches,Test Election,CA\r
+\r
+######## CONTESTS ########\r
+Contest Name,Targeted?,Number of Winners,Votes Allowed,Total Ballots Cast,Vote Totals,Vote Totals from Batches,Pending Ballots\r
+Contest 1,Targeted,1,2,4600,candidate 1: 4600; candidate 2: 2300; candidate 3: 2300,candidate 1: 4600; candidate 2: 2300; candidate 3: 2300,0\r
+\r
+######## AUDIT SETTINGS ########\r
+Audit Name,Audit Type,Audit Math Type,Risk Limit,Random Seed,Online Data Entry?\r
+Test Audit test_required_batches[TEST-ORG/required-batches],BATCH_COMPARISON,MACRO,10%,1234567890,No\r
+\r
+######## ROUNDS ########\r
+Round Number,Contest Name,Targeted?,Sample Size,Risk Limit Met?,P-Value,Start Time,End Time,Audited Votes,Batches Sampled,Ballots Sampled,Reported Votes\r
+1,Contest 1,Targeted,7,Yes,0.0585276635,DATETIME,DATETIME,candidate 1: 2100; candidate 2: 1050; candidate 3: 1050,5,2100,candidate 1: 2100; candidate 2: 1050; candidate 3: 1050\r
+\r
+######## SAMPLED BATCHES ########\r
+Jurisdiction Name,Batch Name,Ballots in Batch,Ticket Numbers: Contest 1,Audited?,Reported Results: Contest 1,Audit Results: Contest 1,Change in Results: Contest 1,Change in Margin: Contest 1,Last Edited By,Precinct Audit Batch\r
+J1,Batch 01,500,"Round 1: 0.302716308664955135, 0.336361592874418453",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,Yes\r
+J1,Batch 03,500,Round 1: 0.460991031946439599,Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,\r
+J1,Batch 04,500,Round 1: 0.9841272498736112234,Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,\r
+J1,Batch 05,100,Round 1: EXTRA,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,Yes\r
+J1,Batch 07,100,Round 1: 0.644005359033749581,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,\r
+J1,Batch 11,500,"Round 1: 0.9831918631389931679, 0.9890301455414025321",Yes,candidate 1: 500; candidate 2: 250; candidate 3: 250,candidate 1: 500; candidate 2: 250; candidate 3: 250,,,support@example.org,\r
+J2,Batch 02,100,Round 1: EXTRA,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,Yes\r
+J3,Batch 02,100,Round 1: EXTRA,Yes,candidate 1: 100; candidate 2: 50; candidate 3: 50,candidate 1: 100; candidate 2: 50; candidate 3: 50,,,support@example.org,\r
+Totals,,2400,,,candidate 1: 2400; candidate 2: 1200; candidate 3: 1200,candidate 1: 2400; candidate 2: 1200; candidate 3: 1200,,\r
+"""

--- a/server/tests/batch_comparison/test_required_batches.py
+++ b/server/tests/batch_comparison/test_required_batches.py
@@ -155,6 +155,50 @@ def batch_id_by_name(jurisdiction_id: str, name: str) -> str:
     return Batch.query.filter_by(jurisdiction_id=jurisdiction_id, name=name).one().id
 
 
+def start_round_1(client: FlaskClient, election_id: str) -> str:
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
+    assert rv.status_code == 200
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 1,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
+    assert_ok(rv)
+    rv = client.get(f"/api/election/{election_id}/round")
+    return json.loads(rv.data)["rounds"][0]["id"]
+
+
+def get_sampled_batches(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: list[str],
+    round_id: str,
+    jurisdiction_index: int,
+):
+    set_logged_in_ja(client, election_id, jurisdiction_index)
+    rv = client.get(
+        f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[jurisdiction_index]}/round/{round_id}/batches"
+    )
+    assert rv.status_code == 200
+    return json.loads(rv.data)["batches"]
+
+
+def extra_ticket_numbers(batch_id: str) -> list[str]:
+    return [
+        draw.ticket_number
+        for draw in SampledBatchDraw.query.filter_by(batch_id=batch_id)
+        if draw.ticket_number == EXTRA_TICKET_NUMBER
+    ]
+
+
 @pytest.mark.parametrize("org_id", [REQUIRED_BATCHES_ORG], indirect=True)
 def test_required_batches(
     client: FlaskClient,
@@ -195,44 +239,14 @@ def test_required_batches(
     } == {"Batch 01": True, "Batch 05": True}
 
     # Start the audit
-    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
-    assert rv.status_code == 200
-    sample_size_options = json.loads(rv.data)["sampleSizes"]
-    rv = post_json(
-        client,
-        f"/api/election/{election_id}/round",
-        {
-            "roundNum": 1,
-            "sampleSizes": {
-                contest_id: options[0]
-                for contest_id, options in sample_size_options.items()
-            },
-        },
-    )
-    assert_ok(rv)
-    rv = client.get(f"/api/election/{election_id}/round")
-    round_1_id = json.loads(rv.data)["rounds"][0]["id"]
-
-    def sampled_batches(jurisdiction_index):
-        set_logged_in_ja(client, election_id, jurisdiction_index)
-        rv = client.get(
-            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[jurisdiction_index]}/round/{round_1_id}/batches"
-        )
-        assert rv.status_code == 200
-        return json.loads(rv.data)["batches"]
-
-    def extra_ticket_numbers(batch_id):
-        return [
-            draw.ticket_number
-            for draw in SampledBatchDraw.query.filter_by(batch_id=batch_id)
-            if draw.ticket_number == EXTRA_TICKET_NUMBER
-        ]
+    round_1_id = start_round_1(client, election_id)
 
     # In J1, the required Batch 01 was randomly sampled, so it shouldn't get an
     # extra draw. The required Batch 05 wasn't, so it should be added as an
     # extra batch.
-    j1_batches = sampled_batches(0)
+    j1_batches = get_sampled_batches(
+        client, election_id, jurisdiction_ids, round_1_id, 0
+    )
     expected_random_sample = [
         "Batch 01",
         "Batch 03",
@@ -251,7 +265,9 @@ def test_required_batches(
     # In J2, nothing was randomly sampled, so the required Batch 02 should be
     # added as an extra batch. It also counts as J2's one batch per
     # jurisdiction, so no additional batch should be selected.
-    j2_batches = sampled_batches(1)
+    j2_batches = get_sampled_batches(
+        client, election_id, jurisdiction_ids, round_1_id, 1
+    )
     assert {batch["name"] for batch in j2_batches} == {"Batch 02"}
     assert extra_ticket_numbers(batch_id_by_name(jurisdiction_ids[1], "Batch 02")) == [
         EXTRA_TICKET_NUMBER
@@ -259,7 +275,9 @@ def test_required_batches(
 
     # In J3, nothing was randomly sampled and there are no required batches, so
     # one batch should be selected to ensure one batch per jurisdiction.
-    j3_batches = sampled_batches(2)
+    j3_batches = get_sampled_batches(
+        client, election_id, jurisdiction_ids, round_1_id, 2
+    )
     assert {batch["name"] for batch in j3_batches} == {"Batch 02"}
     assert extra_ticket_numbers(batch_id_by_name(jurisdiction_ids[2], "Batch 02")) == [
         EXTRA_TICKET_NUMBER
@@ -273,7 +291,9 @@ def test_required_batches(
 
     for jurisdiction_index, jurisdiction_id in enumerate(jurisdiction_ids):
         reported_tallies = Jurisdiction.query.get(jurisdiction_id).batch_tallies
-        for batch in sampled_batches(jurisdiction_index):
+        for batch in get_sampled_batches(
+            client, election_id, jurisdiction_ids, round_1_id, jurisdiction_index
+        ):
             results = {
                 choice_id: reported_tallies[batch["name"]][contest_ids[0]][choice_id]
                 for choice_id in choice_ids
@@ -315,3 +335,215 @@ def test_required_batches(
             ("J2", "Batch 02"),
         ]
         assert row.endswith(",Yes") == is_required
+
+
+@pytest.mark.parametrize("org_id", [REQUIRED_BATCHES_ORG], indirect=True)
+def test_required_batches_validation(
+    client: FlaskClient,
+    org_id: str,
+    election_id: str,
+    jurisdiction_ids: list[str],
+    contest_ids: list[str],
+    election_settings,
+    batch_tallies,
+):
+    def put_required_batches(jurisdiction_id, batch_ids):
+        return put_json(
+            client,
+            f"/api/support/jurisdictions/{jurisdiction_id}/required-batches",
+            {"batchIds": batch_ids},
+        )
+
+    def assert_conflict(rv, expected_message):
+        assert rv.status_code == 409
+        assert json.loads(rv.data)["errors"][0]["message"] == expected_message
+
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+
+    # Invalid jurisdiction
+    rv = put_required_batches("not-a-real-jurisdiction", [])
+    assert rv.status_code == 404
+
+    # Invalid JSON
+    rv = put_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/required-batches",
+        {},
+    )
+    assert rv.status_code == 400
+
+    # Batches from another jurisdiction
+    rv = put_required_batches(
+        jurisdiction_ids[0], [batch_id_by_name(jurisdiction_ids[1], "Batch 01")]
+    )
+    assert rv.status_code == 400
+    assert json.loads(rv.data)["errors"][0]["message"] == "Invalid batch ids"
+
+    # Non-batch-comparison audit
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    ballot_polling_election_id = create_election(
+        client,
+        audit_name="Test Audit test_required_batches_validation ballot polling",
+        organization_id=org_id,
+    )
+    rv = upload_jurisdictions_file(
+        client,
+        io.BytesIO(
+            f"Jurisdiction,Admin Email\nJ1,{default_ja_email(ballot_polling_election_id)}\n".encode()
+        ),
+        ballot_polling_election_id,
+    )
+    assert_ok(rv)
+    ballot_polling_jurisdiction_id = (
+        Jurisdiction.query.filter_by(election_id=ballot_polling_election_id).one().id
+    )
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+    rv = put_required_batches(ballot_polling_jurisdiction_id, [])
+    assert_conflict(
+        rv, "Required batches are only supported for batch comparison audits"
+    )
+
+    # Batch comparison audit in an org without the feature flag enabled
+    no_flag_org_id = "TEST-ORG/required-batches-not-enabled"
+    if not Organization.query.get(no_flag_org_id):
+        create_org(no_flag_org_id)
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    no_flag_election_id = create_election(
+        client,
+        audit_name="Test Audit test_required_batches_validation flag disabled",
+        audit_type=AuditType.BATCH_COMPARISON,
+        audit_math_type=AuditMathType.MACRO,
+        organization_id=no_flag_org_id,
+    )
+    rv = upload_jurisdictions_file(
+        client,
+        io.BytesIO(
+            f"Jurisdiction,Admin Email\nJ1,{default_ja_email(no_flag_election_id)}\n".encode()
+        ),
+        no_flag_election_id,
+    )
+    assert_ok(rv)
+    no_flag_jurisdiction_id = (
+        Jurisdiction.query.filter_by(election_id=no_flag_election_id).one().id
+    )
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+    rv = put_required_batches(no_flag_jurisdiction_id, [])
+    assert_conflict(rv, "Required batches are not enabled for this organization")
+
+    # After the audit has launched
+    start_round_1(client, election_id)
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+    rv = put_required_batches(
+        jurisdiction_ids[0], [batch_id_by_name(jurisdiction_ids[0], "Batch 01")]
+    )
+    assert_conflict(
+        rv, "Batches cannot be marked as required after the audit has launched"
+    )
+
+
+@pytest.mark.parametrize("org_id", [REQUIRED_BATCHES_ORG], indirect=True)
+def test_required_batches_with_combined_batches(
+    client: FlaskClient,
+    org_id: str,
+    election_id: str,
+    jurisdiction_ids: list[str],
+    contest_ids: list[str],
+    election_settings,
+    batch_tallies,
+    snapshot,
+):
+    # J1's Batch 05 won't be randomly sampled, so it will be added as an extra
+    # batch
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+    rv = put_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/required-batches",
+        {"batchIds": [batch_id_by_name(jurisdiction_ids[0], "Batch 05")]},
+    )
+    assert_ok(rv)
+
+    # Start the audit
+    round_1_id = start_round_1(client, election_id)
+    assert extra_ticket_numbers(batch_id_by_name(jurisdiction_ids[0], "Batch 05")) == [
+        EXTRA_TICKET_NUMBER
+    ]
+
+    # Combine the required extra batch with a sampled batch
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+    combined_batch_name = "Combined Batch 1"
+    combined_sub_batch_names = ["Batch 04", "Batch 05"]
+    rv = post_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/combined-batches",
+        {
+            "name": combined_batch_name,
+            "subBatchIds": [
+                batch_id_by_name(jurisdiction_ids[0], name)
+                for name in combined_sub_batch_names
+            ],
+        },
+    )
+    assert_ok(rv)
+
+    # Before J1 finalizes results, the report hides its discrepancy columns but
+    # should still label required batches
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert rv.status_code == 200
+    report_rows = scrub_datetime(rv.data.decode("utf-8")).splitlines()
+    combined_row = next(
+        row for row in report_rows if row.startswith(f"J1,{combined_batch_name},")
+    )
+    assert combined_row.endswith(",Yes (Batch 05)")
+    batch_01_row = next(row for row in report_rows if row.startswith("J1,Batch 01,"))
+    assert batch_01_row.endswith(",")
+
+    # Audit all sampled batches with results matching the reported tallies
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/contest")
+    contest = json.loads(rv.data)["contests"][0]
+    choice_ids = [choice["id"] for choice in contest["choices"]]
+
+    for jurisdiction_index, jurisdiction_id in enumerate(jurisdiction_ids):
+        reported_tallies = Jurisdiction.query.get(jurisdiction_id).batch_tallies
+        for batch in get_sampled_batches(
+            client, election_id, jurisdiction_ids, round_1_id, jurisdiction_index
+        ):
+            batch_names = (
+                combined_sub_batch_names
+                if batch["name"] == combined_batch_name
+                else [batch["name"]]
+            )
+            results = {
+                choice_id: sum(
+                    reported_tallies[name][contest_ids[0]][choice_id]
+                    for name in batch_names
+                )
+                for choice_id in choice_ids
+            }
+            rv = put_json(
+                client,
+                f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_1_id}/batches/{batch['id']}/results",
+                [{"name": "Tally Sheet #1", "results": results}],
+            )
+            assert_ok(rv)
+        rv = post_json(
+            client,
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_1_id}/batches/finalize",
+        )
+        assert_ok(rv)
+
+    # End the round
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.post(f"/api/election/{election_id}/round/current/finish")
+    assert_ok(rv)
+
+    # The final report should label the combined batch with its required sub
+    # batch
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert_match_report(rv.data, snapshot)
+    report_rows = scrub_datetime(rv.data.decode("utf-8")).splitlines()
+    combined_row = next(
+        row for row in report_rows if row.startswith(f"J1,{combined_batch_name},")
+    )
+    assert combined_row.endswith(",Yes (Batch 05)")

--- a/server/tests/batch_comparison/test_required_batches.py
+++ b/server/tests/batch_comparison/test_required_batches.py
@@ -1,0 +1,317 @@
+import pytest
+from flask.testing import FlaskClient
+
+from ...models import *
+from ..helpers import *
+
+
+@pytest.fixture
+def org_id(client: FlaskClient, request) -> str:
+    org_id = str(request.param)
+    org = Organization.query.get(org_id)
+    if not org:
+        create_org(org_id)
+    return org_id
+
+
+@pytest.fixture
+def contest_ids(client: FlaskClient, election_id: str, jurisdiction_ids: list[str]):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    contests = [
+        {
+            "id": str(uuid.uuid4()),
+            "name": "Contest 1",
+            "isTargeted": True,
+            "choices": [
+                {"id": str(uuid.uuid4()), "name": "candidate 1", "numVotes": 4600},
+                {"id": str(uuid.uuid4()), "name": "candidate 2", "numVotes": 2300},
+                {"id": str(uuid.uuid4()), "name": "candidate 3", "numVotes": 2300},
+            ],
+            "numWinners": 1,
+            "votesAllowed": 2,
+            "jurisdictionIds": jurisdiction_ids,
+        },
+    ]
+    rv = put_json(client, f"/api/election/{election_id}/contest", contests)
+    assert_ok(rv)
+    return [str(contest["id"]) for contest in contests]
+
+
+# The root conftest assigns a different admin to J3 than J1/J2
+def j3_email(election_id: str) -> str:
+    return f"j3-{election_id}@example.com"
+
+
+def set_logged_in_ja(client: FlaskClient, election_id: str, jurisdiction_index: int):
+    email = (
+        j3_email(election_id)
+        if jurisdiction_index == 2
+        else default_ja_email(election_id)
+    )
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, email)
+
+
+@pytest.fixture
+def manifests(client: FlaskClient, election_id: str, jurisdiction_ids: list[str]):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = upload_ballot_manifest(
+        client,
+        io.BytesIO(
+            b"Batch Name,Number of Ballots\n"
+            b"Batch 01,500\n"
+            b"Batch 02,500\n"
+            b"Batch 03,500\n"
+            b"Batch 04,500\n"
+            b"Batch 05,100\n"
+            b"Batch 06,100\n"
+            b"Batch 07,100\n"
+            b"Batch 08,100\n"
+            b"Batch 09,100\n"
+            b"Batch 10,500\n"
+            b"Batch 11,500\n"
+            b"Batch 12,500\n"
+        ),
+        election_id,
+        jurisdiction_ids[0],
+    )
+    assert_ok(rv)
+    rv = upload_ballot_manifest(
+        client,
+        io.BytesIO(
+            b"Batch Name,Number of Ballots\nBatch 01,100\nBatch 02,100\nBatch 03,100\n"
+        ),
+        election_id,
+        jurisdiction_ids[1],
+    )
+    assert_ok(rv)
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, j3_email(election_id))
+    rv = upload_ballot_manifest(
+        client,
+        io.BytesIO(
+            b"Batch Name,Number of Ballots\nBatch 01,100\nBatch 02,100\nBatch 03,100\n"
+        ),
+        election_id,
+        jurisdiction_ids[2],
+    )
+    assert_ok(rv)
+
+
+@pytest.fixture
+def batch_tallies(
+    client: FlaskClient,
+    election_id: str,
+    jurisdiction_ids: list[str],
+    contest_ids: list[str],
+    manifests,
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+    rv = upload_batch_tallies(
+        client,
+        io.BytesIO(
+            b"Batch Name,candidate 1,candidate 2,candidate 3\n"
+            b"Batch 01,500,250,250\n"
+            b"Batch 02,500,250,250\n"
+            b"Batch 03,500,250,250\n"
+            b"Batch 04,500,250,250\n"
+            b"Batch 05,100,50,50\n"
+            b"Batch 06,100,50,50\n"
+            b"Batch 07,100,50,50\n"
+            b"Batch 08,100,50,50\n"
+            b"Batch 09,100,50,50\n"
+            b"Batch 10,500,250,250\n"
+            b"Batch 11,500,250,250\n"
+            b"Batch 12,500,250,250\n"
+        ),
+        election_id,
+        jurisdiction_ids[0],
+    )
+    assert_ok(rv)
+    for jurisdiction_index, jurisdiction_id in list(enumerate(jurisdiction_ids))[1:]:
+        set_logged_in_ja(client, election_id, jurisdiction_index)
+        rv = upload_batch_tallies(
+            client,
+            io.BytesIO(
+                b"Batch Name,candidate 1,candidate 2,candidate 3\n"
+                b"Batch 01,100,50,50\n"
+                b"Batch 02,100,50,50\n"
+                b"Batch 03,100,50,50\n"
+            ),
+            election_id,
+            jurisdiction_id,
+        )
+        assert_ok(rv)
+
+
+# This org also has sample-extra-batches-to-ensure-one-per-jurisdiction
+# enabled, mirroring Maryland's setup
+REQUIRED_BATCHES_ORG = "TEST-ORG/required-batches"
+
+
+def batch_id_by_name(jurisdiction_id: str, name: str) -> str:
+    return Batch.query.filter_by(jurisdiction_id=jurisdiction_id, name=name).one().id
+
+
+@pytest.mark.parametrize("org_id", [REQUIRED_BATCHES_ORG], indirect=True)
+def test_required_batches(
+    client: FlaskClient,
+    org_id: str,
+    election_id: str,
+    jurisdiction_ids: list[str],
+    contest_ids: list[str],
+    election_settings,
+    batch_tallies,
+    snapshot,
+):
+    # Before launching the audit, a support user marks batches as required in
+    # J1 and J2, not J3
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+    rv = put_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[0]}/required-batches",
+        {
+            "batchIds": [
+                batch_id_by_name(jurisdiction_ids[0], "Batch 01"),
+                batch_id_by_name(jurisdiction_ids[0], "Batch 05"),
+            ]
+        },
+    )
+    assert_ok(rv)
+    rv = put_json(
+        client,
+        f"/api/support/jurisdictions/{jurisdiction_ids[1]}/required-batches",
+        {"batchIds": [batch_id_by_name(jurisdiction_ids[1], "Batch 02")]},
+    )
+    assert_ok(rv)
+
+    rv = client.get(f"/api/support/jurisdictions/{jurisdiction_ids[0]}/batches")
+    assert {
+        batch["name"]: batch["required"]
+        for batch in json.loads(rv.data)["batches"]
+        if batch["required"]
+    } == {"Batch 01": True, "Batch 05": True}
+
+    # Start the audit
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/sample-sizes/1")
+    assert rv.status_code == 200
+    sample_size_options = json.loads(rv.data)["sampleSizes"]
+    rv = post_json(
+        client,
+        f"/api/election/{election_id}/round",
+        {
+            "roundNum": 1,
+            "sampleSizes": {
+                contest_id: options[0]
+                for contest_id, options in sample_size_options.items()
+            },
+        },
+    )
+    assert_ok(rv)
+    rv = client.get(f"/api/election/{election_id}/round")
+    round_1_id = json.loads(rv.data)["rounds"][0]["id"]
+
+    def sampled_batches(jurisdiction_index):
+        set_logged_in_ja(client, election_id, jurisdiction_index)
+        rv = client.get(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[jurisdiction_index]}/round/{round_1_id}/batches"
+        )
+        assert rv.status_code == 200
+        return json.loads(rv.data)["batches"]
+
+    def extra_ticket_numbers(batch_id):
+        return [
+            draw.ticket_number
+            for draw in SampledBatchDraw.query.filter_by(batch_id=batch_id)
+            if draw.ticket_number == EXTRA_TICKET_NUMBER
+        ]
+
+    # In J1, the required Batch 01 was randomly sampled, so it shouldn't get an
+    # extra draw. The required Batch 05 wasn't, so it should be added as an
+    # extra batch.
+    j1_batches = sampled_batches(0)
+    expected_random_sample = [
+        "Batch 01",
+        "Batch 03",
+        "Batch 04",
+        "Batch 07",
+        "Batch 11",
+    ]
+    assert {batch["name"] for batch in j1_batches} == set(
+        expected_random_sample + ["Batch 05"]
+    )
+    assert extra_ticket_numbers(batch_id_by_name(jurisdiction_ids[0], "Batch 01")) == []
+    assert extra_ticket_numbers(batch_id_by_name(jurisdiction_ids[0], "Batch 05")) == [
+        EXTRA_TICKET_NUMBER
+    ]
+
+    # In J2, nothing was randomly sampled, so the required Batch 02 should be
+    # added as an extra batch. It also counts as J2's one batch per
+    # jurisdiction, so no additional batch should be selected.
+    j2_batches = sampled_batches(1)
+    assert {batch["name"] for batch in j2_batches} == {"Batch 02"}
+    assert extra_ticket_numbers(batch_id_by_name(jurisdiction_ids[1], "Batch 02")) == [
+        EXTRA_TICKET_NUMBER
+    ]
+
+    # In J3, nothing was randomly sampled and there are no required batches, so
+    # one batch should be selected to ensure one batch per jurisdiction.
+    j3_batches = sampled_batches(2)
+    assert {batch["name"] for batch in j3_batches} == {"Batch 02"}
+    assert extra_ticket_numbers(batch_id_by_name(jurisdiction_ids[2], "Batch 02")) == [
+        EXTRA_TICKET_NUMBER
+    ]
+
+    # Audit all sampled batches with results matching the reported tallies
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/election/{election_id}/contest")
+    contest = json.loads(rv.data)["contests"][0]
+    choice_ids = [choice["id"] for choice in contest["choices"]]
+
+    for jurisdiction_index, jurisdiction_id in enumerate(jurisdiction_ids):
+        reported_tallies = Jurisdiction.query.get(jurisdiction_id).batch_tallies
+        for batch in sampled_batches(jurisdiction_index):
+            results = {
+                choice_id: reported_tallies[batch["name"]][contest_ids[0]][choice_id]
+                for choice_id in choice_ids
+            }
+            rv = put_json(
+                client,
+                f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_1_id}/batches/{batch['id']}/results",
+                [{"name": "Tally Sheet #1", "results": results}],
+            )
+            assert_ok(rv)
+        rv = post_json(
+            client,
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_id}/round/{round_1_id}/batches/finalize",
+        )
+        assert_ok(rv)
+
+    # End the round
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.post(f"/api/election/{election_id}/round/current/finish")
+    assert_ok(rv)
+    rv = client.get(f"/api/election/{election_id}/round")
+    assert json.loads(rv.data)["rounds"][0]["isAuditComplete"]
+
+    # Check that the report shows required batches as Precinct Audit Batches
+    rv = client.get(f"/api/election/{election_id}/report")
+    assert_match_report(rv.data, snapshot)
+    report_rows = scrub_datetime(rv.data.decode("utf-8")).splitlines()
+    batch_rows = [
+        row
+        for row in report_rows
+        if row.startswith("J1,") or row.startswith("J2,") or row.startswith("J3,")
+    ]
+    assert len(batch_rows) == len(expected_random_sample) + 3
+    for row in batch_rows:
+        jurisdiction_name, batch_name = row.split(",")[:2]
+        is_required = (jurisdiction_name, batch_name) in [
+            ("J1", "Batch 01"),
+            ("J1", "Batch 05"),
+            ("J2", "Batch 02"),
+        ]
+        assert row.endswith(",Yes") == is_required

--- a/server/tests/batch_comparison/test_support_batch_comparison.py
+++ b/server/tests/batch_comparison/test_support_batch_comparison.py
@@ -77,6 +77,7 @@ def test_support_combined_batches(
         dict(
             id=batch.id,
             name=batch.name,
+            required=batch.required,
         )
         for batch in all_batches
     ]
@@ -109,14 +110,17 @@ def test_support_combined_batches(
                 dict(
                     id=sampled_batches[0]["id"],
                     name=sampled_batches[0]["name"],
+                    required=False,
                 ),
                 dict(
                     id=sampled_batches[1]["id"],
                     name=sampled_batches[1]["name"],
+                    required=False,
                 ),
                 dict(
                     id=unsampled_batches[0].id,
                     name=unsampled_batches[0].name,
+                    required=False,
                 ),
             ],
         )
@@ -191,10 +195,12 @@ def test_support_combined_batches(
                 dict(
                     id=sampled_batches[2]["id"],
                     name=sampled_batches[2]["name"],
+                    required=False,
                 ),
                 dict(
                     id=unsampled_batches[1].id,
                     name=unsampled_batches[1].name,
+                    required=False,
                 ),
             ],
         )


### PR DESCRIPTION
Closes https://github.com/votingworks/arlo/issues/2260

Maryland wants the ability to guarantee a specific batch or set of batches is included in the audit. They need the ability to specify which batches to include. If they included by the RLA by the math, nothing additional needs to be done. Otherwise, they need to be tacked on.

1. Add the ability to mark batches as `required`
2. Add all unsampled required batches as Extra batches
3. Update Jurisdiction Support UI to allow setting required batches
4. Update reports to include a column for indicating required batches, named "Precinct Audit Batches" at Maryland's [request](https://votingworks.slack.com/archives/CKCVA0F9S/p1783437460727209?thread_ts=1782170164.065049&cid=CKCVA0F9S) 


https://github.com/user-attachments/assets/6e8a8f94-2d6a-4919-9d90-3ba2e6f59603

<img width="1656" height="273" alt="Screenshot 2026-07-07 at 3 02 01 PM" src="https://github.com/user-attachments/assets/52d80ef0-53c0-4a0f-9621-08c54dddb101" />

