### PR TITLE
Client: Fix expected ballot discrepancies sorting

### DIFF
--- a/client/src/components/AuditAdmin/Progress/Progress.test.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.test.tsx
@@ -228,6 +228,81 @@ describe('Progress screen', () => {
     })
   })
 
+  it('sorts difference from expected ballots with discrepancies first, then zeros, then empty rows', async () => {
+    const expectedCalls = getDefaultExpectedCalls()
+    await withMockFetch(expectedCalls, async () => {
+      const numBallots = jurisdictionMocks.allManifests[0].ballotManifest!
+        .numBallots!
+      render({
+        jurisdictions: [
+          {
+            ...jurisdictionMocks.allManifests[0],
+            name: 'Zero',
+            expectedBallotManifestNumBallots: numBallots,
+          },
+          {
+            ...jurisdictionMocks.allManifests[1],
+            name: 'Surplus',
+            expectedBallotManifestNumBallots: numBallots - 10,
+          },
+          {
+            ...jurisdictionMocks.allManifests[2],
+            name: 'Deficit',
+            expectedBallotManifestNumBallots: numBallots + 20,
+          },
+          {
+            ...jurisdictionMocks.noManifests[0],
+            name: 'No Manifest',
+            expectedBallotManifestNumBallots: 30,
+          },
+          {
+            ...jurisdictionMocks.allManifests[1],
+            name: 'No Expected',
+            expectedBallotManifestNumBallots: null,
+          },
+        ],
+      })
+
+      await screen.findByRole('heading', { name: 'Audit Progress' })
+
+      const differenceHeader = screen.getByRole('columnheader', {
+        name: 'Difference From Expected Ballots',
+      })
+
+      const expectRowOrder = (discrepancyRows: [string, string][]) => {
+        const rows = screen.getAllByRole('row')
+        discrepancyRows.forEach(([name, difference], i) => {
+          const cells = within(rows[i + 1]).getAllByRole('cell')
+          expect(cells[0]).toHaveTextContent(name)
+          expect(cells[4]).toHaveTextContent(difference)
+        })
+        // The two empty rows tie, so their relative order isn't guaranteed
+        const emptyRows = [4, 5].map(i => within(rows[i]).getAllByRole('cell'))
+        expect(emptyRows.map(cells => cells[0].textContent).sort()).toEqual([
+          'No Expected',
+          'No Manifest',
+        ])
+        emptyRows.forEach(cells => expect(cells[4]).toBeEmptyDOMElement())
+      }
+
+      // Ascending: discrepancies in signed order, then zeros, then empty rows
+      userEvent.click(differenceHeader)
+      expectRowOrder([
+        ['Deficit', '-20'],
+        ['Surplus', '10'],
+        ['Zero', '0'],
+      ])
+
+      // Descending: discrepancies flip, zeros and empty rows stay at the bottom
+      userEvent.click(differenceHeader)
+      expectRowOrder([
+        ['Surplus', '10'],
+        ['Deficit', '-20'],
+        ['Zero', '0'],
+      ])
+    })
+  })
+
   it('shows round status for ballot polling', async () => {
     const expectedCalls = getDefaultExpectedCalls()
     await withMockFetch(expectedCalls, async () => {

--- a/client/src/components/AuditAdmin/Progress/Progress.tsx
+++ b/client/src/components/AuditAdmin/Progress/Progress.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
-import { Column, Cell, TableInstance, SortingRule } from 'react-table'
+import { Column, Cell, TableInstance, SortingRule, SortByFn } from 'react-table'
 import { Button, Switch, Icon, AnchorButton, Spinner } from '@blueprintjs/core'
 import H2Title from '../../Atoms/H2Title'
 import {
@@ -54,6 +54,34 @@ const formatNumber = ({ value }: { value: number | null }) =>
 const totalFooter = <T extends object>(headerName: string) => (
   info: TableInstance<T>
 ) => sum(info.rows.map(row => row.values[headerName])).toLocaleString()
+
+// Sorts rows with a discrepancy first, then zeros, then empty rows, so
+// discrepancies aren't buried below the zeros/empty on either sort direction.
+const sortDiscrepanciesFirst: SortByFn<IJurisdiction> = (
+  rowA,
+  rowB,
+  columnId,
+  desc
+) => {
+  const a: number | null = rowA.values[columnId]
+  const b: number | null = rowB.values[columnId]
+
+  // react-table negates the comparator's result when sorting descending, so
+  // this is the value to return to keep row A below row B in both directions
+  const aBelowB = desc ? -1 : 1
+
+  if (a === b) return 0
+
+  // Empty rows stay at the very bottom
+  if (a === null) return aBelowB
+  if (b === null) return -aBelowB
+
+  // Zeros stay below all discrepancies
+  if (a === 0) return aBelowB
+  if (b === 0) return -aBelowB
+
+  return a - b
+}
 
 // We count the number of batch-contest pairs with discrepancies, not the number
 // of batches with discrepancies.
@@ -303,6 +331,7 @@ const Progress: React.FC<IProgressProps> = ({
           numBallots !== null && expectedBallotManifestNumBallots !== null
             ? numBallots - expectedBallotManifestNumBallots
             : null,
+        sortType: sortDiscrepanciesFirst,
         Cell: formatNumber,
       })
     }


### PR DESCRIPTION
Closes https://github.com/votingworks/arlo/issues/2121

### Overview

From ticket:

> Noticing that when sorting Expected ballots discrepancies, if a jurisdiction has a deficit number of ballots, that shows up all the way at the bottom, after all the 0 discrepancies. I understand why it does but if anything can be done to change that, it would be helpful. Easy to miss all the way at the bottom.

### Recording

https://github.com/user-attachments/assets/09538bb5-2670-41c2-b4e0-943236cc5c97
