### PR TITLE
Server: Reject ballot manifest if 1+ batch has 0 ballots

### DIFF
--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -178,7 +178,7 @@ def process_ballot_manifest_file(
                         f'Invalid value for column "Container", row {row_index + 2}: "{counting_group}". Use the Batch Audit File Preparation Tool to create your ballot manifest, or correct this value to one of the following: {", ".join(counting_group_allowlist)}.'
                     )
 
-            if row[NUMBER_OF_BALLOTS] < 1:
+            if row[NUMBER_OF_BALLOTS] == 0:
                 rows_without_ballots.append(row_index + 2)
                 continue
 
@@ -195,14 +195,14 @@ def process_ballot_manifest_file(
             num_batches += 1
             num_ballots += batch.num_ballots
 
+        manifest_file.close()
+
         if len(rows_without_ballots) > 0:
             num_rows = len(rows_without_ballots)
             displayed_rows = ", ".join(str(row) for row in rows_without_ballots)
             raise CSVParseError(
-                f'Found {num_rows} {"batch" if num_rows == 1 else "batches"} with 0 ballots in column "Number of Ballots" ({pluralize("row", num_rows)} {displayed_rows}). Batches with 0 ballots cannot be audited. Please remove {"this row" if num_rows == 1 else "these rows"} from the CSV.'
+                f'Found {num_rows} {"batch" if num_rows == 1 else "batches"} with 0 ballots in column "Number of Ballots" ({pluralize("row", num_rows)} {displayed_rows}). Batches must have at least 1 ballot. Please remove {"this row" if num_rows == 1 else "these rows"} from the CSV.'
             )
-
-        manifest_file.close()
 
         jurisdiction.manifest_num_ballots = num_ballots
         jurisdiction.manifest_num_batches = num_batches

--- a/server/api/ballot_manifest.py
+++ b/server/api/ballot_manifest.py
@@ -33,6 +33,7 @@ from ..util.csv_parse import (
     CSVValueType,
     CSVColumnType,
     parse_csv,
+    pluralize,
 )
 from ..audit_math.suite import HybridPair
 from . import contests
@@ -158,6 +159,7 @@ def process_ballot_manifest_file(
 
         num_batches = 0
         num_ballots = 0
+        rows_without_ballots: list[int] = []
 
         for row_index, row in enumerate(manifest_csv):
             # For the "sample extra batches by counting group" feature, we
@@ -176,6 +178,10 @@ def process_ballot_manifest_file(
                         f'Invalid value for column "Container", row {row_index + 2}: "{counting_group}". Use the Batch Audit File Preparation Tool to create your ballot manifest, or correct this value to one of the following: {", ".join(counting_group_allowlist)}.'
                     )
 
+            if row[NUMBER_OF_BALLOTS] < 1:
+                rows_without_ballots.append(row_index + 2)
+                continue
+
             batch = Batch(
                 id=str(uuid.uuid4()),
                 name=row[BATCH_NAME],
@@ -188,6 +194,13 @@ def process_ballot_manifest_file(
             db_session.add(batch)
             num_batches += 1
             num_ballots += batch.num_ballots
+
+        if len(rows_without_ballots) > 0:
+            num_rows = len(rows_without_ballots)
+            displayed_rows = ", ".join(str(row) for row in rows_without_ballots)
+            raise CSVParseError(
+                f'Found {num_rows} {"batch" if num_rows == 1 else "batches"} with 0 ballots in column "Number of Ballots" ({pluralize("row", num_rows)} {displayed_rows}). Batches with 0 ballots cannot be audited. Please remove {"this row" if num_rows == 1 else "these rows"} from the CSV.'
+            )
 
         manifest_file.close()
 

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -14,7 +14,7 @@ def test_ballot_manifest_upload(
     )
     rv = upload_ballot_manifest(
         client,
-        io.BytesIO(b"Batch Name,Number of Ballots\n1,23\n12,100\n6,0\n"),
+        io.BytesIO(b"Batch Name,Number of Ballots\n1,23\n12,100\n6,7\n"),
         election_id,
         jurisdiction_ids[0],
     )
@@ -41,14 +41,14 @@ def test_ballot_manifest_upload(
 
     jurisdiction = Jurisdiction.query.get(jurisdiction_ids[0])
     assert jurisdiction.manifest_num_batches == 3
-    assert jurisdiction.manifest_num_ballots == 123
+    assert jurisdiction.manifest_num_ballots == 130
     assert len(jurisdiction.batches) == 3
     assert jurisdiction.batches[0].name == "1"
     assert jurisdiction.batches[0].num_ballots == 23
     assert jurisdiction.batches[1].name == "12"
     assert jurisdiction.batches[1].num_ballots == 100
     assert jurisdiction.batches[2].name == "6"
-    assert jurisdiction.batches[2].num_ballots == 0
+    assert jurisdiction.batches[2].num_ballots == 7
 
 
 def test_ballot_manifest_clear(
@@ -92,7 +92,7 @@ def test_ballot_manifest_replace_as_audit_admin(
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = upload_ballot_manifest(
         client,
-        io.BytesIO(b"Batch Name,Number of Ballots\n1,23\n12,100\n6,0,,\n"),
+        io.BytesIO(b"Batch Name,Number of Ballots\n1,23\n12,100\n6,7,,\n"),
         election_id,
         jurisdiction_ids[0],
     )
@@ -314,6 +314,60 @@ def test_ballot_manifest_upload_invalid_num_ballots(
             },
         },
     )
+
+
+def test_ballot_manifest_upload_zero_ballot_batches(
+    client: FlaskClient, election_id: str, jurisdiction_ids: list[str]
+):
+    set_logged_in_user(
+        client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+    )
+
+    zero_ballot_rows = "\n".join(f"Batch {i},0" for i in range(1, 13))
+    for manifest, expected_error in [
+        (
+            b"Batch Name,Number of Ballots\nBatch 1,0\nBatch 2,23\n",
+            'Found 1 batch with 0 ballots in column "Number of Ballots" (row 2).'
+            " Batches with 0 ballots cannot be audited."
+            " Please remove this row from the CSV.",
+        ),
+        (
+            b"Batch Name,Number of Ballots\nBatch 1,0\nBatch 2,-2\nBatch 3,5\n",
+            'Found 2 batches with 0 ballots in column "Number of Ballots" (rows 2, 3).'
+            " Batches with 0 ballots cannot be audited."
+            " Please remove these rows from the CSV.",
+        ),
+        (
+            f"Batch Name,Number of Ballots\n{zero_ballot_rows}\n".encode(),
+            'Found 12 batches with 0 ballots in column "Number of Ballots"'
+            " (rows 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)."
+            " Batches with 0 ballots cannot be audited."
+            " Please remove these rows from the CSV.",
+        ),
+    ]:
+        rv = upload_ballot_manifest(
+            client, io.BytesIO(manifest), election_id, jurisdiction_ids[0]
+        )
+        assert_ok(rv)
+
+        rv = client.get(
+            f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[0]}/ballot-manifest"
+        )
+        compare_json(
+            json.loads(rv.data),
+            {
+                "file": {
+                    "name": asserts_startswith("manifest"),
+                    "uploadedAt": assert_is_date,
+                },
+                "processing": {
+                    "status": ProcessingStatus.ERRORED,
+                    "startedAt": assert_is_date,
+                    "completedAt": assert_is_date,
+                    "error": expected_error,
+                },
+            },
+        )
 
 
 def test_ballot_manifest_upload_duplicate_batch_name(

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -327,22 +327,19 @@ def test_ballot_manifest_upload_zero_ballot_batches(
     for manifest, expected_error in [
         (
             b"Batch Name,Number of Ballots\nBatch 1,0\nBatch 2,23\n",
-            'Found 1 batch with 0 ballots in column "Number of Ballots" (row 2).'
-            " Batches with 0 ballots cannot be audited."
-            " Please remove this row from the CSV.",
+            'Found 1 batch with 0 ballots in column "Number of Ballots" (row 2). Batches must have at least 1 ballot. Please remove this row from the CSV.',
         ),
         (
-            b"Batch Name,Number of Ballots\nBatch 1,0\nBatch 2,-2\nBatch 3,5\n",
-            'Found 2 batches with 0 ballots in column "Number of Ballots" (rows 2, 3).'
-            " Batches with 0 ballots cannot be audited."
-            " Please remove these rows from the CSV.",
+            b"Batch Name,Number of Ballots\nBatch 1,0\nBatch 2,0\nBatch 3,5\n",
+            'Found 2 batches with 0 ballots in column "Number of Ballots" (rows 2, 3). Batches must have at least 1 ballot. Please remove these rows from the CSV.',
+        ),
+        (
+            b"Batch Name,Number of Ballots\nBatch 1,5\nBatch 2,-2\n",
+            "Expected a number greater than or equal to 0 in column Number of Ballots, row 3. Got: -2.",
         ),
         (
             f"Batch Name,Number of Ballots\n{zero_ballot_rows}\n".encode(),
-            'Found 12 batches with 0 ballots in column "Number of Ballots"'
-            " (rows 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)."
-            " Batches with 0 ballots cannot be audited."
-            " Please remove these rows from the CSV.",
+            'Found 12 batches with 0 ballots in column "Number of Ballots" (rows 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13). Batches must have at least 1 ballot. Please remove these rows from the CSV.',
         ),
     ]:
         rv = upload_ballot_manifest(

--- a/server/tests/util/test_csv_parse.py
+++ b/server/tests/util/test_csv_parse.py
@@ -199,6 +199,20 @@ def test_parse_csv_bad_number():
     )
 
 
+def test_parse_csv_negative_number():
+    with pytest.raises(CSVParseError) as error:
+        list(
+            parse_csv(
+                ("Batch Name,Number of Ballots\n1,-2"),
+                BALLOT_MANIFEST_COLUMNS,
+            )
+        )
+    assert (
+        str(error.value)
+        == "Expected a number greater than or equal to 0 in column Number of Ballots, row 2. Got: -2."
+    )
+
+
 def test_parse_csv_bad_email():
     bad_emails = ["not an email", "a@b", "@b.com", "@", "a@.com"]
     for bad_email in bad_emails:

--- a/server/util/csv_parse.py
+++ b/server/util/csv_parse.py
@@ -271,9 +271,14 @@ def validate_and_parse_values(
 
         if column.value_type is CSVValueType.NUMBER:
             try:
-                return locale.atoi(value)
+                number = locale.atoi(value)
             except ValueError:
                 raise CSVParseError(f"Expected a number in {where}. Got: {value}.")
+            if number < 0:
+                raise CSVParseError(
+                    f"Expected a number greater than or equal to 0 in {where}. Got: {value}."
+                )
+            return number
 
         if column.value_type is CSVValueType.EMAIL:
             if not EMAIL_REGEX.match(value):


### PR DESCRIPTION
Closes https://github.com/votingworks/arlo/issues/2299

Some of the tools states use to produce their ballot manifests generate batches with 0 ballots. These batches could be selected during extra batch selection, though not RLA sample selection. We could ignore them during extra batch selection, but Ginny advised we should reject ballot manifests with these rows. 

**0 ballot batch**
<img width="1053" height="357" alt="Screenshot 2026-07-14 at 3 05 53 PM" src="https://github.com/user-attachments/assets/b543686e-9ea7-4ed5-9560-74f995d98e74" />

**Negative ballot batch**
<img width="1111" height="654" alt="Screenshot 2026-07-14 at 3 56 12 PM" src="https://github.com/user-attachments/assets/fa7360b7-d5e1-4897-989e-5b65cf7a2c06" />
