### PR TITLE
Allow support users to archive/unarchive organizations

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -4450,32 +4450,40 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 25,
+                    "startColumn": 12,
+                    "endColumn": 18,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownArgumentType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 74,
+                    "startColumn": 12,
+                    "endColumn": 41,
+                    "lineCount": 2
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownVariableType",
                 "range": {
-                    "startColumn": 49,
-                    "endColumn": 52,
+                    "startColumn": 16,
+                    "endColumn": 19,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 56,
-                    "endColumn": 74,
+                    "startColumn": 23,
+                    "endColumn": 41,
                     "lineCount": 1
                 }
             },
@@ -56384,6 +56392,30 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 21,
                     "lineCount": 1
                 }
             },

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -49608,32 +49608,16 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 39,
+                    "startColumn": 24,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnknownMemberType",
+                "code": "reportUnknownArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 60,
+                    "startColumn": 24,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -129182,10 +129166,50 @@
                 }
             },
             {
-                "code": "reportUnusedCallResult",
+                "code": "reportUnknownVariableType",
                 "range": {
                     "startColumn": 4,
-                    "endColumn": 86,
+                    "endColumn": 8,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             },

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -20422,6 +20422,14 @@
                     "endColumn": 41,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
             }
         ],
         "./server/api/full_hand_tally.py": [
@@ -47534,6 +47542,30 @@
             {
                 "code": "reportUnknownVariableType",
                 "range": {
+                    "startColumn": 4,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
                     "startColumn": 8,
                     "endColumn": 12,
                     "lineCount": 1
@@ -48762,7 +48794,7 @@
                 "range": {
                     "startColumn": 26,
                     "endColumn": 13,
-                    "lineCount": 10
+                    "lineCount": 11
                 }
             },
             {
@@ -48838,6 +48870,30 @@
                 }
             },
             {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportUnknownVariableType",
                 "range": {
                     "startColumn": 8,
@@ -48856,24 +48912,56 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 11,
-                    "endColumn": 35,
+                    "startColumn": 12,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 11,
-                    "endColumn": 44,
+                    "startColumn": 12,
+                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 11,
-                    "endColumn": 55,
+                    "startColumn": 12,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 74,
                     "lineCount": 1
                 }
             },
@@ -49072,16 +49160,40 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 36,
+                    "startColumn": 16,
+                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 47,
+                    "startColumn": 16,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
@@ -49488,16 +49600,32 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 50,
+                    "startColumn": 12,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 50,
+                    "startColumn": 12,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
             },

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -52935,6 +52935,22 @@
                 "code": "reportUnknownVariableType",
                 "range": {
                     "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnannotatedClassAttribute",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
                     "endColumn": 13,
                     "lineCount": 1
                 }

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -39808,32 +39808,48 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 35,
+                    "startColumn": 19,
+                    "endColumn": 34,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 35,
+                    "startColumn": 19,
+                    "endColumn": 34,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 59,
+                    "startColumn": 21,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 59,
+                    "startColumn": 21,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 61,
                     "lineCount": 1
                 }
             },
@@ -40272,6 +40288,22 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
+                    "startColumn": 29,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
                     "startColumn": 19,
                     "endColumn": 30,
                     "lineCount": 1
@@ -40586,6 +40618,38 @@
                 "range": {
                     "startColumn": 22,
                     "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 16,
                     "lineCount": 1
                 }
             },

--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -73452,6 +73452,142 @@
             {
                 "code": "reportAny",
                 "range": {
+                    "startColumn": 19,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 7,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 6,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
                     "startColumn": 4,
                     "endColumn": 6,
                     "lineCount": 1
@@ -128990,6 +129126,38 @@
                 }
             },
             {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportUnknownParameterType",
                 "range": {
                     "startColumn": 31,
@@ -131482,6 +131650,78 @@
                 "range": {
                     "startColumn": 20,
                     "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             },

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/Contests.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
   >
     <section
       aria-label="Opportunistic Contests"
-      class="sc-hzDkRC jOtlEn"
+      class="sc-bRBYWo gEFjPK"
     >
       <h2
         class="bp3-heading sc-gPEVay buZaEY"
@@ -16,7 +16,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-hrWEMg ewoHSM"
+        class="bp3-card bp3-elevation-0 sc-bwCtUz ktUBWY"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -123,19 +123,19 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-eXEjpC epWVSm"
+            class="sc-kIPQKe inKPiS"
           >
             <div
-              class="sc-ibxdXY fkpltL"
+              class="sc-eXEjpC lfXKhs"
             >
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -150,13 +150,13 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
                 </div>
               </label>
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -172,17 +172,17 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
               </label>
             </div>
             <div
-              class="sc-ibxdXY fkpltL"
+              class="sc-eXEjpC lfXKhs"
               style="margin-top: 15px;"
             >
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -197,13 +197,13 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
                 </div>
               </label>
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -219,7 +219,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
               </label>
             </div>
             <p
-              class="sc-bwCtUz iNHxMf"
+              class="sc-iQKALj cNTZdD"
             >
               Add a new candidate/choice
             </p>
@@ -276,7 +276,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
           <div
-            class="sc-gwVKww eubOEq"
+            class="sc-eTuwsz elMWQe"
           >
             <span
               class="bp3-popover-wrapper"
@@ -341,7 +341,7 @@ exports[`Audit Setup > Contests > renders empty opportunistic state correctly 1`
       </div>
     </section>
     <div
-      class="sc-kIPQKe bHIKoH"
+      class="sc-esjQYD ANKzV"
       style="margin-top: 15px;"
     >
       <button
@@ -415,7 +415,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
   >
     <section
       aria-label="Target Contests"
-      class="sc-hzDkRC jOtlEn"
+      class="sc-bRBYWo gEFjPK"
     >
       <h2
         class="bp3-heading sc-gPEVay buZaEY"
@@ -423,7 +423,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-hrWEMg ewoHSM"
+        class="bp3-card bp3-elevation-0 sc-bwCtUz ktUBWY"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -530,19 +530,19 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-eXEjpC epWVSm"
+            class="sc-kIPQKe inKPiS"
           >
             <div
-              class="sc-ibxdXY fkpltL"
+              class="sc-eXEjpC lfXKhs"
             >
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -557,13 +557,13 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -579,17 +579,17 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <div
-              class="sc-ibxdXY fkpltL"
+              class="sc-eXEjpC lfXKhs"
               style="margin-top: 15px;"
             >
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -604,13 +604,13 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -626,7 +626,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
               </label>
             </div>
             <p
-              class="sc-bwCtUz iNHxMf"
+              class="sc-iQKALj cNTZdD"
             >
               Add a new candidate/choice
             </p>
@@ -683,7 +683,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
           <div
-            class="sc-gwVKww eubOEq"
+            class="sc-eTuwsz elMWQe"
           >
             <span
               class="bp3-popover-wrapper"
@@ -748,7 +748,7 @@ exports[`Audit Setup > Contests > renders empty targeted state correctly 1`] = `
       </div>
     </section>
     <div
-      class="sc-kIPQKe bHIKoH"
+      class="sc-esjQYD ANKzV"
       style="margin-top: 15px;"
     >
       <button
@@ -822,7 +822,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
   >
     <section
       aria-label="Opportunistic Contests"
-      class="sc-hzDkRC jOtlEn"
+      class="sc-bRBYWo gEFjPK"
     >
       <h2
         class="bp3-heading sc-gPEVay buZaEY"
@@ -830,7 +830,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
         Opportunistic Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-hrWEMg ewoHSM"
+        class="bp3-card bp3-elevation-0 sc-bwCtUz ktUBWY"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -937,19 +937,19 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-eXEjpC epWVSm"
+            class="sc-kIPQKe inKPiS"
           >
             <div
-              class="sc-ibxdXY fkpltL"
+              class="sc-eXEjpC lfXKhs"
             >
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -964,13 +964,13 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
                 </div>
               </label>
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -986,17 +986,17 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
               </label>
             </div>
             <div
-              class="sc-ibxdXY fkpltL"
+              class="sc-eXEjpC lfXKhs"
               style="margin-top: 15px;"
             >
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -1011,13 +1011,13 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
                 </div>
               </label>
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -1033,7 +1033,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
               </label>
             </div>
             <p
-              class="sc-bwCtUz iNHxMf"
+              class="sc-iQKALj cNTZdD"
             >
               Add a new candidate/choice
             </p>
@@ -1090,7 +1090,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
           <div
-            class="sc-gwVKww eubOEq"
+            class="sc-eTuwsz elMWQe"
           >
             <span
               class="bp3-popover-wrapper"
@@ -1155,7 +1155,7 @@ exports[`Audit Setup > Contests > renders filled opportunistic state correctly 1
       </div>
     </section>
     <div
-      class="sc-kIPQKe bHIKoH"
+      class="sc-esjQYD ANKzV"
       style="margin-top: 15px;"
     >
       <button
@@ -1229,7 +1229,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
   >
     <section
       aria-label="Target Contests"
-      class="sc-hzDkRC jOtlEn"
+      class="sc-bRBYWo gEFjPK"
     >
       <h2
         class="bp3-heading sc-gPEVay buZaEY"
@@ -1237,7 +1237,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-hrWEMg ewoHSM"
+        class="bp3-card bp3-elevation-0 sc-bwCtUz ktUBWY"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -1344,19 +1344,19 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-eXEjpC epWVSm"
+            class="sc-kIPQKe inKPiS"
           >
             <div
-              class="sc-ibxdXY fkpltL"
+              class="sc-eXEjpC lfXKhs"
             >
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -1371,13 +1371,13 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
                 </div>
               </label>
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -1393,17 +1393,17 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
               </label>
             </div>
             <div
-              class="sc-ibxdXY fkpltL"
+              class="sc-eXEjpC lfXKhs"
               style="margin-top: 15px;"
             >
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -1418,13 +1418,13 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
                 </div>
               </label>
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -1440,7 +1440,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
               </label>
             </div>
             <p
-              class="sc-bwCtUz iNHxMf"
+              class="sc-iQKALj cNTZdD"
             >
               Add a new candidate/choice
             </p>
@@ -1497,7 +1497,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
             Select the jurisdictions where this contest appeared on the ballot.
           </div>
           <div
-            class="sc-gwVKww eubOEq"
+            class="sc-eTuwsz elMWQe"
           >
             <span
               class="bp3-popover-wrapper"
@@ -1562,7 +1562,7 @@ exports[`Audit Setup > Contests > renders filled targeted state correctly 1`] = 
       </div>
     </section>
     <div
-      class="sc-kIPQKe bHIKoH"
+      class="sc-esjQYD ANKzV"
       style="margin-top: 15px;"
     >
       <button

--- a/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
+++ b/client/src/components/AuditAdmin/Setup/Contests/__snapshots__/HybridContestForm.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
   >
     <section
       aria-label="Target Contests"
-      class="sc-hzDkRC jOtlEn"
+      class="sc-bRBYWo gEFjPK"
     >
       <h2
         class="bp3-heading sc-gPEVay buZaEY"
@@ -16,7 +16,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
         Target Contests
       </h2>
       <div
-        class="bp3-card bp3-elevation-0 sc-hrWEMg ewoHSM"
+        class="bp3-card bp3-elevation-0 sc-bwCtUz ktUBWY"
         style="background: rgb(245, 248, 250);"
       >
         <div
@@ -43,7 +43,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
                Name
               <br />
               <div
-                class="bp3-html-select sc-hXRMBi cHmoZg"
+                class="bp3-html-select sc-gwVKww iHbfsO"
               >
                 <select
                   field="[object Object]"
@@ -159,19 +159,19 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
             Enter the name of each candidate choice that appears on the ballot for this contest.
           </div>
           <div
-            class="sc-eXEjpC epWVSm"
+            class="sc-kIPQKe inKPiS"
           >
             <div
-              class="sc-ibxdXY fkpltL"
+              class="sc-eXEjpC lfXKhs"
             >
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 1
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -186,13 +186,13 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 1
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -208,17 +208,17 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
               </label>
             </div>
             <div
-              class="sc-ibxdXY fkpltL"
+              class="sc-eXEjpC lfXKhs"
               style="margin-top: 15px;"
             >
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Name of Candidate/Choice 
                 2
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -233,13 +233,13 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
                 </div>
               </label>
               <label
-                class="bp3-label sc-iQKALj LZCOX"
+                class="bp3-label sc-RefOD lnlWQL"
                 style="margin-bottom: 0px;"
               >
                 Votes for Candidate/Choice 
                 2
                 <div
-                  class="sc-RefOD dVvqKK sc-fjdhpX hpEPln"
+                  class="sc-ibxdXY jqjDdW sc-fjdhpX hpEPln"
                 >
                   <div
                     class="bp3-input-group sc-jzJRlG lpfNbV"
@@ -255,7 +255,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
               </label>
             </div>
             <p
-              class="sc-bwCtUz iNHxMf"
+              class="sc-iQKALj cNTZdD"
             >
               Add a new candidate/choice
             </p>
@@ -297,7 +297,7 @@ exports[`Audit Setup > Contests (Hybrid) > Audit Setup > Contests 1`] = `
       </div>
     </section>
     <div
-      class="sc-kIPQKe bHIKoH"
+      class="sc-esjQYD ANKzV"
       style="margin-top: 15px;"
     >
       <button

--- a/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
+++ b/client/src/components/AuditBoard/__snapshots__/AuditBoardView.test.tsx.snap
@@ -70,19 +70,19 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
         class="sc-bwzfXH bIwzaO"
       >
         <div
-          class="sc-fONwsr hzCAfP"
+          class="sc-giadOv dWuAfT"
         >
           <div
-            class="sc-VJcYb gYDKZM"
+            class="sc-fONwsr iOEGel"
           >
             <div
-              class="sc-ipXKqB HevyK"
+              class="sc-VJcYb fmYyPq"
             >
               <div
-                class="sc-dliRfk dkVfRo"
+                class="sc-cqCuEk iQSiJa"
               >
                 <button
-                  class="bp3-button bp3-minimal sc-cqCuEk gHzCOk"
+                  class="bp3-button bp3-minimal sc-hmXxxW ZmoKu"
                   href="/election/1/audit-board/audit-board-1"
                   type="button"
                 >
@@ -112,56 +112,56 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                   </span>
                 </button>
                 <h3
-                  class="bp3-heading sc-giadOv bjjKkb"
+                  class="bp3-heading sc-kUaPvJ iuTkcg"
                 >
                   Audit Ballot Selections
                 </h3>
               </div>
               <div
-                class="bp3-divider sc-jzgbtB fybxul"
+                class="bp3-divider sc-fhYwyz bCqfDZ"
               />
               <div
-                class="sc-itybZL buxjUz"
+                class="sc-dTdPqK hAhAol"
               >
                 <div>
                   <h5
-                    class="bp3-heading sc-krDsej ldDgap"
+                    class="bp3-heading sc-bHwgHz evkCaY"
                   >
                     Tabulator
                   </h5>
                   <h4
-                    class="bp3-heading sc-eMigcr ccyRbT"
+                    class="bp3-heading sc-itybZL dJQQkH"
                   >
                     11
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-krDsej ldDgap"
+                    class="bp3-heading sc-bHwgHz evkCaY"
                   >
                     Batch
                   </h5>
                   <h4
-                    class="bp3-heading sc-eMigcr ccyRbT"
+                    class="bp3-heading sc-itybZL dJQQkH"
                   >
                     0003-04-Precinct 19 (Jonesboro Fire Department)
                   </h4>
                 </div>
                 <div>
                   <h5
-                    class="bp3-heading sc-krDsej ldDgap"
+                    class="bp3-heading sc-bHwgHz evkCaY"
                   >
                     Ballot Number
                   </h5>
                   <h4
-                    class="bp3-heading sc-eMigcr ccyRbT"
+                    class="bp3-heading sc-itybZL dJQQkH"
                   >
                     2112
                   </h4>
                 </div>
                 <div>
                   <button
-                    class="bp3-button bp3-large bp3-intent-danger sc-fzsDOv gGBvSV"
+                    class="bp3-button bp3-large bp3-intent-danger sc-eMigcr ipvEwD"
                     type="button"
                   >
                     <span
@@ -173,36 +173,36 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                 </div>
               </div>
               <div
-                class="bp3-divider sc-jzgbtB fybxul"
+                class="bp3-divider sc-fhYwyz bCqfDZ"
               />
               <div
-                class="sc-gJWqzi kebwtN"
+                class="sc-jzgbtB bnMeMk"
               >
                 <div
                   class="ballot-main"
                 >
                   <h5
-                    class="bp3-heading sc-krDsej ldDgap"
+                    class="bp3-heading sc-bHwgHz evkCaY"
                   >
                     Ballot Contests
                   </h5>
                   <form>
                     <div
-                      class="sc-rBLzX jjlXvd"
+                      class="sc-gJWqzi iBFhF"
                     >
                       <div
-                        class="sc-fjmCvl kLsxHI"
+                        class="sc-hGoxap ldoFkT"
                       >
                         <div
-                          class="sc-TFwJa hlfald"
+                          class="sc-fjmCvl iEPDwp"
                         >
                           <h3
-                            class="bp3-heading sc-jVODtj guUxfA"
+                            class="bp3-heading sc-gPWkxV kaSlNF"
                           >
                             Contest 1
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-dTdPqK hhDibj"
+                            class="bp3-control bp3-checkbox sc-krDsej fBQoNq"
                           >
                             <input
                               type="checkbox"
@@ -218,7 +218,7 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dTdPqK hhDibj"
+                            class="bp3-control bp3-checkbox sc-krDsej fBQoNq"
                           >
                             <input
                               type="checkbox"
@@ -235,10 +235,10 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-bHwgHz dmTCaR"
+                          class="sc-TFwJa bLuNve"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-dTdPqK hhDibj"
+                            class="bp3-control bp3-checkbox sc-krDsej fBQoNq"
                           >
                             <input
                               type="checkbox"
@@ -254,7 +254,7 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dTdPqK hhDibj"
+                            class="bp3-control bp3-checkbox sc-krDsej fBQoNq"
                           >
                             <input
                               type="checkbox"
@@ -270,7 +270,7 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dTdPqK hhDibj"
+                            class="bp3-control bp3-checkbox sc-krDsej fBQoNq"
                           >
                             <input
                               type="checkbox"
@@ -286,7 +286,7 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-gPWkxV gAnTBe"
+                            class="bp3-input sc-fzsDOv gKLgKz"
                             name="comment-Contest 1"
                             placeholder="Add Note"
                           />
@@ -294,21 +294,21 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-rBLzX jjlXvd"
+                      class="sc-gJWqzi iBFhF"
                     >
                       <div
-                        class="sc-fjmCvl kLsxHI"
+                        class="sc-hGoxap ldoFkT"
                       >
                         <div
-                          class="sc-TFwJa hlfald"
+                          class="sc-fjmCvl iEPDwp"
                         >
                           <h3
-                            class="bp3-heading sc-jVODtj guUxfA"
+                            class="bp3-heading sc-gPWkxV kaSlNF"
                           >
                             Contest 2
                           </h3>
                           <label
-                            class="bp3-control bp3-checkbox sc-dTdPqK hhDibj"
+                            class="bp3-control bp3-checkbox sc-krDsej fBQoNq"
                           >
                             <input
                               type="checkbox"
@@ -324,7 +324,7 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dTdPqK hhDibj"
+                            class="bp3-control bp3-checkbox sc-krDsej fBQoNq"
                           >
                             <input
                               type="checkbox"
@@ -341,10 +341,10 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                           </label>
                         </div>
                         <div
-                          class="sc-bHwgHz dmTCaR"
+                          class="sc-TFwJa bLuNve"
                         >
                           <label
-                            class="bp3-control bp3-checkbox sc-dTdPqK hhDibj"
+                            class="bp3-control bp3-checkbox sc-krDsej fBQoNq"
                           >
                             <input
                               type="checkbox"
@@ -360,7 +360,7 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dTdPqK hhDibj"
+                            class="bp3-control bp3-checkbox sc-krDsej fBQoNq"
                           >
                             <input
                               type="checkbox"
@@ -376,7 +376,7 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                             </span>
                           </label>
                           <label
-                            class="bp3-control bp3-checkbox sc-dTdPqK hhDibj"
+                            class="bp3-control bp3-checkbox sc-krDsej fBQoNq"
                           >
                             <input
                               type="checkbox"
@@ -392,7 +392,7 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                             </span>
                           </label>
                           <textarea
-                            class="bp3-input sc-gPWkxV gAnTBe"
+                            class="bp3-input sc-fzsDOv gKLgKz"
                             name="comment-Contest 2"
                             placeholder="Add Note"
                           />
@@ -400,10 +400,10 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                       </div>
                     </div>
                     <div
-                      class="sc-CtfFt jTDPOj"
+                      class="sc-bMvGRv fFYRYN"
                     >
                       <button
-                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-kUaPvJ bCzZgP sc-gqjmRU eotNvg"
+                        class="bp3-button bp3-disabled bp3-large bp3-intent-success sc-jVODtj kaKwrz sc-gqjmRU eotNvg"
                         disabled=""
                         tabindex="-1"
                         type="submit"
@@ -430,7 +430,7 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
               </div>
             </div>
             <div
-              class="sc-hmXxxW kmhxPM"
+              class="sc-ipXKqB fWazMb"
             >
               <h4
                 class="bp3-heading"
@@ -438,7 +438,7 @@ exports[`AuditBoardView > ballot interaction > renders ballot route 1`] = `
                 Instructions
               </h4>
               <ol
-                class="bp3-list sc-kLIISr hHWqFM"
+                class="bp3-list sc-dliRfk eZERgW"
               >
                 <li>
                   Confirm that you are looking at the correct ballot for the batch and position. If the ballot was not located, select
@@ -552,13 +552,13 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
       class="board-table-container"
     >
       <div
-        class="sc-cbkKFq bnGWyJ"
+        class="sc-eLExRp kxnjIF"
       >
         <section
-          class="sc-bwzfXH sc-krvtoX hezULE"
+          class="sc-bwzfXH sc-cbkKFq iXfDzl"
         >
           <div
-            class="sc-lkqHmb kSVTCw"
+            class="sc-bXGyLb eiHjrd"
           >
             <p>
               18
@@ -567,23 +567,23 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-emmjRN fIRdem"
+              class="summary-label sc-eerKOB fAIeLb"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-cpmLhU eaCJmT"
+              class="summary-label sc-emmjRN eLlxwW"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-eLExRp hvAiSe"
+            class="sc-lkqHmb dMuWlS"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bnXvFD qATUh"
+              class="bp3-button bp3-intent-success sc-dymIpo eIEnxs"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -600,10 +600,10 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
         class="sc-bwzfXH bIwzaO"
       >
         <div
-          class="sc-fYiAbW jOhkVa"
+          class="sc-krvtoX icRbSZ"
         >
           <div
-            class="sc-fOKMvo hatXDO"
+            class="sc-fYiAbW cMlqCd"
           >
             <h3
               class="bp3-heading"
@@ -612,7 +612,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
               Audit Board #1
             </h3>
             <div
-              class="sc-dUjcNx dewsjI"
+              class="sc-fOKMvo llZIzY"
             >
               <table
                 class="sc-eHgmQL ehyFrf"
@@ -817,7 +817,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -827,7 +827,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -837,7 +837,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -847,7 +847,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -876,7 +876,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -895,7 +895,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -904,7 +904,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -913,7 +913,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -922,7 +922,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -931,7 +931,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -952,7 +952,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -962,7 +962,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -972,7 +972,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -982,7 +982,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1011,7 +1011,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -1030,7 +1030,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1040,7 +1040,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1050,7 +1050,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1060,7 +1060,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1089,7 +1089,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -1108,7 +1108,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -1117,7 +1117,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1126,7 +1126,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -1135,7 +1135,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -1144,7 +1144,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -1165,7 +1165,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1175,7 +1175,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1185,7 +1185,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1195,7 +1195,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1224,7 +1224,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -1243,7 +1243,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1253,7 +1253,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1263,7 +1263,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1273,7 +1273,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1302,7 +1302,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -1321,7 +1321,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -1330,7 +1330,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1339,7 +1339,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -1348,7 +1348,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -1357,7 +1357,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -1378,7 +1378,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1388,7 +1388,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1398,7 +1398,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1408,7 +1408,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1437,7 +1437,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -1456,7 +1456,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1466,7 +1466,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1476,7 +1476,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1486,7 +1486,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1515,7 +1515,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -1534,7 +1534,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -1543,7 +1543,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1552,7 +1552,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -1561,7 +1561,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -1570,7 +1570,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -1591,7 +1591,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1601,7 +1601,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1611,7 +1611,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1621,7 +1621,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1650,7 +1650,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -1669,7 +1669,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1679,7 +1679,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1689,7 +1689,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1699,7 +1699,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1728,7 +1728,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -1747,7 +1747,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -1756,7 +1756,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1765,7 +1765,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -1774,7 +1774,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -1783,7 +1783,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -1804,7 +1804,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1814,7 +1814,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -1824,7 +1824,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -1834,7 +1834,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1863,7 +1863,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -1882,7 +1882,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -1892,7 +1892,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -1902,7 +1902,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -1912,7 +1912,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -1941,7 +1941,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -1960,7 +1960,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -1969,7 +1969,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -1978,7 +1978,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -1987,7 +1987,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -1996,7 +1996,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -2017,7 +2017,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2027,7 +2027,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2037,7 +2037,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2047,7 +2047,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2076,7 +2076,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -2095,7 +2095,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2105,7 +2105,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2115,7 +2115,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2125,7 +2125,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2154,7 +2154,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -2173,7 +2173,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -2182,7 +2182,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2191,7 +2191,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -2200,7 +2200,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -2209,7 +2209,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -2230,7 +2230,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2240,7 +2240,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2250,7 +2250,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2260,7 +2260,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2289,7 +2289,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -2308,7 +2308,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2318,7 +2318,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2328,7 +2328,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2338,7 +2338,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2367,7 +2367,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -2386,7 +2386,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -2395,7 +2395,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2404,7 +2404,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -2413,7 +2413,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -2422,7 +2422,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -2443,7 +2443,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2453,7 +2453,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2463,7 +2463,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2473,7 +2473,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2502,7 +2502,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -2521,7 +2521,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2531,7 +2531,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -2541,7 +2541,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -2551,7 +2551,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2580,7 +2580,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -2599,7 +2599,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -2608,7 +2608,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -2617,7 +2617,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -2626,7 +2626,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -2635,7 +2635,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -2656,7 +2656,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -2666,7 +2666,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -2676,7 +2676,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -2686,7 +2686,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -2715,7 +2715,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -2731,7 +2731,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-gFaPwZ kDswKV"
+              class="bp3-button bp3-disabled bp3-large sc-bnXvFD hELVWq"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -2745,7 +2745,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
             </button>
           </div>
           <div
-            class="sc-gHboQg AYGQX"
+            class="sc-dUjcNx gHgKwN"
           >
             <h4
               class="bp3-heading"
@@ -2753,7 +2753,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with ballots 
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-dymIpo fHBfbb"
+              class="bp3-list sc-cpmLhU hrfEWY"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -2842,13 +2842,13 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
       class="board-table-container"
     >
       <div
-        class="sc-cbkKFq bnGWyJ"
+        class="sc-eLExRp kxnjIF"
       >
         <section
-          class="sc-bwzfXH sc-krvtoX hezULE"
+          class="sc-bwzfXH sc-cbkKFq iXfDzl"
         >
           <div
-            class="sc-lkqHmb kSVTCw"
+            class="sc-bXGyLb eiHjrd"
           >
             <p>
               0
@@ -2857,23 +2857,23 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-emmjRN fIRdem"
+              class="summary-label sc-eerKOB fAIeLb"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-cpmLhU eaCJmT"
+              class="summary-label sc-emmjRN eLlxwW"
             >
               Not Audited: 
               27
             </span>
           </div>
           <div
-            class="sc-eLExRp hvAiSe"
+            class="sc-lkqHmb dMuWlS"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bnXvFD qATUh"
+              class="bp3-button bp3-intent-success sc-dymIpo eIEnxs"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
               type="button"
             >
@@ -2890,10 +2890,10 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
         class="sc-bwzfXH bIwzaO"
       >
         <div
-          class="sc-fYiAbW jOhkVa"
+          class="sc-krvtoX icRbSZ"
         >
           <div
-            class="sc-fOKMvo hatXDO"
+            class="sc-fYiAbW cMlqCd"
           >
             <h3
               class="bp3-heading"
@@ -2902,7 +2902,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
               Audit Board #1
             </h3>
             <div
-              class="sc-dUjcNx dewsjI"
+              class="sc-fOKMvo llZIzY"
             >
               <table
                 class="sc-eHgmQL ehyFrf"
@@ -3107,7 +3107,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3116,7 +3116,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3125,7 +3125,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         313
                       </p>
@@ -3134,7 +3134,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3143,7 +3143,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -3164,7 +3164,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3173,7 +3173,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3182,7 +3182,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -3191,7 +3191,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3200,7 +3200,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -3221,7 +3221,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3230,7 +3230,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3239,7 +3239,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         1789
                       </p>
@@ -3248,7 +3248,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3257,7 +3257,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -3278,7 +3278,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3287,7 +3287,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3296,7 +3296,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         313
                       </p>
@@ -3305,7 +3305,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3314,7 +3314,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -3335,7 +3335,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3344,7 +3344,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3353,7 +3353,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -3362,7 +3362,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3371,7 +3371,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -3392,7 +3392,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3401,7 +3401,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3410,7 +3410,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         1789
                       </p>
@@ -3419,7 +3419,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3428,7 +3428,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -3449,7 +3449,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3458,7 +3458,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3467,7 +3467,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         313
                       </p>
@@ -3476,7 +3476,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3485,7 +3485,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -3506,7 +3506,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3515,7 +3515,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3524,7 +3524,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -3533,7 +3533,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3542,7 +3542,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -3563,7 +3563,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3572,7 +3572,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3581,7 +3581,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         1789
                       </p>
@@ -3590,7 +3590,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3599,7 +3599,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -3620,7 +3620,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3629,7 +3629,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3638,7 +3638,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         313
                       </p>
@@ -3647,7 +3647,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3656,7 +3656,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -3677,7 +3677,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3686,7 +3686,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3695,7 +3695,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -3704,7 +3704,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3713,7 +3713,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -3734,7 +3734,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3743,7 +3743,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3752,7 +3752,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         1789
                       </p>
@@ -3761,7 +3761,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3770,7 +3770,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -3791,7 +3791,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3800,7 +3800,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3809,7 +3809,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         313
                       </p>
@@ -3818,7 +3818,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3827,7 +3827,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -3848,7 +3848,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3857,7 +3857,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -3866,7 +3866,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -3875,7 +3875,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3884,7 +3884,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -3905,7 +3905,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3914,7 +3914,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -3923,7 +3923,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         1789
                       </p>
@@ -3932,7 +3932,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3941,7 +3941,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -3962,7 +3962,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -3971,7 +3971,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -3980,7 +3980,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         313
                       </p>
@@ -3989,7 +3989,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -3998,7 +3998,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -4019,7 +4019,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -4028,7 +4028,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4037,7 +4037,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -4046,7 +4046,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -4055,7 +4055,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -4076,7 +4076,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -4085,7 +4085,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4094,7 +4094,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         1789
                       </p>
@@ -4103,7 +4103,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -4112,7 +4112,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -4133,7 +4133,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -4142,7 +4142,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4151,7 +4151,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         313
                       </p>
@@ -4160,7 +4160,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -4169,7 +4169,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -4190,7 +4190,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -4199,7 +4199,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4208,7 +4208,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -4217,7 +4217,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -4226,7 +4226,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -4247,7 +4247,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -4256,7 +4256,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4265,7 +4265,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         1789
                       </p>
@@ -4274,7 +4274,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -4283,7 +4283,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -4304,7 +4304,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -4313,7 +4313,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4322,7 +4322,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         313
                       </p>
@@ -4331,7 +4331,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -4340,7 +4340,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -4361,7 +4361,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -4370,7 +4370,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4379,7 +4379,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -4388,7 +4388,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -4397,7 +4397,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -4418,7 +4418,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -4427,7 +4427,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4436,7 +4436,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         1789
                       </p>
@@ -4445,7 +4445,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -4454,7 +4454,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -4475,7 +4475,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -4484,7 +4484,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
                       </p>
@@ -4493,7 +4493,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         313
                       </p>
@@ -4502,7 +4502,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -4511,7 +4511,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -4532,7 +4532,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -4541,7 +4541,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -4550,7 +4550,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -4559,7 +4559,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -4568,7 +4568,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -4589,7 +4589,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -4598,7 +4598,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
                       </p>
@@ -4607,7 +4607,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         1789
                       </p>
@@ -4616,7 +4616,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -4625,7 +4625,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -4643,7 +4643,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-gFaPwZ kDswKV"
+              class="bp3-button bp3-disabled bp3-large sc-bnXvFD hELVWq"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -4657,7 +4657,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
             </button>
           </div>
           <div
-            class="sc-gHboQg AYGQX"
+            class="sc-dUjcNx gHgKwN"
           >
             <h4
               class="bp3-heading"
@@ -4665,7 +4665,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no audit
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-dymIpo fHBfbb"
+              class="bp3-list sc-cpmLhU hrfEWY"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -4754,13 +4754,13 @@ exports[`AuditBoardView > ballot interaction > renders board table with no ballo
       class="board-table-container"
     >
       <div
-        class="sc-cbkKFq bnGWyJ"
+        class="sc-eLExRp kxnjIF"
       >
         <section
-          class="sc-bwzfXH sc-krvtoX hezULE"
+          class="sc-bwzfXH sc-cbkKFq iXfDzl"
         >
           <div
-            class="sc-lkqHmb kSVTCw"
+            class="sc-bXGyLb eiHjrd"
           >
             <p>
               0
@@ -4769,23 +4769,23 @@ exports[`AuditBoardView > ballot interaction > renders board table with no ballo
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-emmjRN fIRdem"
+              class="summary-label sc-eerKOB fAIeLb"
             >
               Audited: 
               0
             </span>
             <span
-              class="summary-label sc-cpmLhU eaCJmT"
+              class="summary-label sc-emmjRN eLlxwW"
             >
               Not Audited: 
               0
             </span>
           </div>
           <div
-            class="sc-eLExRp hvAiSe"
+            class="sc-lkqHmb dMuWlS"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bnXvFD qATUh"
+              class="bp3-button bp3-intent-success sc-dymIpo eIEnxs"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4802,10 +4802,10 @@ exports[`AuditBoardView > ballot interaction > renders board table with no ballo
         class="sc-bwzfXH bIwzaO"
       >
         <div
-          class="sc-fYiAbW jOhkVa"
+          class="sc-krvtoX icRbSZ"
         >
           <div
-            class="sc-fOKMvo hatXDO"
+            class="sc-fYiAbW cMlqCd"
           >
             <h3
               class="bp3-heading"
@@ -4814,7 +4814,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no ballo
               Audit Board #1
             </h3>
             <div
-              class="sc-dUjcNx dewsjI"
+              class="sc-fOKMvo llZIzY"
             >
               <table
                 class="sc-eHgmQL ehyFrf"
@@ -4978,7 +4978,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no ballo
               </table>
             </div>
             <button
-              class="bp3-button bp3-large bp3-intent-success sc-gFaPwZ kDswKV"
+              class="bp3-button bp3-large bp3-intent-success sc-bnXvFD hELVWq"
               href="/election/1/audit-board/audit-board-1/signoff"
               type="button"
             >
@@ -4990,7 +4990,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no ballo
             </button>
           </div>
           <div
-            class="sc-gHboQg AYGQX"
+            class="sc-dUjcNx gHgKwN"
           >
             <h4
               class="bp3-heading"
@@ -4998,7 +4998,7 @@ exports[`AuditBoardView > ballot interaction > renders board table with no ballo
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-dymIpo fHBfbb"
+              class="bp3-list sc-cpmLhU hrfEWY"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.
@@ -5087,13 +5087,13 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
       class="board-table-container"
     >
       <div
-        class="sc-cbkKFq bnGWyJ"
+        class="sc-eLExRp kxnjIF"
       >
         <section
-          class="sc-bwzfXH sc-krvtoX hezULE"
+          class="sc-bwzfXH sc-cbkKFq iXfDzl"
         >
           <div
-            class="sc-lkqHmb kSVTCw"
+            class="sc-bXGyLb eiHjrd"
           >
             <p>
               18
@@ -5102,23 +5102,23 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                ballots have been audited.
             </p>
             <span
-              class="summary-label sc-emmjRN fIRdem"
+              class="summary-label sc-eerKOB fAIeLb"
             >
               Audited: 
               18
             </span>
             <span
-              class="summary-label sc-cpmLhU eaCJmT"
+              class="summary-label sc-emmjRN eLlxwW"
             >
               Not Audited: 
               9
             </span>
           </div>
           <div
-            class="sc-eLExRp hvAiSe"
+            class="sc-lkqHmb dMuWlS"
           >
             <button
-              class="bp3-button bp3-intent-success sc-bnXvFD qATUh"
+              class="bp3-button bp3-intent-success sc-dymIpo eIEnxs"
               href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
               type="button"
             >
@@ -5135,10 +5135,10 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
         class="sc-bwzfXH bIwzaO"
       >
         <div
-          class="sc-fYiAbW jOhkVa"
+          class="sc-krvtoX icRbSZ"
         >
           <div
-            class="sc-fOKMvo hatXDO"
+            class="sc-fYiAbW cMlqCd"
           >
             <h3
               class="bp3-heading"
@@ -5147,7 +5147,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
               Audit Board #1
             </h3>
             <div
-              class="sc-dUjcNx dewsjI"
+              class="sc-fOKMvo llZIzY"
             >
               <table
                 class="sc-eHgmQL ehyFrf"
@@ -5352,7 +5352,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5362,7 +5362,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5372,7 +5372,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5382,7 +5382,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5411,7 +5411,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/313"
                         type="button"
                       >
@@ -5430,7 +5430,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -5439,7 +5439,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5448,7 +5448,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -5457,7 +5457,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -5466,7 +5466,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/2112"
                         type="button"
                       >
@@ -5487,7 +5487,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5497,7 +5497,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5507,7 +5507,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5517,7 +5517,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5546,7 +5546,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-1/ballot/1789"
                         type="button"
                       >
@@ -5565,7 +5565,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5575,7 +5575,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5585,7 +5585,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5595,7 +5595,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5624,7 +5624,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/313"
                         type="button"
                       >
@@ -5643,7 +5643,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -5652,7 +5652,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5661,7 +5661,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -5670,7 +5670,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -5679,7 +5679,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/2112"
                         type="button"
                       >
@@ -5700,7 +5700,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5710,7 +5710,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5720,7 +5720,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5730,7 +5730,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5759,7 +5759,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-2/ballot/1789"
                         type="button"
                       >
@@ -5778,7 +5778,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5788,7 +5788,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -5798,7 +5798,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -5808,7 +5808,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5837,7 +5837,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/313"
                         type="button"
                       >
@@ -5856,7 +5856,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -5865,7 +5865,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -5874,7 +5874,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -5883,7 +5883,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -5892,7 +5892,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/2112"
                         type="button"
                       >
@@ -5913,7 +5913,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -5923,7 +5923,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -5933,7 +5933,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -5943,7 +5943,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -5972,7 +5972,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-3/ballot/1789"
                         type="button"
                       >
@@ -5991,7 +5991,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6001,7 +6001,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6011,7 +6011,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6021,7 +6021,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6050,7 +6050,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/313"
                         type="button"
                       >
@@ -6069,7 +6069,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -6078,7 +6078,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6087,7 +6087,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -6096,7 +6096,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -6105,7 +6105,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/2112"
                         type="button"
                       >
@@ -6126,7 +6126,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6136,7 +6136,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6146,7 +6146,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6156,7 +6156,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6185,7 +6185,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-4/ballot/1789"
                         type="button"
                       >
@@ -6204,7 +6204,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6214,7 +6214,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6224,7 +6224,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6234,7 +6234,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6263,7 +6263,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/313"
                         type="button"
                       >
@@ -6282,7 +6282,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -6291,7 +6291,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6300,7 +6300,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -6309,7 +6309,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -6318,7 +6318,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/2112"
                         type="button"
                       >
@@ -6339,7 +6339,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6349,7 +6349,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6359,7 +6359,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6369,7 +6369,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6398,7 +6398,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-5/ballot/1789"
                         type="button"
                       >
@@ -6417,7 +6417,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6427,7 +6427,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6437,7 +6437,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6447,7 +6447,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6476,7 +6476,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/313"
                         type="button"
                       >
@@ -6495,7 +6495,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -6504,7 +6504,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6513,7 +6513,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -6522,7 +6522,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -6531,7 +6531,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/2112"
                         type="button"
                       >
@@ -6552,7 +6552,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6562,7 +6562,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6572,7 +6572,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6582,7 +6582,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6611,7 +6611,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-6/ballot/1789"
                         type="button"
                       >
@@ -6630,7 +6630,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6640,7 +6640,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6650,7 +6650,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6660,7 +6660,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6689,7 +6689,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/313"
                         type="button"
                       >
@@ -6708,7 +6708,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -6717,7 +6717,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6726,7 +6726,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -6735,7 +6735,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -6744,7 +6744,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/2112"
                         type="button"
                       >
@@ -6765,7 +6765,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6775,7 +6775,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6785,7 +6785,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -6795,7 +6795,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6824,7 +6824,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-7/ballot/1789"
                         type="button"
                       >
@@ -6843,7 +6843,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6853,7 +6853,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -6863,7 +6863,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -6873,7 +6873,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -6902,7 +6902,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/313"
                         type="button"
                       >
@@ -6921,7 +6921,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -6930,7 +6930,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -6939,7 +6939,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -6948,7 +6948,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -6957,7 +6957,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/2112"
                         type="button"
                       >
@@ -6978,7 +6978,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -6988,7 +6988,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -6998,7 +6998,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -7008,7 +7008,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7037,7 +7037,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-8/ballot/1789"
                         type="button"
                       >
@@ -7056,7 +7056,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7066,7 +7066,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 13 (Jonesboro Fire Department)
@@ -7076,7 +7076,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         313
@@ -7086,7 +7086,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7115,7 +7115,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/313"
                         type="button"
                       >
@@ -7134,7 +7134,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         11
                       </p>
@@ -7143,7 +7143,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         0003-04-Precinct 19 (Jonesboro Fire Department)
                       </p>
@@ -7152,7 +7152,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                       >
                         2112
                       </p>
@@ -7161,7 +7161,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <span
-                        class="sc-cpmLhU eaCJmT"
+                        class="sc-emmjRN eLlxwW"
                       >
                         Not Audited
                       </span>
@@ -7170,7 +7170,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/2112"
                         type="button"
                       >
@@ -7191,7 +7191,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         11
@@ -7201,7 +7201,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         0003-04-Precinct 29 (Jonesboro Fire Department)
@@ -7211,7 +7211,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         1789
@@ -7221,7 +7221,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <p
-                        class="sc-fhYwyz kvdhVI"
+                        class="sc-gFaPwZ kJKYX"
                         style="color: rgb(138, 155, 168);"
                       >
                         <span
@@ -7250,7 +7250,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
                       role="cell"
                     >
                       <button
-                        class="bp3-button bp3-fill bp3-minimal sc-eilVRo eSHelE"
+                        class="bp3-button bp3-fill bp3-minimal sc-gHboQg ftSwhT"
                         href="/election/1/audit-board/audit-board-1/batch/batch-id-9/ballot/1789"
                         type="button"
                       >
@@ -7266,7 +7266,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
               </table>
             </div>
             <button
-              class="bp3-button bp3-disabled bp3-large sc-gFaPwZ kDswKV"
+              class="bp3-button bp3-disabled bp3-large sc-bnXvFD hELVWq"
               disabled=""
               href="/election/1/audit-board/audit-board-1/signoff"
               tabindex="-1"
@@ -7280,7 +7280,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
             </button>
           </div>
           <div
-            class="sc-gHboQg AYGQX"
+            class="sc-dUjcNx gHgKwN"
           >
             <h4
               class="bp3-heading"
@@ -7288,7 +7288,7 @@ exports[`AuditBoardView > member form > submits, goes to ballot table, and heade
               Instructions
             </h4>
             <ol
-              class="bp3-list sc-dymIpo fHBfbb"
+              class="bp3-list sc-cpmLhU hrfEWY"
             >
               <li>
                 Locate and retrieve the list of ballots to audit from storage.

--- a/client/src/components/HomeScreen.test.tsx
+++ b/client/src/components/HomeScreen.test.tsx
@@ -261,6 +261,20 @@ describe('Home screen', () => {
     })
   })
 
+  it('shows a message for audit admins with no organizations', async () => {
+    const expectedCalls = [aaApiCalls.getUser, aaApiCalls.getOrganizations([])]
+    await withMockFetch(expectedCalls, async () => {
+      renderView('/')
+      await screen.findByRole('heading', { name: 'All Audits' })
+      screen.getByText(
+        'You do not have access to any organizations. Contact your Arlo administrator for access.'
+      )
+      expect(
+        screen.queryByRole('heading', { name: 'New Audit' })
+      ).not.toBeInTheDocument()
+    })
+  })
+
   it('shows a list of audits and create audit form for audit admins with multiple orgs', async () => {
     const expectedCalls = [
       aaApiCalls.getUser,

--- a/client/src/components/HomeScreen.tsx
+++ b/client/src/components/HomeScreen.tsx
@@ -331,6 +331,17 @@ const AuditAdminHomeScreen = ({ user }: { user: IAuditAdmin }) => {
 
   if (!organizations.isSuccess) return null
 
+  if (organizations.data.length === 0)
+    return (
+      <Wrapper>
+        <H1>All Audits</H1>
+        <p style={{ marginTop: '30px' }}>
+          You do not have access to any organizations. Contact your Arlo
+          administrator for access.
+        </p>
+      </Wrapper>
+    )
+
   return (
     <Wrapper>
       <H1>All Audits</H1>

--- a/client/src/components/JurisdictionAdmin/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
+++ b/client/src/components/JurisdictionAdmin/__snapshots__/FullHandTallyDataEntry.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`full hand tally data entry > deletes full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-TOsTZ ivoYiL"
+    class="sc-cHGsZl clSosl"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -159,7 +159,7 @@ exports[`full hand tally data entry > deletes full hand tally batch result 1`] =
 exports[`full hand tally data entry > edits full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-TOsTZ ivoYiL"
+    class="sc-cHGsZl clSosl"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -360,7 +360,7 @@ exports[`full hand tally data entry > edits full hand tally batch result 1`] = `
 exports[`full hand tally data entry > finalizes full hand tally results 1`] = `
 <div>
   <form
-    class="sc-TOsTZ ivoYiL"
+    class="sc-cHGsZl clSosl"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -593,7 +593,7 @@ exports[`full hand tally data entry > finalizes full hand tally results 1`] = `
 exports[`full hand tally data entry > renders 1`] = `
 <div>
   <form
-    class="sc-TOsTZ ivoYiL"
+    class="sc-cHGsZl clSosl"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -749,7 +749,7 @@ exports[`full hand tally data entry > renders 1`] = `
 exports[`full hand tally data entry > renders with full hand tally results 1`] = `
 <div>
   <form
-    class="sc-TOsTZ ivoYiL"
+    class="sc-cHGsZl clSosl"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -950,7 +950,7 @@ exports[`full hand tally data entry > renders with full hand tally results 1`] =
 exports[`full hand tally data entry > renders with proper totals 1`] = `
 <div>
   <form
-    class="sc-TOsTZ ivoYiL"
+    class="sc-cHGsZl clSosl"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -1203,7 +1203,7 @@ exports[`full hand tally data entry > renders with proper totals 1`] = `
 exports[`full hand tally data entry > submits full hand tally batch result 1`] = `
 <div>
   <form
-    class="sc-TOsTZ ivoYiL"
+    class="sc-cHGsZl clSosl"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"
@@ -1404,7 +1404,7 @@ exports[`full hand tally data entry > submits full hand tally batch result 1`] =
 exports[`full hand tally data entry > validation error for blank submission 1`] = `
 <div>
   <form
-    class="sc-TOsTZ ivoYiL"
+    class="sc-cHGsZl clSosl"
   >
     <div
       style="width: 510px; margin-bottom: 20px;"

--- a/client/src/components/SupportTools/Organization.tsx
+++ b/client/src/components/SupportTools/Organization.tsx
@@ -17,6 +17,8 @@ import {
   IAuditAdmin,
   useDeleteOrganization,
   useUpdateOrganization,
+  useArchiveOrganization,
+  useUnarchiveOrganization,
   useRemoveAuditAdmin,
   useDeleteElection,
   IElectionBase,
@@ -33,6 +35,8 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
   const removeAuditAdmin = useRemoveAuditAdmin(organizationId)
   const deleteOrganization = useDeleteOrganization(organizationId)
   const updateOrganization = useUpdateOrganization(organizationId)
+  const archiveOrganization = useArchiveOrganization(organizationId)
+  const unarchiveOrganization = useUnarchiveOrganization(organizationId)
   const deleteElection = useDeleteElection()
   const { confirm, confirmProps } = useConfirm()
 
@@ -59,7 +63,13 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
     }
   }
 
-  const { name, defaultState, elections, auditAdmins } = organization.data
+  const {
+    name,
+    defaultState,
+    archivedAt,
+    elections,
+    auditAdmins,
+  } = organization.data
 
   const sortedElections = sortBy(elections, a =>
     new Date(a.createdAt).getTime()
@@ -84,6 +94,28 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
       onYesClick: async () => {
         await deleteOrganization.mutateAsync()
         toast.success(`Deleted organization ${name}`)
+      },
+    })
+
+  const onClickArchiveOrg = () =>
+    confirm({
+      title: 'Confirm',
+      description: `Are you sure you want to archive organization ${name}? Its users will no longer be able to access their audits.`,
+      yesButtonLabel: 'Archive',
+      onYesClick: async () => {
+        await archiveOrganization.mutateAsync()
+        toast.success(`Archived organization ${name}`)
+      },
+    })
+
+  const onClickUnarchiveOrg = () =>
+    confirm({
+      title: 'Confirm',
+      description: `Are you sure you want to unarchive organization ${name}?`,
+      yesButtonLabel: 'Unarchive',
+      onYesClick: async () => {
+        await unarchiveOrganization.mutateAsync()
+        toast.success(`Unarchived organization ${name}`)
       },
     })
 
@@ -171,6 +203,15 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
           <Button icon="edit" minimal onClick={onClickEditOrg}>
             Edit
           </Button>
+          {archivedAt === null ? (
+            <Button icon="archive" minimal onClick={onClickArchiveOrg}>
+              Archive
+            </Button>
+          ) : (
+            <Button icon="unarchive" minimal onClick={onClickUnarchiveOrg}>
+              Unarchive
+            </Button>
+          )}
           <Button
             icon="delete"
             intent={Intent.DANGER}
@@ -181,9 +222,16 @@ const Organization = ({ organizationId }: { organizationId: string }) => {
           </Button>
         </div>
       </div>
-      <Tag large style={{ alignSelf: 'flex-start' }}>
-        {`Default State: ${defaultState ? states[defaultState] : 'None'}`}
-      </Tag>
+      <div style={{ display: 'flex', gap: '10px' }}>
+        {archivedAt !== null && (
+          <Tag large intent={Intent.WARNING}>
+            Archived
+          </Tag>
+        )}
+        <Tag large>
+          {`Default State: ${defaultState ? states[defaultState] : 'None'}`}
+        </Tag>
+      </div>
       <Row>
         <Column>
           <H2>Audits</H2>

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -16,6 +16,7 @@ import AuthDataProvider from '../UserContext'
 import { supportApiCalls } from '../_mocks'
 import {
   IOrganizationBase,
+  IOrganizationListItem,
   IElection,
   IJurisdictionBase,
   IJurisdiction,
@@ -30,6 +31,11 @@ import {
 const mockOrganizationBase: IOrganizationBase = {
   id: 'organization-id-1',
   name: 'Organization 1',
+}
+
+const mockOrganizationListItem: IOrganizationListItem = {
+  ...mockOrganizationBase,
+  archivedAt: null,
 }
 
 const mockElectionBase: IElectionBase = {
@@ -152,7 +158,7 @@ const mockJurisdictionBatches: {
 }
 
 const apiCalls = {
-  getOrganizations: (response: IOrganizationBase[]) => ({
+  getOrganizations: (response: IOrganizationListItem[]) => ({
     url: '/api/support/organizations',
     response,
   }),
@@ -186,6 +192,16 @@ const apiCalls = {
   deleteOrganization: {
     url: '/api/support/organizations/organization-id-1',
     options: { method: 'DELETE' },
+    response: { status: 'ok' },
+  },
+  archiveOrganization: {
+    url: '/api/support/organizations/organization-id-1/archive',
+    options: { method: 'POST' },
+    response: { status: 'ok' },
+  },
+  unarchiveOrganization: {
+    url: '/api/support/organizations/organization-id-1/unarchive',
+    options: { method: 'POST' },
     response: { status: 'ok' },
   },
   deleteElection: {
@@ -321,8 +337,8 @@ describe('Support Tools', () => {
     const expectedCalls = [
       supportApiCalls.getUser,
       apiCalls.getOrganizations([
-        mockOrganizationBase,
-        { id: 'organization-id-2', name: 'Organization 2' },
+        mockOrganizationListItem,
+        { id: 'organization-id-2', name: 'Organization 2', archivedAt: null },
       ]),
       apiCalls.getActiveElections([]),
       apiCalls.getOrganization(mockOrganization),
@@ -360,7 +376,11 @@ describe('Support Tools', () => {
       apiCalls.getActiveElections([]),
       apiCalls.postOrganization,
       apiCalls.getOrganizations([
-        { id: 'new-organization-id', name: 'New Organization' },
+        {
+          id: 'new-organization-id',
+          name: 'New Organization',
+          archivedAt: null,
+        },
       ]),
     ]
     await withMockFetch(expectedCalls, async () => {
@@ -797,6 +817,144 @@ describe('Support Tools', () => {
       expect(history.location.pathname).toEqual(
         '/support/orgs/organization-id-1'
       )
+    })
+  })
+
+  it('home screen hides archived orgs, which are listed on a separate page', async () => {
+    const expectedCalls = [
+      supportApiCalls.getUser,
+      apiCalls.getOrganizations([
+        mockOrganizationListItem,
+        {
+          id: 'organization-id-2',
+          name: 'Organization 2',
+          archivedAt: '2022-03-08T21:03:35.487Z',
+        },
+      ]),
+      apiCalls.getActiveElections([]),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      const { history } = renderRoute('/support')
+
+      await screen.findByRole('heading', { name: 'Organizations' })
+      screen.getByRole('link', { name: 'Organization 1' })
+      expect(
+        screen.queryByRole('link', { name: 'Organization 2' })
+      ).not.toBeInTheDocument()
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'archive View Archived Organizations',
+        })
+      )
+
+      await screen.findByRole('heading', { name: 'Archived Organizations' })
+      expect(history.location.pathname).toEqual('/support/archived-orgs')
+      screen.getByRole('link', { name: 'Organization 2' })
+      expect(
+        screen.queryByRole('link', { name: 'Organization 1' })
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('org screen has a button to archive the org', async () => {
+    const expectedCalls = [
+      supportApiCalls.getUser,
+      apiCalls.getOrganization(mockOrganization),
+      apiCalls.archiveOrganization,
+      apiCalls.getOrganization({
+        ...mockOrganization,
+        archivedAt: '2022-03-08T21:03:35.487Z',
+      }),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderRoute('/support/orgs/organization-id-1')
+
+      await screen.findByRole('heading', { name: 'Organization 1' })
+      expect(screen.queryByText('Archived')).not.toBeInTheDocument()
+
+      userEvent.click(screen.getByRole('button', { name: 'archive Archive' }))
+
+      // Confirm dialog should open
+      const dialog = (
+        await screen.findByRole('heading', {
+          name: /Confirm/,
+        })
+      ).closest('.bp3-dialog')! as HTMLElement
+      within(dialog).getByText(
+        'Are you sure you want to archive organization Organization 1?' +
+          ' Its users will no longer be able to access their audits.'
+      )
+      userEvent.click(within(dialog).getByRole('button', { name: 'Archive' }))
+
+      await findAndCloseToast('Archived organization Organization 1')
+
+      await screen.findByText('Archived')
+      screen.getByRole('button', { name: 'unarchive Unarchive' })
+    })
+  })
+
+  it('org screen has a button to unarchive an archived org', async () => {
+    const expectedCalls = [
+      supportApiCalls.getUser,
+      apiCalls.getOrganization({
+        ...mockOrganization,
+        archivedAt: '2022-03-08T21:03:35.487Z',
+      }),
+      apiCalls.unarchiveOrganization,
+      apiCalls.getOrganization(mockOrganization),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderRoute('/support/orgs/organization-id-1')
+
+      await screen.findByRole('heading', { name: 'Organization 1' })
+      screen.getByText('Archived')
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'unarchive Unarchive' })
+      )
+
+      // Confirm dialog should open
+      const dialog = (
+        await screen.findByRole('heading', {
+          name: /Confirm/,
+        })
+      ).closest('.bp3-dialog')! as HTMLElement
+      within(dialog).getByText(
+        'Are you sure you want to unarchive organization Organization 1?'
+      )
+      userEvent.click(within(dialog).getByRole('button', { name: 'Unarchive' }))
+
+      await findAndCloseToast('Unarchived organization Organization 1')
+
+      await waitFor(() =>
+        expect(screen.queryByText('Archived')).not.toBeInTheDocument()
+      )
+      screen.getByRole('button', { name: 'archive Archive' })
+    })
+  })
+
+  it('org screen handles error on archive org', async () => {
+    const expectedCalls = [
+      supportApiCalls.getUser,
+      apiCalls.getOrganization(mockOrganization),
+      serverError('archiveOrganization', apiCalls.archiveOrganization),
+    ]
+    await withMockFetch(expectedCalls, async () => {
+      renderRoute('/support/orgs/organization-id-1')
+
+      await screen.findByRole('heading', { name: 'Organization 1' })
+
+      userEvent.click(screen.getByRole('button', { name: 'archive Archive' }))
+
+      const dialog = (
+        await screen.findByRole('heading', {
+          name: /Confirm/,
+        })
+      ).closest('.bp3-dialog')! as HTMLElement
+      userEvent.click(within(dialog).getByRole('button', { name: 'Archive' }))
+
+      await findAndCloseToast('something went wrong: archiveOrganization')
     })
   })
 

--- a/client/src/components/SupportTools/SupportTools.test.tsx
+++ b/client/src/components/SupportTools/SupportTools.test.tsx
@@ -55,6 +55,7 @@ const mockJurisdictionBase: IJurisdictionBase = {
 const mockOrganization: IOrganizationForSupport = {
   ...mockOrganizationBase,
   defaultState: null,
+  archivedAt: null,
   elections: [
     mockElectionForSupport,
     {

--- a/client/src/components/SupportTools/SupportTools.tsx
+++ b/client/src/components/SupportTools/SupportTools.tsx
@@ -18,6 +18,7 @@ import Jurisdiction from './Jurisdiction'
 import { AuditStatusTag, Row } from './shared'
 import { FilterInput } from '../Atoms/Table'
 import H2Title from '../Atoms/H2Title'
+import LinkButton from '../Atoms/LinkButton'
 
 const SupportToolsOuterColumn = styled.div`
   display: flex;
@@ -53,6 +54,18 @@ const SupportTools: React.FC = () => {
                 </div>
                 <div style={{ flex: '0 0 25%' }}>
                   <Tools />
+                </div>
+              </Row>
+            </SupportToolsOuterColumn>
+          </Route>
+          <Route exact path="/support/archived-orgs">
+            <SupportToolsOuterColumn>
+              <Row>
+                <H1>Support Tools</H1>
+              </Row>
+              <Row>
+                <div style={{ flex: '0 0 25%' }}>
+                  <Organizations archived />
                 </div>
               </Row>
             </SupportToolsOuterColumn>
@@ -112,7 +125,7 @@ const ActiveAudits = () => {
   )
 }
 
-const Organizations = () => {
+const Organizations = ({ archived = false }: { archived?: boolean }) => {
   const organizations = useOrganizations()
   const [filterText, setFilterText] = useState<string>('')
 
@@ -120,7 +133,7 @@ const Organizations = () => {
 
   return (
     <>
-      <H2Title>Organizations</H2Title>
+      <H2Title>{archived ? 'Archived Organizations' : 'Organizations'}</H2Title>
       <FilterInput
         onChange={setFilterText}
         placeholder="Filter organizations..."
@@ -128,6 +141,7 @@ const Organizations = () => {
       />
       <List style={{ marginTop: '20px' }}>
         {organizations.data
+          .filter(org => Boolean(org.archivedAt) === archived)
           .filter(org =>
             org.name
               .toLocaleLowerCase()
@@ -145,10 +159,6 @@ const Organizations = () => {
     </>
   )
 }
-
-const DownloadUsersButton = styled(AnchorButton)`
-  margin-bottom: 10px;
-`
 
 const Tools = () => {
   const createOrganization = useCreateOrganization()
@@ -210,14 +220,19 @@ const Tools = () => {
               </p>
             }
           >
-            <DownloadUsersButton
+            <AnchorButton
               icon="download"
               intent="none"
               href="/api/support/organizations/users"
             >
               Download User List
-            </DownloadUsersButton>
+            </AnchorButton>
           </Tooltip>
+        </div>
+        <div>
+          <LinkButton icon="archive" to="/support/archived-orgs">
+            View Archived Organizations
+          </LinkButton>
         </div>
       </div>
     </>

--- a/client/src/components/SupportTools/support-api.tsx
+++ b/client/src/components/SupportTools/support-api.tsx
@@ -8,6 +8,10 @@ export interface IOrganizationBase {
   name: string
 }
 
+export interface IOrganizationListItem extends IOrganizationBase {
+  archivedAt: string | null
+}
+
 export interface IOrganization extends IOrganizationBase {
   defaultState: string | null
   elections: IElection[]
@@ -16,6 +20,7 @@ export interface IOrganization extends IOrganizationBase {
 
 export interface IOrganizationForSupport extends IOrganizationBase {
   defaultState: string | null
+  archivedAt: string | null
   elections: IElectionForSupport[]
   auditAdmins: IAuditAdmin[]
 }
@@ -97,7 +102,7 @@ export const useActiveElections = () =>
   )
 
 export const useOrganizations = () =>
-  useQuery<IOrganizationBase[], Error>(['organizations'], () =>
+  useQuery<IOrganizationListItem[], Error>(['organizations'], () =>
     fetchApi('/api/support/organizations')
   )
 
@@ -155,6 +160,32 @@ export const useDeleteOrganization = (organizationId: string) => {
       queryClient.resetQueries(['organizations'], { exact: true })
       history.push('/support')
     },
+  })
+}
+
+export const useArchiveOrganization = (organizationId: string) => {
+  const archiveOrganization = async () =>
+    fetchApi(`/api/support/organizations/${organizationId}/archive`, {
+      method: 'POST',
+    })
+
+  const queryClient = useQueryClient()
+
+  return useMutation(archiveOrganization, {
+    onSuccess: () => queryClient.invalidateQueries(['organizations']),
+  })
+}
+
+export const useUnarchiveOrganization = (organizationId: string) => {
+  const unarchiveOrganization = async () =>
+    fetchApi(`/api/support/organizations/${organizationId}/unarchive`, {
+      method: 'POST',
+    })
+
+  const queryClient = useQueryClient()
+
+  return useMutation(unarchiveOrganization, {
+    onSuccess: () => queryClient.invalidateQueries(['organizations']),
   })
 }
 

--- a/server/api/activity.py
+++ b/server/api/activity.py
@@ -43,7 +43,10 @@ def list_activities(organization_id: str):
     if (
         not user
         or user_type != UserType.AUDIT_ADMIN
-        or not any(org.id == organization_id for org in user.organizations)
+        or not any(
+            org.id == organization_id and org.archived_at is None
+            for org in user.organizations
+        )
     ):
         return Forbidden()
 

--- a/server/api/elections.py
+++ b/server/api/elections.py
@@ -159,5 +159,6 @@ def list_organizations_and_elections(audit_admin_id: str):
                 ],
             }
             for org in user.organizations
+            if org.archived_at is None
         ]
     )

--- a/server/api/support.py
+++ b/server/api/support.py
@@ -132,7 +132,11 @@ def list_organizations():
     organizations = Organization.query.order_by(Organization.name).all()
     return jsonify(
         [
-            dict(id=organization.id, name=organization.name)
+            dict(
+                id=organization.id,
+                name=organization.name,
+                archivedAt=isoformat(organization.archived_at),
+            )
             for organization in organizations
         ]
     )
@@ -228,6 +232,7 @@ def get_organization(organization_id: str):
         id=organization.id,
         name=organization.name,
         defaultState=organization.default_state,
+        archivedAt=isoformat(organization.archived_at),
         elections=[
             dict(
                 id=election.id,
@@ -262,6 +267,24 @@ def delete_organization(organization_id: str):
         )
 
     db_session.delete(organization)
+    db_session.commit()
+    return jsonify(status="ok")
+
+
+@api.route("/support/organizations/<organization_id>/archive", methods=["POST"])
+@restrict_access_support
+def archive_organization(organization_id: str):
+    organization = get_or_404(Organization, organization_id)
+    organization.archived_at = datetime.now(timezone.utc)
+    db_session.commit()
+    return jsonify(status="ok")
+
+
+@api.route("/support/organizations/<organization_id>/unarchive", methods=["POST"])
+@restrict_access_support
+def unarchive_organization(organization_id: str):
+    organization = get_or_404(Organization, organization_id)
+    organization.archived_at = None
     db_session.commit()
     return jsonify(status="ok")
 

--- a/server/auth/auth_helpers.py
+++ b/server/auth/auth_helpers.py
@@ -123,6 +123,11 @@ def check_access(
     if user_type not in user_types:
         raise Forbidden(f"Access forbidden for user type {user_type}")
 
+    # Elections in archived orgs are hidden from everyone except support users
+    organization = Organization.query.get(election.organization_id)
+    if organization is not None and organization.archived_at is not None:
+        raise NotFound(f"Election {election.id} not found")
+
     # Check that the user has access to the resource they are requesting
     if user_type == UserType.AUDIT_ADMIN:
         user = User.query.filter_by(email=user_key).one()

--- a/server/auth/auth_routes.py
+++ b/server/auth/auth_routes.py
@@ -111,11 +111,15 @@ def api_me():
                 }
                 for jurisdiction in db_user.jurisdictions
                 if jurisdiction.election.deleted_at is None
+                and jurisdiction.election.organization.archived_at is None
             ],
         )
     elif user_type == UserType.AUDIT_BOARD:
         audit_board = AuditBoard.query.get(user_key)
-        if audit_board.jurisdiction.election.deleted_at is None:
+        if (
+            audit_board.jurisdiction.election.deleted_at is None
+            and audit_board.jurisdiction.election.organization.archived_at is None
+        ):
             user = dict(
                 type=user_type,
                 id=audit_board.id,
@@ -134,7 +138,10 @@ def api_me():
             clear_loggedin_user(session)
         else:
             jurisdiction = tally_entry_user.jurisdiction
-            if jurisdiction.election.deleted_at is None:
+            if (
+                jurisdiction.election.deleted_at is None
+                and jurisdiction.election.organization.archived_at is None
+            ):
                 # Tally entry users get a reponse from /api/me before their login
                 # code is confirmed by the JA. Thus, it's important to make sure
                 # that we only return data that they are allowed to see during the
@@ -221,7 +228,10 @@ def auditadmin_login_callback():
 
     if userinfo and userinfo["email"] and userinfo.get("email_verified") is True:
         user = User.query.filter_by(email=userinfo["email"]).first()
-        if user and len(user.audit_administrations) > 0:
+        if user and any(
+            administration.organization.archived_at is None
+            for administration in user.audit_administrations
+        ):
             set_loggedin_user(session, UserType.AUDIT_ADMIN, userinfo["email"])
 
     return redirect("/")

--- a/server/auth/auth_routes.py
+++ b/server/auth/auth_routes.py
@@ -228,10 +228,7 @@ def auditadmin_login_callback():
 
     if userinfo and userinfo["email"] and userinfo.get("email_verified") is True:
         user = User.query.filter_by(email=userinfo["email"]).first()
-        if user and any(
-            administration.organization.archived_at is None
-            for administration in user.audit_administrations
-        ):
+        if user and len(user.audit_administrations) > 0:
             set_loggedin_user(session, UserType.AUDIT_ADMIN, userinfo["email"])
 
     return redirect("/")

--- a/server/migrations/versions/ea036eb33e57_organization_archived_at.py
+++ b/server/migrations/versions/ea036eb33e57_organization_archived_at.py
@@ -1,0 +1,27 @@
+"""Organization.archived_at
+
+Revision ID: ea036eb33e57
+Revises: 233f4348c3bc
+Create Date: 2026-08-25 00:00:00.000000+00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ea036eb33e57"
+down_revision = "233f4348c3bc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "organization", sa.Column("archived_at", sa.DateTime(), nullable=True)
+    )
+
+
+def downgrade():  # pragma: no cover
+    pass

--- a/server/models.py
+++ b/server/models.py
@@ -110,6 +110,9 @@ class Organization(BaseModel):
     name = Column(String(200), nullable=False, unique=True)
     # Default setting for US state for this org's audits
     default_state = Column(String(100))
+    # When a support user archives an org, we keep it and its audits in the
+    # database, but flag it so that we can hide it and restrict access
+    archived_at = Column(UTCDateTime)
 
     elections = relationship(
         "Election",

--- a/server/tests/api/test_activity.py
+++ b/server/tests/api/test_activity.py
@@ -162,6 +162,19 @@ def test_list_activities_wrong_org(
     assert rv.status_code == 403
 
 
+def test_list_activities_archived_org(
+    client: FlaskClient,
+    org_id: str,
+):
+    organization = Organization.query.get(org_id)
+    organization.archived_at = datetime.now(timezone.utc)
+    db_session.commit()
+
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, DEFAULT_AA_EMAIL)
+    rv = client.get(f"/api/organizations/{org_id}/activities")
+    assert rv.status_code == 403
+
+
 def test_list_activities_wrong_user_type(
     client: FlaskClient, org_id: str, election_id: str
 ):

--- a/server/tests/api/test_support.py
+++ b/server/tests/api/test_support.py
@@ -21,7 +21,11 @@ def test_support_list_organizations(client: FlaskClient, org_id: str):
     # This will load orgs from all tests, so we can't check its exact length/value
     assert len(orgs) >= 1
     org = next(org for org in orgs if org["id"] == org_id)
-    assert org == {"id": org_id, "name": "Test Org test_support_list_organizations"}
+    assert org == {
+        "id": org_id,
+        "name": "Test Org test_support_list_organizations",
+        "archivedAt": None,
+    }
 
 
 def test_support_create_organization(client: FlaskClient):
@@ -60,6 +64,7 @@ def test_support_get_organization(client: FlaskClient, org_id: str, election_id:
             "id": org_id,
             "name": "Test Org test_support_get_organization",
             "defaultState": None,
+            "archivedAt": None,
             "elections": [
                 {
                     "id": election_id,
@@ -96,6 +101,7 @@ def test_support_get_organization_round(
             "id": org_id,
             "name": "Test Org test_support_get_organization_round",
             "defaultState": None,
+            "archivedAt": None,
             "elections": [
                 {
                     "id": election_id,
@@ -151,6 +157,60 @@ def test_support_delete_organization(client: FlaskClient):
     assert json.loads(rv.data) == []
 
     assert Election.query.get(election_id) is None
+
+
+def test_support_archive_organization(client: FlaskClient):
+    set_support_user(client, DEFAULT_SUPPORT_EMAIL)
+    org_id, aa_id = create_org_and_admin(
+        "Test Archive Org", "admin-archive@example.com"
+    )
+    set_logged_in_user(client, UserType.AUDIT_ADMIN, "admin-archive@example.com")
+    election_id = create_election(client, organization_id=org_id)
+
+    # Unlike delete, archiving is allowed for an org with audits
+    rv = client.post(f"/api/support/organizations/{org_id}/archive")
+    assert_ok(rv)
+
+    rv = client.get(f"/api/support/organizations/{org_id}")
+    assert_is_date(json.loads(rv.data)["archivedAt"])
+
+    rv = client.get("/api/support/organizations")
+    org = next(org for org in json.loads(rv.data) if org["id"] == org_id)
+    assert_is_date(org["archivedAt"])
+
+    # Audit admins can't see the org anymore
+    rv = client.get(f"/api/audit_admins/{aa_id}/organizations")
+    assert json.loads(rv.data) == []
+
+    # Nor access its audits
+    rv = client.get(f"/api/election/{election_id}/settings")
+    assert rv.status_code == 404
+
+    # Nor create new audits in it
+    rv = post_json(
+        client,
+        "/api/election",
+        {
+            "auditName": "Test Audit Archived Org",
+            "auditType": "BALLOT_POLLING",
+            "auditMathType": "BRAVO",
+            "organizationId": org_id,
+        },
+    )
+    assert rv.status_code == 404
+
+    # Unarchiving restores access
+    rv = client.post(f"/api/support/organizations/{org_id}/unarchive")
+    assert_ok(rv)
+
+    rv = client.get(f"/api/support/organizations/{org_id}")
+    assert json.loads(rv.data)["archivedAt"] is None
+
+    rv = client.get(f"/api/audit_admins/{aa_id}/organizations")
+    assert len(json.loads(rv.data)) == 1
+
+    rv = client.get(f"/api/election/{election_id}/settings")
+    assert rv.status_code == 200
 
 
 def test_support_update_organization(client: FlaskClient, org_id: str):

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -288,6 +288,40 @@ def test_auditadmin_callback_rejected_unverified_email(
                 assert auth0_aa.get.called
 
 
+def test_auditadmin_callback_archived_org(
+    client: FlaskClient, org_id: str, aa_email: str
+):
+    organization = Organization.query.get(org_id)
+    organization.archived_at = datetime.now(timezone.utc)
+    db_session.commit()
+
+    def log_in():
+        with patch.object(auth0_aa, "authorize_access_token", return_value=None):
+            mock_response = Mock()
+            mock_response.json = MagicMock(
+                return_value={"email": aa_email, "email_verified": True}
+            )
+            with patch.object(auth0_aa, "get", return_value=mock_response):
+                return client.get("/auth/auditadmin/callback?code=foobar")
+
+    rv = log_in()
+    assert rv.status_code == 302
+    assert urlparse(rv.location).path == "/"
+
+    with client.session_transaction() as session:  # type: ignore
+        assert session.get("_user") is None
+
+    # A user in both an archived org and an active org can still log in
+    create_org_and_admin("Test Org test_auditadmin_callback_archived_org 2", aa_email)
+
+    rv = log_in()
+    assert rv.status_code == 302
+
+    with client.session_transaction() as session:  # type: ignore
+        assert session["_user"]["type"] == UserType.AUDIT_ADMIN
+        assert session["_user"]["key"] == aa_email
+
+
 def parse_login_code(text: str):
     code_match = re.search(r"Your verification code is: (\d\d\d\d\d\d)", text)
     assert code_match
@@ -1309,6 +1343,46 @@ def test_auth_me_audit_board(
         },
         "supportUser": None,
     }
+
+
+def archive_org(org_id: str):
+    organization = Organization.query.get(org_id)
+    organization.archived_at = datetime.now(timezone.utc)
+    db_session.commit()
+
+
+def test_auth_me_jurisdiction_admin_archived_org(
+    client: FlaskClient, org_id: str, ja_email: str
+):
+    archive_org(org_id)
+    set_logged_in_user(client, UserType.JURISDICTION_ADMIN, ja_email)
+    rv = client.get("/api/me")
+    assert json.loads(rv.data) == {
+        "user": {
+            "type": UserType.JURISDICTION_ADMIN,
+            "email": ja_email,
+            "jurisdictions": [],
+        },
+        "supportUser": None,
+    }
+
+
+def test_auth_me_audit_board_archived_org(
+    client: FlaskClient, org_id: str, audit_board_id: str
+):
+    archive_org(org_id)
+    set_logged_in_user(client, UserType.AUDIT_BOARD, audit_board_id)
+    rv = client.get("/api/me")
+    assert json.loads(rv.data) == {"user": None, "supportUser": None}
+
+
+def test_auth_me_tally_entry_archived_org(
+    client: FlaskClient, org_id: str, tally_entry_user_id: str
+):
+    archive_org(org_id)
+    set_logged_in_user(client, UserType.TALLY_ENTRY, tally_entry_user_id)
+    rv = client.get("/api/me")
+    assert json.loads(rv.data) == {"user": None, "supportUser": None}
 
 
 def test_auth_me_not_logged_in(client: FlaskClient):

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -291,35 +291,28 @@ def test_auditadmin_callback_rejected_unverified_email(
 def test_auditadmin_callback_archived_org(
     client: FlaskClient, org_id: str, aa_email: str
 ):
+    # Audit admins whose orgs are all archived can still log in, matching
+    # jurisdiction admin behavior - they just won't see any organizations
     organization = Organization.query.get(org_id)
     organization.archived_at = datetime.now(timezone.utc)
     db_session.commit()
 
-    def log_in():
-        with patch.object(auth0_aa, "authorize_access_token", return_value=None):
-            mock_response = Mock()
-            mock_response.json = MagicMock(
-                return_value={"email": aa_email, "email_verified": True}
-            )
-            with patch.object(auth0_aa, "get", return_value=mock_response):
-                return client.get("/auth/auditadmin/callback?code=foobar")
+    with patch.object(auth0_aa, "authorize_access_token", return_value=None):
+        mock_response = Mock()
+        mock_response.json = MagicMock(
+            return_value={"email": aa_email, "email_verified": True}
+        )
+        with patch.object(auth0_aa, "get", return_value=mock_response):
+            rv = client.get("/auth/auditadmin/callback?code=foobar")
+            assert rv.status_code == 302
 
-    rv = log_in()
-    assert rv.status_code == 302
-    assert urlparse(rv.location).path == "/"
+            with client.session_transaction() as session:  # type: ignore
+                assert session["_user"]["type"] == UserType.AUDIT_ADMIN
+                assert session["_user"]["key"] == aa_email
 
-    with client.session_transaction() as session:  # type: ignore
-        assert session.get("_user") is None
-
-    # A user in both an archived org and an active org can still log in
-    create_org_and_admin("Test Org test_auditadmin_callback_archived_org 2", aa_email)
-
-    rv = log_in()
-    assert rv.status_code == 302
-
-    with client.session_transaction() as session:  # type: ignore
-        assert session["_user"]["type"] == UserType.AUDIT_ADMIN
-        assert session["_user"]["key"] == aa_email
+    user = User.query.filter_by(email=aa_email).one()
+    rv = client.get(f"/api/audit_admins/{user.id}/organizations")
+    assert json.loads(rv.data) == []
 
 
 def parse_login_code(text: str):


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/arlo/issues/2104

Outdated organizations, such as the CA orgs, fill up the space on the Support Tools Org list. When support is logging in to different orgs multiples times a day, this is an unnessary slowdown. Especially given there are only ~10 active customers alongside some valid sandboxes, there is no need to have such a long list. 

This PR adds the ability to archive organizations, preventing users from that org from logging in if that is there only org through `check_access` checks. Support users can archive, view archived orgs, and unarchive orgs. 

The core change is adding an `archivedAt` field to an organization, along with a simple API to read/update it.

## Screenshot

https://github.com/user-attachments/assets/d523fd2f-c486-4e9f-974f-5b172e439b93

https://github.com/user-attachments/assets/1889c143-64c6-4bf0-9802-6fc47d37992c

If an audit admin logs in and all orgs it is associated with (usually 1) are archived it will see the above notice.
Note: Added some padding above "All Audits" post screen recording