### PR TITLE
Server: Improve behavior of zip filename handling

### DIFF
--- a/server/tests/util/test_file_storage.py
+++ b/server/tests/util/test_file_storage.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 import io
 from unittest.mock import patch
+from zipfile import ZipFile
 from werkzeug.exceptions import BadRequest
 import pytest
 
@@ -19,10 +20,12 @@ from ...util.file import (
     retrieve_file_to_buffer,
     store_file,
     get_file_upload_url,
+    unzip_files,
     validate_and_get_standard_file_upload_request_params,
     timestamp_filename,
     zip_files,
 )
+from ...worker.tasks import UserError
 from ... import config
 
 
@@ -350,3 +353,63 @@ def test_get_full_storage_path():
 def test_read_zip_filenames():
     zip = zip_files({"a": io.BytesIO(b"hello"), "b": io.BytesIO(b"world")})
     assert read_zip_filenames(io.BytesIO(zip.read())) == ["a", "b"]
+
+
+def build_zip(entries: dict[str, bytes]) -> io.BytesIO:
+    zip_stream = io.BytesIO()
+    with ZipFile(zip_stream, "w") as zip_archive:
+        for entry_name, contents in entries.items():
+            zip_archive.writestr(entry_name, contents)
+    _ = zip_stream.seek(0)
+    return zip_stream
+
+
+def test_read_zip_filenames_rejects_path_traversal_names():
+    zip_stream = build_zip({"a.csv": b"a", "nested/b.csv": b"b"})
+    assert read_zip_filenames(zip_stream) == ["a.csv", "nested/b.csv"]
+
+    for bad_name in ["/etc/passwd", "a/../../evil.csv"]:
+        zip_stream = build_zip({"a.csv": b"a", bad_name: b"bad"})
+        with pytest.raises(UserError, match="Invalid file name in ZIP file"):
+            _ = read_zip_filenames(zip_stream)
+
+
+def test_unzip_files():
+    with tempfile.TemporaryDirectory() as directory:
+        zip_stream = build_zip(
+            {
+                "cvr.csv": b"cvr",
+                "nested/ballots.csv": b"ballots",
+                "__MACOSX/junk": b"junk",
+                ".hidden": b"hidden",
+            }
+        )
+        file_names = unzip_files(zip_stream, directory)
+        assert sorted(file_names) == ["cvr.csv", "nested/ballots.csv"]
+        for file_name in file_names:
+            assert os.path.isfile(os.path.join(directory, file_name))
+
+
+def test_unzip_files_sanitizes_path_traversal_names():
+    with tempfile.TemporaryDirectory() as directory:
+        zip_stream = build_zip(
+            {
+                "/etc/passwd": b"absolute",
+                "../../outside.csv": b"relative",
+                "a/../../evil.csv": b"nested relative",
+                "cvr.csv": b"cvr",
+            }
+        )
+        file_names = unzip_files(zip_stream, directory)
+        assert sorted(file_names) == [
+            "a/evil.csv",
+            "cvr.csv",
+            "etc/passwd",
+            "outside.csv",
+        ]
+        for file_name in file_names:
+            full_path = os.path.realpath(os.path.join(directory, file_name))
+            assert os.path.isfile(full_path)
+            assert os.path.commonpath(
+                [full_path, os.path.realpath(directory)]
+            ) == os.path.realpath(directory)

--- a/server/util/file.py
+++ b/server/util/file.py
@@ -14,7 +14,7 @@ from flask import Request
 
 from .. import config
 from ..models import *
-from ..worker.tasks import serialize_background_task
+from ..worker.tasks import UserError, serialize_background_task
 from ..util.isoformat import isoformat
 from ..util.jsonschema import JSONDict
 from ..util.csv_parse import is_filetype_csv_mimetype
@@ -125,24 +125,36 @@ def zip_files(files: Mapping[str, IO[bytes]]) -> IO[bytes]:
 
 def read_zip_filenames(zip_file: BinaryIO) -> list[str]:
     with ZipFile(zip_file, "r") as zip_archive:
-        return [
+        file_names = [
             entry_name
             for entry_name in zip_archive.namelist()
             # ZIP files created on Macs include a hidden __MACOSX folder
             if not entry_name.startswith("__") and not entry_name.startswith(".")
         ]
+        for file_name in file_names:
+            normalized = os.path.normpath(file_name)
+            # Guarantee the path name is within the zip file
+            if os.path.isabs(normalized) or normalized.startswith(".."):
+                raise UserError(f"Invalid file name in ZIP file: {file_name}")
+        return file_names
 
 
 # Extracts the contents of the provided zip file to the specified directory and returns the list of
 # extracted file names
 def unzip_files(zip_file: BinaryIO, directory_to_extract_to: str) -> list[str]:
     with ZipFile(zip_file, "r") as zip_archive:
-        zip_archive.extractall(directory_to_extract_to)
-        return [
-            entry_name
+        extracted_file_names = [
+            os.path.relpath(
+                zip_archive.extract(entry_name, directory_to_extract_to),
+                directory_to_extract_to,
+            )
             for entry_name in zip_archive.namelist()
+        ]
+        return [
+            file_name
+            for file_name in extracted_file_names
             # ZIP files created on Macs include a hidden __MACOSX folder
-            if not entry_name.startswith("__") and not entry_name.startswith(".")
+            if not file_name.startswith("__") and not file_name.startswith(".")
         ]
 
 


### PR DESCRIPTION
### Summary

Return actual extracted file paths from ZIP upload helpers

### Description

`unzip_files()` extracted uploaded ZIPs with `extractall()` but returned the original archive's raw entry names rather than the names of the files extraction actually wrote. The two can differ, since extraction normalizes entry names before writing. Callers rebuild paths from the returned names to re-open the extracted files, so a mismatch leaves them pointing at paths that were never written.

`unzip_files()` now extracts entry-by-entry and returns the paths that were actually written, relative to the extraction directory.

`read_zip_filenames()`, which lists entry names without extracting, now rejects names that wouldn't correspond to a file inside the extraction directory.

### Testing
Added tests covering nested folders and irregular entry names in both helpers.