### PR TITLE
Server: Require election/jurisdiction authorization for file uploads and cap upload size

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -24354,16 +24354,16 @@
             {
                 "code": "reportUnknownVariableType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 51,
+                    "startColumn": 4,
+                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownVariableType",
                 "range": {
-                    "startColumn": 53,
-                    "endColumn": 84,
+                    "startColumn": 4,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
@@ -24516,6 +24516,86 @@
                 "range": {
                     "startColumn": 51,
                     "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportImplicitStringConcatenation",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 14,
+                    "lineCount": 3
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 12,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 7,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 73,
+                    "endColumn": 84,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 73,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 75,
+                    "endColumn": 87,
                     "lineCount": 1
                 }
             },
@@ -51077,6 +51157,62 @@
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 1,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUntypedFunctionDecorator",
+                "range": {
+                    "startColumn": 1,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 1,
                     "endColumn": 38,
                     "lineCount": 1
                 }
@@ -69488,10 +69624,58 @@
                 }
             },
             {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAny",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 29,
+                    "startColumn": 26,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -69544,10 +69728,42 @@
                 }
             },
             {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAny",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 29,
+                    "startColumn": 8,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             }

--- a/server/api/public.py
+++ b/server/api/public.py
@@ -1,12 +1,20 @@
 import math
+import os
+import re
 from typing import Any
 
-from werkzeug.exceptions import Conflict, BadRequest
+from werkzeug.exceptions import Conflict, BadRequest, NotFound
 from flask import jsonify, request
 
 
 from . import api
-from ..auth.auth_helpers import allow_public_access, allow_any_logged_in_user_access
+from ..auth.auth_helpers import (
+    UserType,
+    allow_public_access,
+    allow_any_logged_in_user_access,
+    check_access,
+    find_or_404,
+)
 from ..audit_math import bravo, sampler_contest, supersimple
 from ..util.jsonschema import validate
 from ..models import *
@@ -151,6 +159,41 @@ def compute_batch_comparison_sample_size(
     return min(sample_size, contest.ballots)
 
 
+# Matches the storage keys issued by get_file_upload_url:
+# audits/<election_id>[/jurisdictions/<jurisdiction_id>]/<file_name>
+UPLOAD_STORAGE_KEY_PATTERN = re.compile(
+    r"^audits/(?P<election_id>[^/]+)"  # required electionId
+    r"(?:/jurisdictions/(?P<jurisdiction_id>[^/]+))?"  # optional jurisdictionId
+    r"/[^/]+$"  # required filename
+)
+
+
+def validate_and_authorize_storage_key(unvalidated_storage_key: str):
+    key_match = UPLOAD_STORAGE_KEY_PATTERN.match(unvalidated_storage_key)
+    # Detect if a key filename is "." or ".." e.g.
+    # audits/E1/jurisdictions/J1/.. really points at audits/E1/jurisdictions
+    key_hides_its_real_path = (
+        os.path.normpath(unvalidated_storage_key) != unvalidated_storage_key
+    )
+    if key_match is None or key_hides_its_real_path:
+        raise BadRequest("Invalid storage path")
+
+    election: Election = get_or_404(Election, key_match["election_id"])
+    if election.deleted_at is not None:
+        raise NotFound(f"Election {key_match['election_id']} not found")
+
+    jurisdiction_id = key_match["jurisdiction_id"]
+    if jurisdiction_id is None:
+        check_access([UserType.AUDIT_ADMIN], election)
+    else:
+        jurisdiction: Jurisdiction = find_or_404(
+            Jurisdiction.query.filter_by(id=jurisdiction_id, election_id=election.id)
+        )
+        check_access(
+            [UserType.AUDIT_ADMIN, UserType.JURISDICTION_ADMIN], election, jurisdiction
+        )
+
+
 @api.route(
     "/file-upload",
     methods=["POST"],
@@ -164,6 +207,7 @@ def upload_file_to_local_filesystem():
     if file is None:
         raise BadRequest("Missing required form parameter 'file'")
 
+    validate_and_authorize_storage_key(storage_key)
     store_file(
         file.stream,
         storage_key,

--- a/server/app.py
+++ b/server/app.py
@@ -8,6 +8,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from .config import (
     FLASK_ENV,
     HTTP_ORIGIN,
+    MAX_UPLOAD_FILE_SIZE_BYTES,
     STATIC_FOLDER,
 )
 from .database import init_db, db_session, engine
@@ -26,6 +27,7 @@ if FLASK_ENV not in ["development", "test"]:
 app = Flask("arlo", static_folder=None, template_folder=STATIC_FOLDER)
 app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore
 app.testing = FLASK_ENV == "test"
+app.config["MAX_CONTENT_LENGTH"] = MAX_UPLOAD_FILE_SIZE_BYTES
 Talisman(
     app,
     force_https_permanent=True,

--- a/server/config.py
+++ b/server/config.py
@@ -141,6 +141,11 @@ FILE_UPLOAD_STORAGE_PATH = read_env_var(
     "ARLO_FILE_UPLOAD_STORAGE_PATH",
     env_defaults=dict(development="/tmp/arlo", test="/tmp/arlo-test"),
 )
+# Cap the size of a single upload request. Defaults to 5 GB to match the limit
+# S3 imposes on single POST uploads.
+MAX_UPLOAD_FILE_SIZE_BYTES = int(
+    read_env_var("ARLO_MAX_UPLOAD_FILE_SIZE_BYTES", default=str(5 * 1024**3))
+)
 # If using S3, AWS credentials are required as well
 AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION = (
     (

--- a/server/errors.py
+++ b/server/errors.py
@@ -6,6 +6,7 @@ from werkzeug.exceptions import (
     Unauthorized,
     InternalServerError,
     Forbidden,
+    RequestEntityTooLarge,
 )
 
 from .app import app
@@ -48,6 +49,22 @@ def handle_403(error):
     return (
         jsonify(errors=[{"message": error.description, "errorType": "Forbidden"}]),
         Forbidden.code,
+    )
+
+
+@app.errorhandler(RequestEntityTooLarge)
+def handle_413(error):
+    max_size_gb = round(app.config["MAX_CONTENT_LENGTH"] / 1024**3, 2)
+    return (
+        jsonify(
+            errors=[
+                {
+                    "message": f"Upload cannot be larger than {max_size_gb:g} GB",
+                    "errorType": "Request Entity Too Large",
+                }
+            ]
+        ),
+        RequestEntityTooLarge.code,
     )
 
 

--- a/server/tests/api/test_ballot_manifest.py
+++ b/server/tests/api/test_ballot_manifest.py
@@ -203,7 +203,7 @@ def test_ballot_manifest_upload_bad_csv(
                 io.BytesIO(b"not a CSV file"),
                 "random.txt",
             ),
-            "key": "test_dir/random.txt",
+            "key": f"{get_jurisdiction_folder_path(election_id, jurisdiction_ids[0])}/random.txt",
         },
     )
     assert_ok(rv)

--- a/server/tests/api/test_public.py
+++ b/server/tests/api/test_public.py
@@ -554,46 +554,123 @@ def test_public_compute_sample_sizes(client: FlaskClient, snapshot):
         snapshot.assert_match(response, test_case["description"])
 
 
-def test_public_file_upload(client: FlaskClient):
-    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+def upload_to_key(client: FlaskClient, key: str):
+    return client.post(
+        "/api/file-upload",
+        data={"file": (io.BytesIO(b"a file"), "random.csv"), "key": key},
+    )
+
+
+def test_public_file_upload(
+    client: FlaskClient, election_id: str, jurisdiction_ids: list[str]
+):
+    original_storage_path = config.FILE_UPLOAD_STORAGE_PATH
     with tempfile.TemporaryDirectory() as temp_dir:
         config.FILE_UPLOAD_STORAGE_PATH = temp_dir
-        rv = client.post(
-            "/api/file-upload",
-            data={
-                "file": (
-                    io.BytesIO(b"hello, I am a file"),
-                    "random.txt",
-                ),
-                "key": "test_dir/random.txt",
-            },
-        )
-        assert_ok(rv)
-        with open(f"{temp_dir}/test_dir/random.txt", "rb") as stored_file:
-            assert stored_file.read() == b"hello, I am a file"
+        try:
+            set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+            election_key = f"audits/{election_id}/random.csv"
+            assert_ok(upload_to_key(client, election_key))
+            with open(f"{temp_dir}/{election_key}", "rb") as stored_file:
+                assert stored_file.read() == b"a file"
+
+            set_logged_in_user(
+                client, UserType.JURISDICTION_ADMIN, default_ja_email(election_id)
+            )
+            jurisdiction_key = (
+                f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/random.csv"
+            )
+            assert_ok(upload_to_key(client, jurisdiction_key))
+            with open(f"{temp_dir}/{jurisdiction_key}", "rb") as stored_file:
+                assert stored_file.read() == b"a file"
+        finally:
+            config.FILE_UPLOAD_STORAGE_PATH = original_storage_path
 
 
-def test_public_file_upload_path_traversal(client: FlaskClient):
-    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
-    rv = client.post(
-        "/api/file-upload",
-        data={
-            "file": (
-                io.BytesIO(b"hello, I am a file"),
-                "random.txt",
-            ),
-            "key": "../test_dir/random.txt",
-        },
+def test_public_file_upload_forbidden(
+    client: FlaskClient, election_id: str, jurisdiction_ids: list[str], org_id: str
+):
+    election_key = f"audits/{election_id}/random.csv"
+    jurisdiction_key = (
+        f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/random.csv"
     )
-    assert rv.status_code == 400
-    assert json.loads(rv.data) == {
-        "errors": [
-            {
-                "errorType": "Bad Request",
-                "message": "Invalid storage path",
-            }
-        ]
-    }
+    ja_email = default_ja_email(election_id)
+    create_org_and_admin("Other Org", "other-admin@example.com")
+
+    forbidden_cases = [
+        # (user_type, user_key, storage_key, expected_message)
+        (
+            UserType.AUDIT_BOARD,
+            "fake-audit-board-id",
+            jurisdiction_key,
+            "Access forbidden for user type audit_board",
+        ),
+        # Jurisdiction admins can't upload election-level files...
+        (
+            UserType.JURISDICTION_ADMIN,
+            ja_email,
+            election_key,
+            "Access forbidden for user type jurisdiction_admin",
+        ),
+        # ...nor upload to a jurisdiction they don't administer
+        (
+            UserType.JURISDICTION_ADMIN,
+            ja_email,
+            f"audits/{election_id}/jurisdictions/{jurisdiction_ids[2]}/random.csv",
+            f"{ja_email} does not have access to jurisdiction {jurisdiction_ids[2]}",
+        ),
+        (
+            UserType.AUDIT_ADMIN,
+            "other-admin@example.com",
+            jurisdiction_key,
+            f"other-admin@example.com does not have access to organization {org_id}",
+        ),
+    ]
+    for user_type, user_key, storage_key, expected_message in forbidden_cases:
+        set_logged_in_user(client, user_type, user_key)
+        rv = upload_to_key(client, storage_key)
+        assert rv.status_code == 403, storage_key
+        assert json.loads(rv.data) == {
+            "errors": [{"errorType": "Forbidden", "message": expected_message}]
+        }, storage_key
+
+
+def test_public_file_upload_not_found(client: FlaskClient, election_id: str):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+
+    rv = upload_to_key(client, "audits/not-a-real-election-id/random.csv")
+    assert rv.status_code == 404
+
+    rv = upload_to_key(
+        client,
+        f"audits/{election_id}/jurisdictions/not-a-real-jurisdiction-id/random.csv",
+    )
+    assert rv.status_code == 404
+
+    Election.query.get(election_id).deleted_at = datetime.now(timezone.utc)
+    db_session.commit()
+    rv = upload_to_key(client, f"audits/{election_id}/random.csv")
+    assert rv.status_code == 404
+
+
+def test_public_file_upload_invalid_key(
+    client: FlaskClient, election_id: str, jurisdiction_ids: list[str]
+):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    invalid_keys = [
+        "test_dir/random.csv",  # not under audits/
+        f"audits/{election_id}/",  # missing file name
+        f"audits/{election_id}/nested/random.csv",  # unrecognized subfolder
+        f"audits/{election_id}/..",  # points at the audits folder
+        f"audits/{election_id}/jurisdictions/{jurisdiction_ids[0]}/..",  # points at the jurisdictions folder
+        "../test_dir/random.txt",  # path traversal above the storage root
+    ]
+    for invalid_key in invalid_keys:
+        rv = upload_to_key(client, invalid_key)
+        assert rv.status_code == 400, invalid_key
+        assert json.loads(rv.data) == {
+            "errors": [{"errorType": "Bad Request", "message": "Invalid storage path"}]
+        }, invalid_key
 
 
 def test_public_file_upload_unauthorized(client: FlaskClient):

--- a/server/tests/api/test_public.py
+++ b/server/tests/api/test_public.py
@@ -731,3 +731,28 @@ def test_public_file_upload_error(client: FlaskClient):
             }
         ]
     }
+
+
+def test_public_file_upload_too_large(client: FlaskClient):
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    original_max_size = client.application.config["MAX_CONTENT_LENGTH"]
+    client.application.config["MAX_CONTENT_LENGTH"] = 1000
+    try:
+        rv = client.post(
+            "/api/file-upload",
+            data={
+                "file": (
+                    io.BytesIO(b"x" * 2000),
+                    "too_large.csv",
+                ),
+                "key": "audits/election-id/too_large.csv",
+            },
+        )
+        assert rv.status_code == 413
+        response = json.loads(rv.data)
+        assert response["errors"][0]["errorType"] == "Request Entity Too Large"
+        assert response["errors"][0]["message"].startswith(
+            "Upload cannot be larger than"
+        )
+    finally:
+        client.application.config["MAX_CONTENT_LENGTH"] = original_max_size

--- a/server/tests/batch_comparison/test_batch_tallies.py
+++ b/server/tests/batch_comparison/test_batch_tallies.py
@@ -304,7 +304,7 @@ def test_batch_tallies_upload_bad_csv(
                 io.BytesIO(b"not a CSV file"),
                 "random.txt",
             ),
-            "key": "test_dir/random.txt",
+            "key": f"{get_jurisdiction_folder_path(election_id, jurisdiction_ids[0])}/random.txt",
         },
     )
     assert_ok(rv)

--- a/server/tests/util/test_file_storage.py
+++ b/server/tests/util/test_file_storage.py
@@ -329,17 +329,22 @@ def test_validate_and_get_standard_file_upload_request_params_errors(mock_reques
 
 
 def test_get_full_storage_path():
+    original_storage_path = config.FILE_UPLOAD_STORAGE_PATH
     config.FILE_UPLOAD_STORAGE_PATH = "/test/storage/path"
     assert (
         get_full_storage_path("test_dir/test_file.csv")
         == "/test/storage/path/test_dir/test_file.csv"
     )
 
+    with pytest.raises(BadRequest, match="Invalid storage path"):
+        _ = get_full_storage_path("../escaped.csv")
+
     config.FILE_UPLOAD_STORAGE_PATH = "s3://test_bucket"
     assert (
         get_full_storage_path("test_dir/test_file.csv")
         == "s3://test_bucket/test_dir/test_file.csv"
     )
+    config.FILE_UPLOAD_STORAGE_PATH = original_storage_path
 
 
 def test_read_zip_filenames():


### PR DESCRIPTION
### Summary


1. Updates the `file-upload` api to validate the provided storage key and ensure the logged in user has access to the election/jurisdiction. An alternative implementation could rely on the `restrict_access` decorator but that change was ballooning a bit, so I went with this simpler version that calls `check_access` directly.
2. Adds a 5gb file size upload limit, matching the s3 client default.



### Details

On filesystem-storage deployments, `POST /api/file-upload` (step 2 of the 3 step upload process) — previously required only a logged-in session of any type, and wrote the client-supplied storage key as provided. S3-based deployments are unaffected (uploads go browser → S3 via presigned POST, and S3 itself caps single uploads at 5 GB). This brings the endpoint in line with the access control that the upload-URL (step 1) and upload-complete (step 3) steps already enforce:

- Key validation — the storage key must have exactly the shape issued by the upload-URL endpoints, `audits/<election_id>[/jurisdictions/<jurisdiction_id>]/<file_name>`: with ./.. segments and nested paths rejected.
- Authorization — the caller must pass the same `check_access` used by `restrict_access` for the election/jurisdiction named in the key: audit admins (of the election's org) for election-level files; audit admins or that jurisdiction's admins for jurisdiction files. The jurisdiction must belong to the keyed election, so an admin of a jurisdiction in one election can't write under another election's path.
- Size cap — request bodies are capped at 5 GB (configurable via `ARLO_MAX_UPLOAD_FILE_SIZE_BYTES`), matching the ceiling S3 already imposes.

### Test plan

Tests that did not pass the storage key requirements are updated.
New tests added to cover authorization, upload size cap.