### PR TITLE
Require email verification for support and audit admin login

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -49169,6 +49169,14 @@
                 "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 12,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
                     "endColumn": 35,
                     "lineCount": 1
                 }
@@ -49266,6 +49274,14 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
@@ -128354,6 +128370,54 @@
                 "range": {
                     "startColumn": 28,
                     "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             },

--- a/poetry.lock
+++ b/poetry.lock
@@ -1406,7 +1406,7 @@ Flask = "^3.1.2"
 type = "git"
 url = "https://github.com/votingworks/nOAuth.git"
 reference = "main"
-resolved_reference = "01ebe1ae50704050df5b23cb0c3f705170bb4719"
+resolved_reference = "542245905c0024977a2d2ef08309b606a7ae98c8"
 
 [[package]]
 name = "nodejs-wheel-binaries"

--- a/server/auth/auth_routes.py
+++ b/server/auth/auth_routes.py
@@ -196,6 +196,7 @@ def support_login_callback():
     if (
         userinfo
         and userinfo["email"]
+        and userinfo.get("email_verified") is True
         and userinfo["email"].split("@")[-1] in config.SUPPORT_EMAIL_DOMAINS
     ):
         set_support_user(session, userinfo["email"])
@@ -218,7 +219,7 @@ def auditadmin_login_callback():
     resp = auth0_aa.get("userinfo")
     userinfo = resp.json()
 
-    if userinfo and userinfo["email"]:
+    if userinfo and userinfo["email"] and userinfo.get("email_verified") is True:
         user = User.query.filter_by(email=userinfo["email"]).first()
         if user and len(user.audit_administrations) > 0:
             set_loggedin_user(session, UserType.AUDIT_ADMIN, userinfo["email"])

--- a/server/tests/api/test_activity.py
+++ b/server/tests/api/test_activity.py
@@ -242,7 +242,9 @@ def test_list_activities_logins(
     # Log in an audit admin
     with patch.object(auth0_aa, "authorize_access_token", return_value=None):
         mock_response = Mock()
-        mock_response.json = MagicMock(return_value={"email": DEFAULT_AA_EMAIL})
+        mock_response.json = MagicMock(
+            return_value={"email": DEFAULT_AA_EMAIL, "email_verified": True}
+        )
         with patch.object(auth0_aa, "get", return_value=mock_response):
             rv = client.get("/auth/auditadmin/callback?code=foobar")
             assert rv.status_code == 302

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -157,7 +157,9 @@ def test_support_callback(
 ):
     with patch.object(auth0_sa, "authorize_access_token", return_value=None):
         mock_response = Mock()
-        mock_response.json = MagicMock(return_value={"email": SA_EMAIL})
+        mock_response.json = MagicMock(
+            return_value={"email": SA_EMAIL, "email_verified": True}
+        )
         with patch.object(auth0_sa, "get", return_value=mock_response):
             rv = client.get("/auth/support/callback?code=foobar")
             assert rv.status_code == 302
@@ -183,7 +185,14 @@ def test_support_callback_rejected(
     client: FlaskClient,
     org_id: str,
 ):
-    bad_user_infos: list[JSONDict | None] = [None, {}, {"email": AA_EMAIL}]
+    bad_user_infos: list[JSONDict | None] = [
+        None,
+        {},
+        {"email": AA_EMAIL},
+        {"email": AA_EMAIL, "email_verified": False},
+        {"email": AA_EMAIL, "email_verified": None},
+        {"email": SA_EMAIL, "email_verified": False},
+    ]
     for bad_user_info in bad_user_infos:
         with patch.object(auth0_sa, "authorize_access_token", return_value=None):
             mock_response = Mock()
@@ -207,7 +216,9 @@ def test_support_callback_multiple_allowed_domains(
     config.SUPPORT_EMAIL_DOMAINS = ["voting.works", "example.gov"]
     with patch.object(auth0_sa, "authorize_access_token", return_value=None):
         mock_response = Mock()
-        mock_response.json = MagicMock(return_value={"email": "sa@example.gov"})
+        mock_response.json = MagicMock(
+            return_value={"email": "sa@example.gov", "email_verified": True}
+        )
         with patch.object(auth0_sa, "get", return_value=mock_response):
             rv = client.get("/auth/support/callback?code=foobar")
             assert rv.status_code == 302
@@ -226,7 +237,9 @@ def test_auditadmin_start(client: FlaskClient):
 def test_auditadmin_callback(client: FlaskClient, aa_email: str):
     with patch.object(auth0_aa, "authorize_access_token", return_value=None):
         mock_response = Mock()
-        mock_response.json = MagicMock(return_value={"email": aa_email})
+        mock_response.json = MagicMock(
+            return_value={"email": aa_email, "email_verified": True}
+        )
         with patch.object(auth0_aa, "get", return_value=mock_response):
             rv = client.get("/auth/auditadmin/callback?code=foobar")
             assert rv.status_code == 302
@@ -247,6 +260,32 @@ def test_auditadmin_callback(client: FlaskClient, aa_email: str):
 
             assert auth0_aa.authorize_access_token.called
             assert auth0_aa.get.called
+
+
+def test_auditadmin_callback_rejected_unverified_email(
+    client: FlaskClient, aa_email: str
+):
+    bad_user_infos: list[JSONDict | None] = [
+        None,
+        {},
+        {"email": aa_email},
+        {"email": aa_email, "email_verified": False},
+        {"email": aa_email, "email_verified": None},
+    ]
+    for bad_user_info in bad_user_infos:
+        with patch.object(auth0_aa, "authorize_access_token", return_value=None):
+            mock_response = Mock()
+            mock_response.json = MagicMock(return_value=bad_user_info)
+            with patch.object(auth0_aa, "get", return_value=mock_response):
+                rv = client.get("/auth/auditadmin/callback?code=foobar")
+                assert rv.status_code == 302
+                assert urlparse(rv.location).path == "/"
+
+                with client.session_transaction() as session:  # type: ignore
+                    assert session.get("_user") is None
+
+                assert auth0_aa.authorize_access_token.called
+                assert auth0_aa.get.called
 
 
 def parse_login_code(text: str):


### PR DESCRIPTION
## Summary
This change adds email verification validation to the authentication flow for both support users and audit administrators. For all OAuth identity providers we use in production, emails are already verified, but for other installations that may use different OAuth servers, this check is important. Users must now have a verified email address (as indicated by the `email_verified` field from Auth0) to successfully log in.

## Key Changes
- **Support login callback** (`support_login_callback`): Added check to ensure `email_verified` is `True` before allowing login
- **Audit admin login callback** (`auditadmin_login_callback`): Added check to ensure `email_verified` is `True` before allowing login
- **Test coverage**: 
  - Updated existing tests to include `email_verified: True` in mock responses for successful login scenarios
  - Added comprehensive test cases for rejection scenarios including missing `email_verified`, `email_verified: False`, and `email_verified: None`
  - Added new test `test_auditadmin_callback_rejected_unverified_email` to specifically validate rejection of unverified emails for audit admins

https://claude.ai/code/session_01F5KaRAGNtrp7GZA4KJJwsq