### PR TITLE
Server: Include discrepancy counts in Slack messages when batches are finalized

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -102998,6 +102998,126 @@
                 }
             },
             {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 19,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 21,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 18,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 4,
@@ -103170,6 +103290,38 @@
                 "range": {
                     "startColumn": 14,
                     "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 65,
                     "lineCount": 1
                 }
             },

--- a/server/activity_log/activity_log.py
+++ b/server/activity_log/activity_log.py
@@ -78,7 +78,7 @@ class RecordResults(JurisdictionActivity):
 
 @dataclass
 class FinalizeBatchResults(JurisdictionActivity):
-    pass
+    num_batches_with_discrepancies: int
 
 
 @dataclass

--- a/server/activity_log/slack_worker.py
+++ b/server/activity_log/slack_worker.py
@@ -283,8 +283,17 @@ def slack_message(activity: activity_log.Activity):
         )
 
     if isinstance(activity, activity_log.FinalizeBatchResults):
+        num_discrepancies = activity.num_batches_with_discrepancies
+        discrepancy_status = (
+            f"{num_discrepancies} batch{'es' if num_discrepancies > 1 else ''} with discrepancies"
+            if num_discrepancies > 0
+            else "no discrepancies"
+        )
+        discrepancy_emoji = (
+            ":warning:" if num_discrepancies > 0 else ":white_check_mark:"
+        )
         return dict(
-            text=f"Finalized batch results for {activity.jurisdiction_name}",
+            text=f"Finalized batch results for {activity.jurisdiction_name} ({discrepancy_status})",
             blocks=[
                 dict(
                     type="section",
@@ -292,6 +301,15 @@ def slack_message(activity: activity_log.Activity):
                         type="mrkdwn",
                         text=f"*Finalized batch results for {activity.jurisdiction_name}*",
                     ),
+                ),
+                dict(
+                    type="context",
+                    elements=[
+                        dict(
+                            type="mrkdwn",
+                            text=f"{discrepancy_emoji} {discrepancy_status.capitalize()}",
+                        )
+                    ],
                 ),
                 dict(
                     type="context",

--- a/server/api/batches.py
+++ b/server/api/batches.py
@@ -21,6 +21,7 @@ from ..activity_log.activity_log import (
     activity_base,
     record_activity,
 )
+from .discrepancies import get_batch_comparison_discrepancies_by_jurisdiction
 from ..util.get_json import safe_get_json_list
 
 
@@ -382,12 +383,19 @@ def finalize_batch_results(
         BatchResultsFinalized(jurisdiction_id=jurisdiction.id, round_id=round.id)
     )
 
+    discrepancies_by_jurisdiction = get_batch_comparison_discrepancies_by_jurisdiction(
+        election, round.id
+    )
+
     record_activity(
         FinalizeBatchResults(
             timestamp=datetime.now(timezone.utc),
             base=activity_base(election),
             jurisdiction_id=jurisdiction.id,
             jurisdiction_name=jurisdiction.name,
+            num_batches_with_discrepancies=len(
+                discrepancies_by_jurisdiction.get(jurisdiction.id, {})
+            ),
         )
     )
 

--- a/server/tests/batch_comparison/test_batch_comparison.py
+++ b/server/tests/batch_comparison/test_batch_comparison.py
@@ -329,6 +329,25 @@ def test_batch_comparison_round_2(
     )
     assert_ok(rv)
 
+    organization_id = Election.query.get(election_id).organization_id
+
+    def latest_finalize_record() -> ActivityLogRecord:
+        record = (
+            ActivityLogRecord.query.filter_by(
+                organization_id=organization_id, activity_name="FinalizeBatchResults"
+            )
+            .order_by(ActivityLogRecord.timestamp.desc())
+            .first()
+        )
+        assert record is not None
+        return record
+
+    finalize_record = latest_finalize_record()
+    assert finalize_record.info["jurisdiction_id"] == jurisdiction_ids[0]
+    assert finalize_record.info["num_batches_with_discrepancies"] == len(
+        expected_discrepancies_j1
+    )
+
     # Check jurisdiction status after finalizing results
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
     rv = client.get(f"/api/election/{election_id}/jurisdiction")
@@ -417,6 +436,12 @@ def test_batch_comparison_round_2(
         f"/api/election/{election_id}/jurisdiction/{jurisdiction_ids[1]}/round/{round_1_id}/batches/finalize",
     )
     assert_ok(rv)
+
+    finalize_record = latest_finalize_record()
+    assert finalize_record.info["jurisdiction_id"] == jurisdiction_ids[1]
+    assert finalize_record.info["num_batches_with_discrepancies"] == len(
+        expected_discrepancies_j2
+    )
 
     # Check jurisdiction status after recording results
     set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)

--- a/server/tests/snapshots/snap_test_slack_worker.py
+++ b/server/tests/snapshots/snap_test_slack_worker.py
@@ -124,6 +124,12 @@ snapshots["test_slack_worker_message_format 12"] = {
         },
         {
             "elements": [
+                {"text": ":white_check_mark: No discrepancies", "type": "mrkdwn"}
+            ],
+            "type": "context",
+        },
+        {
+            "elements": [
                 {
                     "text": ":flag-us: <http://localhost:3000/support/orgs/test_org_id|Test Org>",
                     "type": "mrkdwn",
@@ -148,7 +154,7 @@ snapshots["test_slack_worker_message_format 12"] = {
             "type": "context",
         },
     ],
-    "text": "Finalized batch results for Test Jurisdiction",
+    "text": "Finalized batch results for Test Jurisdiction (no discrepancies)",
 }
 
 snapshots["test_slack_worker_message_format 13"] = {

--- a/server/tests/test_slack_worker.py
+++ b/server/tests/test_slack_worker.py
@@ -235,6 +235,7 @@ def test_slack_worker_message_format(snapshot):
                 base,
                 jurisdiction_id="test_jurisdiction_id",
                 jurisdiction_name="Test Jurisdiction",
+                num_batches_with_discrepancies=0,
             )
         )
     )
@@ -283,6 +284,37 @@ def test_slack_worker_state_flag_emoji():
     # States without an uploaded emoji fall back to the US flag
     base.state = "OH"
     assert ":flag-us:" in message_json(base)
+
+
+def test_slack_worker_finalize_batch_results_discrepancies():
+    timestamp = datetime.fromisoformat("2021-05-19T18:31:13.576657+00:00")
+    base = activity_log.ActivityBase(
+        organization_id="test_org_id",
+        organization_name="Test Org",
+        election_id="test_election_id",
+        audit_name="Test Audit",
+        audit_type="BATCH_COMPARISON",
+        user_type="jurisdiction_admin",
+        user_key="test_user@example.com",
+        support_user_email=None,
+    )
+
+    def message_json(num_batches_with_discrepancies: int) -> str:
+        return json.dumps(
+            slack_worker.slack_message(
+                activity_log.FinalizeBatchResults(
+                    timestamp,
+                    base,
+                    jurisdiction_id="test_jurisdiction_id",
+                    jurisdiction_name="Test Jurisdiction",
+                    num_batches_with_discrepancies=num_batches_with_discrepancies,
+                )
+            )
+        )
+
+    assert ":white_check_mark: No discrepancies" in message_json(0)
+    assert ":warning: 1 batch with discrepancies" in message_json(1)
+    assert ":warning: 3 batches with discrepancies" in message_json(3)
 
 
 def test_slack_worker_truncate_long_error_messages():


### PR DESCRIPTION
Closes https://github.com/votingworks/arlo/issues/2113

## Overview

Typically whenever a batch is finalized, support team logs into Arlo to see whether that batch had discrepancies. Now, they can see directly from the Slack message. 

## Screenshot 

<img width="792" height="380" alt="Screenshot 2026-08-18 at 5 05 16 PM" src="https://github.com/user-attachments/assets/291daae4-7dcd-4c71-8da1-5fe0e27f7bb0" />
